### PR TITLE
feat(playback): persist H.264 copy-safety verdicts and race remux optimistically

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -48,7 +48,9 @@ The server never claims something it did not verify.
 **Route events are diagnostics, not control.** A client reports what happened
 (`first_frame`, `plan_failed`, `terminal`) so the server can learn; the report
 never changes the session. Playback recovery goes through replan (§6), which is a
-request with a response, not a fire-and-forget event.
+request with a response, not a fire-and-forget event. The server may *ask* for a
+replan — the `plan_invalidated` realtime command, §6.1 — but even then the plan
+only changes when the client comes back through the replan endpoint.
 
 Two consequences worth stating early, because they surprise implementers:
 
@@ -99,13 +101,13 @@ the document is always the full one:
   "features": ["playback_plan_v3", "neutral_playback_v3_contract_v1", "layout_aware_passthrough", "playback_route_diagnostics",
                "device_quirks_v1", "seek_reanchor_v1", "output_change_v1", "direct_stream_resume_v1",
                "header_authenticated_media_v1", "authorized_media_origins_v1", "software_video_decode_v1",
-               "plan_source_duration_v1"],
+               "plan_invalidated_v1", "plan_source_duration_v1"],
   "deliveries": ["original_http", "server_remux_progressive", "server_remux_hls", "server_transcode_hls"],
   "transformations": [{"name": "audio_to_aac", "executor": "server", "recipe_version": "1", "validated_claims": ["audio_decode"]}]
 }
 ```
 
-The twelve feature strings above are the full set this server version advertises:
+The thirteen feature strings above are the full set this server version advertises:
 
 | Feature | What it promises |
 | --- | --- |
@@ -120,6 +122,7 @@ The twelve feature strings above are the full set this server version advertises
 | `header_authenticated_media_v1` | An opted-in client receives media URLs without signed credentials in their query or path, and authenticates every media request with its normal Authorization header (§4.1) |
 | `authorized_media_origins_v1` | Meaningful only with the token above: the client also honors credential-free absolute media URLs on server-designated proxy origins, which restores distributed egress for a header-authenticated attempt (§4.1) |
 | `software_video_decode_v1` | Exact/platform-attested clients may qualify bounded `video_decode[]` entries with `hardware: false` for direct/original delivery; without the opt-in those evidence tiers remain hardware-only (§3) |
+| `plan_invalidated_v1` | The client can be told mid-session that the plan it is playing was withdrawn, over the realtime `plan_invalidated` command, and replans off it. A session that did not negotiate it is stopped instead (§6.1) |
 | `plan_source_duration_v1` | `source.duration_seconds` is populated when known, so its absence means *unknown* rather than *unsupported* (§5) |
 
 That last one is the reason feature detection is a list and not a version
@@ -731,6 +734,93 @@ The server silently restores the negotiated state of each, whatever the replan
 sends — including an explicit list that omits one, which is otherwise a valid
 way to drop a feature. Seek replans never replace the feature list at all.
 Changing any of these modes means stopping and starting a new attempt.
+
+### 6.1 `plan_invalidated_v1` — the server withdraws a plan
+
+Every other control message in this protocol travels client → server. This one
+does not: `plan_invalidated` is the only **server-initiated control push**, and
+it exists because the server can learn a route is wrong *after* the plan is
+already playing.
+
+The concrete case is H.264 stream-copy safety. Some encoders redefine the same
+`pic_parameter_set_id` in-band with conflicting content, which cannot be copied
+into an avc1/fMP4 segment (§4). Detecting it means reading the opening seconds
+of the source, which on remote storage costs seconds — so the server no longer
+waits for it. An unresolved verdict plans **optimistically** (a remux is
+allowed), the scan runs behind the issued plan, and if it comes back unsafe the
+plan that was handed out has to be taken back.
+
+The push is a realtime **command** on the session control socket
+(`GET /playback/sessions/{session_id}/control/ws`) — acked and answered like
+any other, not a fire-and-forget event:
+
+```json
+{
+  "type": "command",
+  "command_id": "…",
+  "session_id": "…",
+  "name": "plan_invalidated",
+  "reason": "video_copy_unsafe",
+  "deadline_ms": 8000,
+  "payload": {"reason": "video_copy_unsafe", "plan_id": "<the invalidated plan>"}
+}
+```
+
+`payload.plan_id` names the plan being withdrawn, which is not necessarily the
+one on screen: a client that has already replanned past it has nothing to do and
+completes the command as a no-op. That is why the field is required — acting
+without checking it would evict a route the server never complained about.
+
+A client that advertises `plan_invalidated_v1` in `client_features` promises to:
+
+1. send `{"type":"ack","status":"accepted"}` immediately,
+2. run its ordinary recovery replan — `operation: "failure_recovery"`, with the
+   invalidated plan's `plan_attempt_key` in `attempted_plan_keys` so the copy
+   route is excluded deterministically (the now-persisted verdict excludes it
+   too), and
+3. send `{"type":"result","status":"completed"}` when the replan is done.
+
+**Everything else is a session stop.** The server pushes the command only to a
+session that negotiated the feature *and* holds a live realtime connection. No
+feature, no connection, no `completed` result within `deadline_ms` (an ack
+alone does not stop the clock), or a `rejected` result, and the session is
+terminated instead. That is deliberate, and it is the whole
+backwards-compatibility story: a client shipped before this token sees its
+session end, runs the recovery it already has, and its fresh attempt is planned
+against the persisted verdict — which lands it on a transcode. No client has to
+implement anything to stay correct; the feature only buys a seamless switch
+instead of a stopped session.
+
+An inconclusive scan changes nothing: nothing is persisted, no command is
+pushed, and live sessions keep the route they were given. Only a positive
+"this source cannot be copied" verdict withdraws a plan.
+
+Three scoping rules keep the stop from firing where it cannot help:
+
+- **The verdict is about the effective file.** A session whose *requested*
+  edition turned out to be copy-unsafe, but which is streaming a different
+  edition after the 4K guard or a version replan, is left alone: the bytes it is
+  serving are copy-safe.
+- **A session still being established is given time.** A session exists in the
+  session manager before its attempt record is written and long before its
+  client can open a realtime channel. A verdict landing inside that window would
+  see a session it cannot tell and stop one that is mid-start, so a session that
+  would otherwise be stopped waits out `CopySafetySessionSettleWindow` and is
+  examined once more; by then it is normally reachable and gets the command.
+- **Jellyfin-compatibility sessions are exempt.** That surface decides direct
+  stream from the device profile and the catalog version, never from the
+  copy-safety verdict, so a stopped compat client reconnects onto the identical
+  remux. The stop is only correct for clients whose recovery re-decides the
+  route, which for a Silo client means planning against the persisted verdict.
+
+That persisted verdict is read from the `media_files` row on every path that
+plans a route — start, replan, and the v2 resolver — not only from the probe
+ensurer's in-memory stamp. A replan that did not see it would simply walk from
+one stream-copy delivery to the other.
+
+Delivery is in-process: the replica that owns the session owns its realtime
+connection, so a verdict resolved on one node acts on the sessions that node is
+serving.
 
 ---
 

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -844,6 +844,33 @@ rebuild at all. The progressive route decides after the load, because the same
 file lookup serves its other preflight checks, and tears the reconstructed
 session back down when it refuses.
 
+The row alone is not the whole answer, in two directions.
+
+A verdict can be **known but unwritten**: the scan reached it and the
+`media_files` write failed, so it lives only in the memo of the process that
+reached it, and the row cannot tell that apart from "never scanned". The revival
+gate therefore asks the row first and the local scanner second, and the scanner
+retries the failed write — without ffmpeg — while it answers.
+
+A verdict can be **not yet reached at all**, which is the ordinary optimistic
+case and is allowed. But the gate runs once, at the revival request, while a
+progressive remux is a single response that runs for the length of the title:
+nothing later re-examines it, and the replica that is racing for the verdict can
+only reach its own sessions. So a revival the verdict does not condemn
+*re-engages the race on the reviving replica*, which makes the session it just
+built the property of a race running here. That pass costs no ffmpeg when the
+answer is already known locally or on the row; it re-runs the notification for
+the sessions this replica now holds.
+
+Two smaller rules keep that machinery honest. A race request that arrives while
+a scan for the same file is running is folded into one follow-up pass rather
+than dropped, because the sessions a pass acts on are the ones that exist when
+it runs and a replan can commit a replacement stream-copy mid-scan. And the
+verdict write is conditional on the row still holding the size and mtime that
+were scanned: a file rewritten in place while the scan read it produces a
+verdict about bytes nobody is serving, which is neither persisted nor pushed at
+any session.
+
 ---
 
 ## 7. Registries

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -822,6 +822,19 @@ Delivery is in-process: the replica that owns the session owns its realtime
 connection, so a verdict resolved on one node acts on the sessions that node is
 serving.
 
+The row is what covers the gap that leaves. A signed stream URL is a durable
+capability the client replays on whichever replica answers next, and a replica
+that dies between persisting a verdict and pushing the invalidation takes the
+only notifier that knew about it with it. The replacement replica has no live
+session, so it rebuilds one from the recipe card — which would replay the exact
+remux the verdict condemned. Reconstruction therefore re-reads the persisted
+verdict before it rebuilds a video stream-copy transport (a progressive remux,
+or an HLS transport whose video target is `copy`) and refuses with the ordinary
+playback-session not-found when the verdict says the source is unsafe. The
+client's existing recovery mints a fresh attempt, which plans against the same
+row and lands on a transcode. Transcode reconstruction is untouched: re-encoding
+the bitstream is unaffected by conflicting parameter sets.
+
 ---
 
 ## 7. Registries

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -827,13 +827,22 @@ capability the client replays on whichever replica answers next, and a replica
 that dies between persisting a verdict and pushing the invalidation takes the
 only notifier that knew about it with it. The replacement replica has no live
 session, so it rebuilds one from the recipe card — which would replay the exact
-remux the verdict condemned. Reconstruction therefore re-reads the persisted
-verdict before it rebuilds a video stream-copy transport (a progressive remux,
-or an HLS transport whose video target is `copy`) and refuses with the ordinary
-playback-session not-found when the verdict says the source is unsafe. The
-client's existing recovery mints a fresh attempt, which plans against the same
-row and lands on a transcode. Transcode reconstruction is untouched: re-encoding
-the bitstream is unaffected by conflicting parameter sets.
+remux the verdict condemned. The serve routes therefore re-read the persisted
+verdict for a video stream-copy recipe (a progressive remux, or an HLS transport
+whose video target is `copy`) and refuse with the ordinary playback-session
+not-found when the row says the source is unsafe. The client's existing recovery
+mints a fresh attempt, which plans against the same row and lands on a
+transcode. Transcode reconstruction is untouched: re-encoding the bitstream is
+unaffected by conflicting parameter sets.
+
+On the HLS routes the check runs *before* the session is rebuilt, not before the
+transport is. Rebuilding registers the playback session against the user's
+stream caps, so a later refusal would leave a session nobody serves holding a
+slot the replacement attempt needs; and an HLS recipe pinned to a transcode node
+is revived by proxying to that node, a path that never reaches a local transport
+rebuild at all. The progressive route decides after the load, because the same
+file lookup serves its other preflight checks, and tears the reconstructed
+session back down when it refuses.
 
 ---
 

--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
@@ -15,6 +15,7 @@
     "header_authenticated_media_v1",
     "authorized_media_origins_v1",
     "software_video_decode_v1",
+    "plan_invalidated_v1",
     "plan_source_duration_v1"
   ],
   "deliveries": [

--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/decision_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/decision_response.json
@@ -12,6 +12,7 @@
     "header_authenticated_media_v1",
     "authorized_media_origins_v1",
     "software_video_decode_v1",
+    "plan_invalidated_v1",
     "plan_source_duration_v1"
   ],
   "outcome": "playable",

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,13 @@
 
 ## 2026-08-23
 
+### Never wait on H.264 stream-copy analysis to start playing
+The check that decides whether an H.264 file can be stream-copied reads the opening seconds of the source, which on remote or cloud storage takes seconds. It used to run before playback could start, and a file it had never seen was held at the Play button; when the check itself failed, playback fell back to a full transcode even though nothing had actually proven the file unsafe.
+
+It no longer runs on the request path at all. A file with no stored verdict is now played optimistically — the cheap stream-copy route — and the analysis runs behind the stream that is already playing. Watch pages behave the same way: they start the analysis and render immediately.
+
+If the analysis then finds the file genuinely cannot be copied, Silo moves the sessions playing it off that route. Clients that advertise the new `plan_invalidated_v1` capability are told to switch, and they re-plan onto a transcode without the viewer seeing more than a brief rebuffer. Any other client — including every app version shipped before this change — has its session ended and recovers the way it already does; because the verdict is now stored, its next attempt starts on the transcode directly. An analysis that fails or is inconclusive changes nothing: nothing is stored and playback continues untouched, instead of the old behavior of transcoding on a failed check.
+
 ### Browsing no longer waits on H.264 stream-copy analysis
 Silo checks each H.264 file once for a bitstream quirk that makes stream-copying unsafe. That check reads the opening seconds of the file, and it used to run while a media page was loading and be forgotten on every restart — so browsing a library, especially after a reboot, re-read part of every H.264 file. On remote or cloud storage that was the difference between an instant page and a slow one.
 

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,13 @@
 
 ## 2026-08-23
 
+### Browsing no longer waits on H.264 stream-copy analysis
+Silo checks each H.264 file once for a bitstream quirk that makes stream-copying unsafe. That check reads the opening seconds of the file, and it used to run while a media page was loading and be forgotten on every restart — so browsing a library, especially after a reboot, re-read part of every H.264 file. On remote or cloud storage that was the difference between an instant page and a slow one.
+
+Three things change. Media pages no longer trigger the analysis at all; it now happens when a play is actually being prepared, so browsing is fast regardless of where the files live. The result is stored on the file instead of being kept only in memory, so it survives restarts and is computed at most once per file. And the check itself reads 5 seconds instead of 15.
+
+A file that changes on disk is re-checked automatically: the stored answer is only trusted while the file's size and modification time still match, so re-encoding or replacing a file in place invalidates it without any manual step. Nothing is recorded when an analysis fails, so a transient error never turns into a stale verdict — the next request simply retries. No configuration changes, and playback behavior is unchanged.
+
 ### Serve tokenless playback from proxy nodes again
 Playback protocol v3 now advertises the engine-neutral `authorized_media_origins_v1` opt-in, which a client sends together with `header_authenticated_media_v1`. Plans for such an attempt may return absolute, still credential-free media URLs on server-designated proxy origins (`/stream/v3/...`), so direct play, progressive remux, and HLS egress from the node pool instead of the API server. The proxy validates the caller's own access token against the same live login session the API checks, so revoking a session stops proxy playback immediately; replans and every other control-plane call stay on the API. A client that sends only `header_authenticated_media_v1` keeps today's API-local behavior unchanged, and so does a deployment with no proxy pool.
 

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -12,7 +12,7 @@ If the analysis then finds the file genuinely cannot be copied, Silo moves the s
 ### Browsing no longer waits on H.264 stream-copy analysis
 Silo checks each H.264 file once for a bitstream quirk that makes stream-copying unsafe. That check reads the opening seconds of the file, and it used to run while a media page was loading and be forgotten on every restart — so browsing a library, especially after a reboot, re-read part of every H.264 file. On remote or cloud storage that was the difference between an instant page and a slow one.
 
-Three things change. Media pages no longer trigger the analysis at all; it now happens when a play is actually being prepared, so browsing is fast regardless of where the files live. The result is stored on the file instead of being kept only in memory, so it survives restarts and is computed at most once per file. And the check itself reads 5 seconds instead of 15.
+Three things change. Media pages no longer trigger the analysis at all; it now happens when a play is actually being prepared, so browsing is fast regardless of where the files live. The result is stored on the file instead of being kept only in memory, so it survives restarts and is reused while the file's size and modification time still match. And the check itself reads 5 seconds instead of 15.
 
 A file that changes on disk is re-checked automatically: the stored answer is only trusted while the file's size and modification time still match, so re-encoding or replacing a file in place invalidates it without any manual step. Nothing is recorded when an analysis fails, so a transient error never turns into a stale verdict — the next request simply retries. No configuration changes, and playback behavior is unchanged.
 

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -148,6 +148,15 @@ type PlaybackProbeEnsurer interface {
 // *playback.CopySafetyRace implements it.
 type PlaybackCopySafetyRacer interface {
 	RaceScanForPlan(fileID int, plan *playback.PlanV3)
+	// RaceScan re-engages the race for a file whose verdict is still open. The
+	// serve paths use it when they revive a stream-copy transport: the replica
+	// that planned it may be gone, and only a race running *here* can withdraw
+	// the route from the session this replica just rebuilt.
+	RaceScan(fileID int)
+	// VideoCopyUnsafeKnown answers, without ffmpeg and without waiting, whether
+	// this replica can already condemn a video stream-copy of the file —
+	// including from a verdict whose write to the row failed.
+	VideoCopyUnsafeKnown(ctx context.Context, file *models.MediaFile) bool
 }
 
 type PlaybackChapterThumbnailQueuer interface {
@@ -513,8 +522,10 @@ func (h *PlaybackHandler) loadTranscodeServeSession(r *http.Request, sessionID s
 	// holding an admission slot the client's fresh attempt needs — and a
 	// remote-node recipe never reaches the local transport reconstruct at all
 	// (the serve handlers proxy to the node instead), so a gate down there would
-	// miss it entirely. See playback_copy_safety.go.
-	if videoCopyReconstructRefused(r.Context(), h.fileResolver, card) {
+	// miss it entirely. A revival the verdict does not condemn re-engages the
+	// race here, so the session about to be rebuilt is covered by a race this
+	// replica owns. See playback_copy_safety.go.
+	if videoCopyReconstructRefused(r.Context(), h.fileResolver, h.CopySafetyRacer, card) {
 		return nil, playback.SessionMissing, nil, nil
 	}
 	session, status := h.tm.LoadOrReconstructSession(r.Context(), h.sessionMgr.GetSession, sessionID, requestUserID, card)

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -123,15 +123,26 @@ type PlaybackFileVersionFetcher interface {
 	GetByEpisodeID(ctx context.Context, episodeID string) ([]*models.MediaFile, error)
 }
 
-// PlaybackProbeEnsurer repairs probe metadata and resolves the H.264
-// copy-safety verdict. Playback keeps the full Ensure: the planner consumes
-// the verdict to decide whether a video stream-copy is safe.
+// PlaybackProbeEnsurer repairs probe metadata and stamps the H.264 copy-safety
+// verdict when it is already known.
 //
-// EnsureProbeOnly is declared so the same value satisfies catalog's narrower
-// browse-side contract when it is handed to the detail service.
+// It deliberately exposes no blocking variant: a play must never wait on the
+// multi-second bitstream scan, so an unknown verdict is planned optimistically
+// and resolved behind the play (see PlaybackCopySafetyRacer).
+//
+// EnsureProbeOnly is declared because this interface is also the type the
+// router carries the shared ensurer in when handing it to the catalog and
+// chapter-thumbnail services, which repair probe metadata and nothing else.
 type PlaybackProbeEnsurer interface {
-	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	EnsureCopySafetyCached(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+}
+
+// PlaybackCopySafetyRacer resolves an unknown H.264 copy-safety verdict out of
+// band, after a plan that stream-copies video has already been issued.
+// *playback.CopySafetyRace implements it.
+type PlaybackCopySafetyRacer interface {
+	RaceScanForPlan(fileID int, plan *playback.PlanV3)
 }
 
 type PlaybackChapterThumbnailQueuer interface {
@@ -179,14 +190,18 @@ type PlaybackHandler struct {
 	// relayed request has nothing to reconstruct from. Optional and best effort:
 	// without it (or without Redis behind it) such a session replans instead of
 	// recovering, exactly as before.
-	NodeRecipeStore        recipeCardStoreV3
-	ItemAccess             PlaybackItemAccessChecker // optional; enables file authorization checks
-	EpisodeLookup          PlaybackEpisodeLookup     // optional; resolves episode files to their series
-	ExtraLookup            PlaybackExtraLookup       // optional; resolves extras files to their parent item
-	OriginalLangLookup     PlaybackOriginalLanguageLookup
-	SettingsRepo           PlaybackSettingsReader     // optional; reads server settings (e.g., allow_4k_transcode)
-	FileVersionFetcher     PlaybackFileVersionFetcher // optional; queries sibling file versions for 4K guard
-	ProbeEnsurer           PlaybackProbeEnsurer       // optional; repairs missing probe metadata on demand
+	NodeRecipeStore    recipeCardStoreV3
+	ItemAccess         PlaybackItemAccessChecker // optional; enables file authorization checks
+	EpisodeLookup      PlaybackEpisodeLookup     // optional; resolves episode files to their series
+	ExtraLookup        PlaybackExtraLookup       // optional; resolves extras files to their parent item
+	OriginalLangLookup PlaybackOriginalLanguageLookup
+	SettingsRepo       PlaybackSettingsReader     // optional; reads server settings (e.g., allow_4k_transcode)
+	FileVersionFetcher PlaybackFileVersionFetcher // optional; queries sibling file versions for 4K guard
+	ProbeEnsurer       PlaybackProbeEnsurer       // optional; repairs missing probe metadata on demand
+	// CopySafetyRacer resolves an unknown H.264 copy-safety verdict behind an
+	// already-issued stream-copy plan. Optional: without it an unknown verdict
+	// simply stays unknown and the copy route is never withdrawn.
+	CopySafetyRacer        PlaybackCopySafetyRacer
 	ChapterThumbnailQueuer PlaybackChapterThumbnailQueuer
 	IntroAnalyzer          IntroEpisodeAnalyzer
 	IntroRepository        PlaybackIntroEligibilityChecker
@@ -390,11 +405,16 @@ func semanticPlayMethod(s *playback.Session) playback.PlayMethod {
 	return s.PlayMethod
 }
 
+// ensurePlaybackProbe repairs probe metadata and stamps the H.264 copy-safety
+// verdict when it is already known. It never runs the bitstream scan: an
+// unknown verdict plans optimistically (the planner reads nil MultiplePPS as
+// "copy is allowed") and is resolved asynchronously once the plan is issued, so
+// starting playback never waits on a multi-second read of the source.
 func (h *PlaybackHandler) ensurePlaybackProbe(ctx context.Context, file *models.MediaFile) *models.MediaFile {
 	if h == nil || h.ProbeEnsurer == nil || file == nil {
 		return file
 	}
-	repaired, err := h.ProbeEnsurer.Ensure(ctx, file)
+	repaired, err := h.ProbeEnsurer.EnsureCopySafetyCached(ctx, file)
 	if err != nil {
 		slog.WarnContext(ctx, "playback probe repair failed", "component", "api", "file_id", file.ID, "path", file.FilePath, "error", err)
 		return file

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -55,6 +55,11 @@ type SessionManagerInterface interface {
 	TouchActivity(sessionID string) error
 	BeginTransport(sessionID string) error
 	EndTransport(sessionID string) error
+	// WatchTransportStop is required rather than probed for at run time: it is
+	// the only thing that can interrupt a single-response transport, so an
+	// implementation without it would serve progressive remuxes that no session
+	// stop can withdraw.
+	WatchTransportStop(sessionID string) (<-chan struct{}, func())
 	SetRemoteTransport(sessionID string, remote bool) error
 	SetEffectiveMediaFileID(sessionID string, fileID int) error
 	SetTranscodeNodeURL(sessionID, url string) error

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -123,8 +123,15 @@ type PlaybackFileVersionFetcher interface {
 	GetByEpisodeID(ctx context.Context, episodeID string) ([]*models.MediaFile, error)
 }
 
+// PlaybackProbeEnsurer repairs probe metadata and resolves the H.264
+// copy-safety verdict. Playback keeps the full Ensure: the planner consumes
+// the verdict to decide whether a video stream-copy is safe.
+//
+// EnsureProbeOnly is declared so the same value satisfies catalog's narrower
+// browse-side contract when it is handed to the detail service.
 type PlaybackProbeEnsurer interface {
 	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 }
 
 type PlaybackChapterThumbnailQueuer interface {

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -507,6 +507,16 @@ func (h *PlaybackHandler) loadTranscodeServeSession(r *http.Request, sessionID s
 	// Genuine miss (e.g. after a restart): now — and only now — pay for the token
 	// decode so the recipe is available for reconstruction.
 	card, claims := verifiedStreamCardFromToken(r.URL.Query().Get(streamTokenParam), sessionID, h.JWTSecret)
+	// The copy-safety verdict gates the revival before it happens, not after.
+	// Reconstruction registers the playback session against the user's stream
+	// caps, so a refusal that ran later would leave a session nobody serves
+	// holding an admission slot the client's fresh attempt needs — and a
+	// remote-node recipe never reaches the local transport reconstruct at all
+	// (the serve handlers proxy to the node instead), so a gate down there would
+	// miss it entirely. See playback_copy_safety.go.
+	if videoCopyReconstructRefused(r.Context(), h.fileResolver, card) {
+		return nil, playback.SessionMissing, nil, nil
+	}
 	session, status := h.tm.LoadOrReconstructSession(r.Context(), h.sessionMgr.GetSession, sessionID, requestUserID, card)
 	return session, status, card, claims
 }

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -1440,11 +1440,7 @@ func (h *PlaybackHandler) HandleGetTranscodeManifest(w http.ResponseWriter, r *h
 		// Local transcode whose process state was lost: reconstruct it from the
 		// token recipe. The manifest path has no segment context, so pass -1 (use
 		// the token's seek position).
-		if card == nil {
-			writeError(w, http.StatusNotFound, "not_found", "Transcode session not found")
-			return
-		}
-		transcodeSession = h.tm.ReconstructTranscode(r.Context(), sessionID, -1, *card)
+		transcodeSession = h.reconstructTransportForServe(r.Context(), sessionID, -1, card)
 		if transcodeSession == nil {
 			writeError(w, http.StatusNotFound, "not_found", "Transcode session not found")
 			return
@@ -1504,11 +1500,7 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 		if segNum, parseErr := playback.ParseSegmentNumber(chi.URLParam(r, "name")); parseErr == nil {
 			requestedSegment = segNum
 		}
-		if card == nil {
-			writeError(w, http.StatusNotFound, "not_found", "Transcode session not found")
-			return
-		}
-		transcodeSession = h.tm.ReconstructTranscode(r.Context(), sessionID, requestedSegment, *card)
+		transcodeSession = h.reconstructTransportForServe(r.Context(), sessionID, requestedSegment, card)
 		if transcodeSession == nil {
 			writeError(w, http.StatusNotFound, "not_found", "Transcode session not found")
 			return

--- a/internal/api/handlers/playback_copy_safety.go
+++ b/internal/api/handlers/playback_copy_safety.go
@@ -34,17 +34,60 @@ import (
 // because that is the failure a client's recovery already knows how to handle
 // — it mints a fresh attempt, which plans against the persisted verdict and
 // lands on a transcode.
+//
+// The gate is only half the answer, because the row is only half the state. A
+// verdict is reached on one replica and may not be on the row at all: the write
+// can fail, or the scan may still be running elsewhere. A revival whose verdict
+// is *unknown* is therefore allowed — the whole point of optimistic remuxing —
+// but this replica puts itself back on the race for the file before serving it,
+// so the session it just built is owned by a live race here rather than by a
+// verdict on a replica that may already be gone. That race costs no ffmpeg when
+// the answer is already known locally or on the row; it simply re-runs the
+// notification for the sessions this replica now holds.
+
+// videoCopyRevivalRefused decides one revived video stream-copy: refuse it when
+// this replica can already call the source copy-unsafe, and otherwise re-engage
+// the race so a verdict reached later still reaches the session being revived.
+//
+// The persisted row is consulted first because it is the state every replica
+// shares. When it says nothing, the racer is asked, because a verdict this
+// process reached but failed to write lives only in its memo — and the row
+// cannot tell that apart from "never scanned". Without that second question a
+// failed write would leave the condemned recipe rebuildable forever.
+//
+// A missing racer (tests, minimal setups) collapses this to the row check plus
+// no race, which is the pre-optimistic behavior.
+func videoCopyRevivalRefused(ctx context.Context, racer PlaybackCopySafetyRacer, file *models.MediaFile, sessionID string) bool {
+	if file == nil {
+		return false
+	}
+	if multi, known := file.PersistedVideoCopyVerdict(); known {
+		if multi {
+			logVideoCopyRevivalRefusal(ctx, file, sessionID)
+		}
+		return multi
+	}
+	if racer == nil {
+		return false
+	}
+	if racer.VideoCopyUnsafeKnown(ctx, file) {
+		logVideoCopyRevivalRefusal(ctx, file, sessionID)
+		return true
+	}
+	racer.RaceScan(file.ID)
+	return false
+}
 
 // videoCopyReconstructRefused reports whether rebuilding a lost transport from
-// card must be refused because the persisted verdict now says its source cannot
-// be video stream-copied. Only copy deliveries are gated; a transcode
-// reconstruct is never touched.
+// card must be refused because the verdict now says its source cannot be video
+// stream-copied, and re-engages the race when it does not. Only copy deliveries
+// are gated; a transcode reconstruct is never touched.
 //
 // An unreadable row is not evidence of anything and does not refuse: the
 // verdict is re-checked on every request, so a database blip costs a later
 // refusal rather than a spurious one. The same applies to a handler with no
 // file resolver wired (optional on PlaybackHandler).
-func videoCopyReconstructRefused(ctx context.Context, files FilePathResolver, card *playback.RecipeCard) bool {
+func videoCopyReconstructRefused(ctx context.Context, files FilePathResolver, racer PlaybackCopySafetyRacer, card *playback.RecipeCard) bool {
 	if card == nil || files == nil || card.MediaFileID <= 0 || !card.VideoStreamCopy() {
 		return false
 	}
@@ -52,7 +95,7 @@ func videoCopyReconstructRefused(ctx context.Context, files FilePathResolver, ca
 	if err != nil || file == nil {
 		return false
 	}
-	return videoCopyUnsafeByVerdict(ctx, file, card.SessionID)
+	return videoCopyRevivalRefused(ctx, racer, file, card.SessionID)
 }
 
 // reconstructTransportForServe rebuilds a lost local transport from the token
@@ -71,20 +114,12 @@ func (h *PlaybackHandler) reconstructTransportForServe(ctx context.Context, sess
 	return h.tm.ReconstructTranscode(ctx, sessionID, requestedSegment, *card)
 }
 
-// videoCopyUnsafeByVerdict reports whether the media_files row carries a valid
-// verdict condemning a video stream-copy of this file, logging the refusal it
-// is about to cause.
-func videoCopyUnsafeByVerdict(ctx context.Context, file *models.MediaFile, sessionID string) bool {
-	multi, known := file.PersistedVideoCopyVerdict()
-	if !known || !multi {
-		return false
-	}
-	slog.InfoContext(ctx, "refusing to reconstruct a copy-unsafe video stream-copy",
+func logVideoCopyRevivalRefusal(ctx context.Context, file *models.MediaFile, sessionID string) {
+	slog.InfoContext(ctx, "refusing to revive a copy-unsafe video stream-copy",
 		"component", "api",
 		"session", sessionID,
 		"playback_session_id", sessionID,
 		"file_id", file.ID,
 		"reason", playback.PlanInvalidatedVideoCopyUnsafe,
 	)
-	return true
 }

--- a/internal/api/handlers/playback_copy_safety.go
+++ b/internal/api/handlers/playback_copy_safety.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/playback"
+)
+
+// Reconstruction replays a recipe that was committed before the H.264
+// copy-safety verdict for its source was known. That is safe for everything
+// except a video stream-copy: the optimistic-remux race resolves the verdict
+// behind the play, and the only mechanism that withdraws a condemned remux —
+// CopySafetyNotifier — reaches the in-process sessions of the replica that
+// reached the verdict.
+//
+// A client whose replica dies between the verdict landing and the notification
+// retries its signed stream URL elsewhere. The replacement replica has no live
+// session, so it rebuilds one from the card and re-serves the same unsafe
+// remux, with nothing left to withdraw it. Re-checking the persisted verdict at
+// the moment of reconstruction closes that hole: the row is the one piece of
+// state every replica shares.
+//
+// The refusal is a plain not-found, matching an expired or missing recipe,
+// because that is the failure a client's recovery already knows how to handle
+// — it mints a fresh attempt, which plans against the persisted verdict and
+// lands on a transcode.
+
+// videoCopyReconstructRefused reports whether rebuilding a lost transport from
+// card must be refused because the persisted verdict now says its source cannot
+// be video stream-copied. Only copy deliveries are gated; a transcode
+// reconstruct is never touched.
+//
+// An unreadable row is not evidence of anything and does not refuse: the
+// verdict is re-checked on every request, so a database blip costs a later
+// refusal rather than a spurious one. The same applies to a handler with no
+// file resolver wired (optional on PlaybackHandler).
+func videoCopyReconstructRefused(ctx context.Context, files FilePathResolver, card *playback.RecipeCard) bool {
+	if card == nil || files == nil || card.MediaFileID <= 0 || !card.VideoStreamCopy() {
+		return false
+	}
+	file, err := files.GetByID(ctx, card.MediaFileID)
+	if err != nil || file == nil {
+		return false
+	}
+	return videoCopyUnsafeByVerdict(ctx, file, card.SessionID)
+}
+
+// reconstructTransportForServe rebuilds a lost local transport from the token
+// recipe for the manifest and segment serve routes, refusing a video
+// stream-copy the persisted copy-safety verdict has since condemned. A nil
+// result is the caller's not-found, which is also what a missing card yields —
+// the two are the same thing to a client: this recipe is no longer serveable.
+func (h *PlaybackHandler) reconstructTransportForServe(ctx context.Context, sessionID string, requestedSegment int, card *playback.RecipeCard) *playback.TranscodeSession {
+	if card == nil {
+		return nil
+	}
+	if videoCopyReconstructRefused(ctx, h.fileResolver, card) {
+		return nil
+	}
+	return h.tm.ReconstructTranscode(ctx, sessionID, requestedSegment, *card)
+}
+
+// videoCopyUnsafeByVerdict reports whether the media_files row carries a valid
+// verdict condemning a video stream-copy of this file, logging the refusal it
+// is about to cause.
+func videoCopyUnsafeByVerdict(ctx context.Context, file *models.MediaFile, sessionID string) bool {
+	multi, known := file.PersistedVideoCopyVerdict()
+	if !known || !multi {
+		return false
+	}
+	slog.InfoContext(ctx, "refusing to reconstruct a copy-unsafe video stream-copy",
+		"component", "api",
+		"session", sessionID,
+		"playback_session_id", sessionID,
+		"file_id", file.ID,
+		"reason", playback.PlanInvalidatedVideoCopyUnsafe,
+	)
+	return true
+}

--- a/internal/api/handlers/playback_copy_safety.go
+++ b/internal/api/handlers/playback_copy_safety.go
@@ -22,6 +22,14 @@ import (
 // the moment of reconstruction closes that hole: the row is the one piece of
 // state every replica shares.
 //
+// The check belongs BEFORE the session is rebuilt, for two reasons. Rebuilding
+// registers the session against the user's stream caps, so a later refusal
+// leaves a session nobody serves holding a slot the client's replacement
+// attempt has to admit through. And the transport is not the only thing a card
+// can revive: an HLS recipe pinned to a transcode node is served by proxying to
+// that node, a path that never reaches a local transport rebuild — gating there
+// would let exactly the remote remux keep streaming.
+//
 // The refusal is a plain not-found, matching an expired or missing recipe,
 // because that is the failure a client's recovery already knows how to handle
 // — it mints a fresh attempt, which plans against the persisted verdict and
@@ -48,15 +56,16 @@ func videoCopyReconstructRefused(ctx context.Context, files FilePathResolver, ca
 }
 
 // reconstructTransportForServe rebuilds a lost local transport from the token
-// recipe for the manifest and segment serve routes, refusing a video
-// stream-copy the persisted copy-safety verdict has since condemned. A nil
-// result is the caller's not-found, which is also what a missing card yields —
-// the two are the same thing to a client: this recipe is no longer serveable.
+// recipe for the manifest and segment serve routes. A nil card yields a nil
+// result, which is the caller's not-found: to a client, a recipe it cannot
+// present and a recipe that no longer rebuilds are the same thing.
+//
+// The copy-safety verdict is not consulted here. It is consulted in
+// loadTranscodeServeSession, which is the only producer of the cards that reach
+// this function and runs before the session is registered — see the file
+// comment for why the earlier point is the correct one.
 func (h *PlaybackHandler) reconstructTransportForServe(ctx context.Context, sessionID string, requestedSegment int, card *playback.RecipeCard) *playback.TranscodeSession {
 	if card == nil {
-		return nil
-	}
-	if videoCopyReconstructRefused(ctx, h.fileResolver, card) {
 		return nil
 	}
 	return h.tm.ReconstructTranscode(ctx, sessionID, requestedSegment, *card)

--- a/internal/api/handlers/playback_copy_safety_test.go
+++ b/internal/api/handlers/playback_copy_safety_test.go
@@ -44,6 +44,12 @@ type recordingCopySafetyRacer struct {
 	mu    sync.Mutex
 	plans []playback.DeliveryV3
 	files []int
+	// bare records the files handed to RaceScan — the revival path, which has
+	// no plan to hand over.
+	bare []int
+	// knownUnsafe stands in for a verdict this replica holds without the row
+	// carrying it: an unsafe scan whose write to media_files failed.
+	knownUnsafe bool
 }
 
 func (r *recordingCopySafetyRacer) RaceScanForPlan(fileID int, plan *playback.PlanV3) {
@@ -55,10 +61,28 @@ func (r *recordingCopySafetyRacer) RaceScanForPlan(fileID int, plan *playback.Pl
 	}
 }
 
+func (r *recordingCopySafetyRacer) RaceScan(fileID int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.bare = append(r.bare, fileID)
+}
+
+func (r *recordingCopySafetyRacer) VideoCopyUnsafeKnown(context.Context, *models.MediaFile) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.knownUnsafe
+}
+
 func (r *recordingCopySafetyRacer) raced() ([]int, []playback.DeliveryV3) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]int(nil), r.files...), append([]playback.DeliveryV3(nil), r.plans...)
+}
+
+func (r *recordingCopySafetyRacer) bareRaces() []int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]int(nil), r.bare...)
 }
 
 // Starting playback must never wait on the H.264 copy-safety scan: it takes the

--- a/internal/api/handlers/playback_copy_safety_test.go
+++ b/internal/api/handlers/playback_copy_safety_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/playback"
+)
+
+// blockingProbeEnsurer fails the test if the start path asks for anything but
+// the cached-only ensure — the other variants can run the multi-second
+// bitstream scan, which must never happen on a request path.
+type blockingProbeEnsurer struct {
+	t           *testing.T
+	mu          sync.Mutex
+	cachedCalls int
+}
+
+func (e *blockingProbeEnsurer) EnsureProbeOnly(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	e.t.Helper()
+	e.t.Fatal("playback start called EnsureProbeOnly; it must resolve a known copy-safety verdict")
+	return file, nil
+}
+
+func (e *blockingProbeEnsurer) EnsureCopySafetyCached(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.cachedCalls++
+	return file, nil
+}
+
+func (e *blockingProbeEnsurer) calls() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.cachedCalls
+}
+
+type recordingCopySafetyRacer struct {
+	mu    sync.Mutex
+	plans []playback.DeliveryV3
+	files []int
+}
+
+func (r *recordingCopySafetyRacer) RaceScanForPlan(fileID int, plan *playback.PlanV3) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.files = append(r.files, fileID)
+	if plan != nil {
+		r.plans = append(r.plans, plan.Delivery)
+	}
+}
+
+func (r *recordingCopySafetyRacer) raced() ([]int, []playback.DeliveryV3) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]int(nil), r.files...), append([]playback.DeliveryV3(nil), r.plans...)
+}
+
+// Starting playback must never wait on the H.264 copy-safety scan: it takes the
+// cached-only ensure, and the plan it issues is handed to the racer that
+// resolves the verdict behind it.
+func TestHandleStartPlaybackV3DoesNotBlockOnCopySafetyScan(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	file := v3HandlerFixtureFile(t)
+	ensurer := &blockingProbeEnsurer{t: t}
+	racer := &recordingCopySafetyRacer{}
+
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{}}
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.ProbeEnsurer = ensurer
+	handler.CopySafetyRacer = racer
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/playback/start",
+		strings.NewReader(marshalV3StartRequest(t, v3HandlerStartRequest()))).WithContext(newAuthorizedPlaybackContext())
+	rr := httptest.NewRecorder()
+	handler.HandleStartPlayback(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if ensurer.calls() == 0 {
+		t.Fatal("start did not resolve the cached copy-safety verdict")
+	}
+	files, _ := racer.raced()
+	if len(files) != 1 || files[0] != file.ID {
+		t.Fatalf("raced files = %v, want the planned file %d handed to the racer", files, file.ID)
+	}
+}
+
+// The route test is the racer's; the handler's job is only to hand it the plan
+// it issued, for every route, and to stay silent when no racer is wired.
+func TestRaceCopySafetyV3HandsThePlanToTheRacer(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	racer := &recordingCopySafetyRacer{}
+	handler.CopySafetyRacer = racer
+
+	handler.raceCopySafetyV3(42, &playback.PlanV3{PlanID: "plan-1", Delivery: playback.DeliveryRemuxHLSV3})
+	handler.raceCopySafetyV3(0, &playback.PlanV3{PlanID: "plan-2", Delivery: playback.DeliveryRemuxHLSV3})
+	handler.raceCopySafetyV3(43, nil)
+
+	files, deliveries := racer.raced()
+	if len(files) != 1 || files[0] != 42 {
+		t.Fatalf("raced files = %v, want only the valid file/plan pair", files)
+	}
+	if len(deliveries) != 1 || deliveries[0] != playback.DeliveryRemuxHLSV3 {
+		t.Fatalf("raced deliveries = %v, want the issued plan's delivery", deliveries)
+	}
+
+	without := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	without.raceCopySafetyV3(42, &playback.PlanV3{PlanID: "plan-1", Delivery: playback.DeliveryRemuxHLSV3})
+}

--- a/internal/api/handlers/playback_realtime.go
+++ b/internal/api/handlers/playback_realtime.go
@@ -63,6 +63,44 @@ func (h *PlaybackHandler) abortPlaybackSessionByID(ctx context.Context, sessionI
 	return h.abortPlaybackSession(ctx, session)
 }
 
+// CopySafetyPlaybackControl adapts the playback handler to the session control
+// playback.CopySafetyNotifier needs: the notifier owns the decision to withdraw
+// a plan, the handler owns realtime command bookkeeping and session teardown.
+type CopySafetyPlaybackControl struct {
+	playback *PlaybackHandler
+}
+
+// NewCopySafetyPlaybackControl returns the adapter, or nil without a handler.
+func NewCopySafetyPlaybackControl(handler *PlaybackHandler) *CopySafetyPlaybackControl {
+	if handler == nil {
+		return nil
+	}
+	return &CopySafetyPlaybackControl{playback: handler}
+}
+
+func (c *CopySafetyPlaybackControl) RememberRealtimeCommand(commandID, sessionID string, name playback.CommandName) {
+	if c == nil {
+		return
+	}
+	c.playback.rememberRealtimeCommand(commandID, sessionID, name)
+}
+
+func (c *CopySafetyPlaybackControl) ForgetRealtimeCommand(commandID string) {
+	if c == nil {
+		return
+	}
+	c.playback.forgetRealtimeCommand(commandID)
+}
+
+// StopSession ends the session as a system teardown, not a user stop: the
+// recipe card is kept so the client's recovery can rebuild from it.
+func (c *CopySafetyPlaybackControl) StopSession(ctx context.Context, sessionID string) error {
+	if c == nil {
+		return playback.ErrSessionNotFound
+	}
+	return c.playback.stopPlaybackSessionByID(ctx, sessionID, false)
+}
+
 func (h *PlaybackHandler) rememberRealtimeCommand(commandID, sessionID string, name playback.CommandName) {
 	if h == nil || commandID == "" || sessionID == "" {
 		return

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -185,6 +185,10 @@ func (failingSessionManager) BeginTransport(string) error { return nil }
 
 func (failingSessionManager) EndTransport(string) error { return nil }
 
+func (failingSessionManager) WatchTransportStop(string) (<-chan struct{}, func()) {
+	return nil, func() {}
+}
+
 func (failingSessionManager) SetRemoteTransport(string, bool) error { return nil }
 
 func (failingSessionManager) SetEffectiveMediaFileID(string, int) error { return nil }

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -860,6 +860,7 @@ func (h *PlaybackHandler) startPlannedPlaybackV3(r *http.Request, userID int, pr
 		h.ChapterThumbnailQueuer.QueuePriorityFileAtPosition(r.Context(), effectiveFile.ID, session.Position)
 	}
 	h.maybeQueueLazyPlaybackMarkers(r.Context(), session, effectiveFile)
+	h.raceCopySafetyV3(effectiveFile.ID, result.Plan)
 	h.persistSeriesSelectionsV3(r.Context(), userID, profileID, effectiveFile, plannedAudioTrackIndexV3(result, audioIndex))
 	h.syncSessionsNow(r.Context(), "v3_start")
 	h.enqueueRouteEventV3(playback.RouteEventRecordV3{RouteEventV3: playback.RouteEventV3{ProtocolVersion: playback.ProtocolV3, PlaybackAttemptID: req.PlaybackAttemptID, SessionID: session.ID, PlanID: result.Plan.PlanID, Event: playback.RouteEventPlanSelectedV3, AppliedQuirkIDs: appliedQuirkIDsV3(result.Plan), QuirkRegistryRevision: appliedQuirkRevisionV3(result.Plan), OutputContextID: req.ClientPlaybackContext.Output.OutputContextID}, UserID: userID, ProfileID: profileID, ClientName: clientInfo.Name, ClientVersion: clientInfo.Version, ClientBuild: clientInfo.Build, ClientChannel: clientInfo.Channel, ClientModel: req.ClientPlaybackContext.Device.Model})
@@ -2300,7 +2301,19 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 			transport.afterDurableCommit()
 		}
 	}
+	h.raceCopySafetyV3(updated.EffectiveMediaFileID, response.PlaybackPlan)
 	writeJSON(w, http.StatusOK, response)
+}
+
+// raceCopySafetyV3 resolves an unknown H.264 copy-safety verdict behind a plan
+// that stream-copies video. It is called after the durable commit on both the
+// start and replan paths, so the scan only ever chases a route a client was
+// actually handed, and it returns immediately — no response waits on it.
+func (h *PlaybackHandler) raceCopySafetyV3(fileID int, plan *playback.PlanV3) {
+	if h == nil || h.CopySafetyRacer == nil || fileID <= 0 || plan == nil {
+		return
+	}
+	h.CopySafetyRacer.RaceScanForPlan(fileID, plan)
 }
 
 func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.AttemptRecordV3, req playback.ReplanRequestV3) (playback.DecisionResponseV3, playback.AttemptRecordV3, *preparedTransportV3, *transportErrorV3) {

--- a/internal/api/handlers/session_ws.go
+++ b/internal/api/handlers/session_ws.go
@@ -166,17 +166,22 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 			return playback.ErrInvalidRealtimePayload
 		}
 		h.touchSessionActivity(sessionID)
+		// Establish ownership before mutating anything: a result naming another
+		// session's command must be rejected without canceling that command's
+		// deadline or dropping its record. An unknown command_id is not an
+		// error — a duplicate or late result for an already-completed command
+		// is normal traffic.
+		record, ok := h.getRealtimeCommand(result.CommandID)
+		if ok && record.SessionID != sessionID {
+			return playback.ErrInvalidRealtimePayload
+		}
 		if h.CommandTracker != nil {
 			h.CommandTracker.Result(result.CommandID)
 		}
-		record, ok := h.getRealtimeCommand(result.CommandID)
 		if !ok {
 			return nil
 		}
 		h.forgetRealtimeCommand(result.CommandID)
-		if record.SessionID != sessionID {
-			return playback.ErrInvalidRealtimePayload
-		}
 		if result.Status != playback.RealtimeResultStatusCompleted {
 			// A rejected plan_invalidated leaves the client running a route the
 			// server has withdrawn, and the tracker's deadline was already

--- a/internal/api/handlers/session_ws.go
+++ b/internal/api/handlers/session_ws.go
@@ -178,6 +178,18 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 			return playback.ErrInvalidRealtimePayload
 		}
 		if result.Status != playback.RealtimeResultStatusCompleted {
+			// A rejected plan_invalidated leaves the client running a route the
+			// server has withdrawn, and the tracker's deadline was already
+			// canceled by the result. Fall back to the same session stop an
+			// unnegotiated client gets; its recovery replans against the
+			// persisted verdict.
+			if record.Name == playback.CommandPlanInvalidated {
+				slog.Warn("client rejected a plan invalidation; stopping the session",
+					"session", sessionID, "playback_session_id", sessionID, "error", result.Error)
+				if err := h.stopPlaybackSessionByID(context.Background(), sessionID, false); err != nil && !errors.Is(err, playback.ErrSessionNotFound) {
+					slog.Error("failed to stop playback after a rejected plan invalidation", "session", sessionID, "playback_session_id", sessionID, "error", err)
+				}
+			}
 			return nil
 		}
 		switch record.Name {
@@ -186,6 +198,9 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 			if err != nil && !errors.Is(err, playback.ErrSessionNotFound) {
 				slog.Error("failed to stop playback after realtime completion", "session", sessionID, "playback_session_id", sessionID, "error", err)
 			}
+		case playback.CommandPlanInvalidated:
+			// Completion means the client replanned itself; the session stays
+			// alive on its replacement plan and nothing else is required here.
 		}
 		return nil
 	default:

--- a/internal/api/handlers/session_ws_plan_invalidated_test.go
+++ b/internal/api/handlers/session_ws_plan_invalidated_test.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/playback"
 )
@@ -67,5 +69,47 @@ func TestRealtimeCompletedPlanInvalidationKeepsSession(t *testing.T) {
 
 	if _, err := sessionMgr.GetSession(session.ID); err != nil {
 		t.Fatalf("GetSession after a completed replan: %v, want the session kept", err)
+	}
+}
+
+// Rejecting a result has to be side-effect-free: a client claiming another
+// session's command_id must not cancel that command's fallback deadline or
+// drop its record, or one session could silently disarm another's recovery.
+func TestRealtimeResultForOtherSessionCommandLeavesTrackerArmed(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	handler := NewPlaybackHandler(sessionMgr)
+	handler.CommandTracker = playback.NewCommandTracker()
+	defer handler.CommandTracker.Close()
+
+	sessionA, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession A: %v", err)
+	}
+	sessionB, err := sessionMgr.StartSession(2, "profile-2", 200, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession B: %v", err)
+	}
+	if sessionA.ID == sessionB.ID {
+		t.Fatal("StartSession returned colliding session IDs, want distinct sessions")
+	}
+
+	handler.rememberRealtimeCommand("cmd-1", sessionB.ID, playback.CommandPlanInvalidated)
+	fired := make(chan struct{})
+	handler.CommandTracker.Track("cmd-1", 20*time.Millisecond, func() { close(fired) })
+
+	err = handler.handleRealtimeClientMessage(sessionA.ID,
+		realtimeResultMessage(t, sessionA.ID, "cmd-1", playback.RealtimeResultStatusCompleted))
+	if !errors.Is(err, playback.ErrInvalidRealtimePayload) {
+		t.Fatalf("handleRealtimeClientMessage: %v, want ErrInvalidRealtimePayload", err)
+	}
+
+	if _, ok := handler.getRealtimeCommand("cmd-1"); !ok {
+		t.Fatal("a rejected cross-session result forgot the command record, want it kept")
+	}
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("command deadline never fired, want it still armed after a rejected cross-session result")
 	}
 }

--- a/internal/api/handlers/session_ws_plan_invalidated_test.go
+++ b/internal/api/handlers/session_ws_plan_invalidated_test.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/playback"
+)
+
+func realtimeResultMessage(t *testing.T, sessionID, commandID string, status playback.RealtimeResultStatus) []byte {
+	t.Helper()
+	data, err := json.Marshal(playback.ResultEnvelope{
+		Type:      playback.RealtimeMessageTypeResult,
+		CommandID: commandID,
+		SessionID: sessionID,
+		Status:    status,
+	})
+	if err != nil {
+		t.Fatalf("marshal result envelope: %v", err)
+	}
+	return data
+}
+
+// A client that refuses a plan invalidation is left running a route the server
+// has withdrawn, and its rejection already canceled the command deadline —
+// so the rejection itself has to stop the session.
+func TestRealtimeRejectedPlanInvalidationStopsSession(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	handler := NewPlaybackHandler(sessionMgr)
+	handler.CommandTracker = playback.NewCommandTracker()
+	defer handler.CommandTracker.Close()
+
+	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	handler.rememberRealtimeCommand("cmd-1", session.ID, playback.CommandPlanInvalidated)
+
+	if err := handler.handleRealtimeClientMessage(session.ID,
+		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusRejected)); err != nil {
+		t.Fatalf("handleRealtimeClientMessage: %v", err)
+	}
+
+	if _, err := sessionMgr.GetSession(session.ID); err == nil {
+		t.Fatal("session survived a rejected plan invalidation, want it stopped")
+	}
+}
+
+// A completed invalidation means the client replanned itself: the session must
+// stay alive on its replacement plan.
+func TestRealtimeCompletedPlanInvalidationKeepsSession(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	handler := NewPlaybackHandler(sessionMgr)
+	handler.CommandTracker = playback.NewCommandTracker()
+	defer handler.CommandTracker.Close()
+
+	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	handler.rememberRealtimeCommand("cmd-1", session.ID, playback.CommandPlanInvalidated)
+
+	if err := handler.handleRealtimeClientMessage(session.ID,
+		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusCompleted)); err != nil {
+		t.Fatalf("handleRealtimeClientMessage: %v", err)
+	}
+
+	if _, err := sessionMgr.GetSession(session.ID); err != nil {
+		t.Fatalf("GetSession after a completed replan: %v, want the session kept", err)
+	}
+}

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -51,6 +51,12 @@ type StreamHandler struct {
 	// PlaybackConfig returns the current playback config; read it through
 	// ffmpegPath(). May be nil (tests).
 	PlaybackConfig func() config.PlaybackConfig
+	// CopySafetyRacer gates and covers a revived progressive remux: it answers
+	// whether this replica already condemns a video stream-copy of the source,
+	// and re-engages the copy-safety race for one whose verdict is still open.
+	// Optional — without it a revived remux is gated on the persisted row alone
+	// and no race is started here.
+	CopySafetyRacer PlaybackCopySafetyRacer
 	// SubtitleCache stores full-track PGS (.sup) extracts under the transcode
 	// dir so repeat selections skip the whole-file ffmpeg demux. May be nil
 	// (tests / minimal setups) — extraction then always streams uncached.
@@ -151,8 +157,13 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 
 	// A reconstructed remux replays a recipe committed before the copy-safety
 	// verdict existed, and no notifier can reach it — see playback_copy_safety.go.
+	// One that the verdict does not condemn re-engages the race here, which is
+	// what gives the single long response below something able to withdraw it.
+	// Starting that race before the abort watcher is registered is safe: a
+	// verdict fast enough to stop the session first leaves WatchTransportStop
+	// with no session to watch, and it reports the stop it missed.
 	if reconstructed && session.PlayMethod == playback.PlayRemux &&
-		videoCopyUnsafeByVerdict(r.Context(), file, sessionID) {
+		videoCopyRevivalRefused(r.Context(), h.CopySafetyRacer, file, sessionID) {
 		// The reconstruct already registered the session; tear it down again so
 		// the refusal leaves no half-live session behind the client's replan.
 		h.abortPlaybackSession(r.Context(), session)

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -106,7 +106,7 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 	// Without a token (or signing secret) reconstruct is off, collapsing to a
 	// plain GetSession + ownership check.
 	card, claims := verifiedStreamCardFromToken(r.URL.Query().Get(streamTokenParam), sessionID, h.JWTSecret)
-	session, status := h.TM.LoadOrReconstructSession(r.Context(), h.sessionMgr.GetSession, sessionID, userID, card)
+	session, status, reconstructed := h.TM.LoadOrReconstructSessionDetail(r.Context(), h.sessionMgr.GetSession, sessionID, userID, card)
 	switch status {
 	case playback.SessionMissing:
 		writePlaybackSessionNotFound(w)
@@ -148,6 +148,17 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	attachPlaybackSession(r.Context(), session, claims)
+
+	// A reconstructed remux replays a recipe committed before the copy-safety
+	// verdict existed, and no notifier can reach it — see playback_copy_safety.go.
+	if reconstructed && session.PlayMethod == playback.PlayRemux &&
+		videoCopyUnsafeByVerdict(r.Context(), file, sessionID) {
+		// The reconstruct already registered the session; tear it down again so
+		// the refusal leaves no half-live session behind the client's replan.
+		h.abortPlaybackSession(r.Context(), session)
+		writePlaybackSessionNotFound(w)
+		return
+	}
 
 	switch session.PlayMethod {
 	case playback.PlayDirect:

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -166,6 +166,12 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 				_ = h.sessionMgr.EndTransport(sessionID)
 			}()
 		}
+		// A progressive remux runs for the length of the title behind a single
+		// response, so a stop decided while it is playing — a copy-safety
+		// verdict withdrawing the route, an admin kill — has to reach the
+		// stream itself. Nothing else can: the ffmpeg belongs to this request.
+		abort, releaseAbort := h.sessionMgr.WatchTransportStop(sessionID)
+		defer releaseAbort()
 		seekSeconds := 0.0
 		if seekStr := r.URL.Query().Get("seek"); seekStr != "" {
 			if s, err := strconv.ParseFloat(seekStr, 64); err == nil && s >= 0 {
@@ -183,6 +189,7 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 			AudioOnly:              file.IsAudioOnly(),
 			TargetAudioChannels:    session.TargetAudioChannels,
 			TargetAudioBitrateKbps: session.TargetAudioBitrateKbps,
+			Abort:                  abort,
 		}); err != nil {
 			h.handleTransportStartFailure(r.Context(), session, file, err)
 		}

--- a/internal/api/handlers/stream_copy_safety_test.go
+++ b/internal/api/handlers/stream_copy_safety_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -141,6 +144,177 @@ func TestHandleStream_ReconstructsARemuxThatIsStillCopySafe(t *testing.T) {
 				t.Fatalf("status = %d, body = %s; want the reconstruct served", rr.Code, rr.Body.String())
 			}
 		})
+	}
+}
+
+// copySafetyHLSCard is a lost HLS transport whose video target was pinned to a
+// stream copy — the remux_hls recipe. nodeURL pins it to a transcode node,
+// which is what makes the serve handlers proxy rather than rebuild locally.
+func copySafetyHLSCard(sessionID string, fileID int, nodeURL string) playback.RecipeCard {
+	return playback.RecipeCard{
+		SessionID:            sessionID,
+		UserID:               1,
+		ProfileID:            "profile-1",
+		MediaFileID:          fileID,
+		PlayMethod:           playback.PlayTranscode,
+		TargetCodecVideo:     "copy",
+		TargetCodecAudio:     "copy",
+		SegmentDuration:      2,
+		TranscodeNodeURL:     nodeURL,
+		TranscodeTransportID: sessionID + "-transport",
+	}
+}
+
+// copySafetyHLSRequest builds one signed manifest or segment request for a
+// session this replica has never seen.
+func copySafetyHLSRequest(t *testing.T, secret, segmentName string, card playback.RecipeCard) *http.Request {
+	t.Helper()
+	token, err := streamtoken.Sign(card.ToClaims(), secret, playback.MaxTokenTTL)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	path := "/api/v1/playback/transcode/" + card.SessionID + "/master.m3u8?st=" + token
+	if segmentName != "" {
+		path = "/api/v1/playback/transcode/" + card.SessionID + "/segment/" + segmentName + "?st=" + token
+	}
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req = req.WithContext(newAuthorizedPlaybackContext())
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("session_id", card.SessionID)
+	if segmentName != "" {
+		routeCtx.URLParams.Add("name", segmentName)
+	}
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+// The HLS serve routes revive a lost session in two different ways: locally, by
+// rebuilding the ffmpeg from the card, and remotely, by proxying to the
+// transcode node the card names. Both start by registering the playback session
+// the card describes, so both have to be refused before that happens — a gate
+// on the local transport rebuild alone would never see the remote recipe at all,
+// and would leave the local one holding a stream slot it can no longer use.
+func TestHandleTranscodeServe_RefusesRevivingACopyUnsafeHLSRecipe(t *testing.T) {
+	const secret = "test-stream-signing-secret"
+
+	nodeHits := 0
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nodeHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer node.Close()
+
+	for _, route := range []struct {
+		name    string
+		segment string
+		handle  func(*PlaybackHandler) func(http.ResponseWriter, *http.Request)
+	}{
+		{
+			name:   "manifest",
+			handle: func(h *PlaybackHandler) func(http.ResponseWriter, *http.Request) { return h.HandleGetTranscodeManifest },
+		},
+		{
+			name:    "segment",
+			segment: "seg_00001.m4s",
+			handle:  func(h *PlaybackHandler) func(http.ResponseWriter, *http.Request) { return h.HandleGetTranscodeSegment },
+		},
+	} {
+		for _, executor := range []struct {
+			name    string
+			nodeURL string
+		}{
+			{name: "local"},
+			{name: "transcode-node", nodeURL: node.URL},
+		} {
+			t.Run(route.name+"/"+executor.name, func(t *testing.T) {
+				unsafe := true
+				file := copySafetyStreamFile(t, &unsafe)
+
+				sessionMgr := playback.NewSessionManager(0, 0)
+				handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+				handler.JWTSecret = secret
+
+				sessionID := "lost-hls-" + route.name + "-" + executor.name
+				card := copySafetyHLSCard(sessionID, file.ID, executor.nodeURL)
+
+				rr := httptest.NewRecorder()
+				route.handle(handler)(rr, copySafetyHLSRequest(t, secret, route.segment, card))
+
+				if rr.Code != http.StatusNotFound {
+					t.Fatalf("status = %d, body = %s; want the revival refused as not-found", rr.Code, rr.Body.String())
+				}
+				// Nothing may be registered: the refused session would otherwise
+				// count against the user's stream cap with no transport behind it.
+				if _, err := sessionMgr.GetSession(sessionID); !errors.Is(err, playback.ErrSessionNotFound) {
+					t.Fatalf("GetSession error = %v, want no session registered by a refused revival", err)
+				}
+				if nodeHits != 0 {
+					t.Fatalf("transcode node received %d proxied requests, want the condemned stream never proxied", nodeHits)
+				}
+			})
+		}
+	}
+}
+
+// The refusal is only worth anything if the client's recovery can get back in.
+// A user at their stream cap has exactly one slot, and a session left registered
+// by a refused revival would spend it on a stream nobody is serving.
+func TestHandleTranscodeServe_RefusedRevivalLeavesTheStreamSlotFree(t *testing.T) {
+	const (
+		secret    = "test-stream-signing-secret"
+		sessionID = "lost-hls-capped"
+	)
+	unsafe := true
+	file := copySafetyStreamFile(t, &unsafe)
+
+	// One stream per user: the refused revival and the recovery attempt cannot
+	// both be admitted.
+	sessionMgr := playback.NewSessionManager(1, 1)
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.JWTSecret = secret
+
+	rr := httptest.NewRecorder()
+	handler.HandleGetTranscodeManifest(rr, copySafetyHLSRequest(t, secret, "", copySafetyHLSCard(sessionID, file.ID, "")))
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s; want the revival refused", rr.Code, rr.Body.String())
+	}
+
+	// The client's ordinary recovery: a fresh attempt, which plans against the
+	// persisted verdict and lands on a transcode.
+	recovery, err := sessionMgr.StartSession(1, "profile-1", file.ID, playback.PlayTranscode, false)
+	if err != nil {
+		t.Fatalf("StartSession after a refused revival: %v, want the stream slot free", err)
+	}
+	if recovery == nil {
+		t.Fatal("StartSession returned no session after a refused revival")
+	}
+}
+
+// The gate is the verdict and the route, not the reconstruct: a lost HLS
+// transport that re-encodes its video is unaffected by multi-PPS and must still
+// rebuild its session, whatever the row says.
+func TestHandleTranscodeServe_RevivesARealTranscodeForACopyUnsafeSource(t *testing.T) {
+	const (
+		secret    = "test-stream-signing-secret"
+		sessionID = "lost-hls-transcode"
+	)
+	unsafe := true
+	file := copySafetyStreamFile(t, &unsafe)
+
+	sessionMgr := playback.NewSessionManager(0, 0)
+	handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.JWTSecret = secret
+
+	card := copySafetyHLSCard(sessionID, file.ID, "")
+	card.TargetCodecVideo = "h264"
+
+	rr := httptest.NewRecorder()
+	handler.HandleGetTranscodeManifest(rr, copySafetyHLSRequest(t, secret, "", card))
+
+	// The ffmpeg behind the transport is deliberately absent in this fixture, so
+	// the response is still a not-found; the registered session is what proves
+	// the copy-safety gate let the recipe through.
+	if _, err := sessionMgr.GetSession(sessionID); err != nil {
+		t.Fatalf("GetSession error = %v, want a real transcode reconstructed despite the verdict", err)
 	}
 }
 

--- a/internal/api/handlers/stream_copy_safety_test.go
+++ b/internal/api/handlers/stream_copy_safety_test.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/playback"
+	"github.com/Silo-Server/silo-server/internal/streamtoken"
+)
+
+// copySafetyStreamFile builds an H.264 file on disk with an optional persisted
+// multi-PPS verdict, valid for the size and mtime the row reports.
+func copySafetyStreamFile(t *testing.T, multiplePPS *bool) *models.MediaFile {
+	t.Helper()
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	modified := mtime
+	file := &models.MediaFile{
+		ID:             42,
+		ContentID:      "movie-1",
+		FilePath:       writePlaybackTestMediaFile(t, "movie.mkv"),
+		FileSize:       1234,
+		FileModifiedAt: &modified,
+		CodecVideo:     "h264",
+		CodecAudio:     "aac",
+		VideoTracks:    []models.VideoTrack{{Codec: "h264"}},
+		Duration:       3600,
+	}
+	if multiplePPS != nil {
+		verdict := *multiplePPS
+		scanSize := file.FileSize
+		scanMtime := mtime
+		file.MultiplePPS = &verdict
+		file.MultiplePPSScanSize = &scanSize
+		file.MultiplePPSScanMtime = &scanMtime
+	}
+	return file
+}
+
+// A signed stream URL is a durable capability: the client replays it on
+// whichever replica answers next. When the replica that started the play dies
+// between the copy-safety scan persisting a multi-PPS verdict and the in-process
+// notification going out, the retry lands somewhere with no live session, and
+// the recipe card rebuilds the very remux the verdict condemned — with no
+// notifier left anywhere that could withdraw it. The reconstruct has to consult
+// the row, which is the only state the replicas share.
+func TestHandleStream_RefusesReconstructingACopyUnsafeRemux(t *testing.T) {
+	const (
+		secret    = "test-stream-signing-secret"
+		sessionID = "lost-remux-session"
+	)
+	unsafe := true
+	file := copySafetyStreamFile(t, &unsafe)
+
+	sessionMgr := playback.NewSessionManager(0, 0)
+	tm := playback.NewTranscodeManager()
+	tm.Sessions = sessionMgr
+
+	handler := NewStreamHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.TM = tm
+	handler.JWTSecret = secret
+
+	card := playback.NewRemuxRecipeCard(sessionID, 1, "profile-1", file.ID, false, 0)
+	card.InputPath = file.FilePath
+	token, err := streamtoken.Sign(card.ToClaims(), secret, playback.MaxTokenTTL)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stream/"+sessionID+"?st="+token, nil)
+	req = req.WithContext(newAuthorizedPlaybackContext())
+	req = withPlaybackRouteParam(req, "session_id", sessionID)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStream(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s; want the reconstruct refused as not-found", rr.Code, rr.Body.String())
+	}
+	// The refusal must not leave the session it rebuilt behind: the client's
+	// recovery mints a fresh attempt, and this one has no route left.
+	if _, err := sessionMgr.GetSession(sessionID); !errors.Is(err, playback.ErrSessionNotFound) {
+		t.Fatalf("GetSession error = %v, want the refused reconstruction torn down", err)
+	}
+}
+
+// The gate is the verdict, not the route: a remux whose source has no verdict,
+// or a verdict saying the copy is safe, still reconstructs and streams.
+func TestHandleStream_ReconstructsARemuxThatIsStillCopySafe(t *testing.T) {
+	const secret = "test-stream-signing-secret"
+	safe := false
+
+	for _, tc := range []struct {
+		name      string
+		sessionID string
+		verdict   *bool
+	}{
+		{name: "verdict says safe", sessionID: "lost-remux-safe", verdict: &safe},
+		{name: "verdict unknown", sessionID: "lost-remux-unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionID := tc.sessionID
+			file := copySafetyStreamFile(t, tc.verdict)
+
+			sessionMgr := playback.NewSessionManager(0, 0)
+			tm := playback.NewTranscodeManager()
+			tm.Sessions = sessionMgr
+
+			ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
+			if err := os.WriteFile(ffmpeg, []byte("#!/bin/sh\nprintf muxed\n"), 0o755); err != nil {
+				t.Fatalf("write fake ffmpeg: %v", err)
+			}
+			handler := NewStreamHandler(sessionMgr, testPlaybackFileResolver{file: file})
+			handler.TM = tm
+			handler.JWTSecret = secret
+			handler.PlaybackConfig = func() config.PlaybackConfig {
+				return config.PlaybackConfig{FFmpegPath: ffmpeg}
+			}
+
+			card := playback.NewRemuxRecipeCard(sessionID, 1, "profile-1", file.ID, false, 0)
+			card.InputPath = file.FilePath
+			token, err := streamtoken.Sign(card.ToClaims(), secret, playback.MaxTokenTTL)
+			if err != nil {
+				t.Fatalf("Sign: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/stream/"+sessionID+"?st="+token, nil)
+			req = req.WithContext(newAuthorizedPlaybackContext())
+			req = withPlaybackRouteParam(req, "session_id", sessionID)
+
+			rr := httptest.NewRecorder()
+			handler.HandleStream(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s; want the reconstruct served", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+// Only video stream-copy deliveries are gated. A transcode re-encodes the
+// bitstream, so conflicting parameter sets cannot reach the client's decoder
+// and the recipe stays serveable whatever the verdict says.
+func TestVideoCopyReconstructRefusedOnlyGatesCopyDeliveries(t *testing.T) {
+	unsafe := true
+	file := copySafetyStreamFile(t, &unsafe)
+	files := testPlaybackFileResolver{file: file}
+
+	remux := playback.NewRemuxRecipeCard("s", 1, "profile-1", file.ID, false, 0)
+	copyHLS := playback.RecipeCard{SessionID: "s", UserID: 1, MediaFileID: file.ID, PlayMethod: playback.PlayTranscode, TargetCodecVideo: "copy"}
+	transcode := playback.RecipeCard{SessionID: "s", UserID: 1, MediaFileID: file.ID, PlayMethod: playback.PlayTranscode, TargetCodecVideo: "h264"}
+	direct := playback.NewDirectRecipeCard("s", 1, "profile-1", file.ID)
+
+	for _, tc := range []struct {
+		name string
+		card playback.RecipeCard
+		want bool
+	}{
+		{name: "progressive remux", card: remux, want: true},
+		{name: "hls video copy", card: copyHLS, want: true},
+		{name: "real transcode", card: transcode},
+		{name: "direct play", card: direct},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			card := tc.card
+			if got := videoCopyReconstructRefused(t.Context(), files, &card); got != tc.want {
+				t.Fatalf("videoCopyReconstructRefused() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/stream_copy_safety_test.go
+++ b/internal/api/handlers/stream_copy_safety_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -147,6 +148,102 @@ func TestHandleStream_ReconstructsARemuxThatIsStillCopySafe(t *testing.T) {
 	}
 }
 
+// Refusing a revival is only possible where a verdict exists. The dangerous
+// case is the one where it does not yet: replica A is still scanning (or has
+// scanned and failed to write the row) when replica B revives the transport
+// from the card. B's response is a single progressive remux that runs for the
+// length of the title, and the gate it just passed never runs again — so unless
+// B puts itself on the race for the file, no withdrawal can ever reach it, and
+// A's notifier cannot: it only reaches A's own sessions.
+func TestHandleStream_RevivedRemuxWithNoVerdictReEngagesTheRace(t *testing.T) {
+	const (
+		secret    = "test-stream-signing-secret"
+		sessionID = "lost-remux-unverdicted"
+	)
+	file := copySafetyStreamFile(t, nil)
+
+	sessionMgr := playback.NewSessionManager(0, 0)
+	tm := playback.NewTranscodeManager()
+	tm.Sessions = sessionMgr
+
+	ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
+	if err := os.WriteFile(ffmpeg, []byte("#!/bin/sh\nprintf muxed\n"), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	racer := &recordingCopySafetyRacer{}
+	handler := NewStreamHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.TM = tm
+	handler.JWTSecret = secret
+	handler.CopySafetyRacer = racer
+	handler.PlaybackConfig = func() config.PlaybackConfig {
+		return config.PlaybackConfig{FFmpegPath: ffmpeg}
+	}
+
+	card := playback.NewRemuxRecipeCard(sessionID, 1, "profile-1", file.ID, false, 0)
+	card.InputPath = file.FilePath
+	token, err := streamtoken.Sign(card.ToClaims(), secret, playback.MaxTokenTTL)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stream/"+sessionID+"?st="+token, nil)
+	req = req.WithContext(newAuthorizedPlaybackContext())
+	req = withPlaybackRouteParam(req, "session_id", sessionID)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStream(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s; want an undecided remux served optimistically", rr.Code, rr.Body.String())
+	}
+	if got := racer.bareRaces(); len(got) != 1 || got[0] != file.ID {
+		t.Fatalf("raced files = %v, want the revived file %d raced on this replica", got, file.ID)
+	}
+}
+
+// A verdict whose write to media_files failed lives only in the memo of the
+// process that reached it. The row cannot tell that apart from "never scanned",
+// so a revival gated on the row alone would rebuild the condemned remux for as
+// long as the client keeps retrying its stream URL — and nothing would
+// re-invoke the ensurer that holds the answer. Asking the racer closes it.
+func TestHandleStream_RefusesARevivalTheRowDoesNotKnowIsUnsafe(t *testing.T) {
+	const (
+		secret    = "test-stream-signing-secret"
+		sessionID = "lost-remux-unpersisted"
+	)
+	file := copySafetyStreamFile(t, nil)
+
+	sessionMgr := playback.NewSessionManager(0, 0)
+	tm := playback.NewTranscodeManager()
+	tm.Sessions = sessionMgr
+
+	handler := NewStreamHandler(sessionMgr, testPlaybackFileResolver{file: file})
+	handler.TM = tm
+	handler.JWTSecret = secret
+	handler.CopySafetyRacer = &recordingCopySafetyRacer{knownUnsafe: true}
+
+	card := playback.NewRemuxRecipeCard(sessionID, 1, "profile-1", file.ID, false, 0)
+	card.InputPath = file.FilePath
+	token, err := streamtoken.Sign(card.ToClaims(), secret, playback.MaxTokenTTL)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stream/"+sessionID+"?st="+token, nil)
+	req = req.WithContext(newAuthorizedPlaybackContext())
+	req = withPlaybackRouteParam(req, "session_id", sessionID)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStream(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, body = %s; want the revival refused on the unpersisted verdict", rr.Code, rr.Body.String())
+	}
+	if _, err := sessionMgr.GetSession(sessionID); !errors.Is(err, playback.ErrSessionNotFound) {
+		t.Fatalf("GetSession error = %v, want the refused revival torn down", err)
+	}
+}
+
 // copySafetyHLSCard is a lost HLS transport whose video target was pinned to a
 // stream copy — the remux_hls recipe. nodeURL pins it to a transcode node,
 // which is what makes the serve handlers proxy rather than rebuild locally.
@@ -196,9 +293,11 @@ func copySafetyHLSRequest(t *testing.T, secret, segmentName string, card playbac
 func TestHandleTranscodeServe_RefusesRevivingACopyUnsafeHLSRecipe(t *testing.T) {
 	const secret = "test-stream-signing-secret"
 
-	nodeHits := 0
+	// The httptest handler runs on its own goroutine; the assertions read this
+	// from the test's.
+	var nodeHits atomic.Int64
 	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		nodeHits++
+		nodeHits.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer node.Close()
@@ -247,8 +346,8 @@ func TestHandleTranscodeServe_RefusesRevivingACopyUnsafeHLSRecipe(t *testing.T) 
 				if _, err := sessionMgr.GetSession(sessionID); !errors.Is(err, playback.ErrSessionNotFound) {
 					t.Fatalf("GetSession error = %v, want no session registered by a refused revival", err)
 				}
-				if nodeHits != 0 {
-					t.Fatalf("transcode node received %d proxied requests, want the condemned stream never proxied", nodeHits)
+				if got := nodeHits.Load(); got != 0 {
+					t.Fatalf("transcode node received %d proxied requests, want the condemned stream never proxied", got)
 				}
 			})
 		}
@@ -318,6 +417,58 @@ func TestHandleTranscodeServe_RevivesARealTranscodeForACopyUnsafeSource(t *testi
 	}
 }
 
+// The HLS revival path needs the same two halves as the progressive one: an
+// undecided recipe is revived and raced here, and one this replica already
+// knows is unsafe — from a verdict whose write never landed — is refused even
+// though the row says nothing.
+func TestHandleTranscodeServe_UndecidedRevivalIsRacedAndKnownUnsafeIsRefused(t *testing.T) {
+	const secret = "test-stream-signing-secret"
+
+	t.Run("undecided revival re-engages the race", func(t *testing.T) {
+		const sessionID = "lost-hls-unverdicted"
+		file := copySafetyStreamFile(t, nil)
+
+		sessionMgr := playback.NewSessionManager(0, 0)
+		racer := &recordingCopySafetyRacer{}
+		handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+		handler.JWTSecret = secret
+		handler.CopySafetyRacer = racer
+
+		rr := httptest.NewRecorder()
+		handler.HandleGetTranscodeManifest(rr, copySafetyHLSRequest(t, secret, "", copySafetyHLSCard(sessionID, file.ID, "")))
+
+		// The ffmpeg behind the transport is absent in this fixture, so the
+		// response is a not-found either way; the registered session is what
+		// proves the gate let the undecided recipe through.
+		if _, err := sessionMgr.GetSession(sessionID); err != nil {
+			t.Fatalf("GetSession error = %v, want an undecided recipe revived optimistically", err)
+		}
+		if got := racer.bareRaces(); len(got) != 1 || got[0] != file.ID {
+			t.Fatalf("raced files = %v, want the revived file %d raced on this replica", got, file.ID)
+		}
+	})
+
+	t.Run("verdict known only in memory still refuses", func(t *testing.T) {
+		const sessionID = "lost-hls-unpersisted"
+		file := copySafetyStreamFile(t, nil)
+
+		sessionMgr := playback.NewSessionManager(0, 0)
+		handler := NewPlaybackHandler(sessionMgr, testPlaybackFileResolver{file: file})
+		handler.JWTSecret = secret
+		handler.CopySafetyRacer = &recordingCopySafetyRacer{knownUnsafe: true}
+
+		rr := httptest.NewRecorder()
+		handler.HandleGetTranscodeManifest(rr, copySafetyHLSRequest(t, secret, "", copySafetyHLSCard(sessionID, file.ID, "")))
+
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, body = %s; want the revival refused", rr.Code, rr.Body.String())
+		}
+		if _, err := sessionMgr.GetSession(sessionID); !errors.Is(err, playback.ErrSessionNotFound) {
+			t.Fatalf("GetSession error = %v, want no session registered by a refused revival", err)
+		}
+	})
+}
+
 // Only video stream-copy deliveries are gated. A transcode re-encodes the
 // bitstream, so conflicting parameter sets cannot reach the client's decoder
 // and the recipe stays serveable whatever the verdict says.
@@ -343,7 +494,7 @@ func TestVideoCopyReconstructRefusedOnlyGatesCopyDeliveries(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			card := tc.card
-			if got := videoCopyReconstructRefused(t.Context(), files, &card); got != tc.want {
+			if got := videoCopyReconstructRefused(t.Context(), files, nil, &card); got != tc.want {
 				t.Fatalf("videoCopyReconstructRefused() = %v, want %v", got, tc.want)
 			}
 		})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1070,6 +1070,14 @@ func NewRouter(deps Dependencies) chi.Router {
 				if detailSvc != nil {
 					detailSvc.SetCopySafetyRacer(copySafetyRace)
 				}
+				if streamHandler != nil {
+					// The progressive remux serve path revives stream-copy
+					// transports of its own, and its single long response is
+					// the one thing no later request can gate. It needs the
+					// same racer to refuse a condemned revival and to cover an
+					// undecided one.
+					streamHandler.CopySafetyRacer = copySafetyRace
+				}
 			}
 		}
 		// A resolver lets subtitle realtime events carry the combined ordinal

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1049,6 +1049,29 @@ func NewRouter(deps Dependencies) chi.Router {
 			playbackHandler.MarkerUpserter = deps.FileRepo
 		}
 		playbackHandler.MarkerUpdateNotifier = playback.NewMarkerUpdateNotifier(deps.SessionMgr, realtimeHub)
+		// Optimistic remux: a play is never blocked on the H.264 copy-safety
+		// scan, so the scan runs behind the issued plan and the notifier moves
+		// any session that is already stream-copying an unsafe source off that
+		// route (or stops it, for a client that cannot be told). Both halves
+		// need the same probe ensurer the playback and detail surfaces use.
+		if copySafetyScanner, ok := deps.ProbeEnsurer.(playback.CopySafetyScanner); ok && deps.FileRepo != nil {
+			copySafetyRace := playback.NewCopySafetyRace(
+				copySafetyScanner,
+				deps.FileRepo,
+				playback.NewCopySafetyNotifier(
+					deps.SessionMgr,
+					playbackHandler.PlanStoreV3,
+					playbackHandler.CommandDispatcher,
+					handlers.NewCopySafetyPlaybackControl(playbackHandler),
+				),
+			)
+			if copySafetyRace != nil {
+				playbackHandler.CopySafetyRacer = copySafetyRace
+				if detailSvc != nil {
+					detailSvc.SetCopySafetyRacer(copySafetyRace)
+				}
+			}
+		}
 		// A resolver lets subtitle realtime events carry the combined ordinal
 		// the new track will hold in the next plan. Without a file repository
 		// the notifier still fires; its events just omit the track block.

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -44,7 +44,11 @@ type batchDurationFetcher interface {
 }
 
 type PlaybackProbeEnsurer interface {
+	// Ensure repairs probe metadata and resolves the H.264 copy-safety
+	// verdict; EnsureProbeOnly does the repair alone. Browse surfaces use the
+	// latter — see prepareBrowseFiles.
 	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 }
 
 type ChapterThumbnailQueuer interface {
@@ -1359,7 +1363,7 @@ func (s *DetailService) buildExtraItemDetail(ctx context.Context, contentID stri
 		return nil, fmt.Errorf("fetching extra files: %w", err)
 	}
 	files = FilterMediaFilesByAccess(files, filter)
-	files = s.preparePlaybackFiles(ctx, files)
+	files = s.prepareBrowseFiles(ctx, files)
 
 	detail := &ItemDetail{
 		ContentID: extra.ContentID,
@@ -1846,7 +1850,7 @@ func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.M
 		if item.Type == "audiobook" {
 			sortAudiobookMediaFiles(files)
 		}
-		files = s.preparePlaybackFiles(ctx, files)
+		files = s.prepareBrowseFiles(ctx, files)
 		detail.Versions, detail.PlaybackVariants, detail.Subtitles, detail.Intro, detail.Credits, detail.Recap, detail.Preview = s.buildPlaybackInfo(
 			ctx,
 			files,
@@ -2697,7 +2701,7 @@ func (s *DetailService) buildEpisodeDetail(ctx context.Context, episode *models.
 		return nil, fmt.Errorf("fetching file versions: %w", err)
 	}
 	files = FilterMediaFilesByAccess(files, filter)
-	files = s.preparePlaybackFiles(ctx, files)
+	files = s.prepareBrowseFiles(ctx, files)
 	detail.Versions, detail.PlaybackVariants, detail.Subtitles, detail.Intro, detail.Credits, detail.Recap, detail.Preview = s.buildPlaybackInfo(
 		ctx,
 		files,
@@ -3694,7 +3698,22 @@ func fileIDOrZero(version *FileVersion) int {
 	return version.FileID
 }
 
+// preparePlaybackFiles repairs probe metadata and resolves the H.264
+// copy-safety verdict. Used by the watch surfaces, where a play is being
+// prepared and the verdict is about to matter.
 func (s *DetailService) preparePlaybackFiles(ctx context.Context, files []*models.MediaFile) []*models.MediaFile {
+	return s.prepareFiles(ctx, files, true)
+}
+
+// prepareBrowseFiles repairs probe metadata only. Item, episode and extra
+// detail pages never consume the copy-safety verdict — it is not serialized
+// into their responses — so scanning for it there was pure warm-up that cost a
+// multi-second read per H.264 file on remote storage.
+func (s *DetailService) prepareBrowseFiles(ctx context.Context, files []*models.MediaFile) []*models.MediaFile {
+	return s.prepareFiles(ctx, files, false)
+}
+
+func (s *DetailService) prepareFiles(ctx context.Context, files []*models.MediaFile, withCopySafety bool) []*models.MediaFile {
 	if len(files) == 0 {
 		return files
 	}
@@ -3705,7 +3724,13 @@ func (s *DetailService) preparePlaybackFiles(ctx context.Context, files []*model
 			continue
 		}
 		if s.probeEnsurer != nil {
-			ensured, err := s.probeEnsurer.Ensure(ctx, file)
+			var ensured *models.MediaFile
+			var err error
+			if withCopySafety {
+				ensured, err = s.probeEnsurer.Ensure(ctx, file)
+			} else {
+				ensured, err = s.probeEnsurer.EnsureProbeOnly(ctx, file)
+			}
 			if err == nil && ensured != nil {
 				file = ensured
 			}

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -43,12 +43,27 @@ type batchDurationFetcher interface {
 	FirstDurationsByEpisodeIDs(ctx context.Context, ids []string) (map[string]int, error)
 }
 
+// PlaybackProbeEnsurer repairs probe metadata for catalog responses. Neither
+// half of it runs the H.264 bitstream scan: no catalog surface may block on it.
 type PlaybackProbeEnsurer interface {
-	// Ensure repairs probe metadata and resolves the H.264 copy-safety
-	// verdict; EnsureProbeOnly does the repair alone. Browse surfaces use the
-	// latter — see prepareBrowseFiles.
-	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	// EnsureProbeOnly does the probe repair alone. Browse surfaces use it — see
+	// prepareBrowseFiles.
 	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	// EnsureCopySafetyCached adds the copy-safety verdict when it is already
+	// known, and never execs ffmpeg. Watch surfaces use it — see
+	// preparePlaybackFiles.
+	EnsureCopySafetyCached(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+}
+
+// CopySafetyRacer resolves an unknown H.264 copy-safety verdict out of band.
+// The watch page asks for it and never waits: the verdict is not part of the
+// response, and any session that later ends up on a stream-copy route for the
+// file is switched off it by the playback-side notifier when the scan lands.
+//
+// It is a narrow injected interface so the catalog keeps no dependency on the
+// playback session machinery that implements it.
+type CopySafetyRacer interface {
+	RaceScan(fileID int)
 }
 
 type ChapterThumbnailQueuer interface {
@@ -662,6 +677,7 @@ type DetailService struct {
 	workSummary       WorkSummaryProvider
 	originalLangFn    func(context.Context, string) string
 	probeEnsurer      PlaybackProbeEnsurer
+	copySafetyRacer   CopySafetyRacer
 	chapterThumbs     ChapterThumbnailQueuer
 
 	// resolver is built once on first use; see settingsResolver.
@@ -710,6 +726,15 @@ func (s *DetailService) SetWorkSummaryProvider(provider WorkSummaryProvider) {
 
 func (s *DetailService) SetProbeEnsurer(ensurer PlaybackProbeEnsurer) {
 	s.probeEnsurer = ensurer
+}
+
+// SetCopySafetyRacer wires the out-of-band H.264 copy-safety scan the watch
+// surfaces trigger. Optional: without it an unknown verdict is simply left
+// unknown until a play resolves it.
+func (s *DetailService) SetCopySafetyRacer(racer CopySafetyRacer) {
+	if s != nil {
+		s.copySafetyRacer = racer
+	}
 }
 
 func (s *DetailService) SetChapterThumbnailQueuer(queuer ChapterThumbnailQueuer) {
@@ -3698,9 +3723,15 @@ func fileIDOrZero(version *FileVersion) int {
 	return version.FileID
 }
 
-// preparePlaybackFiles repairs probe metadata and resolves the H.264
-// copy-safety verdict. Used by the watch surfaces, where a play is being
-// prepared and the verdict is about to matter.
+// preparePlaybackFiles repairs probe metadata and stamps the H.264 copy-safety
+// verdict when it is already known. Used by the watch surfaces, where a play is
+// about to be prepared and the verdict is about to matter.
+//
+// It deliberately does not wait for an unknown verdict: the bitstream scan is
+// started in the background instead, so opening the watch page costs nothing
+// even for a file nobody has played yet. No session exists at this point — if
+// one appears and lands on a stream-copy route before the scan finishes, the
+// playback-side notifier switches it off that route when the verdict lands.
 func (s *DetailService) preparePlaybackFiles(ctx context.Context, files []*models.MediaFile) []*models.MediaFile {
 	return s.prepareFiles(ctx, files, true)
 }
@@ -3727,13 +3758,16 @@ func (s *DetailService) prepareFiles(ctx context.Context, files []*models.MediaF
 			var ensured *models.MediaFile
 			var err error
 			if withCopySafety {
-				ensured, err = s.probeEnsurer.Ensure(ctx, file)
+				ensured, err = s.probeEnsurer.EnsureCopySafetyCached(ctx, file)
 			} else {
 				ensured, err = s.probeEnsurer.EnsureProbeOnly(ctx, file)
 			}
 			if err == nil && ensured != nil {
 				file = ensured
 			}
+		}
+		if withCopySafety && s.copySafetyRacer != nil && file.ID > 0 && file.VideoCopySafetyUnknown() {
+			s.copySafetyRacer.RaceScan(file.ID)
 		}
 		prepared = append(prepared, file)
 	}

--- a/internal/catalog/detail_prepare_files_test.go
+++ b/internal/catalog/detail_prepare_files_test.go
@@ -1,0 +1,78 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// recordingProbeEnsurer records which half of the ensurer contract each
+// prepare path asks for.
+type recordingProbeEnsurer struct {
+	fullCalls  []int
+	probeCalls []int
+}
+
+func (e *recordingProbeEnsurer) Ensure(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	e.fullCalls = append(e.fullCalls, file.ID)
+	return file, nil
+}
+
+func (e *recordingProbeEnsurer) EnsureProbeOnly(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	e.probeCalls = append(e.probeCalls, file.ID)
+	return file, nil
+}
+
+// Browse detail must never trigger the H.264 copy-safety scan: the verdict is
+// not serialized into those responses, so the scan is pure warm-up and its
+// read is what made first-time browsing slow on remote storage.
+func TestPrepareBrowseFilesSkipsCopySafety(t *testing.T) {
+	ensurer := &recordingProbeEnsurer{}
+	svc := &DetailService{probeEnsurer: ensurer}
+	files := []*models.MediaFile{{ID: 1}, {ID: 2}}
+
+	prepared := svc.prepareBrowseFiles(context.Background(), files)
+
+	if len(prepared) != 2 {
+		t.Fatalf("prepareBrowseFiles() returned %d files, want 2", len(prepared))
+	}
+	if len(ensurer.fullCalls) != 0 {
+		t.Fatalf("browse path called Ensure for %v, want no copy-safety scans", ensurer.fullCalls)
+	}
+	if len(ensurer.probeCalls) != 2 {
+		t.Fatalf("browse path called EnsureProbeOnly %d times, want 2 — probe repair must still run", len(ensurer.probeCalls))
+	}
+}
+
+// The watch surfaces are where a play is being prepared, so they keep the
+// full ensure and warm the verdict while the user looks at the Play button.
+func TestPreparePlaybackFilesKeepsCopySafety(t *testing.T) {
+	ensurer := &recordingProbeEnsurer{}
+	svc := &DetailService{probeEnsurer: ensurer}
+	files := []*models.MediaFile{{ID: 1}, {ID: 2}}
+
+	prepared := svc.preparePlaybackFiles(context.Background(), files)
+
+	if len(prepared) != 2 {
+		t.Fatalf("preparePlaybackFiles() returned %d files, want 2", len(prepared))
+	}
+	if len(ensurer.fullCalls) != 2 {
+		t.Fatalf("watch path called Ensure %d times, want 2", len(ensurer.fullCalls))
+	}
+	if len(ensurer.probeCalls) != 0 {
+		t.Fatalf("watch path called EnsureProbeOnly for %v, want the full ensure", ensurer.probeCalls)
+	}
+}
+
+func TestPrepareFilesWithoutEnsurerPassesFilesThrough(t *testing.T) {
+	svc := &DetailService{}
+	files := []*models.MediaFile{{ID: 1}, nil, {ID: 2}}
+
+	if got := len(svc.prepareBrowseFiles(context.Background(), files)); got != 2 {
+		t.Fatalf("prepareBrowseFiles() returned %d files, want 2 (nil entries dropped)", got)
+	}
+	if got := len(svc.preparePlaybackFiles(context.Background(), files)); got != 2 {
+		t.Fatalf("preparePlaybackFiles() returned %d files, want 2 (nil entries dropped)", got)
+	}
+}

--- a/internal/catalog/detail_prepare_files_test.go
+++ b/internal/catalog/detail_prepare_files_test.go
@@ -10,13 +10,8 @@ import (
 // recordingProbeEnsurer records which half of the ensurer contract each
 // prepare path asks for.
 type recordingProbeEnsurer struct {
-	fullCalls  []int
-	probeCalls []int
-}
-
-func (e *recordingProbeEnsurer) Ensure(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
-	e.fullCalls = append(e.fullCalls, file.ID)
-	return file, nil
+	probeCalls  []int
+	cachedCalls []int
 }
 
 func (e *recordingProbeEnsurer) EnsureProbeOnly(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
@@ -24,44 +19,93 @@ func (e *recordingProbeEnsurer) EnsureProbeOnly(_ context.Context, file *models.
 	return file, nil
 }
 
+func (e *recordingProbeEnsurer) EnsureCopySafetyCached(_ context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	e.cachedCalls = append(e.cachedCalls, file.ID)
+	return file, nil
+}
+
+type recordingCopySafetyRacer struct {
+	raced []int
+}
+
+func (r *recordingCopySafetyRacer) RaceScan(fileID int) {
+	r.raced = append(r.raced, fileID)
+}
+
+func h264File(id int, multiplePPS *bool) *models.MediaFile {
+	return &models.MediaFile{
+		ID:         id,
+		CodecVideo: "h264",
+		VideoTracks: []models.VideoTrack{{
+			Codec:       "h264",
+			MultiplePPS: multiplePPS,
+		}},
+	}
+}
+
 // Browse detail must never trigger the H.264 copy-safety scan: the verdict is
 // not serialized into those responses, so the scan is pure warm-up and its
 // read is what made first-time browsing slow on remote storage.
 func TestPrepareBrowseFilesSkipsCopySafety(t *testing.T) {
 	ensurer := &recordingProbeEnsurer{}
-	svc := &DetailService{probeEnsurer: ensurer}
-	files := []*models.MediaFile{{ID: 1}, {ID: 2}}
+	racer := &recordingCopySafetyRacer{}
+	svc := &DetailService{probeEnsurer: ensurer, copySafetyRacer: racer}
+	files := []*models.MediaFile{h264File(1, nil), h264File(2, nil)}
 
 	prepared := svc.prepareBrowseFiles(context.Background(), files)
 
 	if len(prepared) != 2 {
 		t.Fatalf("prepareBrowseFiles() returned %d files, want 2", len(prepared))
 	}
-	if len(ensurer.fullCalls) != 0 {
-		t.Fatalf("browse path called Ensure for %v, want no copy-safety scans", ensurer.fullCalls)
+	if len(ensurer.cachedCalls) != 0 {
+		t.Fatalf("browse path resolved copy safety for %v, want probe repair only", ensurer.cachedCalls)
 	}
 	if len(ensurer.probeCalls) != 2 {
 		t.Fatalf("browse path called EnsureProbeOnly %d times, want 2 — probe repair must still run", len(ensurer.probeCalls))
 	}
+	if len(racer.raced) != 0 {
+		t.Fatalf("browse path raced scans for %v, want none", racer.raced)
+	}
 }
 
-// The watch surfaces are where a play is being prepared, so they keep the
-// full ensure and warm the verdict while the user looks at the Play button.
-func TestPreparePlaybackFilesKeepsCopySafety(t *testing.T) {
+// The watch surfaces prepare a play, but must not block on the bitstream scan:
+// they take the cached-only ensure and start the scan in the background.
+func TestPreparePlaybackFilesUsesCachedEnsureAndRacesScan(t *testing.T) {
 	ensurer := &recordingProbeEnsurer{}
-	svc := &DetailService{probeEnsurer: ensurer}
-	files := []*models.MediaFile{{ID: 1}, {ID: 2}}
+	racer := &recordingCopySafetyRacer{}
+	svc := &DetailService{probeEnsurer: ensurer, copySafetyRacer: racer}
+	files := []*models.MediaFile{h264File(1, nil), h264File(2, nil)}
 
 	prepared := svc.preparePlaybackFiles(context.Background(), files)
 
 	if len(prepared) != 2 {
 		t.Fatalf("preparePlaybackFiles() returned %d files, want 2", len(prepared))
 	}
-	if len(ensurer.fullCalls) != 2 {
-		t.Fatalf("watch path called Ensure %d times, want 2", len(ensurer.fullCalls))
+	if len(ensurer.cachedCalls) != 2 {
+		t.Fatalf("watch path called EnsureCopySafetyCached %d times, want 2", len(ensurer.cachedCalls))
 	}
-	if len(ensurer.probeCalls) != 0 {
-		t.Fatalf("watch path called EnsureProbeOnly for %v, want the full ensure", ensurer.probeCalls)
+	if len(racer.raced) != 2 || racer.raced[0] != 1 || racer.raced[1] != 2 {
+		t.Fatalf("watch path raced %v, want scans for files 1 and 2", racer.raced)
+	}
+}
+
+// A file whose verdict is already known, or that is not H.264, has nothing to
+// resolve: no background scan may be started for it.
+func TestPreparePlaybackFilesSkipsRaceWhenNothingToScan(t *testing.T) {
+	known := false
+	ensurer := &recordingProbeEnsurer{}
+	racer := &recordingCopySafetyRacer{}
+	svc := &DetailService{probeEnsurer: ensurer, copySafetyRacer: racer}
+	files := []*models.MediaFile{
+		h264File(1, &known),
+		{ID: 2, CodecVideo: "hevc", VideoTracks: []models.VideoTrack{{Codec: "hevc"}}},
+		{ID: 3},
+	}
+
+	svc.preparePlaybackFiles(context.Background(), files)
+
+	if len(racer.raced) != 0 {
+		t.Fatalf("watch path raced %v, want no scans for known or non-H.264 files", racer.raced)
 	}
 }
 

--- a/internal/chapterthumbs/service.go
+++ b/internal/chapterthumbs/service.go
@@ -67,8 +67,11 @@ type FolderRepository interface {
 	GetByID(ctx context.Context, id int) (*models.MediaFolder, error)
 }
 
+// ProbeEnsurer repairs probe metadata. Only the repair half is needed here:
+// chapter extraction reads Chapters, never the H.264 copy-safety verdict, so
+// this deliberately does not ask for the bitstream scan.
 type ProbeEnsurer interface {
-	Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
+	EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error)
 }
 
 type SettingsReader interface {
@@ -541,7 +544,7 @@ func (s *Service) ensureChapters(ctx context.Context, file *models.MediaFile, no
 		return file, nil
 	}
 
-	ensured, err := s.probeEnsurer.Ensure(ctx, file)
+	ensured, err := s.probeEnsurer.EnsureProbeOnly(ctx, file)
 	if err == nil && ensured != nil {
 		return ensured, nil
 	}

--- a/internal/chapterthumbs/service_test.go
+++ b/internal/chapterthumbs/service_test.go
@@ -221,7 +221,7 @@ type testProbeEnsurer struct {
 	err  error
 }
 
-func (e testProbeEnsurer) Ensure(context.Context, *models.MediaFile) (*models.MediaFile, error) {
+func (e testProbeEnsurer) EnsureProbeOnly(context.Context, *models.MediaFile) (*models.MediaFile, error) {
 	if e.err != nil {
 		return nil, e.err
 	}

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -9,6 +9,7 @@ const (
 	mediaBaseTypeAudiobook = "audiobook"
 	mediaBaseTypePodcast   = "podcast"
 	mediaCodecMJPEG        = "mjpeg"
+	mediaCodecH264         = "h264"
 )
 
 // MediaFolder represents a row in the media_folders table.
@@ -168,6 +169,68 @@ func (f *MediaFile) PrimaryDVProfile() int {
 		return 0
 	}
 	return f.VideoTracks[0].DVProfile
+}
+
+// VideoCopySafetyUnknown reports whether this file is an H.264 video whose
+// multi-PPS copy-safety verdict is not stamped on the in-memory track. Only
+// H.264 can carry the conflicting in-band parameter sets that make a video
+// stream-copy unsafe, so every other codec is trivially known-safe.
+//
+// This is the single definition of "the verdict is still open", shared by the
+// scanner that resolves it, the catalog surfaces that trigger the resolution,
+// and playback.
+func (f *MediaFile) VideoCopySafetyUnknown() bool {
+	if f == nil || len(f.VideoTracks) == 0 {
+		return false
+	}
+	if f.VideoTracks[0].MultiplePPS != nil {
+		return false
+	}
+	codec := strings.ToLower(strings.TrimSpace(f.VideoTracks[0].Codec))
+	if codec == "" {
+		codec = strings.ToLower(strings.TrimSpace(f.CodecVideo))
+	}
+	return codec == mediaCodecH264 || codec == "avc" || codec == "avc1"
+}
+
+// PersistedVideoCopyVerdict returns the H.264 multi-PPS verdict recorded on the
+// media_files row and whether it still describes the file as it stands.
+//
+// The verdict is self-validating: it is only honored while the size and mtime
+// it was computed from still match the row, so a rewrite in place falls through
+// to a rescan without any writer having to clear it. A verdict recorded for a
+// row that carries no mtime is trusted on size alone — that is the only signal
+// such a row has, and it is the same rule the scanner's in-process memo
+// applies.
+//
+// This lives on the model because the row columns are loaded by every media
+// file read, while the VideoTrack copy-safety flags are runtime-only and are
+// stamped by the probe ensurer, which not every path that loads a file runs.
+func (f *MediaFile) PersistedVideoCopyVerdict() (bool, bool) {
+	if f == nil || f.MultiplePPS == nil || f.MultiplePPSScanSize == nil {
+		return false, false
+	}
+	if *f.MultiplePPSScanSize != f.FileSize {
+		return false, false
+	}
+	if f.MultiplePPSScanMtime == nil || f.FileModifiedAt == nil {
+		if f.MultiplePPSScanMtime != nil || f.FileModifiedAt != nil {
+			return false, false
+		}
+		return *f.MultiplePPS, true
+	}
+	if !NormalizeFileModifiedAt(*f.MultiplePPSScanMtime).Equal(NormalizeFileModifiedAt(*f.FileModifiedAt)) {
+		return false, false
+	}
+	return *f.MultiplePPS, true
+}
+
+// NormalizeFileModifiedAt puts a filesystem mtime in the one shape every
+// comparison uses. Postgres stores microseconds and local filesystems report
+// nanoseconds, so a round trip through the database is only equal to the value
+// that was written after truncation.
+func NormalizeFileModifiedAt(ts time.Time) time.Time {
+	return ts.UTC().Truncate(time.Microsecond)
 }
 
 // AudioOnlyProbeFacts is the compact probe shape needed to distinguish known

--- a/internal/models/media.go
+++ b/internal/models/media.go
@@ -113,12 +113,23 @@ type MediaFile struct {
 	PresentationPartTotal        int
 	MultiEpisodeStart            int
 	MultiEpisodeEnd              int
-	ProbeSource                  string // arrs, local
-	ProbeUpdatedAt               *time.Time
-	MatchAttemptedAt             *time.Time
-	MissingSince                 *time.Time
-	CreatedAt                    time.Time
-	UpdatedAt                    time.Time
+	// MultiplePPS is the persisted H.264 multi-PPS copy-safety verdict; nil
+	// means the file has never been successfully analyzed. It is trusted only
+	// when MultiplePPSScanSize and MultiplePPSScanMtime still match the file's
+	// current size and mtime, so a rewritten file self-invalidates without any
+	// coordination from the writers that touch media_files.
+	//
+	// json:"-" on all three: MediaFile is not a client-facing shape, and the
+	// runtime copy-safety signal clients do act on lives on VideoTrack.
+	MultiplePPS          *bool      `json:"-"`
+	MultiplePPSScanSize  *int64     `json:"-"`
+	MultiplePPSScanMtime *time.Time `json:"-"`
+	ProbeSource          string     // arrs, local
+	ProbeUpdatedAt       *time.Time
+	MatchAttemptedAt     *time.Time
+	MissingSince         *time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
 }
 
 // MediaChapter represents a single media chapter derived from embedded file metadata.

--- a/internal/playback/command_dispatcher_test.go
+++ b/internal/playback/command_dispatcher_test.go
@@ -2,17 +2,29 @@ package playback
 
 import (
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 )
 
 type dispatchTestConn struct {
+	mu       sync.Mutex
 	messages []any
 }
 
 func (c *dispatchTestConn) WriteJSON(v any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.messages = append(c.messages, v)
 	return nil
+}
+
+// sent is the safe reader for tests where a command is dispatched from a
+// background goroutine rather than inline.
+func (c *dispatchTestConn) sent() []any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]any(nil), c.messages...)
 }
 
 func TestCommandDispatcherDispatchToSession(t *testing.T) {

--- a/internal/playback/copy_safety_notifier.go
+++ b/internal/playback/copy_safety_notifier.go
@@ -108,6 +108,24 @@ func NewCopySafetyNotifier(
 	}
 }
 
+// copySafetyDisposition is what one call to consider did with a session, and
+// therefore whether the post-settle sweep still owes it a second look.
+type copySafetyDisposition int
+
+const (
+	// copySafetyUnresolved: consider reached no decision about this session. It
+	// did not look like it was stream-copying this file — which is the ordinary
+	// answer for an unrelated session, and also the answer during the brief
+	// window where a replan has already moved the live session but has not yet
+	// committed the durable attempt that names the new file and plan. Only the
+	// sweep can tell those apart, so the session stays eligible for it.
+	copySafetyUnresolved copySafetyDisposition = iota
+	// copySafetyDisposed: consider dealt with the session — invalidated it,
+	// stopped it, scheduled its own deferred second look, or deliberately
+	// exempted it. The sweep must leave it alone.
+	copySafetyDisposed
+)
+
 // VideoCopyUnsafe reports that fileID cannot be video stream-copied after all.
 // Sessions that are not on a copy route for that file are left alone.
 //
@@ -116,8 +134,17 @@ func NewCopySafetyNotifier(
 // scan can win by milliseconds. One immediate pass would miss such a session
 // entirely and leave it playing a route the verdict just condemned, so a second
 // file-wide look runs after the settle window for sessions that appeared late.
-// Sessions the first pass saw are excluded: they were either acted on or have
-// their own per-session deferred look.
+//
+// Only sessions the first pass actually disposed of are excluded from that
+// sweep. A session the first pass merely could not classify has to stay
+// eligible: mid-replan, the live session already names the replacement file
+// while the durable attempt still names the previous one, and the durable
+// record wins the identity test — so the session reads as "serving another
+// file" for as long as the commit takes. Marking it seen there would strand it
+// permanently, because the persisted verdict also stops any later scan from
+// re-notifying. Re-considering a genuinely unrelated session in the sweep costs
+// one plan-store read and re-runs every check, so the conservative direction is
+// free.
 func (n *CopySafetyNotifier) VideoCopyUnsafe(ctx context.Context, fileID int) {
 	if n == nil || fileID <= 0 {
 		return
@@ -125,17 +152,16 @@ func (n *CopySafetyNotifier) VideoCopyUnsafe(ctx context.Context, fileID int) {
 
 	seen := make(map[string]struct{})
 	for _, session := range n.sessions.GetSessionsByMediaFileID(fileID) {
-		if session != nil && session.ID != "" {
+		if n.consider(ctx, session, fileID, true) == copySafetyDisposed {
 			seen[session.ID] = struct{}{}
 		}
-		n.consider(ctx, session, fileID, true)
 	}
 	n.sweepLateSessionsAfter(ctx, fileID, seen, n.settleWindow())
 }
 
 // sweepLateSessionsAfter re-lists the file's sessions once the settle window
-// has passed and considers only the ones the immediate pass never saw. Like
-// reconsiderAfter, it must not inherit the scan context's cancellation.
+// has passed and considers every one the immediate pass did not dispose of.
+// Like reconsiderAfter, it must not inherit the scan context's cancellation.
 func (n *CopySafetyNotifier) sweepLateSessionsAfter(ctx context.Context, fileID int, seen map[string]struct{}, wait time.Duration) {
 	parent := context.WithoutCancel(ctx)
 	go func() {
@@ -159,19 +185,19 @@ func (n *CopySafetyNotifier) sweepLateSessionsAfter(ctx context.Context, fileID 
 	}()
 }
 
-// consider decides what to do with one session the file lookup returned.
-// maySettle is false on the deferred second look, so a session can never be
-// postponed twice.
-func (n *CopySafetyNotifier) consider(ctx context.Context, session *Session, fileID int, maySettle bool) {
+// consider decides what to do with one session the file lookup returned, and
+// reports whether it disposed of it. maySettle is false on the deferred second
+// look, so a session can never be postponed twice.
+func (n *CopySafetyNotifier) consider(ctx context.Context, session *Session, fileID int, maySettle bool) copySafetyDisposition {
 	if session == nil || session.ID == "" {
-		return
+		return copySafetyUnresolved
 	}
 	record := n.attempt(ctx, session.ID)
 	if !sessionServesFileV3(session, record, fileID) {
-		return
+		return copySafetyUnresolved
 	}
 	if !sessionOnVideoCopyRouteV3(session, record) {
-		return
+		return copySafetyUnresolved
 	}
 	if session.IsJellyfinCompat {
 		// Stopping only helps a client whose recovery re-decides the route
@@ -188,15 +214,16 @@ func (n *CopySafetyNotifier) consider(ctx context.Context, session *Session, fil
 			"file_id", fileID,
 			"reason", PlanInvalidatedVideoCopyUnsafe,
 		)
-		return
+		return copySafetyDisposed
 	}
 	if maySettle && !n.canTellClient(session, record) {
 		if wait := n.settleRemaining(session); wait > 0 {
 			n.reconsiderAfter(ctx, session.ID, fileID, wait)
-			return
+			return copySafetyDisposed
 		}
 	}
 	n.invalidate(ctx, session, record, fileID)
+	return copySafetyDisposed
 }
 
 // reconsiderAfter re-examines one session once the settle window has passed.

--- a/internal/playback/copy_safety_notifier.go
+++ b/internal/playback/copy_safety_notifier.go
@@ -1,0 +1,364 @@
+package playback
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CopySafetyInvalidationDeadline bounds how long a client has to ack a
+// plan_invalidated command and report the replan it triggered. It is long
+// enough for a client to run a full replan round trip and short enough that a
+// wedged player is not left decoding a stream its decoder will desync on. When
+// it expires the session is stopped, which is the same recovery an
+// unnegotiated client gets.
+const CopySafetyInvalidationDeadline = 8 * time.Second
+
+// CopySafetySessionSettleWindow is how long a session is treated as still being
+// established. A session is registered with the manager well before its start
+// handler has written the v3 attempt record, and the client cannot open its
+// realtime channel until it has the response, so a verdict landing inside that
+// window would see a session that looks unreachable and stop one that is still
+// being built — a hard failure exactly where the graceful path was meant to
+// apply. Sessions that are already reachable are acted on immediately; only the
+// ones that would otherwise be stopped wait out the remainder of this window
+// and are then re-examined once.
+const CopySafetySessionSettleWindow = 5 * time.Second
+
+// copySafetyReconsiderTimeout bounds the work a deferred second look does. The
+// scan context it inherited is already gone by then, so it carries no deadline
+// of its own.
+const copySafetyReconsiderTimeout = 30 * time.Second
+
+// CommandIssuedByServer marks a command the server originated on its own,
+// distinct from the "admin" commands an operator sends from the admin surface.
+const CommandIssuedByServer = "server"
+
+type copySafetySessionLookup interface {
+	GetSessionsByMediaFileID(fileID int) []*Session
+}
+
+// copySafetyAttemptLookup reads the durable attempt for a live session: the
+// plan currently issued for it and the features its client negotiated.
+type copySafetyAttemptLookup interface {
+	GetAttempt(ctx context.Context, sessionID string) (*AttemptRecordV3, error)
+}
+
+// CopySafetySessionControl is the small slice of playback-session lifecycle the
+// notifier needs and does not own. The API handler implements it: it is the
+// component that tracks realtime commands by ID and knows how to tear a
+// playback session down completely.
+type CopySafetySessionControl interface {
+	// RememberRealtimeCommand records a dispatched command so the realtime
+	// result handler can attribute it back to this notifier.
+	RememberRealtimeCommand(commandID, sessionID string, name CommandName)
+	// ForgetRealtimeCommand drops a command that was never delivered.
+	ForgetRealtimeCommand(commandID string)
+	// StopSession ends a playback session, which is the fallback whenever the
+	// command cannot be delivered or is not honored.
+	StopSession(ctx context.Context, sessionID string) error
+}
+
+// CopySafetyNotifier switches live sessions off a video stream-copy route after
+// the asynchronous H.264 copy-safety scan reports the source is unsafe to copy.
+//
+// Playback no longer waits for that scan, so a session can already be running a
+// remux when the verdict lands. For a client that negotiated
+// FeaturePlanInvalidatedV3 and is connected, the notifier pushes a
+// plan_invalidated command and lets the client replan itself. Every other v3
+// session — no feature, no realtime connection, no ack, or a rejected result —
+// is stopped, and the client's ordinary recovery mints a fresh attempt that
+// plans against the now-persisted verdict and lands on a transcode.
+// Jellyfin-compatibility sessions are exempt from the stop because their route
+// decision never consults the verdict; see consider.
+//
+// Delivery is in-process only, matching the other realtime notifiers: it acts
+// on the sessions this replica owns, which are exactly the ones whose realtime
+// connections it holds.
+type CopySafetyNotifier struct {
+	sessions   copySafetySessionLookup
+	attempts   copySafetyAttemptLookup
+	dispatcher *CommandDispatcher
+	control    CopySafetySessionControl
+	deadline   time.Duration
+	settle     time.Duration
+}
+
+// NewCopySafetyNotifier returns a notifier, or nil when a dependency it cannot
+// work without is missing. A nil notifier is safe to call.
+func NewCopySafetyNotifier(
+	sessions copySafetySessionLookup,
+	attempts copySafetyAttemptLookup,
+	dispatcher *CommandDispatcher,
+	control CopySafetySessionControl,
+) *CopySafetyNotifier {
+	if sessions == nil || control == nil {
+		return nil
+	}
+	return &CopySafetyNotifier{
+		sessions:   sessions,
+		attempts:   attempts,
+		dispatcher: dispatcher,
+		control:    control,
+		deadline:   CopySafetyInvalidationDeadline,
+		settle:     CopySafetySessionSettleWindow,
+	}
+}
+
+// VideoCopyUnsafe reports that fileID cannot be video stream-copied after all.
+// Sessions that are not on a copy route for that file are left alone.
+func (n *CopySafetyNotifier) VideoCopyUnsafe(ctx context.Context, fileID int) {
+	if n == nil || fileID <= 0 {
+		return
+	}
+
+	for _, session := range n.sessions.GetSessionsByMediaFileID(fileID) {
+		n.consider(ctx, session, fileID, true)
+	}
+}
+
+// consider decides what to do with one session the file lookup returned.
+// maySettle is false on the deferred second look, so a session can never be
+// postponed twice.
+func (n *CopySafetyNotifier) consider(ctx context.Context, session *Session, fileID int, maySettle bool) {
+	if session == nil || session.ID == "" {
+		return
+	}
+	record := n.attempt(ctx, session.ID)
+	if !sessionServesFileV3(session, record, fileID) {
+		return
+	}
+	if !sessionOnVideoCopyRouteV3(session, record) {
+		return
+	}
+	if session.IsJellyfinCompat {
+		// Stopping only helps a client whose recovery re-decides the route
+		// against the verdict. The Jellyfin-protocol surface picks direct
+		// stream from the device profile and the catalog version alone
+		// (DeviceProfile.SupportsDirectStream) and never reads copy safety, so
+		// a compat client would reconnect straight back onto the same remux —
+		// the kill would be a pure mid-stream interruption with no remedy.
+		// Teaching that surface to read the verdict is the fix; until it does,
+		// leave these sessions playing.
+		slog.InfoContext(ctx, "leaving a Jellyfin-compatibility session on a copy-unsafe route",
+			"component", "playback",
+			"session_id", session.ID,
+			"file_id", fileID,
+			"reason", PlanInvalidatedVideoCopyUnsafe,
+		)
+		return
+	}
+	if maySettle && !n.canTellClient(session, record) {
+		if wait := n.settleRemaining(session); wait > 0 {
+			n.reconsiderAfter(ctx, session.ID, fileID, wait)
+			return
+		}
+	}
+	n.invalidate(ctx, session, record, fileID)
+}
+
+// reconsiderAfter re-examines one session once the settle window has passed.
+// The scan context dies as soon as the caller returns, so the deferred look is
+// deliberately not bound to its cancellation.
+func (n *CopySafetyNotifier) reconsiderAfter(ctx context.Context, sessionID string, fileID int, wait time.Duration) {
+	parent := context.WithoutCancel(ctx)
+	go func() {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		<-timer.C
+		// The second look does its own plan-store read, which needs a bound of
+		// its own now that the scan's is gone.
+		ctx, cancel := context.WithTimeout(parent, copySafetyReconsiderTimeout)
+		defer cancel()
+		for _, session := range n.sessions.GetSessionsByMediaFileID(fileID) {
+			if session == nil || session.ID != sessionID {
+				continue
+			}
+			n.consider(ctx, session, fileID, false)
+			return
+		}
+	}()
+}
+
+// settleRemaining reports how much of the settle window a session still has
+// left. A session with no recorded start is treated as settled.
+func (n *CopySafetyNotifier) settleRemaining(session *Session) time.Duration {
+	if n.settle <= 0 || session.StartedAt.IsZero() {
+		return 0
+	}
+	remaining := n.settle - time.Since(session.StartedAt)
+	if remaining <= 0 {
+		return 0
+	}
+	return remaining
+}
+
+// canTellClient reports whether the session can be handed a plan_invalidated
+// command instead of being stopped.
+func (n *CopySafetyNotifier) canTellClient(session *Session, record *AttemptRecordV3) bool {
+	_, ok := n.tellablePlanID(session, record)
+	return ok
+}
+
+// tellablePlanID returns the plan a plan_invalidated command would withdraw,
+// and whether the session can be told about it at all.
+func (n *CopySafetyNotifier) tellablePlanID(session *Session, record *AttemptRecordV3) (string, bool) {
+	if record == nil || n.dispatcher == nil || !session.HasRealtimeConnection {
+		return "", false
+	}
+	if !HasFeatureV3(record.NormalizedRequest.ClientFeatures, FeaturePlanInvalidatedV3) {
+		return "", false
+	}
+	planID := record.CurrentPlan.PlanID
+	if planID == "" {
+		planID = record.CurrentPlanID
+	}
+	if planID == "" {
+		return "", false
+	}
+	return planID, true
+}
+
+func (n *CopySafetyNotifier) attempt(ctx context.Context, sessionID string) *AttemptRecordV3 {
+	if n.attempts == nil {
+		return nil
+	}
+	record, err := n.attempts.GetAttempt(ctx, sessionID)
+	if err != nil {
+		if !errors.Is(err, ErrSessionNotFound) {
+			// A session with no attempt and a session whose attempt could not be
+			// read lead to the same fallback, so the failure has to be visible:
+			// otherwise a plan-store outage looks exactly like a fleet of
+			// unnegotiated clients in the logs.
+			slog.WarnContext(ctx, "could not read the playback attempt for a copy-unsafe session",
+				"component", "playback", "session_id", sessionID, "error", err)
+		}
+		return nil
+	}
+	return record
+}
+
+func (n *CopySafetyNotifier) invalidate(ctx context.Context, session *Session, record *AttemptRecordV3, fileID int) {
+	negotiated := record != nil && HasFeatureV3(record.NormalizedRequest.ClientFeatures, FeaturePlanInvalidatedV3)
+	planID, tellable := n.tellablePlanID(session, record)
+
+	if !tellable {
+		slog.InfoContext(ctx, "stopping playback session on a copy-unsafe route",
+			"component", "playback",
+			"session_id", session.ID,
+			"file_id", fileID,
+			"reason", PlanInvalidatedVideoCopyUnsafe,
+			"negotiated_plan_invalidated", negotiated,
+			"realtime_connected", session.HasRealtimeConnection,
+		)
+		n.stop(ctx, session.ID, fileID)
+		return
+	}
+
+	commandID := uuid.NewString()
+	command, err := NewPlanInvalidatedCommand(session.ID, commandID, planID, PlanInvalidatedVideoCopyUnsafe)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to encode plan invalidated command",
+			"component", "playback", "session_id", session.ID, "file_id", fileID, "error", err)
+		n.stop(ctx, session.ID, fileID)
+		return
+	}
+	command.Reason = PlanInvalidatedVideoCopyUnsafe
+	command.IssuedBy = &CommandIssuedBy{Kind: CommandIssuedByServer}
+	command.DeadlineMS = int(n.commandDeadline() / time.Millisecond)
+
+	sessionID := session.ID
+	fallback := func() {
+		n.control.ForgetRealtimeCommand(commandID)
+		n.stop(context.WithoutCancel(ctx), sessionID, fileID)
+	}
+
+	n.control.RememberRealtimeCommand(commandID, sessionID, CommandPlanInvalidated)
+	result := n.dispatcher.DispatchToSession(command, n.commandDeadline(), fallback)
+	if result.DispatchErr != nil {
+		// The command never reached the client, so nothing will ack it and the
+		// tracker has already dropped it. Stop the session directly rather than
+		// waiting out a deadline that will not fire.
+		n.control.ForgetRealtimeCommand(commandID)
+		slog.InfoContext(ctx, "plan invalidated command undeliverable; stopping session",
+			"component", "playback", "session_id", sessionID, "file_id", fileID, "error", result.DispatchErr)
+		n.stop(ctx, sessionID, fileID)
+		return
+	}
+	slog.InfoContext(ctx, "playback plan invalidated",
+		"component", "playback",
+		"session_id", sessionID,
+		"file_id", fileID,
+		"plan_id", planID,
+		"reason", PlanInvalidatedVideoCopyUnsafe,
+		"command_id", commandID,
+	)
+}
+
+func (n *CopySafetyNotifier) commandDeadline() time.Duration {
+	if n.deadline <= 0 {
+		return CopySafetyInvalidationDeadline
+	}
+	return n.deadline
+}
+
+func (n *CopySafetyNotifier) stop(ctx context.Context, sessionID string, fileID int) {
+	if err := n.control.StopSession(ctx, sessionID); err != nil && !isSessionGoneV3(err) {
+		slog.WarnContext(ctx, "failed to stop playback session on a copy-unsafe route",
+			"component", "playback", "session_id", sessionID, "file_id", fileID, "error", err)
+	}
+}
+
+func isSessionGoneV3(err error) bool {
+	return errors.Is(err, ErrSessionNotFound)
+}
+
+// sessionServesFileV3 reports whether fileID is the source the session is
+// actually delivering.
+//
+// The session lookup matches the requested file as well as the effective one,
+// which is right for the additive notifiers that share it but wrong here: after
+// the 4K guard or a version replan picks another edition, a session's requested
+// file is an identity the session no longer streams a byte of. Withdrawing its
+// route because a different edition turned out to be copy-unsafe would cost it
+// a perfectly valid remux.
+func sessionServesFileV3(session *Session, record *AttemptRecordV3, fileID int) bool {
+	if session == nil {
+		return false
+	}
+	if record != nil && record.EffectiveMediaFileID > 0 {
+		return record.EffectiveMediaFileID == fileID
+	}
+	return session.MediaFileID == fileID
+}
+
+// sessionOnVideoCopyRouteV3 reports whether the session is currently serving a
+// video stream-copy. The durable plan wins when there is one — it advances
+// atomically with each completed replan, while the live play method can lag —
+// and the session's own play method covers sessions with no v3 attempt at all
+// (reconstructed sessions, and sessions whose attempt has expired).
+//
+// Direct play is deliberately not a copy route here: multi-PPS only breaks the
+// avc1/fMP4 repackaging a remux performs, and the planner gates only the remux
+// branches on it.
+func sessionOnVideoCopyRouteV3(session *Session, record *AttemptRecordV3) bool {
+	if session == nil {
+		return false
+	}
+	if record != nil && record.CurrentPlan.Delivery != "" {
+		switch record.CurrentPlan.Delivery {
+		case DeliveryRemuxHLSV3, DeliveryRemuxProgressiveV3:
+			return true
+		default:
+			return false
+		}
+	}
+	method := session.BasePlayMethod
+	if method == "" {
+		method = session.PlayMethod
+	}
+	return method == PlayRemux
+}

--- a/internal/playback/copy_safety_notifier.go
+++ b/internal/playback/copy_safety_notifier.go
@@ -110,14 +110,53 @@ func NewCopySafetyNotifier(
 
 // VideoCopyUnsafe reports that fileID cannot be video stream-copied after all.
 // Sessions that are not on a copy route for that file are left alone.
+//
+// The verdict can land in the gap between a plan being decided and its session
+// becoming visible to the lookup — the scan and the start path race, and the
+// scan can win by milliseconds. One immediate pass would miss such a session
+// entirely and leave it playing a route the verdict just condemned, so a second
+// file-wide look runs after the settle window for sessions that appeared late.
+// Sessions the first pass saw are excluded: they were either acted on or have
+// their own per-session deferred look.
 func (n *CopySafetyNotifier) VideoCopyUnsafe(ctx context.Context, fileID int) {
 	if n == nil || fileID <= 0 {
 		return
 	}
 
+	seen := make(map[string]struct{})
 	for _, session := range n.sessions.GetSessionsByMediaFileID(fileID) {
+		if session != nil && session.ID != "" {
+			seen[session.ID] = struct{}{}
+		}
 		n.consider(ctx, session, fileID, true)
 	}
+	n.sweepLateSessionsAfter(ctx, fileID, seen, n.settleWindow())
+}
+
+// sweepLateSessionsAfter re-lists the file's sessions once the settle window
+// has passed and considers only the ones the immediate pass never saw. Like
+// reconsiderAfter, it must not inherit the scan context's cancellation.
+func (n *CopySafetyNotifier) sweepLateSessionsAfter(ctx context.Context, fileID int, seen map[string]struct{}, wait time.Duration) {
+	parent := context.WithoutCancel(ctx)
+	go func() {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		<-timer.C
+		ctx, cancel := context.WithTimeout(parent, copySafetyReconsiderTimeout)
+		defer cancel()
+		for _, session := range n.sessions.GetSessionsByMediaFileID(fileID) {
+			if session == nil || session.ID == "" {
+				continue
+			}
+			if _, handled := seen[session.ID]; handled {
+				continue
+			}
+			// The settle window has already elapsed since the verdict; a session
+			// still younger than that was planned after the verdict persisted and
+			// should never have been given a copy route at all.
+			n.consider(ctx, session, fileID, false)
+		}
+	}()
 }
 
 // consider decides what to do with one session the file lookup returned.
@@ -185,6 +224,16 @@ func (n *CopySafetyNotifier) reconsiderAfter(ctx context.Context, sessionID stri
 
 // settleRemaining reports how much of the settle window a session still has
 // left. A session with no recorded start is treated as settled.
+// settleWindow is the delay before the late-session sweep; zero settle keeps a
+// small floor so the sweep still runs after the start path has had time to
+// register the session.
+func (n *CopySafetyNotifier) settleWindow() time.Duration {
+	if n.settle <= 0 {
+		return CopySafetySessionSettleWindow
+	}
+	return n.settle
+}
+
 func (n *CopySafetyNotifier) settleRemaining(session *Session) time.Duration {
 	if n.settle <= 0 || session.StartedAt.IsZero() {
 		return 0

--- a/internal/playback/copy_safety_notifier_test.go
+++ b/internal/playback/copy_safety_notifier_test.go
@@ -52,16 +52,31 @@ func (c *fakeCopySafetyControl) trackedCommands() []playbackCommandNote {
 	return append([]playbackCommandNote(nil), c.remembered...)
 }
 
+// fakeAttemptLookup is read by the notifier's deferred goroutines while a test
+// is still publishing attempts to it, so it is mutex-guarded and hands out
+// copies rather than the stored record.
 type fakeAttemptLookup struct {
+	mu      sync.Mutex
 	records map[string]*AttemptRecordV3
 }
 
 func (l *fakeAttemptLookup) GetAttempt(_ context.Context, sessionID string) (*AttemptRecordV3, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	record, ok := l.records[sessionID]
 	if !ok {
 		return nil, ErrSessionNotFound
 	}
-	return record, nil
+	copied := *record
+	return &copied, nil
+}
+
+// set publishes an attempt, replacing any previous one. Callers must supply a
+// fresh record rather than mutate one they already handed over.
+func (l *fakeAttemptLookup) set(sessionID string, record *AttemptRecordV3) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.records[sessionID] = record
 }
 
 func remuxAttempt(sessionID, planID string, features ...string) *AttemptRecordV3 {
@@ -305,7 +320,7 @@ func TestCopySafetyNotifierWaitsOutTheSettleWindowBeforeStopping(t *testing.T) {
 
 	// The start finishes inside the window: the attempt lands and the client
 	// connects, so the second look finds a session it can tell instead of kill.
-	attempts.records[session.ID] = remuxAttempt(session.ID, "plan-abc", FeaturePlanInvalidatedV3)
+	attempts.set(session.ID, remuxAttempt(session.ID, "plan-abc", FeaturePlanInvalidatedV3))
 	if err := sessions.SetRealtimeConnection(session.ID, true); err != nil {
 		t.Fatalf("SetRealtimeConnection: %v", err)
 	}
@@ -462,6 +477,92 @@ func TestCopySafetyNotifierCompletedResultKeepsSession(t *testing.T) {
 	time.Sleep(150 * time.Millisecond)
 	if stopped := control.stoppedSessions(); len(stopped) != 0 {
 		t.Fatalf("stopped = %v, want the session kept after a completed replan", stopped)
+	}
+}
+
+// Regression for the verdict landing inside a version-changing replan. Between
+// applySession and CompleteReplan the live session already names the
+// replacement file while the durable attempt still names the previous one, and
+// the durable record wins the identity test — so the immediate pass reads the
+// session as "serving another file" and does nothing. Marking it seen there
+// would strand it: the sweep would skip it, and the now-persisted verdict stops
+// any later scan from re-notifying, leaving it remuxing a condemned route for
+// the rest of the title.
+func TestCopySafetyNotifierSweepsSessionSkippedDuringAReplanCommit(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	// The live session has already been moved onto file 11 by applySession.
+	session, err := sessions.StartSessionWithFiles(1, "profile-1", 11, 10, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSessionWithFiles: %v", err)
+	}
+
+	// The durable attempt has not been committed yet, so it still names the
+	// file the replan moved off.
+	stale := remuxAttempt(session.ID, "plan-old")
+	stale.EffectiveMediaFileID = 10
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{session.ID: stale}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 20 * time.Millisecond
+
+	// The verdict for the replacement file lands mid-commit.
+	notifier.VideoCopyUnsafe(context.Background(), 11)
+
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want nothing while the identities disagree", stopped)
+	}
+
+	// CompleteReplan lands: live and durable state now agree on file 11.
+	committed := remuxAttempt(session.ID, "plan-new")
+	committed.EffectiveMediaFileID = 11
+	attempts.set(session.ID, committed)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if stopped := control.stoppedSessions(); len(stopped) == 1 && stopped[0] == session.ID {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stopped = %v, want the mid-replan session swept once its identities agreed", control.stoppedSessions())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// The same hole on the route test rather than the file test: mid-commit the
+// durable plan still describes the transcode the replan moved off, so the
+// session reads as "not on a copy route" even though it is now remuxing.
+func TestCopySafetyNotifierSweepsSessionWhoseDurablePlanLagsTheRoute(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	stale := remuxAttempt(session.ID, "plan-old")
+	stale.CurrentPlan.Delivery = DeliveryTranscodeHLSV3
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{session.ID: stale}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 20 * time.Millisecond
+
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want nothing while the durable plan still says transcode", stopped)
+	}
+
+	committed := remuxAttempt(session.ID, "plan-new")
+	committed.CurrentPlan.Delivery = DeliveryRemuxProgressiveV3
+	attempts.set(session.ID, committed)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if stopped := control.stoppedSessions(); len(stopped) == 1 && stopped[0] == session.ID {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stopped = %v, want the session swept once its durable plan caught up", control.stoppedSessions())
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/internal/playback/copy_safety_notifier_test.go
+++ b/internal/playback/copy_safety_notifier_test.go
@@ -1,0 +1,466 @@
+package playback
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeCopySafetyControl struct {
+	mu         sync.Mutex
+	remembered []playbackCommandNote
+	forgotten  []string
+	stopped    []string
+}
+
+type playbackCommandNote struct {
+	commandID string
+	sessionID string
+	name      CommandName
+}
+
+func (c *fakeCopySafetyControl) RememberRealtimeCommand(commandID, sessionID string, name CommandName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.remembered = append(c.remembered, playbackCommandNote{commandID: commandID, sessionID: sessionID, name: name})
+}
+
+func (c *fakeCopySafetyControl) ForgetRealtimeCommand(commandID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.forgotten = append(c.forgotten, commandID)
+}
+
+func (c *fakeCopySafetyControl) StopSession(_ context.Context, sessionID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stopped = append(c.stopped, sessionID)
+	return nil
+}
+
+func (c *fakeCopySafetyControl) stoppedSessions() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.stopped...)
+}
+
+func (c *fakeCopySafetyControl) trackedCommands() []playbackCommandNote {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]playbackCommandNote(nil), c.remembered...)
+}
+
+type fakeAttemptLookup struct {
+	records map[string]*AttemptRecordV3
+}
+
+func (l *fakeAttemptLookup) GetAttempt(_ context.Context, sessionID string) (*AttemptRecordV3, error) {
+	record, ok := l.records[sessionID]
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	return record, nil
+}
+
+func remuxAttempt(sessionID, planID string, features ...string) *AttemptRecordV3 {
+	return &AttemptRecordV3{
+		SessionID:     sessionID,
+		CurrentPlanID: planID,
+		CurrentPlan: PlanV3{
+			PlanID:   planID,
+			Delivery: DeliveryRemuxHLSV3,
+		},
+		NormalizedRequest: StartRequestV3{ClientFeatures: features},
+	}
+}
+
+func newCopySafetyFixture(t *testing.T) (*SessionManager, *RealtimeHub, *CommandTracker, *fakeCopySafetyControl) {
+	t.Helper()
+	sessions := NewSessionManager(0, 0)
+	hub := NewRealtimeHub()
+	tracker := NewCommandTracker()
+	t.Cleanup(tracker.Close)
+	return sessions, hub, tracker, &fakeCopySafetyControl{}
+}
+
+// A negotiated, connected client is told to replan; the session keeps playing
+// until it reports back.
+func TestCopySafetyNotifierPushesPlanInvalidated(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if err := sessions.SetRealtimeConnection(session.ID, true); err != nil {
+		t.Fatalf("SetRealtimeConnection: %v", err)
+	}
+	conn := &dispatchTestConn{}
+	reg := hub.Register(session.ID, conn)
+	defer hub.Unregister(reg)
+
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{
+		session.ID: remuxAttempt(session.ID, "plan-abc", FeaturePlanInvalidatedV3),
+	}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	if len(conn.messages) != 1 {
+		t.Fatalf("messages = %d, want 1 plan_invalidated command", len(conn.messages))
+	}
+	command, ok := conn.messages[0].(CommandEnvelope)
+	if !ok {
+		t.Fatalf("message type = %T, want CommandEnvelope", conn.messages[0])
+	}
+	if command.Type != RealtimeMessageTypeCommand || command.Name != CommandPlanInvalidated {
+		t.Fatalf("command = %#v, want a plan_invalidated command", command)
+	}
+	if command.DeadlineMS != int(CopySafetyInvalidationDeadline/time.Millisecond) {
+		t.Fatalf("deadline_ms = %d, want %d", command.DeadlineMS, int(CopySafetyInvalidationDeadline/time.Millisecond))
+	}
+	var payload PlanInvalidatedPayload
+	if err := json.Unmarshal(command.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(payload): %v", err)
+	}
+	if payload.Reason != PlanInvalidatedVideoCopyUnsafe || payload.PlanID != "plan-abc" {
+		t.Fatalf("payload = %#v, want the invalidated plan and the copy-unsafe reason", payload)
+	}
+	tracked := control.trackedCommands()
+	if len(tracked) != 1 || tracked[0].sessionID != session.ID || tracked[0].name != CommandPlanInvalidated {
+		t.Fatalf("tracked commands = %#v, want one plan_invalidated for the session", tracked)
+	}
+	if tracked[0].commandID != command.CommandID {
+		t.Fatalf("tracked command id = %q, want the dispatched %q", tracked[0].commandID, command.CommandID)
+	}
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped %v, want the session left running until the client reports back", stopped)
+	}
+}
+
+// Everything that cannot be told to replan is stopped instead: that fallback is
+// the whole backwards-compatibility story for clients shipped before the token.
+func TestCopySafetyNotifierStopsSessionsItCannotTell(t *testing.T) {
+	tests := []struct {
+		name      string
+		features  []string
+		connected bool
+		attempt   bool
+	}{
+		{name: "feature not negotiated", features: []string{FeatureSeekReanchorV3}, connected: true, attempt: true},
+		{name: "no realtime connection", features: []string{FeaturePlanInvalidatedV3}, connected: false, attempt: true},
+		{name: "no durable attempt", connected: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sessions, hub, tracker, control := newCopySafetyFixture(t)
+			session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+			if err != nil {
+				t.Fatalf("StartSession: %v", err)
+			}
+			if tc.connected {
+				if err := sessions.SetRealtimeConnection(session.ID, true); err != nil {
+					t.Fatalf("SetRealtimeConnection: %v", err)
+				}
+			}
+			conn := &dispatchTestConn{}
+			reg := hub.Register(session.ID, conn)
+			defer hub.Unregister(reg)
+
+			attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{}}
+			if tc.attempt {
+				attempts.records[session.ID] = remuxAttempt(session.ID, "plan-abc", tc.features...)
+			}
+			notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+			notifier.settle = 0
+
+			notifier.VideoCopyUnsafe(context.Background(), 100)
+
+			if len(conn.messages) != 0 {
+				t.Fatalf("messages = %d, want no command pushed", len(conn.messages))
+			}
+			if stopped := control.stoppedSessions(); len(stopped) != 1 || stopped[0] != session.ID {
+				t.Fatalf("stopped = %v, want the session terminated", stopped)
+			}
+		})
+	}
+}
+
+// Only sessions actually stream-copying video for the file are touched: a
+// transcode is already safe, and a direct play never repackages into fMP4.
+func TestCopySafetyNotifierIgnoresNonCopyRoutes(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	transcoding, err := sessions.StartSession(1, "profile-1", 100, PlayTranscode, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	direct, err := sessions.StartSession(2, "profile-2", 100, PlayDirect, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	otherFile, err := sessions.StartSession(3, "profile-3", 101, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	transcodeAttempt := remuxAttempt(transcoding.ID, "plan-transcode", FeaturePlanInvalidatedV3)
+	transcodeAttempt.CurrentPlan.Delivery = DeliveryTranscodeHLSV3
+	directAttempt := remuxAttempt(direct.ID, "plan-direct", FeaturePlanInvalidatedV3)
+	directAttempt.CurrentPlan.Delivery = DeliveryOriginalHTTPV3
+
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{
+		transcoding.ID: transcodeAttempt,
+		direct.ID:      directAttempt,
+		otherFile.ID:   remuxAttempt(otherFile.ID, "plan-other", FeaturePlanInvalidatedV3),
+	}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want no session touched", stopped)
+	}
+	if tracked := control.trackedCommands(); len(tracked) != 0 {
+		t.Fatalf("tracked = %#v, want no command pushed", tracked)
+	}
+}
+
+// A session with no v3 attempt at all (a reconstructed session, or one whose
+// attempt expired) is classified by its live play method, and stopped because
+// it can be told nothing.
+func TestCopySafetyNotifierUsesSessionPlayMethodWithoutAnAttempt(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	remuxing, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	transcoding, err := sessions.StartSession(2, "profile-2", 100, PlayTranscode, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	notifier := NewCopySafetyNotifier(sessions, nil, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 0
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	stopped := control.stoppedSessions()
+	if len(stopped) != 1 || stopped[0] != remuxing.ID {
+		t.Fatalf("stopped = %v, want only the remuxing session %q (not %q)", stopped, remuxing.ID, transcoding.ID)
+	}
+}
+
+// The Jellyfin-protocol surface picks direct stream from the device profile
+// alone, so a compat client reconnects onto the identical remux. Stopping it
+// would be a mid-stream interruption that buys nothing.
+func TestCopySafetyNotifierLeavesJellyfinCompatSessionsAlone(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	ctx := WithClientInfo(context.Background(), ClientInfo{Name: "Infuse", IsCompat: true})
+	compat, err := sessions.StartSessionWithFilesContext(ctx, 1, "profile-1", 100, 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSessionWithFilesContext: %v", err)
+	}
+	if !compat.IsJellyfinCompat {
+		t.Fatal("fixture session is not a compat session; the test would prove nothing")
+	}
+	native, err := sessions.StartSession(2, "profile-2", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	notifier := NewCopySafetyNotifier(sessions, nil, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 0
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	stopped := control.stoppedSessions()
+	if len(stopped) != 1 || stopped[0] != native.ID {
+		t.Fatalf("stopped = %v, want only the native session %q (not the compat session %q)", stopped, native.ID, compat.ID)
+	}
+}
+
+// A session is registered with the manager before its start handler has written
+// the attempt record and long before the client has opened a realtime channel.
+// A verdict landing in that window must not stop a session that is still being
+// built: the notifier waits out the settle window and looks again.
+func TestCopySafetyNotifierWaitsOutTheSettleWindowBeforeStopping(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	conn := &dispatchTestConn{}
+	reg := hub.Register(session.ID, conn)
+	defer hub.Unregister(reg)
+
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 60 * time.Millisecond
+
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want the still-establishing session left alone", stopped)
+	}
+
+	// The start finishes inside the window: the attempt lands and the client
+	// connects, so the second look finds a session it can tell instead of kill.
+	attempts.records[session.ID] = remuxAttempt(session.ID, "plan-abc", FeaturePlanInvalidatedV3)
+	if err := sessions.SetRealtimeConnection(session.ID, true); err != nil {
+		t.Fatalf("SetRealtimeConnection: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(conn.sent()) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("no command pushed after the settle window; stopped = %v", control.stoppedSessions())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	sent := conn.sent()
+	if command, ok := sent[0].(CommandEnvelope); !ok || command.Name != CommandPlanInvalidated {
+		t.Fatalf("message = %#v, want a plan_invalidated command", sent[0])
+	}
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want the settled session told rather than terminated", stopped)
+	}
+}
+
+// A session that never becomes reachable is still stopped, just one settle
+// window later than an already-settled one.
+func TestCopySafetyNotifierStopsAfterTheSettleWindow(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	notifier := NewCopySafetyNotifier(sessions, nil, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 20 * time.Millisecond
+
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if stopped := control.stoppedSessions(); len(stopped) == 1 && stopped[0] == session.ID {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stopped = %v, want the unreachable session terminated after the settle window", control.stoppedSessions())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// The session lookup also matches the requested file, which after a 4K guard or
+// a version replan is not the file being streamed. A verdict about that
+// inactive edition must not touch a session remuxing a different, copy-safe one.
+func TestCopySafetyNotifierIgnoresSessionsServingAnotherFile(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	session, err := sessions.StartSessionWithFiles(1, "profile-1", 11, 10, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSessionWithFiles: %v", err)
+	}
+	if err := sessions.SetRealtimeConnection(session.ID, true); err != nil {
+		t.Fatalf("SetRealtimeConnection: %v", err)
+	}
+	conn := &dispatchTestConn{}
+	reg := hub.Register(session.ID, conn)
+	defer hub.Unregister(reg)
+
+	record := remuxAttempt(session.ID, "plan-abc", FeaturePlanInvalidatedV3)
+	record.RequestedMediaFileID = 10
+	record.EffectiveMediaFileID = 11
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{session.ID: record}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 0
+
+	// File 10 is the requested edition the session abandoned; file 11 is playing.
+	notifier.VideoCopyUnsafe(context.Background(), 10)
+
+	if len(conn.messages) != 0 {
+		t.Fatalf("messages = %d, want nothing pushed for an edition the session is not streaming", len(conn.messages))
+	}
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want the session on the other edition left alone", stopped)
+	}
+
+	notifier.VideoCopyUnsafe(context.Background(), 11)
+	if len(conn.messages) != 1 {
+		t.Fatalf("messages = %d, want the effective file's verdict to reach the session", len(conn.messages))
+	}
+}
+
+// The command carries a deadline: a client that acks and then goes quiet loses
+// its session, so it cannot keep decoding a stream the server withdrew.
+func TestCopySafetyNotifierDeadlineStopsUnansweredSession(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if err := sessions.SetRealtimeConnection(session.ID, true); err != nil {
+		t.Fatalf("SetRealtimeConnection: %v", err)
+	}
+	conn := &dispatchTestConn{}
+	reg := hub.Register(session.ID, conn)
+	defer hub.Unregister(reg)
+
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{
+		session.ID: remuxAttempt(session.ID, "plan-abc", FeaturePlanInvalidatedV3),
+	}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.deadline = 10 * time.Millisecond
+
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	if len(conn.messages) != 1 {
+		t.Fatalf("messages = %d, want the command delivered first", len(conn.messages))
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if stopped := control.stoppedSessions(); len(stopped) == 1 && stopped[0] == session.ID {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stopped = %v, want the unanswered session terminated by the deadline", control.stoppedSessions())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// An acked-then-completed command cancels the deadline; here nothing
+	// answered, so the tracker must have released the command as well.
+	if _, tracked := tracker.Status("unused"); tracked {
+		t.Fatal("tracker reported an unknown command as tracked")
+	}
+}
+
+// An acked command whose result completes leaves the session alone: the client
+// replanned itself.
+func TestCopySafetyNotifierCompletedResultKeepsSession(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if err := sessions.SetRealtimeConnection(session.ID, true); err != nil {
+		t.Fatalf("SetRealtimeConnection: %v", err)
+	}
+	conn := &dispatchTestConn{}
+	reg := hub.Register(session.ID, conn)
+	defer hub.Unregister(reg)
+
+	attempts := &fakeAttemptLookup{records: map[string]*AttemptRecordV3{
+		session.ID: remuxAttempt(session.ID, "plan-abc", FeaturePlanInvalidatedV3),
+	}}
+	notifier := NewCopySafetyNotifier(sessions, attempts, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.deadline = 50 * time.Millisecond
+
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+	command := conn.messages[0].(CommandEnvelope)
+	tracker.Ack(command.CommandID)
+	tracker.Result(command.CommandID)
+
+	time.Sleep(150 * time.Millisecond)
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want the session kept after a completed replan", stopped)
+	}
+}

--- a/internal/playback/copy_safety_notifier_test.go
+++ b/internal/playback/copy_safety_notifier_test.go
@@ -464,3 +464,35 @@ func TestCopySafetyNotifierCompletedResultKeepsSession(t *testing.T) {
 		t.Fatalf("stopped = %v, want the session kept after a completed replan", stopped)
 	}
 }
+
+// Regression for the scan winning the race against the start path by
+// milliseconds: the verdict lands while the session is being built, so the
+// immediate pass finds nothing at all. The deferred file-wide sweep must catch
+// the session that appears moments later, or it plays a condemned route
+// forever (observed live: plan decided at t, verdict persisted at t+4ms,
+// session registered after both, zero notifier action).
+func TestCopySafetyNotifierSweepsSessionsThatAppearAfterTheVerdict(t *testing.T) {
+	sessions, hub, tracker, control := newCopySafetyFixture(t)
+	notifier := NewCopySafetyNotifier(sessions, nil, NewCommandDispatcher(sessions, hub, tracker), control)
+	notifier.settle = 20 * time.Millisecond
+
+	// Verdict lands first; no session exists yet.
+	notifier.VideoCopyUnsafe(context.Background(), 100)
+
+	// The start path finishes registering the session just after.
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if stopped := control.stoppedSessions(); len(stopped) == 1 && stopped[0] == session.ID {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stopped = %v, want the late-registered session swept after the settle window", control.stoppedSessions())
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/internal/playback/copy_safety_race.go
+++ b/internal/playback/copy_safety_race.go
@@ -33,11 +33,25 @@ const copySafetyScanConcurrency = 4
 const copySafetyRecheckTimeout = 15 * time.Second
 
 // CopySafetyScanner is the scanner-side half of the race: it decides whether a
-// file still needs the H.264 multi-PPS scan and runs it. *scanner.PlaybackProbeEnsurer
+// file still needs the H.264 multi-PPS scan, runs it, and reports what this
+// process already knows without scanning. *scanner.PlaybackProbeEnsurer
 // implements it.
 type CopySafetyScanner interface {
 	NeedsCopySafetyScan(file *models.MediaFile) bool
-	ScanCopySafety(ctx context.Context, file *models.MediaFile) (bool, error)
+	// ScanCopySafety resolves an unknown verdict. Its second result reports
+	// that the verdict was superseded — computed from a generation of the file
+	// the row no longer holds — which is neither an error nor something any
+	// caller may act on.
+	ScanCopySafety(ctx context.Context, file *models.MediaFile) (multi bool, stale bool, err error)
+	// KnownCopySafetyVerdict answers from the process memo or the persisted
+	// row, never from ffmpeg, and retries a write that never landed.
+	//
+	// It is required rather than probed for: an unsafe verdict whose write
+	// failed lives only in the scanning process's memo, and the row — the only
+	// other place to look — cannot distinguish that from "never scanned". A
+	// racer that could not ask this question would leave the sessions on the
+	// condemned route with nothing left to withdraw them.
+	KnownCopySafetyVerdict(ctx context.Context, file *models.MediaFile) (multi bool, known bool)
 }
 
 // CopySafetyFileLoader loads the media file a race was requested for.
@@ -62,7 +76,7 @@ type CopySafetyRace struct {
 	// already collapses concurrent scans, but every start, replan and watch-page
 	// load for a popular file would otherwise stack a goroutine that does
 	// nothing but wait on it.
-	inFlight sync.Map // file ID -> struct{}
+	inFlight sync.Map // file ID -> *copySafetyRaceState
 	// slots is the replica-wide scan semaphore. A goroutine holds its per-file
 	// inFlight entry while it waits for a slot, so queueing never lets a second
 	// goroutine for the same file through.
@@ -85,9 +99,36 @@ func NewCopySafetyRace(scanner CopySafetyScanner, files CopySafetyFileLoader, no
 	}
 }
 
+// copySafetyRaceState is the per-file entry in inFlight. It exists so a request
+// that arrives while a scan is running is remembered rather than dropped.
+//
+// Dropping it was wrong in one specific, reachable way: the sessions a pass
+// notifies are the ones that exist when it runs, and the notifier excludes the
+// sessions it disposed of from its own late sweep. A replan that commits a
+// replacement stream-copy while the scan is in flight therefore produces a
+// session no pass will ever look at — its race request was swallowed by the
+// dedupe, and the plan it is running was never considered by the pass that
+// preceded it.
+type copySafetyRaceState struct {
+	mu sync.Mutex
+	// recheck records that somebody asked for this file while the owner was
+	// mid-pass, so the owner owes one more pass before it lets go.
+	recheck bool
+	// done marks the owner as retired and its map entry as already removed;
+	// a request that sees it must store a fresh state instead.
+	done bool
+}
+
 // RaceScan resolves the copy-safety verdict for fileID in the background. It
-// returns immediately, and does nothing when the verdict is already known, the
-// file is not H.264, or a scan for the file is already running.
+// returns immediately, and does nothing when the verdict is already known or
+// the file is not H.264.
+//
+// A request that lands while a scan for the same file is running does not start
+// a second scan — and is not dropped either: it is folded into one follow-up
+// pass the running goroutine makes before it retires. That pass normally costs
+// no ffmpeg at all (the verdict it would scan for is by then memoized or
+// persisted, so it takes the known-verdict path) and exists to re-examine the
+// sessions that appeared while the scan ran.
 //
 // The caller's request context is deliberately not used: the scan outlives the
 // request that noticed the verdict was missing, and the whole point is that no
@@ -96,17 +137,53 @@ func (r *CopySafetyRace) RaceScan(fileID int) {
 	if r == nil || fileID <= 0 {
 		return
 	}
-	if _, running := r.inFlight.LoadOrStore(fileID, struct{}{}); running {
+	for {
+		actual, running := r.inFlight.LoadOrStore(fileID, &copySafetyRaceState{})
+		state, _ := actual.(*copySafetyRaceState)
+		if state == nil {
+			return
+		}
+		if !running {
+			go r.runRace(fileID, state)
+			return
+		}
+		state.mu.Lock()
+		if !state.done {
+			state.recheck = true
+			state.mu.Unlock()
+			return
+		}
+		state.mu.Unlock()
+		// The owner retired between the load and the lock. It deletes its map
+		// entry before marking itself done, both under this lock, so observing
+		// done proves the entry is gone and the next LoadOrStore installs a
+		// fresh state: this loop runs at most twice.
+	}
+}
+
+// runRace owns one file's races until nothing is left asking for it.
+func (r *CopySafetyRace) runRace(fileID int, state *copySafetyRaceState) {
+	// The slot is taken before the scan's own deadline starts: time spent
+	// queueing behind other files is not time the scan was given to run.
+	r.acquireSlot()
+	defer r.releaseSlot()
+	for {
+		r.scan(fileID)
+
+		state.mu.Lock()
+		if state.recheck {
+			state.recheck = false
+			state.mu.Unlock()
+			continue
+		}
+		// Retire under the lock, deleting first: a request that already holds
+		// this state can then tell, from done alone, that it has to install a
+		// new one.
+		r.inFlight.Delete(fileID)
+		state.done = true
+		state.mu.Unlock()
 		return
 	}
-	go func() {
-		defer r.inFlight.Delete(fileID)
-		// The slot is taken before the scan's own deadline starts: time spent
-		// queueing behind other files is not time the scan was given to run.
-		r.acquireSlot()
-		defer r.releaseSlot()
-		r.scan(fileID)
-	}()
 }
 
 func (r *CopySafetyRace) acquireSlot() {
@@ -143,9 +220,12 @@ func (r *CopySafetyRace) scan(fileID int) {
 		// Nothing left to scan, but that is not the same as nothing to do. The
 		// verdict may have been reached by another replica between this race
 		// being requested and the file being loaded: that replica notified its
-		// own sessions and has no way to reach ours, so a persisted unsafe
-		// verdict has to be applied locally even though no scan runs here. A
-		// known-safe verdict is silent, as always.
+		// own sessions and has no way to reach ours, so an unsafe verdict has to
+		// be applied locally even though no scan runs here. It may equally have
+		// been reached by *this* process and failed to persist, which is why the
+		// question goes to the scanner (memo first, then row) rather than to the
+		// row alone — the row cannot tell an unpersisted verdict from an unknown
+		// one. A known-safe verdict is silent, as always.
 		//
 		// This closes the window for sessions this replica raced against another
 		// replica's write. It is not distributed invalidation: a verdict that
@@ -153,11 +233,11 @@ func (r *CopySafetyRace) scan(fileID int) {
 		// replica that reached it. Pushing invalidations across replicas —
 		// Redis-backed, like the other cross-replica playback signals — is
 		// follow-up work.
-		r.notifyPersistedUnsafe(ctx, file)
+		r.notifyKnownUnsafe(ctx, file)
 		return
 	}
 
-	multi, err := r.scanner.ScanCopySafety(ctx, file)
+	multi, stale, err := r.scanner.ScanCopySafety(ctx, file)
 	if err != nil {
 		// An inconclusive scan is not evidence of anything. Nothing is persisted
 		// (the scanner only records a verdict it reached), live sessions keep
@@ -173,6 +253,18 @@ func (r *CopySafetyRace) scan(fileID int) {
 		// owns would wait for an unrelated future race to withdraw their route.
 		// Re-reading the row is the one thing that can still resolve them.
 		r.recheckPersistedVerdict(ctx, fileID)
+		return
+	}
+	if stale {
+		// The scan read a generation of the file the row has since moved past —
+		// it was rewritten in place while ffmpeg was working. The verdict is
+		// about bytes nobody is serving, so it neither persists nor withdraws
+		// anything: notifying on it would tear down sessions playing the
+		// replacement over evidence from the file it replaced. The replacement's
+		// own verdict is unknown again, and the next start, replan or revival
+		// for it asks for a fresh race.
+		slog.InfoContext(ctx, "discarding a video copy-safety verdict for a superseded generation of the file",
+			"component", "playback", "file_id", fileID)
 		return
 	}
 	if !multi {
@@ -200,22 +292,37 @@ func (r *CopySafetyRace) recheckPersistedVerdict(ctx context.Context, fileID int
 		}
 		return
 	}
-	r.notifyPersistedUnsafe(ctx, file)
+	r.notifyKnownUnsafe(ctx, file)
 }
 
-// notifyPersistedUnsafe pushes the withdrawal for a row that already carries a
-// valid copy-unsafe verdict. A known-safe or unverdicted row is silent, as
-// always.
-func (r *CopySafetyRace) notifyPersistedUnsafe(ctx context.Context, file *models.MediaFile) {
-	if file == nil {
+// notifyKnownUnsafe pushes the withdrawal for a file this replica can already
+// call copy-unsafe without scanning — from the persisted row, or from a verdict
+// this process reached whose write never landed. A known-safe or unresolved
+// file is silent, as always.
+func (r *CopySafetyRace) notifyKnownUnsafe(ctx context.Context, file *models.MediaFile) {
+	if r == nil || file == nil {
 		return
 	}
-	if multi, known := file.PersistedVideoCopyVerdict(); !known || !multi {
+	multi, known := r.scanner.KnownCopySafetyVerdict(ctx, file)
+	if !known || !multi {
 		return
 	}
-	slog.InfoContext(ctx, "applying a persisted copy-unsafe verdict reached elsewhere",
+	slog.InfoContext(ctx, "applying a copy-unsafe verdict that needed no scan",
 		"component", "playback", "file_id", file.ID)
 	r.notifier.VideoCopyUnsafe(ctx, file.ID)
+}
+
+// VideoCopyUnsafeKnown reports whether this replica can already say the file
+// cannot be video stream-copied, without running ffmpeg and without waiting on
+// anything. It is what the serve paths gate a revived stream-copy on: the
+// persisted row alone would miss a verdict this process reached but failed to
+// write, which is exactly the case where nothing else is left to catch it.
+func (r *CopySafetyRace) VideoCopyUnsafeKnown(ctx context.Context, file *models.MediaFile) bool {
+	if r == nil || file == nil {
+		return false
+	}
+	multi, known := r.scanner.KnownCopySafetyVerdict(ctx, file)
+	return known && multi
 }
 
 // RaceScanForPlan starts a race only when the plan actually stream-copies video

--- a/internal/playback/copy_safety_race.go
+++ b/internal/playback/copy_safety_race.go
@@ -1,0 +1,136 @@
+package playback
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// copySafetyScanTimeout bounds one asynchronous multi-PPS scan. The scan reads
+// the opening seconds of the file, which on cold remote storage is dominated by
+// the read rather than the demux; a minute is generous for that and still
+// guarantees the goroutine cannot outlive the session it was started for by
+// much. It is deliberately not the request timeout: nothing about this work
+// belongs to the HTTP request that triggered it.
+const copySafetyScanTimeout = time.Minute
+
+// CopySafetyScanner is the scanner-side half of the race: it decides whether a
+// file still needs the H.264 multi-PPS scan and runs it. *scanner.PlaybackProbeEnsurer
+// implements it.
+type CopySafetyScanner interface {
+	NeedsCopySafetyScan(file *models.MediaFile) bool
+	ScanCopySafety(ctx context.Context, file *models.MediaFile) (bool, error)
+}
+
+// CopySafetyFileLoader loads the media file a race was requested for.
+type CopySafetyFileLoader interface {
+	GetByID(ctx context.Context, id int) (*models.MediaFile, error)
+}
+
+// CopySafetyRace runs the H.264 copy-safety scan out of band, after a plan that
+// stream-copies video has already been handed to a client (or a watch page has
+// been rendered for a file no session exists for yet).
+//
+// This is the asynchronous half of optimistic remuxing: an unknown verdict no
+// longer blocks a play, so it has to be resolved behind the play instead. A
+// multi-PPS verdict is both persisted — every later plan for the file excludes
+// the copy route deterministically — and pushed at whatever sessions are live
+// on a copy route by the time it lands.
+type CopySafetyRace struct {
+	scanner  CopySafetyScanner
+	files    CopySafetyFileLoader
+	notifier *CopySafetyNotifier
+	// inFlight keeps one goroutine per file. The scanner's own singleflight
+	// already collapses concurrent scans, but every start, replan and watch-page
+	// load for a popular file would otherwise stack a goroutine that does
+	// nothing but wait on it.
+	inFlight sync.Map // file ID -> struct{}
+	timeout  time.Duration
+}
+
+// NewCopySafetyRace returns a racer, or nil when it has nothing to scan with. A
+// nil racer is safe to call.
+func NewCopySafetyRace(scanner CopySafetyScanner, files CopySafetyFileLoader, notifier *CopySafetyNotifier) *CopySafetyRace {
+	if scanner == nil || files == nil {
+		return nil
+	}
+	return &CopySafetyRace{scanner: scanner, files: files, notifier: notifier, timeout: copySafetyScanTimeout}
+}
+
+// RaceScan resolves the copy-safety verdict for fileID in the background. It
+// returns immediately, and does nothing when the verdict is already known, the
+// file is not H.264, or a scan for the file is already running.
+//
+// The caller's request context is deliberately not used: the scan outlives the
+// request that noticed the verdict was missing, and the whole point is that no
+// client ever waits on it.
+func (r *CopySafetyRace) RaceScan(fileID int) {
+	if r == nil || fileID <= 0 {
+		return
+	}
+	if _, running := r.inFlight.LoadOrStore(fileID, struct{}{}); running {
+		return
+	}
+	go func() {
+		defer r.inFlight.Delete(fileID)
+		r.scan(fileID)
+	}()
+}
+
+func (r *CopySafetyRace) scan(fileID int) {
+	timeout := r.timeout
+	if timeout <= 0 {
+		timeout = copySafetyScanTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	file, err := r.files.GetByID(ctx, fileID)
+	if err != nil || file == nil {
+		if err != nil {
+			slog.WarnContext(ctx, "video copy-safety race could not load the file",
+				"component", "playback", "file_id", fileID, "error", err)
+		}
+		return
+	}
+	if !r.scanner.NeedsCopySafetyScan(file) {
+		return
+	}
+
+	multi, err := r.scanner.ScanCopySafety(ctx, file)
+	if err != nil {
+		// An inconclusive scan is not evidence of anything. Nothing is persisted
+		// (the scanner only records a verdict it reached), live sessions keep
+		// playing the route they were given, and a later request retries. The
+		// old behavior — treating a failed scan as copy-unsafe — belonged to a
+		// world where the scan ran before playback started.
+		slog.WarnContext(ctx, "video copy-safety scan failed",
+			"component", "playback", "file_id", fileID, "error", err)
+		return
+	}
+	if !multi {
+		return
+	}
+
+	slog.InfoContext(ctx, "video copy-safety scan disqualified the stream-copy route",
+		"component", "playback", "file_id", fileID)
+	r.notifier.VideoCopyUnsafe(ctx, fileID)
+}
+
+// RaceScanForPlan starts a race only when the plan actually stream-copies video
+// for this file. Callers on the playback start and replan paths use it so the
+// route test lives in one place.
+func (r *CopySafetyRace) RaceScanForPlan(fileID int, plan *PlanV3) {
+	if r == nil || plan == nil {
+		return
+	}
+	switch plan.Delivery {
+	case DeliveryRemuxHLSV3, DeliveryRemuxProgressiveV3:
+	default:
+		return
+	}
+	r.RaceScan(fileID)
+}

--- a/internal/playback/copy_safety_race.go
+++ b/internal/playback/copy_safety_race.go
@@ -17,6 +17,15 @@ import (
 // belongs to the HTTP request that triggered it.
 const copySafetyScanTimeout = time.Minute
 
+// copySafetyScanConcurrency caps how many copy-safety scans run at once across
+// the whole replica. Per-file dedupe collapses the repeat requests for one
+// popular file, but nothing bounds the number of *distinct* unknown files a
+// burst of watch-page loads can name, and each one costs an ffmpeg process
+// reading the opening seconds off remote storage. Excess races block their
+// goroutine on the semaphore rather than being dropped: the scan is cheap to
+// defer and must still happen, goroutines are cheap, ffmpeg is not.
+const copySafetyScanConcurrency = 4
+
 // CopySafetyScanner is the scanner-side half of the race: it decides whether a
 // file still needs the H.264 multi-PPS scan and runs it. *scanner.PlaybackProbeEnsurer
 // implements it.
@@ -48,7 +57,11 @@ type CopySafetyRace struct {
 	// load for a popular file would otherwise stack a goroutine that does
 	// nothing but wait on it.
 	inFlight sync.Map // file ID -> struct{}
-	timeout  time.Duration
+	// slots is the replica-wide scan semaphore. A goroutine holds its per-file
+	// inFlight entry while it waits for a slot, so queueing never lets a second
+	// goroutine for the same file through.
+	slots   chan struct{}
+	timeout time.Duration
 }
 
 // NewCopySafetyRace returns a racer, or nil when it has nothing to scan with. A
@@ -57,7 +70,13 @@ func NewCopySafetyRace(scanner CopySafetyScanner, files CopySafetyFileLoader, no
 	if scanner == nil || files == nil {
 		return nil
 	}
-	return &CopySafetyRace{scanner: scanner, files: files, notifier: notifier, timeout: copySafetyScanTimeout}
+	return &CopySafetyRace{
+		scanner:  scanner,
+		files:    files,
+		notifier: notifier,
+		slots:    make(chan struct{}, copySafetyScanConcurrency),
+		timeout:  copySafetyScanTimeout,
+	}
 }
 
 // RaceScan resolves the copy-safety verdict for fileID in the background. It
@@ -76,8 +95,26 @@ func (r *CopySafetyRace) RaceScan(fileID int) {
 	}
 	go func() {
 		defer r.inFlight.Delete(fileID)
+		// The slot is taken before the scan's own deadline starts: time spent
+		// queueing behind other files is not time the scan was given to run.
+		r.acquireSlot()
+		defer r.releaseSlot()
 		r.scan(fileID)
 	}()
+}
+
+func (r *CopySafetyRace) acquireSlot() {
+	if r.slots == nil {
+		return
+	}
+	r.slots <- struct{}{}
+}
+
+func (r *CopySafetyRace) releaseSlot() {
+	if r.slots == nil {
+		return
+	}
+	<-r.slots
 }
 
 func (r *CopySafetyRace) scan(fileID int) {
@@ -97,6 +134,24 @@ func (r *CopySafetyRace) scan(fileID int) {
 		return
 	}
 	if !r.scanner.NeedsCopySafetyScan(file) {
+		// Nothing left to scan, but that is not the same as nothing to do. The
+		// verdict may have been reached by another replica between this race
+		// being requested and the file being loaded: that replica notified its
+		// own sessions and has no way to reach ours, so a persisted unsafe
+		// verdict has to be applied locally even though no scan runs here. A
+		// known-safe verdict is silent, as always.
+		//
+		// This closes the window for sessions this replica raced against another
+		// replica's write. It is not distributed invalidation: a verdict that
+		// lands after every replica has stopped racing still reaches only the
+		// replica that reached it. Pushing invalidations across replicas —
+		// Redis-backed, like the other cross-replica playback signals — is
+		// follow-up work.
+		if multi, known := file.PersistedVideoCopyVerdict(); known && multi {
+			slog.InfoContext(ctx, "applying a persisted copy-unsafe verdict reached elsewhere",
+				"component", "playback", "file_id", fileID)
+			r.notifier.VideoCopyUnsafe(ctx, fileID)
+		}
 		return
 	}
 

--- a/internal/playback/copy_safety_race.go
+++ b/internal/playback/copy_safety_race.go
@@ -26,6 +26,12 @@ const copySafetyScanTimeout = time.Minute
 // defer and must still happen, goroutines are cheap, ffmpeg is not.
 const copySafetyScanConcurrency = 4
 
+// copySafetyRecheckTimeout bounds the verdict re-read that follows a failed
+// scan. It cannot inherit the scan's context: a scan that failed because its
+// deadline expired leaves that context already dead, which is exactly the case
+// the re-read exists for.
+const copySafetyRecheckTimeout = 15 * time.Second
+
 // CopySafetyScanner is the scanner-side half of the race: it decides whether a
 // file still needs the H.264 multi-PPS scan and runs it. *scanner.PlaybackProbeEnsurer
 // implements it.
@@ -147,11 +153,7 @@ func (r *CopySafetyRace) scan(fileID int) {
 		// replica that reached it. Pushing invalidations across replicas —
 		// Redis-backed, like the other cross-replica playback signals — is
 		// follow-up work.
-		if multi, known := file.PersistedVideoCopyVerdict(); known && multi {
-			slog.InfoContext(ctx, "applying a persisted copy-unsafe verdict reached elsewhere",
-				"component", "playback", "file_id", fileID)
-			r.notifier.VideoCopyUnsafe(ctx, fileID)
-		}
+		r.notifyPersistedUnsafe(ctx, file)
 		return
 	}
 
@@ -164,6 +166,13 @@ func (r *CopySafetyRace) scan(fileID int) {
 		// world where the scan ran before playback started.
 		slog.WarnContext(ctx, "video copy-safety scan failed",
 			"component", "playback", "file_id", fileID, "error", err)
+		// Inconclusive here does not mean inconclusive everywhere. Another
+		// replica may have persisted an unsafe verdict while this scan was
+		// failing, and that verdict now suppresses every later local scan of the
+		// file (NeedsCopySafetyScan reads the row) — so the sessions this replica
+		// owns would wait for an unrelated future race to withdraw their route.
+		// Re-reading the row is the one thing that can still resolve them.
+		r.recheckPersistedVerdict(ctx, fileID)
 		return
 	}
 	if !multi {
@@ -173,6 +182,40 @@ func (r *CopySafetyRace) scan(fileID int) {
 	slog.InfoContext(ctx, "video copy-safety scan disqualified the stream-copy route",
 		"component", "playback", "file_id", fileID)
 	r.notifier.VideoCopyUnsafe(ctx, fileID)
+}
+
+// recheckPersistedVerdict re-reads the row after a local scan failed and applies
+// an unsafe verdict another replica reached in the meantime. A read that fails,
+// or a row with no valid verdict on it, changes nothing: inconclusive stays
+// inconclusive.
+func (r *CopySafetyRace) recheckPersistedVerdict(ctx context.Context, fileID int) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), copySafetyRecheckTimeout)
+	defer cancel()
+
+	file, err := r.files.GetByID(ctx, fileID)
+	if err != nil || file == nil {
+		if err != nil {
+			slog.WarnContext(ctx, "video copy-safety verdict re-read after a failed scan could not load the file",
+				"component", "playback", "file_id", fileID, "error", err)
+		}
+		return
+	}
+	r.notifyPersistedUnsafe(ctx, file)
+}
+
+// notifyPersistedUnsafe pushes the withdrawal for a row that already carries a
+// valid copy-unsafe verdict. A known-safe or unverdicted row is silent, as
+// always.
+func (r *CopySafetyRace) notifyPersistedUnsafe(ctx context.Context, file *models.MediaFile) {
+	if file == nil {
+		return
+	}
+	if multi, known := file.PersistedVideoCopyVerdict(); !known || !multi {
+		return
+	}
+	slog.InfoContext(ctx, "applying a persisted copy-unsafe verdict reached elsewhere",
+		"component", "playback", "file_id", file.ID)
+	r.notifier.VideoCopyUnsafe(ctx, file.ID)
 }
 
 // RaceScanForPlan starts a race only when the plan actually stream-copies video

--- a/internal/playback/copy_safety_race_test.go
+++ b/internal/playback/copy_safety_race_test.go
@@ -65,8 +65,11 @@ func (s *fakeCopySafetyScanner) peakConcurrency() int {
 }
 
 type fakeFileLoader struct {
-	mu    sync.Mutex
-	file  *models.MediaFile
+	mu   sync.Mutex
+	file *models.MediaFile
+	// later, when set, is what every read after the first returns — the row as
+	// another replica has since rewritten it.
+	later *models.MediaFile
 	err   error
 	loads int
 }
@@ -75,6 +78,9 @@ func (l *fakeFileLoader) GetByID(context.Context, int) (*models.MediaFile, error
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.loads++
+	if l.loads > 1 && l.later != nil {
+		return l.later, l.err
+	}
 	return l.file, l.err
 }
 
@@ -93,6 +99,13 @@ func raceFixture(t *testing.T, scanner *fakeCopySafetyScanner) (*CopySafetyRace,
 // that care about what the row carries — a persisted verdict, above all.
 func raceFixtureForFile(t *testing.T, scanner *fakeCopySafetyScanner, file *models.MediaFile) (*CopySafetyRace, *SessionManager, *fakeCopySafetyControl) {
 	t.Helper()
+	return raceFixtureWithLoader(t, scanner, &fakeFileLoader{file: file})
+}
+
+// raceFixtureWithLoader is raceFixtureForFile over a loader the caller controls,
+// for the cases that care about the row changing between two reads.
+func raceFixtureWithLoader(t *testing.T, scanner *fakeCopySafetyScanner, loader *fakeFileLoader) (*CopySafetyRace, *SessionManager, *fakeCopySafetyControl) {
+	t.Helper()
 	sessions := NewSessionManager(0, 0)
 	hub := NewRealtimeHub()
 	tracker := NewCommandTracker()
@@ -102,7 +115,6 @@ func raceFixtureForFile(t *testing.T, scanner *fakeCopySafetyScanner, file *mode
 	// These tests are about the race, not about waiting out the window a
 	// just-started session gets before it can be stopped.
 	notifier.settle = 0
-	loader := &fakeFileLoader{file: file}
 	return NewCopySafetyRace(scanner, loader, notifier), sessions, control
 }
 
@@ -167,6 +179,59 @@ func TestCopySafetyRaceLeavesSessionsAloneOnScanError(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	if stopped := control.stoppedSessions(); len(stopped) != 0 {
 		t.Fatalf("stopped = %v, want live sessions untouched after an inconclusive scan", stopped)
+	}
+}
+
+// A failed local scan and a verdict reached elsewhere can happen at once, and
+// the combination is the worst of both: the persisted verdict suppresses every
+// later local scan of the file, so the failure that just returned empty-handed
+// is this replica's last chance to notice it. Without the re-read, the sessions
+// this replica owns keep the condemned route until some unrelated future race
+// happens to load the row.
+func TestCopySafetyRaceAppliesAVerdictPersistedWhileTheScanFailed(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: true, err: errors.New("ffmpeg exploded")}
+	loader := &fakeFileLoader{
+		file: &models.MediaFile{
+			ID:          100,
+			CodecVideo:  "h264",
+			VideoTracks: []models.VideoTrack{{Codec: "h264"}},
+		},
+		later: fileWithPersistedVerdict(true),
+	}
+	race, sessions, control := raceFixtureWithLoader(t, scanner, loader)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForStop(t, control, session.ID)
+}
+
+// The mirror image: a scan that fails over a row that still carries no verdict
+// anywhere proves nothing, and the re-read must not invent one.
+func TestCopySafetyRaceScanFailureWithNoVerdictAnywhereStaysSilent(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: true, err: errors.New("ffmpeg exploded")}
+	loader := &fakeFileLoader{
+		file: &models.MediaFile{
+			ID:          100,
+			CodecVideo:  "h264",
+			VideoTracks: []models.VideoTrack{{Codec: "h264"}},
+		},
+		later: fileWithPersistedVerdict(false),
+	}
+	race, sessions, control := raceFixtureWithLoader(t, scanner, loader)
+	if _, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForScans(t, scanner, 1)
+	time.Sleep(20 * time.Millisecond)
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want live sessions untouched when no verdict exists anywhere", stopped)
 	}
 }
 

--- a/internal/playback/copy_safety_race_test.go
+++ b/internal/playback/copy_safety_race_test.go
@@ -1,0 +1,234 @@
+package playback
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type fakeCopySafetyScanner struct {
+	mu       sync.Mutex
+	needs    bool
+	multi    bool
+	err      error
+	scans    int
+	release  chan struct{}
+	scanning chan struct{}
+}
+
+func (s *fakeCopySafetyScanner) NeedsCopySafetyScan(*models.MediaFile) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.needs
+}
+
+func (s *fakeCopySafetyScanner) ScanCopySafety(context.Context, *models.MediaFile) (bool, error) {
+	s.mu.Lock()
+	s.scans++
+	s.mu.Unlock()
+	if s.scanning != nil {
+		s.scanning <- struct{}{}
+	}
+	if s.release != nil {
+		<-s.release
+	}
+	return s.multi, s.err
+}
+
+func (s *fakeCopySafetyScanner) scanCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.scans
+}
+
+type fakeFileLoader struct {
+	mu    sync.Mutex
+	file  *models.MediaFile
+	err   error
+	loads int
+}
+
+func (l *fakeFileLoader) GetByID(context.Context, int) (*models.MediaFile, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.loads++
+	return l.file, l.err
+}
+
+// raceFixture wires a racer whose notifier reports into a fake control, so a
+// multi-PPS verdict is observable as a session stop.
+func raceFixture(t *testing.T, scanner *fakeCopySafetyScanner) (*CopySafetyRace, *SessionManager, *fakeCopySafetyControl) {
+	t.Helper()
+	sessions := NewSessionManager(0, 0)
+	hub := NewRealtimeHub()
+	tracker := NewCommandTracker()
+	t.Cleanup(tracker.Close)
+	control := &fakeCopySafetyControl{}
+	notifier := NewCopySafetyNotifier(sessions, nil, NewCommandDispatcher(sessions, hub, tracker), control)
+	// These tests are about the race, not about waiting out the window a
+	// just-started session gets before it can be stopped.
+	notifier.settle = 0
+	loader := &fakeFileLoader{file: &models.MediaFile{ID: 100, CodecVideo: "h264", VideoTracks: []models.VideoTrack{{Codec: "h264"}}}}
+	return NewCopySafetyRace(scanner, loader, notifier), sessions, control
+}
+
+func waitForStop(t *testing.T, control *fakeCopySafetyControl, sessionID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		stopped := control.stoppedSessions()
+		if len(stopped) == 1 && stopped[0] == sessionID {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stopped = %v, want the copy-routed session %q", stopped, sessionID)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestCopySafetyRaceNotifiesOnMultiPPS(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: true, multi: true}
+	race, sessions, control := raceFixture(t, scanner)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForStop(t, control, session.ID)
+}
+
+// A copy-safe verdict is the common case and must be silent: the plan the
+// client is already running stays valid.
+func TestCopySafetyRaceKeepsSessionsWhenCopySafe(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: true, multi: false}
+	race, sessions, control := raceFixture(t, scanner)
+	if _, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForScans(t, scanner, 1)
+	time.Sleep(20 * time.Millisecond)
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want no session touched by a copy-safe verdict", stopped)
+	}
+}
+
+// An inconclusive scan proves nothing, so sessions keep playing. Failing closed
+// here would kill a live playback over a transient ffmpeg or storage error.
+func TestCopySafetyRaceLeavesSessionsAloneOnScanError(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: true, err: errors.New("ffmpeg exploded")}
+	race, sessions, control := raceFixture(t, scanner)
+	if _, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForScans(t, scanner, 1)
+	time.Sleep(20 * time.Millisecond)
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want live sessions untouched after an inconclusive scan", stopped)
+	}
+}
+
+func TestCopySafetyRaceSkipsFilesWithNothingToScan(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: false, multi: true}
+	race, _, control := raceFixture(t, scanner)
+
+	race.RaceScan(100)
+
+	time.Sleep(20 * time.Millisecond)
+	if got := scanner.scanCount(); got != 0 {
+		t.Fatalf("scans = %d, want 0 when the verdict is already known", got)
+	}
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want none", stopped)
+	}
+}
+
+// Every start, replan and watch-page load for a popular file asks for the same
+// race; only one goroutine may be in flight for it.
+func TestCopySafetyRaceDedupesInFlightScans(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{
+		needs:    true,
+		release:  make(chan struct{}),
+		scanning: make(chan struct{}, 1),
+	}
+	race, _, _ := raceFixture(t, scanner)
+
+	race.RaceScan(100)
+	<-scanner.scanning
+	for i := 0; i < 5; i++ {
+		race.RaceScan(100)
+	}
+	close(scanner.release)
+
+	time.Sleep(50 * time.Millisecond)
+	if got := scanner.scanCount(); got != 1 {
+		t.Fatalf("scans = %d, want 1 while a scan for the file is already running", got)
+	}
+}
+
+// The route test lives with the racer so start and replan cannot disagree: only
+// a plan that actually stream-copies video is worth chasing.
+func TestCopySafetyRaceForPlanOnlyChasesCopyRoutes(t *testing.T) {
+	tests := []struct {
+		delivery  DeliveryV3
+		wantScans int
+	}{
+		{delivery: DeliveryRemuxHLSV3, wantScans: 1},
+		{delivery: DeliveryRemuxProgressiveV3, wantScans: 1},
+		{delivery: DeliveryTranscodeHLSV3, wantScans: 0},
+		{delivery: DeliveryOriginalHTTPV3, wantScans: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.delivery), func(t *testing.T) {
+			scanner := &fakeCopySafetyScanner{needs: true}
+			race, _, _ := raceFixture(t, scanner)
+
+			race.RaceScanForPlan(100, &PlanV3{PlanID: "plan-1", Delivery: tc.delivery})
+
+			if tc.wantScans > 0 {
+				waitForScans(t, scanner, tc.wantScans)
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+			if got := scanner.scanCount(); got != 0 {
+				t.Fatalf("scans = %d, want 0 for delivery %q", got, tc.delivery)
+			}
+		})
+	}
+}
+
+func TestCopySafetyRaceNilIsSafe(t *testing.T) {
+	var race *CopySafetyRace
+	race.RaceScan(100)
+	race.RaceScanForPlan(100, &PlanV3{Delivery: DeliveryRemuxHLSV3})
+	if NewCopySafetyRace(nil, nil, nil) != nil {
+		t.Fatal("NewCopySafetyRace() with no dependencies = non-nil, want nil")
+	}
+}
+
+func waitForScans(t *testing.T, scanner *fakeCopySafetyScanner, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if scanner.scanCount() >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("scans = %d, want %d", scanner.scanCount(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/internal/playback/copy_safety_race_test.go
+++ b/internal/playback/copy_safety_race_test.go
@@ -11,13 +11,15 @@ import (
 )
 
 type fakeCopySafetyScanner struct {
-	mu       sync.Mutex
-	needs    bool
-	multi    bool
-	err      error
-	scans    int
-	release  chan struct{}
-	scanning chan struct{}
+	mu        sync.Mutex
+	needs     bool
+	multi     bool
+	err       error
+	scans     int
+	active    int
+	maxActive int
+	release   chan struct{}
+	scanning  chan struct{}
 }
 
 func (s *fakeCopySafetyScanner) NeedsCopySafetyScan(*models.MediaFile) bool {
@@ -29,7 +31,16 @@ func (s *fakeCopySafetyScanner) NeedsCopySafetyScan(*models.MediaFile) bool {
 func (s *fakeCopySafetyScanner) ScanCopySafety(context.Context, *models.MediaFile) (bool, error) {
 	s.mu.Lock()
 	s.scans++
+	s.active++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
 	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.active--
+		s.mu.Unlock()
+	}()
 	if s.scanning != nil {
 		s.scanning <- struct{}{}
 	}
@@ -43,6 +54,14 @@ func (s *fakeCopySafetyScanner) scanCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.scans
+}
+
+// peakConcurrency is the largest number of scans that were ever running at the
+// same time.
+func (s *fakeCopySafetyScanner) peakConcurrency() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxActive
 }
 
 type fakeFileLoader struct {
@@ -63,6 +82,17 @@ func (l *fakeFileLoader) GetByID(context.Context, int) (*models.MediaFile, error
 // multi-PPS verdict is observable as a session stop.
 func raceFixture(t *testing.T, scanner *fakeCopySafetyScanner) (*CopySafetyRace, *SessionManager, *fakeCopySafetyControl) {
 	t.Helper()
+	return raceFixtureForFile(t, scanner, &models.MediaFile{
+		ID:          100,
+		CodecVideo:  "h264",
+		VideoTracks: []models.VideoTrack{{Codec: "h264"}},
+	})
+}
+
+// raceFixtureForFile is raceFixture over a specific media file, for the cases
+// that care about what the row carries — a persisted verdict, above all.
+func raceFixtureForFile(t *testing.T, scanner *fakeCopySafetyScanner, file *models.MediaFile) (*CopySafetyRace, *SessionManager, *fakeCopySafetyControl) {
+	t.Helper()
 	sessions := NewSessionManager(0, 0)
 	hub := NewRealtimeHub()
 	tracker := NewCommandTracker()
@@ -72,7 +102,7 @@ func raceFixture(t *testing.T, scanner *fakeCopySafetyScanner) (*CopySafetyRace,
 	// These tests are about the race, not about waiting out the window a
 	// just-started session gets before it can be stopped.
 	notifier.settle = 0
-	loader := &fakeFileLoader{file: &models.MediaFile{ID: 100, CodecVideo: "h264", VideoTracks: []models.VideoTrack{{Codec: "h264"}}}}
+	loader := &fakeFileLoader{file: file}
 	return NewCopySafetyRace(scanner, loader, notifier), sessions, control
 }
 
@@ -175,6 +205,84 @@ func TestCopySafetyRaceDedupesInFlightScans(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if got := scanner.scanCount(); got != 1 {
 		t.Fatalf("scans = %d, want 1 while a scan for the file is already running", got)
+	}
+}
+
+// fileWithPersistedVerdict is a media file row whose multi-PPS verdict is
+// already recorded and still describes the file, as it would be on a replica
+// that loads the row after another replica wrote it.
+func fileWithPersistedVerdict(multi bool) *models.MediaFile {
+	size := int64(4096)
+	return &models.MediaFile{
+		ID:                  100,
+		CodecVideo:          "h264",
+		VideoTracks:         []models.VideoTrack{{Codec: "h264", MultiplePPS: &multi}},
+		FileSize:            size,
+		MultiplePPS:         &multi,
+		MultiplePPSScanSize: &size,
+	}
+}
+
+// Another replica can reach the verdict first: it persists it, notifies its own
+// sessions, and cannot reach ours. Loading a row that already carries an unsafe
+// verdict therefore has to withdraw this replica's copy-routed sessions even
+// though there is nothing left to scan.
+func TestCopySafetyRaceAppliesPersistedUnsafeVerdict(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: false}
+	race, sessions, control := raceFixtureForFile(t, scanner, fileWithPersistedVerdict(true))
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForStop(t, control, session.ID)
+	if got := scanner.scanCount(); got != 0 {
+		t.Fatalf("scans = %d, want 0 for a verdict that was already reached", got)
+	}
+}
+
+// A persisted copy-safe verdict is the common resolved state and must stay
+// silent: it is exactly the evidence that the route the session is on is fine.
+func TestCopySafetyRaceIgnoresPersistedSafeVerdict(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: false}
+	race, sessions, control := raceFixtureForFile(t, scanner, fileWithPersistedVerdict(false))
+	if _, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	time.Sleep(20 * time.Millisecond)
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want no session touched by a persisted copy-safe verdict", stopped)
+	}
+}
+
+// Per-file dedupe bounds the races for one popular file; nothing bounds the
+// number of distinct files a burst of watch-page loads names, and each scan
+// costs an ffmpeg process against remote storage.
+func TestCopySafetyRaceCapsConcurrentScans(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: true, release: make(chan struct{})}
+	race, _, _ := raceFixture(t, scanner)
+
+	const files = 12
+	for i := 0; i < files; i++ {
+		race.RaceScan(200 + i)
+	}
+
+	waitForScans(t, scanner, copySafetyScanConcurrency)
+	time.Sleep(50 * time.Millisecond)
+	if got := scanner.scanCount(); got != copySafetyScanConcurrency {
+		t.Fatalf("scans = %d, want %d in flight while every slot is held", got, copySafetyScanConcurrency)
+	}
+
+	// Every queued race still runs; the cap defers work rather than dropping it.
+	close(scanner.release)
+	waitForScans(t, scanner, files)
+	if got := scanner.peakConcurrency(); got > copySafetyScanConcurrency {
+		t.Fatalf("peak concurrency = %d, want at most %d", got, copySafetyScanConcurrency)
 	}
 }
 

--- a/internal/playback/copy_safety_race_test.go
+++ b/internal/playback/copy_safety_race_test.go
@@ -11,15 +11,23 @@ import (
 )
 
 type fakeCopySafetyScanner struct {
-	mu        sync.Mutex
-	needs     bool
-	multi     bool
-	err       error
-	scans     int
-	active    int
-	maxActive int
-	release   chan struct{}
-	scanning  chan struct{}
+	mu    sync.Mutex
+	needs bool
+	multi bool
+	// stale makes the scan report a verdict for a generation of the file the
+	// row has moved past.
+	stale bool
+	err   error
+	// known and knownMulti stand in for the process memo: a verdict this
+	// replica reached whose write to media_files never landed, and which is
+	// therefore invisible on the row.
+	known      bool
+	knownMulti bool
+	scans      int
+	active     int
+	maxActive  int
+	release    chan struct{}
+	scanning   chan struct{}
 }
 
 func (s *fakeCopySafetyScanner) NeedsCopySafetyScan(*models.MediaFile) bool {
@@ -28,7 +36,7 @@ func (s *fakeCopySafetyScanner) NeedsCopySafetyScan(*models.MediaFile) bool {
 	return s.needs
 }
 
-func (s *fakeCopySafetyScanner) ScanCopySafety(context.Context, *models.MediaFile) (bool, error) {
+func (s *fakeCopySafetyScanner) ScanCopySafety(context.Context, *models.MediaFile) (bool, bool, error) {
 	s.mu.Lock()
 	s.scans++
 	s.active++
@@ -47,7 +55,22 @@ func (s *fakeCopySafetyScanner) ScanCopySafety(context.Context, *models.MediaFil
 	if s.release != nil {
 		<-s.release
 	}
-	return s.multi, s.err
+	return s.multi, s.stale, s.err
+}
+
+// KnownCopySafetyVerdict mirrors the real ensurer: the process memo first, then
+// the verdict the row carries.
+func (s *fakeCopySafetyScanner) KnownCopySafetyVerdict(_ context.Context, file *models.MediaFile) (bool, bool) {
+	s.mu.Lock()
+	known, multi := s.known, s.knownMulti
+	s.mu.Unlock()
+	if known {
+		return multi, true
+	}
+	if file == nil {
+		return false, false
+	}
+	return file.PersistedVideoCopyVerdict()
 }
 
 func (s *fakeCopySafetyScanner) scanCount() int {
@@ -82,6 +105,12 @@ func (l *fakeFileLoader) GetByID(context.Context, int) (*models.MediaFile, error
 		return l.later, l.err
 	}
 	return l.file, l.err
+}
+
+func (l *fakeFileLoader) loadCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.loads
 }
 
 // raceFixture wires a racer whose notifier reports into a fake control, so a
@@ -228,8 +257,11 @@ func TestCopySafetyRaceScanFailureWithNoVerdictAnywhereStaysSilent(t *testing.T)
 
 	race.RaceScan(100)
 
-	waitForScans(t, scanner, 1)
-	time.Sleep(20 * time.Millisecond)
+	// The re-read after the failed scan is the last thing the pass does, and it
+	// is the only thing that could have produced a stop. Waiting for it is what
+	// makes "nothing was stopped" an assertion about a finished pass rather
+	// than about a moment in time.
+	waitForLoads(t, loader, 2)
 	if stopped := control.stoppedSessions(); len(stopped) != 0 {
 		t.Fatalf("stopped = %v, want live sessions untouched when no verdict exists anywhere", stopped)
 	}
@@ -251,14 +283,20 @@ func TestCopySafetyRaceSkipsFilesWithNothingToScan(t *testing.T) {
 }
 
 // Every start, replan and watch-page load for a popular file asks for the same
-// race; only one goroutine may be in flight for it.
+// race; only one goroutine may be in flight for it, and a burst arriving while
+// it runs collapses into a single follow-up pass rather than one scan each.
 func TestCopySafetyRaceDedupesInFlightScans(t *testing.T) {
 	scanner := &fakeCopySafetyScanner{
 		needs:    true,
 		release:  make(chan struct{}),
-		scanning: make(chan struct{}, 1),
+		scanning: make(chan struct{}, 8),
 	}
-	race, _, _ := raceFixture(t, scanner)
+	loader := &fakeFileLoader{file: &models.MediaFile{
+		ID:          100,
+		CodecVideo:  "h264",
+		VideoTracks: []models.VideoTrack{{Codec: "h264"}},
+	}}
+	race, _, _ := raceFixtureWithLoader(t, scanner, loader)
 
 	race.RaceScan(100)
 	<-scanner.scanning
@@ -267,9 +305,152 @@ func TestCopySafetyRaceDedupesInFlightScans(t *testing.T) {
 	}
 	close(scanner.release)
 
-	time.Sleep(50 * time.Millisecond)
-	if got := scanner.scanCount(); got != 1 {
-		t.Fatalf("scans = %d, want 1 while a scan for the file is already running", got)
+	// One follow-up pass for the whole burst: two row reads, and never five.
+	waitForLoads(t, loader, 2)
+	if got := scanner.scanCount(); got > 2 {
+		t.Fatalf("scans = %d, want at most 2 — the in-flight scan and one follow-up for the burst", got)
+	}
+}
+
+// The dedupe used to drop a request that arrived mid-scan, and that dropped
+// request was sometimes the only thing that would have looked at a session.
+// A replan can commit a replacement stream-copy while the scan runs: the pass
+// already under way lists the sessions as they were, and the notifier excludes
+// the ones it disposed of from its own late sweep, so the replacement is
+// considered by nobody. The follow-up pass is what re-lists them.
+func TestCopySafetyRaceReconsidersSessionsThatAppearedDuringAScan(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{
+		needs:    true,
+		multi:    true,
+		release:  make(chan struct{}),
+		scanning: make(chan struct{}, 1),
+	}
+	race, sessions, control := raceFixture(t, scanner)
+
+	race.RaceScan(100)
+	waitForScanning(t, scanner, "the first pass")
+	// Asked for while the scan is running: under the old dedupe this request
+	// was dropped on the floor.
+	race.RaceScan(100)
+	releaseScan(t, scanner, "the first pass")
+
+	// The second scan starting proves the first pass — its scan, its verdict
+	// and its notification — is over. No session existed for it to touch, so
+	// the follow-up pass is the only thing left that can reach one.
+	waitForScanning(t, scanner, "the follow-up pass")
+	late, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	releaseScan(t, scanner, "the follow-up pass")
+
+	waitForStop(t, control, late.ID)
+}
+
+// waitForScanning blocks until a pass is inside its scan, failing rather than
+// hanging when the pass never comes.
+func waitForScanning(t *testing.T, scanner *fakeCopySafetyScanner, pass string) {
+	t.Helper()
+	select {
+	case <-scanner.scanning:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s never started scanning", pass)
+	}
+}
+
+// releaseScan lets a waiting scan return, failing rather than hanging when
+// nothing is waiting for it.
+func releaseScan(t *testing.T, scanner *fakeCopySafetyScanner, pass string) {
+	t.Helper()
+	select {
+	case scanner.release <- struct{}{}:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("nothing was waiting to be released for %s", pass)
+	}
+}
+
+// A file rewritten in place while the scan reads it produces a verdict about
+// bytes the server is no longer serving. Persisting it would re-validate a dead
+// generation, and notifying on it would tear down sessions playing the
+// replacement over evidence from the file it replaced.
+func TestCopySafetyRaceIgnoresAVerdictForASupersededGeneration(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: true, multi: true, stale: true}
+	race, sessions, control := raceFixture(t, scanner)
+	if _, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false); err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForScans(t, scanner, 1)
+	time.Sleep(20 * time.Millisecond)
+	if stopped := control.stoppedSessions(); len(stopped) != 0 {
+		t.Fatalf("stopped = %v, want no session withdrawn on a verdict for bytes it is not playing", stopped)
+	}
+}
+
+// A verdict this process reached and failed to write is invisible on the row,
+// and the row is all a later pass would otherwise consult. The scanner is the
+// only thing that can still answer, so the pass with nothing left to scan asks
+// it rather than the row.
+func TestCopySafetyRaceAppliesAnUnpersistedUnsafeVerdict(t *testing.T) {
+	scanner := &fakeCopySafetyScanner{needs: false, known: true, knownMulti: true}
+	race, sessions, control := raceFixture(t, scanner)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	race.RaceScan(100)
+
+	waitForStop(t, control, session.ID)
+	if got := scanner.scanCount(); got != 0 {
+		t.Fatalf("scans = %d, want 0 for a verdict this process already holds", got)
+	}
+}
+
+// VideoCopyUnsafeKnown is what the serve paths gate a revived stream-copy on,
+// so it has to answer from the same place the racer does — including the memo
+// the row knows nothing about.
+func TestCopySafetyRaceVideoCopyUnsafeKnown(t *testing.T) {
+	unverdicted := &models.MediaFile{
+		ID:          100,
+		CodecVideo:  "h264",
+		VideoTracks: []models.VideoTrack{{Codec: "h264"}},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		scanner *fakeCopySafetyScanner
+		file    *models.MediaFile
+		want    bool
+	}{
+		{name: "unknown", scanner: &fakeCopySafetyScanner{}, file: unverdicted},
+		{name: "persisted unsafe", scanner: &fakeCopySafetyScanner{}, file: fileWithPersistedVerdict(true), want: true},
+		{name: "persisted safe", scanner: &fakeCopySafetyScanner{}, file: fileWithPersistedVerdict(false)},
+		{
+			name:    "unpersisted unsafe",
+			scanner: &fakeCopySafetyScanner{known: true, knownMulti: true},
+			file:    unverdicted,
+			want:    true,
+		},
+		{
+			name:    "unpersisted safe",
+			scanner: &fakeCopySafetyScanner{known: true},
+			file:    unverdicted,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			race, _, _ := raceFixtureForFile(t, tc.scanner, tc.file)
+			if got := race.VideoCopyUnsafeKnown(t.Context(), tc.file); got != tc.want {
+				t.Fatalf("VideoCopyUnsafeKnown() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	var nilRace *CopySafetyRace
+	if nilRace.VideoCopyUnsafeKnown(t.Context(), unverdicted) {
+		t.Fatal("VideoCopyUnsafeKnown() on a nil racer = true, want false")
 	}
 }
 
@@ -389,6 +570,23 @@ func TestCopySafetyRaceNilIsSafe(t *testing.T) {
 	race.RaceScanForPlan(100, &PlanV3{Delivery: DeliveryRemuxHLSV3})
 	if NewCopySafetyRace(nil, nil, nil) != nil {
 		t.Fatal("NewCopySafetyRace() with no dependencies = non-nil, want nil")
+	}
+}
+
+// waitForLoads waits for the racer to have read the row want times. Each pass
+// opens with exactly one read and a failed scan adds its re-read, so the count
+// is the observable "this much of the pass has happened".
+func waitForLoads(t *testing.T, loader *fakeFileLoader, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if loader.loadCount() >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("file loads = %d, want %d", loader.loadCount(), want)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -46,14 +46,26 @@ const (
 	// origin, so every byte egresses from the API server; with it the plan may
 	// hand out credential-free proxy origins and distributed egress is restored.
 	FeatureAuthorizedMediaOriginsV3 = "authorized_media_origins_v1"
-	PlanRecipeVersionV3             = "v3.4"
-	ClientDV7ToDV81V3               = "client_dv7_to_dv81"
-	ClientDV7ToHDR10V3              = "client_dv7_to_hdr10"
-	ClientDVTransformVersionV3      = "1"
-	ClientDV8HDR10PlusSanitizerV3   = "client_dv8_hdr10plus_sanitizer_v1"
-	ClientPostResumeRecoveryV3      = "client_post_resume_video_recovery_v1"
-	ClientSurfaceRecoveryV3         = "client_surface_recovery_v1"
-	DeviceQuirkRegistryRevisionV3   = "2026-07-13.1"
+	// FeaturePlanInvalidatedV3 is the client's promise to handle the realtime
+	// plan_invalidated command: ack it, replan off the named plan with operation
+	// failure_recovery and the invalidated plan's attempt key in
+	// attempted_plan_keys, then report the result.
+	//
+	// It exists because the server may only learn a route is wrong after the
+	// plan is already playing — the H.264 copy-safety scan now runs
+	// asynchronously so playback never waits on it. A session that did not
+	// negotiate the token, or has no realtime connection, is stopped instead;
+	// the client's ordinary recovery then mints a fresh attempt that plans
+	// against the now-persisted verdict.
+	FeaturePlanInvalidatedV3      = "plan_invalidated_v1"
+	PlanRecipeVersionV3           = "v3.4"
+	ClientDV7ToDV81V3             = "client_dv7_to_dv81"
+	ClientDV7ToHDR10V3            = "client_dv7_to_hdr10"
+	ClientDVTransformVersionV3    = "1"
+	ClientDV8HDR10PlusSanitizerV3 = "client_dv8_hdr10plus_sanitizer_v1"
+	ClientPostResumeRecoveryV3    = "client_post_resume_video_recovery_v1"
+	ClientSurfaceRecoveryV3       = "client_surface_recovery_v1"
+	DeviceQuirkRegistryRevisionV3 = "2026-07-13.1"
 )
 
 // ServerFeaturesV3 returns the complete feature set advertised by protocol-v3
@@ -72,6 +84,7 @@ func ServerFeaturesV3() []string {
 		FeatureHeaderAuthenticatedMediaV3,
 		FeatureAuthorizedMediaOriginsV3,
 		FeatureSoftwareVideoDecodeV3,
+		FeaturePlanInvalidatedV3,
 		// Advertised so a client can tell "this server does not populate
 		// source.duration_seconds" apart from "this server knows the runtime
 		// is genuinely unknown". Without the distinction both look like an

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -33,6 +34,7 @@ func TestServerFeaturesV3ReturnsCompleteIndependentSlices(t *testing.T) {
 		FeatureHeaderAuthenticatedMediaV3: {},
 		FeatureAuthorizedMediaOriginsV3:   {},
 		FeatureSoftwareVideoDecodeV3:      {},
+		FeaturePlanInvalidatedV3:          {},
 		FeaturePlanSourceDurationV3:       {},
 	}
 	if len(first) != len(expected) {
@@ -1104,6 +1106,23 @@ func TestPlanPlaybackV3CopySafeSourceStillCopies(t *testing.T) {
 	}
 }
 
+// An unresolved verdict plans optimistically. Playback no longer waits on the
+// multi-second bitstream scan, so "not scanned yet" must read as "copy is
+// allowed"; the scan runs behind the issued plan and CopySafetyNotifier moves
+// the session off this route if it comes back multi-PPS.
+func TestPlanPlaybackV3UnknownCopySafetyStillCopies(t *testing.T) {
+	file, req := copyUnsafeFixtureV3(false)
+	file.VideoTracks[0].MultiplePPS = nil
+
+	result := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3()})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	if result.Plan.Source.VideoCopyUnsafe {
+		t.Fatal("source.video_copy_unsafe = true for an unresolved verdict, want false")
+	}
+}
+
 func TestPlanPlaybackV3FallsBackFromProgressiveToHLSWithoutRepeatingKey(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].VideoRange = "SDR"
@@ -1126,6 +1145,52 @@ func TestPlanPlaybackV3FallsBackFromProgressiveToHLSWithoutRepeatingKey(t *testi
 	third := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3(), AttemptedKeys: []string{failedKey, secondKey}})
 	if third.Plan == nil || third.Plan.Delivery != DeliveryTranscodeHLSV3 || third.Plan.DecisionReason != "copy_routes_exhausted" {
 		t.Fatalf("third = %#v", third)
+	}
+}
+
+// The copy-safety verdict has to be readable from the row alone. The track
+// flags are stamped by the probe ensurer, which the replan path and the
+// Jellyfin-protocol route decision never run; without this the replan a
+// plan_invalidated command triggers would just walk to the sibling stream-copy
+// delivery, which is broken for exactly the same reason.
+func TestPlanPlaybackV3HonorsThePersistedCopySafetyVerdict(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.VideoTracks[0].ColorTransfer = "bt709"
+	req := validStartRequestV3()
+	req.Capabilities.Containers = []string{"mp4"}
+	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
+	req.Capabilities.HDRDetails = &HDRCapabilitiesV3{HDR10: true}
+
+	// Only the persisted columns carry the verdict, exactly as a raw repository
+	// read delivers them.
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	multi := true
+	scanSize := file.FileSize
+	file.FileModifiedAt = &mtime
+	file.MultiplePPS = &multi
+	file.MultiplePPSScanSize = &scanSize
+	file.MultiplePPSScanMtime = &mtime
+	if file.VideoTracks[0].MultiplePPS != nil || file.VideoTracks[0].VideoCopyUnsafe {
+		t.Fatal("fixture already carries the runtime copy-safety flags; the test would prove nothing")
+	}
+
+	result := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3()})
+	if result.Plan == nil {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	switch result.Plan.Delivery {
+	case DeliveryRemuxProgressiveV3, DeliveryRemuxHLSV3:
+		t.Fatalf("delivery = %q, want a route that does not stream-copy a copy-unsafe source", result.Plan.Delivery)
+	}
+
+	// A stale verdict (the file was rewritten) must not be honored.
+	staleSize := file.FileSize + 1
+	file.MultiplePPSScanSize = &staleSize
+	stale := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3()})
+	if stale.Plan == nil || stale.Plan.Delivery != DeliveryRemuxProgressiveV3 {
+		t.Fatalf("stale verdict = %s, want the ordinary remux back", ExplainPlannerResultV3(stale))
 	}
 }
 

--- a/internal/playback/realtime.go
+++ b/internal/playback/realtime.go
@@ -57,6 +57,13 @@ const (
 	CommandPlayMedia          CommandName = "play_media"
 	CommandSetAudioTrack      CommandName = "set_audio_track"
 	CommandSetSubtitleTrack   CommandName = "set_subtitle_track"
+	// CommandPlanInvalidated tells a playing client that the plan it is running
+	// can no longer serve this source, so it must replan off that plan. It is
+	// the first server-initiated control push in the v3 protocol, and it is only
+	// sent to a session whose attempt negotiated FeaturePlanInvalidatedV3 and
+	// which has a live realtime connection; every other session is stopped
+	// instead. See CopySafetyNotifier.
+	CommandPlanInvalidated CommandName = "plan_invalidated"
 )
 
 var supportedCommandNames = []CommandName{
@@ -73,6 +80,7 @@ var supportedCommandNames = []CommandName{
 	CommandPlayMedia,
 	CommandSetAudioTrack,
 	CommandSetSubtitleTrack,
+	CommandPlanInvalidated,
 }
 
 var supportedCommandNameSet = func() map[CommandName]struct{} {
@@ -397,6 +405,36 @@ type CommandEnvelope struct {
 // CommandIssuedBy identifies the source of a command.
 type CommandIssuedBy struct {
 	Kind string `json:"kind"`
+}
+
+// PlanInvalidationReason values a plan_invalidated command can carry.
+const (
+	// PlanInvalidatedVideoCopyUnsafe means the asynchronous H.264 copy-safety
+	// scan came back multi-PPS after the plan was already playing, so the video
+	// stream-copy route it named cannot serve this source.
+	PlanInvalidatedVideoCopyUnsafe = "video_copy_unsafe"
+)
+
+// PlanInvalidatedPayload names the plan the server withdrew and why.
+//
+// PlanID is required: the client compares it against the plan it is running and
+// does nothing when it has already replanned past it, so a late command can
+// never evict a route the server never complained about.
+type PlanInvalidatedPayload struct {
+	Reason string `json:"reason"`
+	PlanID string `json:"plan_id"`
+}
+
+// NewPlanInvalidatedCommand builds a validated plan_invalidated command.
+func NewPlanInvalidatedCommand(sessionID, commandID, planID, reason string) (CommandEnvelope, error) {
+	if planID == "" || reason == "" {
+		return CommandEnvelope{}, ErrInvalidRealtimePayload
+	}
+	payload, err := json.Marshal(PlanInvalidatedPayload{Reason: reason, PlanID: planID})
+	if err != nil {
+		return CommandEnvelope{}, err
+	}
+	return NewCommandEnvelope(sessionID, commandID, CommandPlanInvalidated, payload)
 }
 
 // NewCommandEnvelope creates a validated command envelope.

--- a/internal/playback/realtime_test.go
+++ b/internal/playback/realtime_test.go
@@ -85,3 +85,45 @@ func TestParseCommandEnvelopeStillWorks(t *testing.T) {
 		t.Fatalf("command.Name = %q, want %q", command.Name, CommandPause)
 	}
 }
+
+func TestNewPlanInvalidatedCommand(t *testing.T) {
+	command, err := NewPlanInvalidatedCommand("session-1", "cmd-1", "plan-1", PlanInvalidatedVideoCopyUnsafe)
+	if err != nil {
+		t.Fatalf("NewPlanInvalidatedCommand() error = %v", err)
+	}
+	if command.Type != RealtimeMessageTypeCommand || command.Name != CommandPlanInvalidated {
+		t.Fatalf("command = %#v, want a plan_invalidated command envelope", command)
+	}
+	var payload PlanInvalidatedPayload
+	if err := json.Unmarshal(command.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(payload): %v", err)
+	}
+	if payload.PlanID != "plan-1" || payload.Reason != PlanInvalidatedVideoCopyUnsafe {
+		t.Fatalf("payload = %#v, want the invalidated plan and reason", payload)
+	}
+}
+
+// The plan id is what lets a client ignore a command for a plan it has already
+// replanned past, so an envelope without one must never be built.
+func TestNewPlanInvalidatedCommandRequiresPlanAndReason(t *testing.T) {
+	if _, err := NewPlanInvalidatedCommand("session-1", "cmd-1", "", PlanInvalidatedVideoCopyUnsafe); err == nil {
+		t.Fatal("NewPlanInvalidatedCommand() with no plan id = nil error, want a rejection")
+	}
+	if _, err := NewPlanInvalidatedCommand("session-1", "cmd-1", "plan-1", ""); err == nil {
+		t.Fatal("NewPlanInvalidatedCommand() with no reason = nil error, want a rejection")
+	}
+}
+
+// A client advertising the command in its hello must validate: the closed
+// command enum is the negotiation surface for the realtime channel.
+func TestHelloAcceptsPlanInvalidatedCapability(t *testing.T) {
+	hello := HelloEnvelope{
+		Type:         RealtimeMessageTypeHello,
+		SessionID:    "session-1",
+		Client:       HelloClientInfo{Name: "silo-web", Version: "1.0.0"},
+		Capabilities: HelloCapabilities{Commands: []CommandName{CommandPause, CommandPlanInvalidated}},
+	}
+	if err := hello.Validate(); err != nil {
+		t.Fatalf("hello.Validate() = %v, want the plan_invalidated capability accepted", err)
+	}
+}

--- a/internal/playback/recipecard.go
+++ b/internal/playback/recipecard.go
@@ -1,6 +1,7 @@
 package playback
 
 import (
+	"strings"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/streamtoken"
@@ -159,6 +160,18 @@ func NewRemuxRecipeCard(sessionID string, userID int, profileID string, mediaFil
 		RemuxDVMode:     mode,
 		AudioTrackIndex: audioTrackIndex,
 	}
+}
+
+// VideoStreamCopy reports whether this recipe delivers the source video
+// bitstream without re-encoding it: a progressive remux, or an HLS transport
+// whose video target was pinned to an explicit copy. Those are exactly the
+// routes an H.264 multi-PPS verdict disqualifies — a real transcode re-encodes
+// the bitstream and is unaffected by conflicting in-band parameter sets.
+func (c RecipeCard) VideoStreamCopy() bool {
+	if c.PlayMethod == PlayRemux {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(c.TargetCodecVideo), "copy")
 }
 
 // TranscodeOpts rebuilds the encode parameters for a reconstruct. outputDir,

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -328,6 +328,20 @@ func (s *RemuxSession) Read(p []byte) (int, error) {
 	return s.outputPipe.Read(p)
 }
 
+// Abort kills the ffmpeg process without draining or reaping it.
+//
+// It exists for callers that are not the owner of the session: killing ffmpeg
+// closes the output pipe, which is what unblocks a copy loop parked in Read, and
+// the owner's deferred Close then does the draining and the wait. Close itself
+// cannot be used for that — it reads the pipe and calls cmd.Wait, neither of
+// which may run concurrently with the owner's Read.
+func (s *RemuxSession) Abort() {
+	if s == nil || s.cancel == nil {
+		return
+	}
+	s.cancel()
+}
+
 // Close stops the ffmpeg process and cleans up all resources.
 // It is safe to call Close multiple times.
 func (s *RemuxSession) Close() error {
@@ -370,6 +384,12 @@ type RemuxServeOptions struct {
 	// output. Zero values retain the historical stereo 192 kbps behavior.
 	TargetAudioChannels    int
 	TargetAudioBitrateKbps int
+	// Abort ends the response early when it is closed. A progressive remux is
+	// one long response, so without it the only thing that can stop the stream
+	// is the client itself — a server-initiated session stop cannot withdraw a
+	// route the client is still being fed. Callers that serve a session pass
+	// SessionManager.WatchTransportStop's channel.
+	Abort <-chan struct{}
 }
 
 // RemuxContentType returns the override required for an audio-only fMP4.
@@ -420,6 +440,20 @@ func ServeRemuxWithOptions(w http.ResponseWriter, r *http.Request, filePath, out
 		return err
 	}
 	defer session.Close()
+
+	if opts.Abort != nil {
+		// Deferred after session.Close, so it runs before it: the watcher is
+		// gone by the time the owner drains and reaps the process.
+		served := make(chan struct{})
+		defer close(served)
+		go func() {
+			select {
+			case <-opts.Abort:
+				session.Abort()
+			case <-served:
+			}
+		}()
+	}
 
 	contentType := opts.ContentType
 	if contentType == "" {

--- a/internal/playback/resolver.go
+++ b/internal/playback/resolver.go
@@ -246,10 +246,21 @@ func containsStr(slice []string, s string) bool {
 // bitstream scan (H.264 sources that redefine a pic_parameter_set_id in-band
 // with conflicting content). Scan failures also disable copy for the current
 // decision while remaining eligible for retry on a later request.
+//
+// The track flags are runtime-only: they are stamped by the probe ensurer,
+// which only the playback start path and the watch surfaces run. The verdict
+// persisted on the media_files row carries the same answer and is present on
+// every repository read, so it is honored directly — a replan, a
+// Jellyfin-protocol route decision, and a fresh start must all reach the same
+// conclusion about the same file.
 func videoCopyUnsafeFile(file *models.MediaFile) bool {
 	if file == nil || len(file.VideoTracks) == 0 {
 		return false
 	}
 	track := file.VideoTracks[0]
-	return track.VideoCopyUnsafe || (track.MultiplePPS != nil && *track.MultiplePPS)
+	if track.VideoCopyUnsafe || (track.MultiplePPS != nil && *track.MultiplePPS) {
+		return true
+	}
+	multi, known := file.PersistedVideoCopyVerdict()
+	return known && multi
 }

--- a/internal/playback/session.go
+++ b/internal/playback/session.go
@@ -1285,6 +1285,13 @@ func (m *SessionManager) EndTransport(sessionID string) error {
 // do not need it: each of their requests is short, and the next one is refused
 // once the session is gone.
 //
+// A session that is already gone yields an immediately-closed channel. The stop
+// that removed it has run and will never run again, so a watcher registered
+// after it would be closed by nobody: the caller's BeginTransport can succeed
+// and the session be stopped before the registration lands, and the progressive
+// remux that hole leaves behind runs to EOF serving bytes the server disowned.
+// Reporting the stop it missed collapses that race into the ordinary path.
+//
 // The channel is closed at most once: StopSession takes the whole watcher set
 // out of the map under the lock before closing it, and release drops a watcher
 // that was never signaled.
@@ -1295,6 +1302,11 @@ func (m *SessionManager) WatchTransportStop(sessionID string) (<-chan struct{}, 
 
 	stop := make(chan struct{})
 	m.mu.Lock()
+	if _, live := m.sessions[sessionID]; !live {
+		m.mu.Unlock()
+		close(stop)
+		return stop, func() {}
+	}
 	if m.transportStops == nil {
 		m.transportStops = make(map[string]map[chan struct{}]struct{})
 	}

--- a/internal/playback/session.go
+++ b/internal/playback/session.go
@@ -257,6 +257,9 @@ type SessionManager struct {
 	activeGrace      time.Duration
 	pausedGrace      time.Duration
 	expireHook       func(*Session)
+	// transportStops holds the stop channels of media transports this replica
+	// is currently serving, keyed by session ID. See WatchTransportStop.
+	transportStops map[string]map[chan struct{}]struct{}
 }
 
 // SessionLimits stores per-user admission limits. Zero values mean unlimited.
@@ -1270,7 +1273,75 @@ func (m *SessionManager) EndTransport(sessionID string) error {
 	return nil
 }
 
-// StopSession removes a session from the manager.
+// WatchTransportStop returns a channel that is closed when the session is
+// stopped, and the release the caller must run when its transport ends.
+//
+// A progressive remux is a single HTTP response whose ffmpeg is owned by the
+// serving handler and canceled only by that request's context, so removing the
+// session from this manager does not reach it: an unnegotiated client would go
+// on consuming a stream the server has already disowned — for a copy-unsafe
+// source, corrupt bytes its decoder cannot recover from. This is the smallest
+// handle that lets a stop interrupt one. Segmented transports (HLS, transcode)
+// do not need it: each of their requests is short, and the next one is refused
+// once the session is gone.
+//
+// The channel is closed at most once: StopSession takes the whole watcher set
+// out of the map under the lock before closing it, and release drops a watcher
+// that was never signaled.
+func (m *SessionManager) WatchTransportStop(sessionID string) (<-chan struct{}, func()) {
+	if m == nil || sessionID == "" {
+		return nil, func() {}
+	}
+
+	stop := make(chan struct{})
+	m.mu.Lock()
+	if m.transportStops == nil {
+		m.transportStops = make(map[string]map[chan struct{}]struct{})
+	}
+	watchers, ok := m.transportStops[sessionID]
+	if !ok {
+		watchers = make(map[chan struct{}]struct{})
+		m.transportStops[sessionID] = watchers
+	}
+	watchers[stop] = struct{}{}
+	m.mu.Unlock()
+
+	var once sync.Once
+	return stop, func() {
+		once.Do(func() { m.releaseTransportStop(sessionID, stop) })
+	}
+}
+
+func (m *SessionManager) releaseTransportStop(sessionID string, stop chan struct{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	watchers, ok := m.transportStops[sessionID]
+	if !ok {
+		return
+	}
+	delete(watchers, stop)
+	if len(watchers) == 0 {
+		delete(m.transportStops, sessionID)
+	}
+}
+
+// stopTransportsLocked signals every transport registered for the session. The
+// close is cheap and never blocks, and the watchers it wakes cancel an ffmpeg
+// rather than calling back into the manager, so it is safe to do under the lock.
+func (m *SessionManager) stopTransportsLocked(sessionID string) {
+	watchers, ok := m.transportStops[sessionID]
+	if !ok {
+		return
+	}
+	delete(m.transportStops, sessionID)
+	for stop := range watchers {
+		close(stop)
+	}
+}
+
+// StopSession removes a session from the manager and interrupts any media
+// transport it is still serving.
 func (m *SessionManager) StopSession(sessionID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1280,6 +1351,7 @@ func (m *SessionManager) StopSession(sessionID string) error {
 	}
 
 	delete(m.sessions, sessionID)
+	m.stopTransportsLocked(sessionID)
 	return nil
 }
 

--- a/internal/playback/testdata/protocol_v3/capability_response.json
+++ b/internal/playback/testdata/protocol_v3/capability_response.json
@@ -15,6 +15,7 @@
     "header_authenticated_media_v1",
     "authorized_media_origins_v1",
     "software_video_decode_v1",
+    "plan_invalidated_v1",
     "plan_source_duration_v1"
   ],
   "deliveries": [

--- a/internal/playback/testdata/protocol_v3/conformance_matrix.json
+++ b/internal/playback/testdata/protocol_v3/conformance_matrix.json
@@ -5411,6 +5411,7 @@
             "header_authenticated_media_v1",
             "authorized_media_origins_v1",
             "software_video_decode_v1",
+            "plan_invalidated_v1",
             "plan_source_duration_v1"
           ],
           "outcome": "adaptation_unavailable",

--- a/internal/playback/testdata/protocol_v3/decision_response.json
+++ b/internal/playback/testdata/protocol_v3/decision_response.json
@@ -12,6 +12,7 @@
     "header_authenticated_media_v1",
     "authorized_media_origins_v1",
     "software_video_decode_v1",
+    "plan_invalidated_v1",
     "plan_source_duration_v1"
   ],
   "outcome": "playable",

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -348,15 +348,27 @@ const (
 // no shared per-session store to fall back on — so a not-found session with a nil
 // card is a genuine miss.
 func (m *TranscodeManager) LoadOrReconstructSession(ctx context.Context, getSession func(string) (*Session, error), sessionID string, requestUserID int, card *RecipeCard) (*Session, SessionLoadStatus) {
+	session, status, _ := m.LoadOrReconstructSessionDetail(ctx, getSession, sessionID, requestUserID, card)
+	return session, status
+}
+
+// LoadOrReconstructSessionDetail is LoadOrReconstructSession plus whether the
+// session it returned was rebuilt from the card rather than found live.
+//
+// A handler needs the distinction when the card pins a route that may have been
+// withdrawn since it was signed: a live session was already re-decided by
+// whatever withdrew it, while a reconstruction replays the recipe verbatim and
+// has to re-check it. See the copy-safety refusal on the stream serve path.
+func (m *TranscodeManager) LoadOrReconstructSessionDetail(ctx context.Context, getSession func(string) (*Session, error), sessionID string, requestUserID int, card *RecipeCard) (*Session, SessionLoadStatus, bool) {
 	session, err := getSession(sessionID)
 	if err != nil {
 		if !errors.Is(err, ErrSessionNotFound) {
-			return nil, SessionLoadFailed
+			return nil, SessionLoadFailed, false
 		}
 		// A nil manager (documented optional on StreamHandler) cannot reconstruct,
 		// so a missing session is simply not-found rather than a panic.
 		if m == nil || card == nil {
-			return nil, SessionMissing
+			return nil, SessionMissing, false
 		}
 		// Lost the in-memory session (e.g. restart): rebuild it from the token's
 		// recipe. ReconstructSession re-binds the session to the card owner and
@@ -364,9 +376,9 @@ func (m *TranscodeManager) LoadOrReconstructSession(ctx context.Context, getSess
 		// the authless bearer routes), so a nil result here is a genuine not-found.
 		session = m.ReconstructSession(ctx, sessionID, requestUserID, *card)
 		if session == nil {
-			return nil, SessionMissing
+			return nil, SessionMissing, false
 		}
-		return session, SessionLoaded
+		return session, SessionLoaded, true
 	}
 	// Live session: enforce the existing ownership check. A zero caller is
 	// allowed (these routes treat the session UUID as a bearer when auth is
@@ -379,12 +391,12 @@ func (m *TranscodeManager) LoadOrReconstructSession(ctx context.Context, getSess
 	// negotiated the mode (legacy v3 and jellycompat alike) keep the bearer
 	// behavior unchanged.
 	if requestUserID == 0 && session.RequireMediaAuthorization {
-		return nil, SessionUnauthorized
+		return nil, SessionUnauthorized, false
 	}
 	if requestUserID != 0 && session.UserID != requestUserID {
-		return nil, SessionForbidden
+		return nil, SessionForbidden, false
 	}
-	return session, SessionLoaded
+	return session, SessionLoaded, false
 }
 
 // ReconstructSession rebuilds the in-memory playback Session from a persisted

--- a/internal/playback/transport_stop_test.go
+++ b/internal/playback/transport_stop_test.go
@@ -167,6 +167,43 @@ func TestWatchTransportStopSignalsEveryTransport(t *testing.T) {
 	}
 }
 
+// The serving handler calls BeginTransport and WatchTransportStop as two
+// separate steps. A stop landing between them used to register a watcher under
+// an id nothing would ever signal again, and the progressive remux it guarded
+// ran to EOF serving a route the server had already withdrawn. A watch for a
+// session that is already gone reports the stop it missed.
+func TestWatchTransportStopAfterStopSessionIsAlreadyClosed(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if err := sessions.BeginTransport(session.ID); err != nil {
+		t.Fatalf("BeginTransport: %v", err)
+	}
+	if err := sessions.StopSession(session.ID); err != nil {
+		t.Fatalf("StopSession: %v", err)
+	}
+
+	stop, release := sessions.WatchTransportStop(session.ID)
+	select {
+	case <-stop:
+	default:
+		t.Fatal("a transport registered after its session was stopped was left waiting for a signal that can never come")
+	}
+
+	// The release is a no-op for a watcher that was never registered, and must
+	// stay safe to call from the serving handler's defer.
+	release()
+	release()
+	sessions.mu.RLock()
+	remaining := len(sessions.transportStops)
+	sessions.mu.RUnlock()
+	if remaining != 0 {
+		t.Fatalf("transportStops holds %d sessions, want 0", remaining)
+	}
+}
+
 // A transport that finished normally unregisters itself, so a later stop for
 // the same session ID has nothing to signal and nothing to leak.
 func TestWatchTransportStopReleaseUnregisters(t *testing.T) {

--- a/internal/playback/transport_stop_test.go
+++ b/internal/playback/transport_stop_test.go
@@ -1,0 +1,196 @@
+package playback
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// countingResponseWriter discards a streamed body and reports how much of it
+// has been written, which is how a test observes that bytes are flowing without
+// buffering a stream that never ends.
+type countingResponseWriter struct {
+	mu      sync.Mutex
+	header  http.Header
+	written int64
+}
+
+func (w *countingResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+	return w.header
+}
+
+func (w *countingResponseWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.written += int64(len(p))
+	w.mu.Unlock()
+	return len(p), nil
+}
+
+func (w *countingResponseWriter) WriteHeader(int) {}
+
+func (w *countingResponseWriter) bytesWritten() int64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.written
+}
+
+// streamingFakeFFmpegScript stands in for a remux: it writes to stdout forever
+// and only ever stops when it is killed. Capability probes (`-bsfs`) answer
+// immediately instead, so the serve path is not blocked before it starts.
+func streamingFakeFFmpegScript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ffmpeg")
+	script := "#!/bin/sh\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$arg\" = \"pipe:1\" ]; then\n" +
+		"    while :; do printf '0123456789'; sleep 0.01; done\n" +
+		"  fi\n" +
+		"done\n" +
+		"exit 0\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func waitForBytes(t *testing.T, w *countingResponseWriter) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for w.bytesWritten() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("no remux bytes reached the response")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// A progressive remux is one long response whose ffmpeg belongs to the request
+// that started it. Withdrawing the route — a copy-safety verdict, an admin kill
+// — only reaches the client if the stop can end the response itself.
+func TestServeRemuxAbortEndsTheResponse(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(source, []byte("not really a movie"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	abort := make(chan struct{})
+	recorder := &countingResponseWriter{}
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/stream/session-1", nil)
+
+	served := make(chan error, 1)
+	go func() {
+		served <- ServeRemuxWithOptions(recorder, request, source, "mp4", 0, false, 0, 0, RemuxServeOptions{
+			FFmpegPath: streamingFakeFFmpegScript(t),
+			Abort:      abort,
+		})
+	}()
+
+	waitForBytes(t, recorder)
+	select {
+	case err := <-served:
+		t.Fatalf("the remux response ended on its own: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(abort)
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Fatalf("ServeRemuxWithOptions after abort = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the remux response outlived the stop that withdrew its session")
+	}
+}
+
+func TestWatchTransportStopSignalsOnStopSession(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	stop, release := sessions.WatchTransportStop(session.ID)
+	defer release()
+
+	select {
+	case <-stop:
+		t.Fatal("the transport was signaled while its session was still live")
+	default:
+	}
+
+	if err := sessions.StopSession(session.ID); err != nil {
+		t.Fatalf("StopSession: %v", err)
+	}
+	select {
+	case <-stop:
+	case <-time.After(time.Second):
+		t.Fatal("stopping the session did not signal its in-flight transport")
+	}
+
+	// A stop that already signaled must not be signaled again by the release
+	// the serving handler runs on its way out; a second close would panic.
+	release()
+	release()
+}
+
+// Two transports can share a session — a client that reconnects while the old
+// response is still draining — and a stop has to end both.
+func TestWatchTransportStopSignalsEveryTransport(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	first, releaseFirst := sessions.WatchTransportStop(session.ID)
+	defer releaseFirst()
+	second, releaseSecond := sessions.WatchTransportStop(session.ID)
+	defer releaseSecond()
+
+	if err := sessions.StopSession(session.ID); err != nil {
+		t.Fatalf("StopSession: %v", err)
+	}
+	for i, stop := range []<-chan struct{}{first, second} {
+		select {
+		case <-stop:
+		case <-time.After(time.Second):
+			t.Fatalf("transport %d was left streaming after its session was stopped", i)
+		}
+	}
+}
+
+// A transport that finished normally unregisters itself, so a later stop for
+// the same session ID has nothing to signal and nothing to leak.
+func TestWatchTransportStopReleaseUnregisters(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, err := sessions.StartSession(1, "profile-1", 100, PlayRemux, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+
+	stop, release := sessions.WatchTransportStop(session.ID)
+	release()
+
+	if err := sessions.StopSession(session.ID); err != nil {
+		t.Fatalf("StopSession: %v", err)
+	}
+	select {
+	case <-stop:
+		t.Fatal("a released transport was signaled")
+	default:
+	}
+	sessions.mu.RLock()
+	remaining := len(sessions.transportStops)
+	sessions.mu.RUnlock()
+	if remaining != 0 {
+		t.Fatalf("transportStops holds %d sessions, want 0", remaining)
+	}
+}

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -1182,12 +1182,13 @@ func (r *FileRepository) SetChapterThumbnailFailure(
 
 // UpdateMultiplePPS records the H.264 multi-PPS copy-safety verdict together
 // with the size and mtime it was computed from, so a later read can tell
-// whether the file has been rewritten since.
+// whether the file has been rewritten since. A nil scanMtime records a verdict
+// for a row that has no file mtime; reading it back validates on size alone.
 //
 // It deliberately does not go through Upsert: that path also clears
 // match_suppressed_at and missing_since, which a copy-safety scan has no
 // business touching.
-func (r *FileRepository) UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error {
+func (r *FileRepository) UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime *time.Time) error {
 	tag, err := r.pool.Exec(ctx, `
 		UPDATE media_files
 		SET multiple_pps = $2,

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -59,6 +59,7 @@ const fileColumns = `id, content_id, episode_id, extra_id, season_number, episod
 	edition_raw, edition_key, edition_confidence, edition_source,
 	presentation_kind, presentation_group_key, presentation_part_index, presentation_part_total,
 	multi_episode_start, multi_episode_end,
+	multiple_pps, multiple_pps_scan_size, multiple_pps_scan_mtime,
 	probe_source, probe_updated_at, match_attempted_at, missing_since, created_at, updated_at`
 
 const overlayFileColumns = `content_id, episode_id, media_folder_id, file_path,
@@ -82,6 +83,7 @@ const mfFileColumns = `mf.id, mf.content_id, mf.episode_id, mf.extra_id, mf.seas
 	mf.edition_raw, mf.edition_key, mf.edition_confidence, mf.edition_source,
 	mf.presentation_kind, mf.presentation_group_key, mf.presentation_part_index, mf.presentation_part_total,
 	mf.multi_episode_start, mf.multi_episode_end,
+	mf.multiple_pps, mf.multiple_pps_scan_size, mf.multiple_pps_scan_mtime,
 	mf.probe_source, mf.probe_updated_at, mf.match_attempted_at, mf.missing_since, mf.created_at, mf.updated_at`
 
 // scanMediaFile scans a single row into a *models.MediaFile.
@@ -196,6 +198,9 @@ func scanMediaFile(row pgx.Row) (*models.MediaFile, error) {
 		&presentationPartTotal,
 		&multiEpisodeStart,
 		&multiEpisodeEnd,
+		&f.MultiplePPS,
+		&f.MultiplePPSScanSize,
+		&f.MultiplePPSScanMtime,
 		&probeSource,
 		&f.ProbeUpdatedAt,
 		&f.MatchAttemptedAt,
@@ -506,6 +511,9 @@ func scanMediaFiles(rows pgx.Rows) ([]*models.MediaFile, error) {
 			&presentationPartTotal,
 			&multiEpisodeStart,
 			&multiEpisodeEnd,
+			&f.MultiplePPS,
+			&f.MultiplePPSScanSize,
+			&f.MultiplePPSScanMtime,
 			&probeSource,
 			&f.ProbeUpdatedAt,
 			&f.MatchAttemptedAt,
@@ -1165,6 +1173,35 @@ func (r *FileRepository) SetChapterThumbnailFailure(
 	)
 	if err != nil {
 		return fmt.Errorf("updating chapter thumbnail failure state: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrFileNotFound
+	}
+	return nil
+}
+
+// UpdateMultiplePPS records the H.264 multi-PPS copy-safety verdict together
+// with the size and mtime it was computed from, so a later read can tell
+// whether the file has been rewritten since.
+//
+// It deliberately does not go through Upsert: that path also clears
+// match_suppressed_at and missing_since, which a copy-safety scan has no
+// business touching.
+func (r *FileRepository) UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE media_files
+		SET multiple_pps = $2,
+		    multiple_pps_scan_size = $3,
+		    multiple_pps_scan_mtime = $4,
+		    updated_at = NOW()
+		WHERE id = $1`,
+		fileID,
+		multiplePPS,
+		scanSize,
+		scanMtime,
+	)
+	if err != nil {
+		return fmt.Errorf("updating multiple pps verdict: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
 		return ErrFileNotFound

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -20,6 +20,12 @@ import (
 // Sentinel errors for file repository operations.
 var (
 	ErrFileNotFound = errors.New("media file not found")
+	// ErrStaleCopySafetyScan reports that a multi-PPS verdict was computed from
+	// a generation of the file the row no longer holds — it was rewritten (or
+	// removed) while the scan ran. The verdict is not wrong, it just describes
+	// bytes nobody is serving any more, so it must not overwrite the row and
+	// must not be pushed at live sessions.
+	ErrStaleCopySafetyScan = errors.New("copy-safety verdict superseded by a newer generation of the file")
 )
 
 // FileRepository provides CRUD operations for the media_files table.
@@ -1188,24 +1194,49 @@ func (r *FileRepository) SetChapterThumbnailFailure(
 // It deliberately does not go through Upsert: that path also clears
 // match_suppressed_at and missing_since, which a copy-safety scan has no
 // business touching.
+//
+// The write is conditional on the row still holding the generation that was
+// scanned. A scan reads the opening seconds of a file over storage that can be
+// slow, so an old-generation scan finishing late would otherwise stamp its
+// verdict — and its stale size and mtime — over the replacement generation's,
+// re-validating a verdict for bytes that are gone and condemning (or clearing
+// the condemnation of) a file nobody scanned. A superseded write reports
+// ErrStaleCopySafetyScan rather than succeeding silently, because the caller
+// must also refrain from notifying live sessions on the strength of it.
+//
+// Both sides of the mtime predicate are normalized to microseconds, exactly as
+// MediaFile.PersistedVideoCopyVerdict normalizes them when it reads the verdict
+// back: Postgres stores timestamptz at microsecond resolution while a
+// filesystem mtime carries nanoseconds, so comparing the raw values would make
+// every write for a row whose mtime came from a stat call fail.
 func (r *FileRepository) UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime *time.Time) error {
+	var normalizedMtime *time.Time
+	if scanMtime != nil {
+		normalized := models.NormalizeFileModifiedAt(*scanMtime)
+		normalizedMtime = &normalized
+	}
 	tag, err := r.pool.Exec(ctx, `
 		UPDATE media_files
 		SET multiple_pps = $2,
 		    multiple_pps_scan_size = $3,
 		    multiple_pps_scan_mtime = $4,
 		    updated_at = NOW()
-		WHERE id = $1`,
+		WHERE id = $1
+		  AND file_size = $3
+		  AND date_trunc('microseconds', file_modified_at) IS NOT DISTINCT FROM $4::timestamptz`,
 		fileID,
 		multiplePPS,
 		scanSize,
-		scanMtime,
+		normalizedMtime,
 	)
 	if err != nil {
 		return fmt.Errorf("updating multiple pps verdict: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return ErrFileNotFound
+		// The row is gone, or it no longer carries the size and mtime that were
+		// scanned. Both mean the same thing to every caller: this verdict does
+		// not describe the file as it stands.
+		return ErrStaleCopySafetyScan
 	}
 	return nil
 }

--- a/internal/scanner/file_repo_copy_safety_db_test.go
+++ b/internal/scanner/file_repo_copy_safety_db_test.go
@@ -1,0 +1,142 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// copySafetyTestRow inserts one media_files row with a known size and mtime and
+// returns its ID. The row is torn down with the test.
+func copySafetyTestRow(t *testing.T, ctx context.Context, pool *pgxpool.Pool, size int64, mtime *time.Time) int {
+	t.Helper()
+
+	suffix := time.Now().UnixNano()
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled) VALUES ('movies', $1, true) RETURNING id`,
+		fmt.Sprintf("PPS Test %d", suffix),
+	).Scan(&folderID); err != nil {
+		t.Fatalf("insert media folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	var fileID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_files (content_id, media_folder_id, file_path, file_size, file_modified_at)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		fmt.Sprintf("pps-content-%d", suffix),
+		folderID,
+		fmt.Sprintf("/tmp/pps-%d/Movie (2020)/Movie (2020).mkv", suffix),
+		size,
+		mtime,
+	).Scan(&fileID); err != nil {
+		t.Fatalf("insert media file: %v", err)
+	}
+	return fileID
+}
+
+func readCopySafetyRow(t *testing.T, ctx context.Context, pool *pgxpool.Pool, fileID int) (*bool, *int64, *time.Time) {
+	t.Helper()
+	var multi *bool
+	var size *int64
+	var mtime *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT multiple_pps, multiple_pps_scan_size, multiple_pps_scan_mtime
+		FROM media_files WHERE id = $1`, fileID).Scan(&multi, &size, &mtime); err != nil {
+		t.Fatalf("read verdict: %v", err)
+	}
+	return multi, size, mtime
+}
+
+// UpdateMultiplePPS is the one write that has to be generation-guarded. A scan
+// reads the opening seconds of a file over storage that can be slow, so a file
+// rewritten in place while the scan runs would otherwise have the old verdict —
+// and the old size and mtime — stamped over the replacement's row, making a
+// verdict for bytes that are gone read back as valid. It also drives a
+// notification, so the refusal has to be visible rather than a silent no-op.
+func TestUpdateMultiplePPSGuardsAgainstAStaleGeneration(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	repo := NewFileRepository(pool)
+
+	// The mtime deliberately carries nanoseconds the row cannot store: a
+	// predicate that compared the raw value would reject every write made from
+	// a freshly stat'ed file.
+	scanned := time.Date(2026, time.March, 4, 5, 6, 7, 123456789, time.UTC)
+	fileID := copySafetyTestRow(t, ctx, pool, 4096, &scanned)
+
+	t.Run("matching generation writes", func(t *testing.T) {
+		if err := repo.UpdateMultiplePPS(ctx, fileID, true, 4096, &scanned); err != nil {
+			t.Fatalf("UpdateMultiplePPS() error = %v, want the write accepted despite sub-microsecond mtime drift", err)
+		}
+		multi, size, mtime := readCopySafetyRow(t, ctx, pool, fileID)
+		if multi == nil || !*multi {
+			t.Fatalf("multiple_pps = %v, want true", multi)
+		}
+		if size == nil || *size != 4096 {
+			t.Fatalf("multiple_pps_scan_size = %v, want 4096", size)
+		}
+		if mtime == nil {
+			t.Fatal("multiple_pps_scan_mtime = NULL, want the scanned mtime")
+		}
+	})
+
+	t.Run("superseded size is refused", func(t *testing.T) {
+		if _, err := pool.Exec(ctx, `UPDATE media_files SET file_size = 8192 WHERE id = $1`, fileID); err != nil {
+			t.Fatalf("rewrite the row: %v", err)
+		}
+		err := repo.UpdateMultiplePPS(ctx, fileID, false, 4096, &scanned)
+		if !errors.Is(err, ErrStaleCopySafetyScan) {
+			t.Fatalf("UpdateMultiplePPS() error = %v, want ErrStaleCopySafetyScan", err)
+		}
+		// The earlier verdict is untouched: a refused write changes nothing.
+		multi, size, _ := readCopySafetyRow(t, ctx, pool, fileID)
+		if multi == nil || !*multi || size == nil || *size != 4096 {
+			t.Fatalf("verdict = (%v, %v), want the refused write to have changed nothing", multi, size)
+		}
+	})
+
+	t.Run("superseded mtime is refused", func(t *testing.T) {
+		if _, err := pool.Exec(ctx, `UPDATE media_files SET file_size = 4096, file_modified_at = $2 WHERE id = $1`,
+			fileID, scanned.Add(time.Hour)); err != nil {
+			t.Fatalf("rewrite the row: %v", err)
+		}
+		if err := repo.UpdateMultiplePPS(ctx, fileID, false, 4096, &scanned); !errors.Is(err, ErrStaleCopySafetyScan) {
+			t.Fatalf("UpdateMultiplePPS() error = %v, want ErrStaleCopySafetyScan", err)
+		}
+	})
+
+	t.Run("row without an mtime", func(t *testing.T) {
+		bare := copySafetyTestRow(t, ctx, pool, 2048, nil)
+		if err := repo.UpdateMultiplePPS(ctx, bare, true, 2048, nil); err != nil {
+			t.Fatalf("UpdateMultiplePPS() error = %v, want a mtime-less row to accept a mtime-less verdict", err)
+		}
+		// The same row will not take a verdict claiming an mtime it does not
+		// have: that pairing is a different generation, not a match.
+		if err := repo.UpdateMultiplePPS(ctx, bare, true, 2048, &scanned); !errors.Is(err, ErrStaleCopySafetyScan) {
+			t.Fatalf("UpdateMultiplePPS() error = %v, want ErrStaleCopySafetyScan", err)
+		}
+	})
+
+	t.Run("missing row", func(t *testing.T) {
+		if err := repo.UpdateMultiplePPS(ctx, -1, true, 4096, &scanned); !errors.Is(err, ErrStaleCopySafetyScan) {
+			t.Fatalf("UpdateMultiplePPS() error = %v, want ErrStaleCopySafetyScan for a row that is gone", err)
+		}
+	})
+}

--- a/internal/scanner/pps.go
+++ b/internal/scanner/pps.go
@@ -10,10 +10,11 @@ import (
 
 // copySafetyScanSeconds bounds how much of the stream the multi-PPS scan
 // demuxes. Affected encoders emit every PPS variant within the opening GOPs
-// (all four in the reference file appear inside the first two seconds); a
-// generous window catches slower rotations while staying a stream-copy, so the
-// scan finishes in well under a second regardless of runtime.
-const copySafetyScanSeconds = 15
+// (all four in the reference file appear inside the first two seconds), so a
+// few seconds of headroom catches slower rotations. Kept short because the
+// window is bytes read off the media store: on remote storage the read, not
+// the demux, is what costs.
+const copySafetyScanSeconds = 5
 
 // DetectMultiplePPSH264 reports whether an H.264 stream redefines the same
 // pic_parameter_set_id in-band with more than one distinct content within the

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -121,6 +121,11 @@ type copySafetyResult struct {
 	size  int64
 	mtime *time.Time
 	multi bool
+	// persisted records whether this verdict reached the media_files row. A
+	// verdict memoized with persisted=false is correct for this process but
+	// invisible to every other replica, so a later lookup retries the write —
+	// the write only, never the scan.
+	persisted bool
 }
 
 // matches reports whether a memoized verdict still describes the given file.
@@ -193,6 +198,7 @@ func (e *PlaybackProbeEnsurer) EnsureCopySafetyCached(ctx context.Context, file 
 		return current, nil
 	}
 	if multi, ok := e.knownCopySafetyVerdict(current); ok {
+		e.retryUnpersistedCopySafety(ctx, current)
 		return fileWithMultiplePPS(current, multi), nil
 	}
 	return current, nil
@@ -234,13 +240,12 @@ func (e *PlaybackProbeEnsurer) knownCopySafetyVerdict(file *models.MediaFile) (b
 	if e == nil || file == nil {
 		return false, false
 	}
-	if cached, ok := e.copySafety.Load(file.ID); ok {
-		if result, ok := cached.(copySafetyResult); ok && result.matches(file) {
-			return result.multi, true
-		}
+	if entry, ok := e.memoizedCopySafety(file); ok {
+		return entry.multi, true
 	}
 	if multi, ok := persistedCopySafetyVerdict(file); ok {
-		e.storeCopySafety(file, multi)
+		// The row already holds it, so there is nothing left to write.
+		e.storeCopySafety(file, multi, true)
 		return multi, true
 	}
 	return false, false
@@ -289,6 +294,7 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 	}
 
 	if multi, ok := e.knownCopySafetyVerdict(file); ok {
+		e.retryUnpersistedCopySafety(ctx, file)
 		return fileWithMultiplePPS(file, multi), nil
 	}
 
@@ -312,7 +318,9 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 // scanAndPersistCopySafety runs the multi-PPS bitstream scan, persists the
 // verdict, and memoizes it. Concurrent callers for the same file share one
 // scan; a failed database write is logged and the scan result is still used,
-// since it is correct for this request and the next one will retry the write.
+// since it is correct for this request. The memo remembers that the write did
+// not land, so the next lookup for the file retries it — see
+// retryUnpersistedCopySafety.
 func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, file *models.MediaFile) (bool, error) {
 	fileID := file.ID
 	filePath := file.FilePath
@@ -331,8 +339,12 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 			return false, err
 		}
 
+		// With no writer there is nowhere for the verdict to land, so it is not
+		// pending: nothing would ever clear the flag.
+		persisted := true
 		if e.copySafetyRepo != nil {
 			if writeErr := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, multi, fileSize, fileModifiedAt); writeErr != nil {
+				persisted = false
 				slog.WarnContext(ctx, "persisting video copy-safety verdict failed",
 					"component", "scanner",
 					"file_id", fileID,
@@ -340,7 +352,7 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 				)
 			}
 		}
-		e.storeCopySafety(file, multi)
+		e.storeCopySafety(file, multi, persisted)
 		return multi, nil
 	})
 	if err != nil {
@@ -350,8 +362,62 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 	return result, nil
 }
 
-func (e *PlaybackProbeEnsurer) storeCopySafety(file *models.MediaFile, multi bool) {
-	entry := copySafetyResult{size: file.FileSize, multi: multi}
+// retryUnpersistedCopySafety re-attempts the media_files write for a verdict
+// this process already reached but never managed to store. No ffmpeg runs: the
+// memo holds the answer, so this is a bare UPDATE.
+//
+// Without the retry a single failed write is lost until the process restarts.
+// The verdict stays correct here, but every other replica keeps rescanning the
+// same file and keeps planning fresh sessions onto the copy route it condemns.
+// The write shares scanAndPersistCopySafety's singleflight key, so a burst of
+// playback requests for one file cannot stampede the row, and a retry racing a
+// scan simply joins it.
+func (e *PlaybackProbeEnsurer) retryUnpersistedCopySafety(ctx context.Context, file *models.MediaFile) {
+	if e == nil || file == nil || e.copySafetyRepo == nil {
+		return
+	}
+	if entry, ok := e.memoizedCopySafety(file); !ok || entry.persisted {
+		return
+	}
+
+	fileID := file.ID
+	_, _, _ = e.copySafetyFlight.Do(strconv.Itoa(fileID), func() (any, error) {
+		// Re-read inside the flight: a concurrent scan or retry may have landed
+		// the write while this caller queued behind it.
+		entry, ok := e.memoizedCopySafety(file)
+		if !ok || entry.persisted {
+			return entry.multi, nil
+		}
+		if err := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, entry.multi, entry.size, entry.mtime); err != nil {
+			slog.WarnContext(ctx, "retrying the video copy-safety verdict write failed",
+				"component", "scanner",
+				"file_id", fileID,
+				"error", err,
+			)
+			return entry.multi, nil
+		}
+		entry.persisted = true
+		e.copySafety.Store(fileID, entry)
+		return entry.multi, nil
+	})
+}
+
+// memoizedCopySafety returns the process-cached verdict for file, but only
+// while it still describes the file as it stands.
+func (e *PlaybackProbeEnsurer) memoizedCopySafety(file *models.MediaFile) (copySafetyResult, bool) {
+	cached, ok := e.copySafety.Load(file.ID)
+	if !ok {
+		return copySafetyResult{}, false
+	}
+	entry, ok := cached.(copySafetyResult)
+	if !ok || !entry.matches(file) {
+		return copySafetyResult{}, false
+	}
+	return entry, true
+}
+
+func (e *PlaybackProbeEnsurer) storeCopySafety(file *models.MediaFile, multi, persisted bool) {
+	entry := copySafetyResult{size: file.FileSize, multi: multi, persisted: persisted}
 	if file.FileModifiedAt != nil {
 		mtime := *file.FileModifiedAt
 		entry.mtime = &mtime

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -315,19 +315,47 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 	return fileWithMultiplePPS(file, multi), nil
 }
 
+// copySafetyFlightKey identifies one generation of one file. The file ID alone
+// is not enough: a rewrite in place keeps the row ID and changes the bytes, so a
+// caller holding the replacement would otherwise join the flight scanning the
+// old file and consume its verdict — condemning a copy-safe replacement, or
+// worse, clearing the condemnation of a copy-unsafe one. Only callers that agree
+// on the size and mtime are looking at the same bitstream, and therefore only
+// they may share a scan.
+//
+// The mtime is normalized exactly as sameFileModifiedAt normalizes it, so two
+// reads of the same generation that differ only in stored precision still share
+// a flight. A row with no mtime gets a marker no timestamp can produce: it is a
+// generation of its own, not a match for every other.
+func copySafetyFlightKey(file *models.MediaFile) string {
+	if file == nil {
+		return ""
+	}
+	mtime := "none"
+	if file.FileModifiedAt != nil {
+		mtime = strconv.FormatInt(normalizeFileModifiedAt(*file.FileModifiedAt).UnixMicro(), 10)
+	}
+	return strconv.Itoa(file.ID) + ":" + strconv.FormatInt(file.FileSize, 10) + ":" + mtime
+}
+
 // scanAndPersistCopySafety runs the multi-PPS bitstream scan, persists the
-// verdict, and memoizes it. Concurrent callers for the same file share one
-// scan; a failed database write is logged and the scan result is still used,
-// since it is correct for this request. The memo remembers that the write did
-// not land, so the next lookup for the file retries it — see
+// verdict, and memoizes it. Concurrent callers for the same file *generation*
+// share one scan; a failed database write is logged and the scan result is still
+// used, since it is correct for this request. The memo remembers that the write
+// did not land, so the next lookup for the file retries it — see
 // retryUnpersistedCopySafety.
+//
+// Everything the flight closure records — the persisted row and the process memo
+// — is bound to the leader's own snapshot of the file, so a joiner never writes
+// another generation's facts. The key is what keeps a joiner from *reading*
+// them.
 func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, file *models.MediaFile) (bool, error) {
 	fileID := file.ID
 	filePath := file.FilePath
 	fileSize := file.FileSize
 	fileModifiedAt := file.FileModifiedAt
 
-	multi, err, _ := e.copySafetyFlight.Do(strconv.Itoa(fileID), func() (any, error) {
+	multi, err, _ := e.copySafetyFlight.Do(copySafetyFlightKey(file), func() (any, error) {
 		timeout := e.timeout
 		if timeout < 30*time.Second {
 			timeout = 30 * time.Second
@@ -369,9 +397,11 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 // Without the retry a single failed write is lost until the process restarts.
 // The verdict stays correct here, but every other replica keeps rescanning the
 // same file and keeps planning fresh sessions onto the copy route it condemns.
-// The write shares scanAndPersistCopySafety's singleflight key, so a burst of
-// playback requests for one file cannot stampede the row, and a retry racing a
-// scan simply joins it.
+// The write shares scanAndPersistCopySafety's singleflight key — the same
+// generation-scoped key, so a retry never joins a flight scanning a different
+// generation of the row — and so a burst of playback requests for one file
+// cannot stampede the row, while a retry racing a scan of its own generation
+// simply joins it.
 func (e *PlaybackProbeEnsurer) retryUnpersistedCopySafety(ctx context.Context, file *models.MediaFile) {
 	if e == nil || file == nil || e.copySafetyRepo == nil {
 		return
@@ -381,7 +411,7 @@ func (e *PlaybackProbeEnsurer) retryUnpersistedCopySafety(ctx context.Context, f
 	}
 
 	fileID := file.ID
-	_, _, _ = e.copySafetyFlight.Do(strconv.Itoa(fileID), func() (any, error) {
+	_, _, _ = e.copySafetyFlight.Do(copySafetyFlightKey(file), func() (any, error) {
 		// Re-read inside the flight: a concurrent scan or retry may have landed
 		// the write while this caller queued behind it.
 		entry, ok := e.memoizedCopySafety(file)

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -3,11 +3,13 @@ package scanner
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
+	"golang.org/x/sync/singleflight"
 )
 
 // NeedsCriticalProbeRepair reports whether playback-critical probe metadata is
@@ -84,6 +86,12 @@ func videoTracksMissingColorRange(tracks []models.VideoTrack) bool {
 	return false
 }
 
+// copySafetyWriter persists a multi-PPS verdict. *FileRepository satisfies it;
+// the indirection keeps the ensurer testable without a database.
+type copySafetyWriter interface {
+	UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error
+}
+
 // PlaybackProbeEnsurer repairs missing playback-critical probe metadata on
 // demand by running a local ffprobe and persisting the result.
 type PlaybackProbeEnsurer struct {
@@ -91,27 +99,76 @@ type PlaybackProbeEnsurer struct {
 	ffprobePath string
 	ffmpegPath  string
 	timeout     time.Duration
+	// copySafetyRepo persists multi-PPS verdicts. Normally the same
+	// *FileRepository as fileRepo; tests substitute a double.
+	copySafetyRepo copySafetyWriter
 	// copySafety memoizes the multi-PPS bitstream scan per file for the life of
-	// the process. It is never persisted: the scan runs on the first playback
-	// after a restart and is recomputed lazily thereafter.
+	// the process, in front of the persisted media_files verdict. Both layers
+	// are validated against the file's current size and mtime.
 	copySafety sync.Map // file ID -> copySafetyResult
+	// copySafetyFlight collapses concurrent first scans of the same file so a
+	// burst of playback/detail requests spawns one ffmpeg, not one each.
+	copySafetyFlight singleflight.Group
 }
 
 type copySafetyResult struct {
 	size  int64
+	mtime *time.Time
 	multi bool
 }
 
+// matches reports whether a memoized verdict still describes the given file.
+func (r copySafetyResult) matches(file *models.MediaFile) bool {
+	if r.size != file.FileSize {
+		return false
+	}
+	if r.mtime == nil || file.FileModifiedAt == nil {
+		// A verdict recorded without an mtime can only be trusted on size.
+		return r.mtime == nil && file.FileModifiedAt == nil
+	}
+	return sameFileModifiedAt(r.mtime, *file.FileModifiedAt)
+}
+
 func NewPlaybackProbeEnsurer(fileRepo *FileRepository, ffprobePath, ffmpegPath string, timeout time.Duration) *PlaybackProbeEnsurer {
-	return &PlaybackProbeEnsurer{
+	e := &PlaybackProbeEnsurer{
 		fileRepo:    fileRepo,
 		ffprobePath: ffprobePath,
 		ffmpegPath:  ffmpegPath,
 		timeout:     timeout,
 	}
+	if fileRepo != nil {
+		e.copySafetyRepo = fileRepo
+	}
+	return e
 }
 
+// Ensure repairs playback-critical probe metadata and resolves the H.264
+// copy-safety verdict. Use it where a play is being prepared — the planner
+// consumes the verdict to decide whether a video stream-copy is safe.
 func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	current, err := e.ensureProbeRepair(ctx, file)
+	if err != nil || current == nil || e == nil {
+		return current, err
+	}
+
+	// Copy-safety analysis is independent of critical probe repair: an
+	// already-probed file still needs its multi-PPS verdict before the planner
+	// can decide whether a video stream-copy is safe.
+	return e.ensureCopySafety(ctx, current)
+}
+
+// EnsureProbeOnly repairs playback-critical probe metadata and stops there.
+//
+// Browse surfaces (item, episode and extra detail pages) use this: they never
+// consume the copy-safety verdict — VideoTrack.MultiplePPS is json:"-" and
+// never reaches a client — so running the bitstream scan there was pure
+// warm-up, and it is exactly what made first-time browsing slow on remote
+// storage. The verdict is resolved when a play is actually being prepared.
+func (e *PlaybackProbeEnsurer) EnsureProbeOnly(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	return e.ensureProbeRepair(ctx, file)
+}
+
+func (e *PlaybackProbeEnsurer) ensureProbeRepair(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
 	if file == nil || e == nil || e.fileRepo == nil {
 		return file, nil
 	}
@@ -140,38 +197,39 @@ func (e *PlaybackProbeEnsurer) Ensure(ctx context.Context, file *models.MediaFil
 		current = repaired
 	}
 
-	// Copy-safety analysis is independent of critical probe repair: an
-	// already-probed file still needs its one-time multi-PPS scan before the
-	// planner can decide whether a video stream-copy is safe.
-	return e.ensureCopySafety(ctx, current)
+	return current, nil
 }
 
-// ensureCopySafety computes the multi-PPS copy-safety flag for H.264 files at
-// playback start and stamps it on an in-memory copy of the file. The result is
-// memoized per process and never written to the database, so it is recomputed
-// on the first play after a restart.
+// ensureCopySafety resolves the multi-PPS copy-safety flag for H.264 files at
+// playback start and stamps it on an in-memory copy of the file. It answers
+// from the process cache first, then from the verdict persisted on the
+// media_files row, and only then runs the bitstream scan — so a restart no
+// longer re-reads the opening seconds of every browsed H.264 file.
 func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
 	if !needsCopySafetyProbe(file) || strings.TrimSpace(e.ffmpegPath) == "" {
 		return file, nil
 	}
 
 	if cached, ok := e.copySafety.Load(file.ID); ok {
-		if result, ok := cached.(copySafetyResult); ok && result.size == file.FileSize {
+		if result, ok := cached.(copySafetyResult); ok && result.matches(file) {
 			return fileWithMultiplePPS(file, result.multi), nil
 		}
 	}
 
-	timeout := e.timeout
-	if timeout < 30*time.Second {
-		timeout = 30 * time.Second
+	// A persisted verdict is self-validating: it is only honored while the
+	// recorded size and mtime still describe the file, so a rewrite in place
+	// falls through to a rescan without any writer having to clear it.
+	if multi, ok := persistedCopySafetyVerdict(file); ok {
+		e.storeCopySafety(file, multi)
+		return fileWithMultiplePPS(file, multi), nil
 	}
-	scanCtx, cancel := context.WithTimeout(ctx, timeout)
-	multi, err := DetectMultiplePPSH264(scanCtx, e.ffmpegPath, file.FilePath)
-	cancel()
+
+	multi, err := e.scanAndPersistCopySafety(ctx, file)
 	if err != nil {
 		// Unknown safety must not fail open to the video-copy path this probe is
-		// intended to guard. Leave MultiplePPS unset and do not cache the result,
-		// so a later request retries the scan without misreporting the cause.
+		// intended to guard. Leave MultiplePPS unset and do not cache or persist
+		// the result, so a later request retries the scan without misreporting
+		// the cause.
 		slog.WarnContext(ctx, "video copy-safety scan failed; disabling stream copy",
 			"component", "scanner",
 			"file_id", file.ID,
@@ -180,8 +238,74 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 		return fileWithCopySafety(file, nil, true), nil
 	}
 
-	e.copySafety.Store(file.ID, copySafetyResult{size: file.FileSize, multi: multi})
 	return fileWithMultiplePPS(file, multi), nil
+}
+
+// scanAndPersistCopySafety runs the multi-PPS bitstream scan, persists the
+// verdict, and memoizes it. Concurrent callers for the same file share one
+// scan; a failed database write is logged and the scan result is still used,
+// since it is correct for this request and the next one will retry the write.
+func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, file *models.MediaFile) (bool, error) {
+	fileID := file.ID
+	filePath := file.FilePath
+	fileSize := file.FileSize
+	fileModifiedAt := file.FileModifiedAt
+
+	multi, err, _ := e.copySafetyFlight.Do(strconv.Itoa(fileID), func() (any, error) {
+		timeout := e.timeout
+		if timeout < 30*time.Second {
+			timeout = 30 * time.Second
+		}
+		scanCtx, cancel := context.WithTimeout(ctx, timeout)
+		multi, err := DetectMultiplePPSH264(scanCtx, e.ffmpegPath, filePath)
+		cancel()
+		if err != nil {
+			return false, err
+		}
+
+		if e.copySafetyRepo != nil && fileModifiedAt != nil {
+			if writeErr := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, multi, fileSize, *fileModifiedAt); writeErr != nil {
+				slog.WarnContext(ctx, "persisting video copy-safety verdict failed",
+					"component", "scanner",
+					"file_id", fileID,
+					"error", writeErr,
+				)
+			}
+		}
+		e.storeCopySafety(file, multi)
+		return multi, nil
+	})
+	if err != nil {
+		return false, err
+	}
+	result, _ := multi.(bool)
+	return result, nil
+}
+
+func (e *PlaybackProbeEnsurer) storeCopySafety(file *models.MediaFile, multi bool) {
+	entry := copySafetyResult{size: file.FileSize, multi: multi}
+	if file.FileModifiedAt != nil {
+		mtime := *file.FileModifiedAt
+		entry.mtime = &mtime
+	}
+	e.copySafety.Store(file.ID, entry)
+}
+
+// persistedCopySafetyVerdict returns the multi-PPS verdict stored on the
+// media_files row, and whether it is still valid for the file as it stands. A
+// verdict is valid only when it was computed from the same size and mtime the
+// row now reports.
+func persistedCopySafetyVerdict(file *models.MediaFile) (bool, bool) {
+	if file == nil || file.MultiplePPS == nil || file.MultiplePPSScanSize == nil || file.MultiplePPSScanMtime == nil {
+		return false, false
+	}
+	if *file.MultiplePPSScanSize != file.FileSize {
+		return false, false
+	}
+	if file.FileModifiedAt == nil || !sameFileModifiedAt(file.MultiplePPSScanMtime, *file.FileModifiedAt) {
+		return false, false
+	}
+	return *file.MultiplePPS, true
 }
 
 // fileWithMultiplePPS returns a shallow copy of file with the (runtime-only)

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -88,8 +89,13 @@ func videoTracksMissingColorRange(tracks []models.VideoTrack) bool {
 
 // copySafetyWriter persists a multi-PPS verdict. *FileRepository satisfies it;
 // the indirection keeps the ensurer testable without a database.
+//
+// scanMtime is nil for a row that carries no file mtime: such a verdict is
+// still recorded, and validated on size alone when it is read back. Refusing to
+// write it would leave those rows permanently unverdicted, so every replica
+// would rescan and re-invalidate the same sessions forever.
 type copySafetyWriter interface {
-	UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error
+	UpdateMultiplePPS(ctx context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime *time.Time) error
 }
 
 // PlaybackProbeEnsurer repairs missing playback-critical probe metadata on
@@ -168,6 +174,78 @@ func (e *PlaybackProbeEnsurer) EnsureProbeOnly(ctx context.Context, file *models
 	return e.ensureProbeRepair(ctx, file)
 }
 
+// EnsureCopySafetyCached repairs playback-critical probe metadata and stamps
+// the copy-safety verdict only when it is already known — from the process
+// cache or from the verdict persisted on the media_files row. It never execs
+// ffmpeg, so it never blocks a play or a watch page on a bitstream scan.
+//
+// An unknown verdict is left unknown: VideoTrack.MultiplePPS stays nil and
+// VideoCopyUnsafe stays false, which the planner reads as "stream copy is
+// allowed". That is the optimistic half of the race — the caller is expected to
+// kick off ScanCopySafety asynchronously and switch live sessions off the copy
+// route if the scan comes back multi-PPS.
+func (e *PlaybackProbeEnsurer) EnsureCopySafetyCached(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
+	current, err := e.ensureProbeRepair(ctx, file)
+	if err != nil || current == nil || e == nil {
+		return current, err
+	}
+	if !needsCopySafetyProbe(current) {
+		return current, nil
+	}
+	if multi, ok := e.knownCopySafetyVerdict(current); ok {
+		return fileWithMultiplePPS(current, multi), nil
+	}
+	return current, nil
+}
+
+// NeedsCopySafetyScan reports whether an asynchronous ScanCopySafety would do
+// real work for this file: an H.264 video whose verdict is neither cached nor
+// persisted, on a server that has an ffmpeg to scan with.
+func (e *PlaybackProbeEnsurer) NeedsCopySafetyScan(file *models.MediaFile) bool {
+	if e == nil || strings.TrimSpace(e.ffmpegPath) == "" || !needsCopySafetyProbe(file) {
+		return false
+	}
+	_, known := e.knownCopySafetyVerdict(file)
+	return !known
+}
+
+// ScanCopySafety runs the multi-PPS bitstream scan for a file whose verdict is
+// unknown, persisting and memoizing the result. Concurrent callers for one file
+// share a single scan, so a start, a replan and a watch-page load racing on the
+// same file spawn one ffmpeg between them.
+func (e *PlaybackProbeEnsurer) ScanCopySafety(ctx context.Context, file *models.MediaFile) (bool, error) {
+	if e == nil || file == nil {
+		return false, nil
+	}
+	if strings.TrimSpace(e.ffmpegPath) == "" {
+		return false, errCopySafetyScanUnavailable
+	}
+	return e.scanAndPersistCopySafety(ctx, file)
+}
+
+var errCopySafetyScanUnavailable = errors.New("ffmpeg path not configured")
+
+// knownCopySafetyVerdict answers the copy-safety question from memory or from
+// the persisted row, never from ffmpeg. A persisted verdict is self-validating:
+// it is only honored while the recorded size and mtime still describe the file,
+// so a rewrite in place falls through to a rescan without any writer having to
+// clear it. Promoting it into the process cache keeps later calls off the row.
+func (e *PlaybackProbeEnsurer) knownCopySafetyVerdict(file *models.MediaFile) (bool, bool) {
+	if e == nil || file == nil {
+		return false, false
+	}
+	if cached, ok := e.copySafety.Load(file.ID); ok {
+		if result, ok := cached.(copySafetyResult); ok && result.matches(file) {
+			return result.multi, true
+		}
+	}
+	if multi, ok := persistedCopySafetyVerdict(file); ok {
+		e.storeCopySafety(file, multi)
+		return multi, true
+	}
+	return false, false
+}
+
 func (e *PlaybackProbeEnsurer) ensureProbeRepair(ctx context.Context, file *models.MediaFile) (*models.MediaFile, error) {
 	if file == nil || e == nil || e.fileRepo == nil {
 		return file, nil
@@ -210,17 +288,7 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 		return file, nil
 	}
 
-	if cached, ok := e.copySafety.Load(file.ID); ok {
-		if result, ok := cached.(copySafetyResult); ok && result.matches(file) {
-			return fileWithMultiplePPS(file, result.multi), nil
-		}
-	}
-
-	// A persisted verdict is self-validating: it is only honored while the
-	// recorded size and mtime still describe the file, so a rewrite in place
-	// falls through to a rescan without any writer having to clear it.
-	if multi, ok := persistedCopySafetyVerdict(file); ok {
-		e.storeCopySafety(file, multi)
+	if multi, ok := e.knownCopySafetyVerdict(file); ok {
 		return fileWithMultiplePPS(file, multi), nil
 	}
 
@@ -263,8 +331,8 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 			return false, err
 		}
 
-		if e.copySafetyRepo != nil && fileModifiedAt != nil {
-			if writeErr := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, multi, fileSize, *fileModifiedAt); writeErr != nil {
+		if e.copySafetyRepo != nil {
+			if writeErr := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, multi, fileSize, fileModifiedAt); writeErr != nil {
 				slog.WarnContext(ctx, "persisting video copy-safety verdict failed",
 					"component", "scanner",
 					"file_id", fileID,
@@ -292,20 +360,11 @@ func (e *PlaybackProbeEnsurer) storeCopySafety(file *models.MediaFile, multi boo
 }
 
 // persistedCopySafetyVerdict returns the multi-PPS verdict stored on the
-// media_files row, and whether it is still valid for the file as it stands. A
-// verdict is valid only when it was computed from the same size and mtime the
-// row now reports.
+// media_files row, and whether it is still valid for the file as it stands.
+// The rule lives on the model because playback reads the same columns from
+// files this package never touches.
 func persistedCopySafetyVerdict(file *models.MediaFile) (bool, bool) {
-	if file == nil || file.MultiplePPS == nil || file.MultiplePPSScanSize == nil || file.MultiplePPSScanMtime == nil {
-		return false, false
-	}
-	if *file.MultiplePPSScanSize != file.FileSize {
-		return false, false
-	}
-	if file.FileModifiedAt == nil || !sameFileModifiedAt(file.MultiplePPSScanMtime, *file.FileModifiedAt) {
-		return false, false
-	}
-	return *file.MultiplePPS, true
+	return file.PersistedVideoCopyVerdict()
 }
 
 // fileWithMultiplePPS returns a shallow copy of file with the (runtime-only)
@@ -329,17 +388,7 @@ func fileWithCopySafety(file *models.MediaFile, multiplePPS *bool, copyUnsafe bo
 // needsCopySafetyProbe reports whether the file is an H.264 video whose
 // multi-PPS copy-safety flag has not yet been computed.
 func needsCopySafetyProbe(file *models.MediaFile) bool {
-	if file == nil || len(file.VideoTracks) == 0 {
-		return false
-	}
-	if file.VideoTracks[0].MultiplePPS != nil {
-		return false
-	}
-	codec := strings.ToLower(strings.TrimSpace(file.VideoTracks[0].Codec))
-	if codec == "" {
-		codec = strings.ToLower(strings.TrimSpace(file.CodecVideo))
-	}
-	return codec == "h264" || codec == "avc" || codec == "avc1"
+	return file.VideoCopySafetyUnknown()
 }
 
 // reprobeMayScanPackets reports whether reprobing this file is likely to hit

--- a/internal/scanner/probe_repair.go
+++ b/internal/scanner/probe_repair.go
@@ -219,14 +219,41 @@ func (e *PlaybackProbeEnsurer) NeedsCopySafetyScan(file *models.MediaFile) bool 
 // unknown, persisting and memoizing the result. Concurrent callers for one file
 // share a single scan, so a start, a replan and a watch-page load racing on the
 // same file spawn one ffmpeg between them.
-func (e *PlaybackProbeEnsurer) ScanCopySafety(ctx context.Context, file *models.MediaFile) (bool, error) {
+//
+// The second return reports that the verdict is stale: the row moved to another
+// generation of the file while the scan ran, so the answer is correct for bytes
+// the server is no longer serving. It is not an error — nothing failed — but a
+// caller must neither trust it nor act on it.
+func (e *PlaybackProbeEnsurer) ScanCopySafety(ctx context.Context, file *models.MediaFile) (multi bool, stale bool, err error) {
 	if e == nil || file == nil {
-		return false, nil
+		return false, false, nil
 	}
 	if strings.TrimSpace(e.ffmpegPath) == "" {
-		return false, errCopySafetyScanUnavailable
+		return false, false, errCopySafetyScanUnavailable
 	}
 	return e.scanAndPersistCopySafety(ctx, file)
+}
+
+// KnownCopySafetyVerdict answers the copy-safety question for a file without
+// ever running ffmpeg, from the process memo or from the persisted row, and
+// re-attempts a write this process reached but never managed to store.
+//
+// It exists because "unknown" and "known but unpersisted" are different states
+// that the media_files row cannot tell apart. A verdict whose write failed is
+// authoritative on this replica and invisible everywhere else, so the paths
+// that gate a revived stream-copy — and the race that withdraws one — have to
+// be able to ask this process what it already knows rather than only asking the
+// row.
+func (e *PlaybackProbeEnsurer) KnownCopySafetyVerdict(ctx context.Context, file *models.MediaFile) (bool, bool) {
+	if e == nil || file == nil {
+		return false, false
+	}
+	multi, known := e.knownCopySafetyVerdict(file)
+	if !known {
+		return false, false
+	}
+	e.retryUnpersistedCopySafety(ctx, file)
+	return multi, true
 }
 
 var errCopySafetyScanUnavailable = errors.New("ffmpeg path not configured")
@@ -298,7 +325,7 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 		return fileWithMultiplePPS(file, multi), nil
 	}
 
-	multi, err := e.scanAndPersistCopySafety(ctx, file)
+	multi, stale, err := e.scanAndPersistCopySafety(ctx, file)
 	if err != nil {
 		// Unknown safety must not fail open to the video-copy path this probe is
 		// intended to guard. Leave MultiplePPS unset and do not cache or persist
@@ -308,6 +335,16 @@ func (e *PlaybackProbeEnsurer) ensureCopySafety(ctx context.Context, file *model
 			"component", "scanner",
 			"file_id", file.ID,
 			"error", err,
+		)
+		return fileWithCopySafety(file, nil, true), nil
+	}
+	if stale {
+		// The caller is holding a snapshot of a generation the row has moved
+		// past. Its verdict describes bytes this file no longer contains, so it
+		// is treated exactly like an unresolved scan rather than stamped on.
+		slog.InfoContext(ctx, "video copy-safety verdict superseded before it could be recorded",
+			"component", "scanner",
+			"file_id", file.ID,
 		)
 		return fileWithCopySafety(file, nil, true), nil
 	}
@@ -349,13 +386,17 @@ func copySafetyFlightKey(file *models.MediaFile) string {
 // — is bound to the leader's own snapshot of the file, so a joiner never writes
 // another generation's facts. The key is what keeps a joiner from *reading*
 // them.
-func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, file *models.MediaFile) (bool, error) {
+//
+// A write refused as stale is neither memoized nor reported as a verdict: the
+// row has moved to a generation this scan never read, and both the memo and any
+// downstream notification would be facts about bytes nobody is serving.
+func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, file *models.MediaFile) (bool, bool, error) {
 	fileID := file.ID
 	filePath := file.FilePath
 	fileSize := file.FileSize
 	fileModifiedAt := file.FileModifiedAt
 
-	multi, err, _ := e.copySafetyFlight.Do(copySafetyFlightKey(file), func() (any, error) {
+	outcome, err, _ := e.copySafetyFlight.Do(copySafetyFlightKey(file), func() (any, error) {
 		timeout := e.timeout
 		if timeout < 30*time.Second {
 			timeout = 30 * time.Second
@@ -364,7 +405,7 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 		multi, err := DetectMultiplePPSH264(scanCtx, e.ffmpegPath, filePath)
 		cancel()
 		if err != nil {
-			return false, err
+			return copySafetyOutcome{}, err
 		}
 
 		// With no writer there is nowhere for the verdict to land, so it is not
@@ -372,6 +413,13 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 		persisted := true
 		if e.copySafetyRepo != nil {
 			if writeErr := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, multi, fileSize, fileModifiedAt); writeErr != nil {
+				if errors.Is(writeErr, ErrStaleCopySafetyScan) {
+					slog.InfoContext(ctx, "discarding a video copy-safety verdict for a superseded generation of the file",
+						"component", "scanner",
+						"file_id", fileID,
+					)
+					return copySafetyOutcome{stale: true}, nil
+				}
 				persisted = false
 				slog.WarnContext(ctx, "persisting video copy-safety verdict failed",
 					"component", "scanner",
@@ -381,13 +429,20 @@ func (e *PlaybackProbeEnsurer) scanAndPersistCopySafety(ctx context.Context, fil
 			}
 		}
 		e.storeCopySafety(file, multi, persisted)
-		return multi, nil
+		return copySafetyOutcome{multi: multi}, nil
 	})
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	result, _ := multi.(bool)
-	return result, nil
+	result, _ := outcome.(copySafetyOutcome)
+	return result.multi, result.stale, nil
+}
+
+// copySafetyOutcome is what one shared scan produced, carried through the
+// singleflight so joiners learn about a superseded write as well as the verdict.
+type copySafetyOutcome struct {
+	multi bool
+	stale bool
 }
 
 // retryUnpersistedCopySafety re-attempts the media_files write for a verdict
@@ -416,19 +471,30 @@ func (e *PlaybackProbeEnsurer) retryUnpersistedCopySafety(ctx context.Context, f
 		// the write while this caller queued behind it.
 		entry, ok := e.memoizedCopySafety(file)
 		if !ok || entry.persisted {
-			return entry.multi, nil
+			return copySafetyOutcome{multi: entry.multi}, nil
 		}
 		if err := e.copySafetyRepo.UpdateMultiplePPS(ctx, fileID, entry.multi, entry.size, entry.mtime); err != nil {
+			if errors.Is(err, ErrStaleCopySafetyScan) {
+				// The row has moved on. The memo stays — it is still the right
+				// answer for the snapshot that produced it, and it can no longer
+				// match a caller holding the current generation — but there is
+				// nothing left to write, so this stops being a failure.
+				slog.InfoContext(ctx, "video copy-safety verdict is no longer writable; the row holds another generation",
+					"component", "scanner",
+					"file_id", fileID,
+				)
+				return copySafetyOutcome{multi: entry.multi, stale: true}, nil
+			}
 			slog.WarnContext(ctx, "retrying the video copy-safety verdict write failed",
 				"component", "scanner",
 				"file_id", fileID,
 				"error", err,
 			)
-			return entry.multi, nil
+			return copySafetyOutcome{multi: entry.multi}, nil
 		}
 		entry.persisted = true
 		e.copySafety.Store(fileID, entry)
-		return entry.multi, nil
+		return copySafetyOutcome{multi: entry.multi}, nil
 	})
 }
 

--- a/internal/scanner/probe_repair_copy_safety_cached_test.go
+++ b/internal/scanner/probe_repair_copy_safety_cached_test.go
@@ -138,9 +138,12 @@ func TestScanCopySafetyPersistsAndMemoizes(t *testing.T) {
 	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
 	file := copySafetyTestFile(mtime)
 
-	multi, err := ensurer.ScanCopySafety(context.Background(), file)
+	multi, stale, err := ensurer.ScanCopySafety(context.Background(), file)
 	if err != nil {
 		t.Fatalf("ScanCopySafety() error = %v", err)
+	}
+	if stale {
+		t.Fatal("ScanCopySafety() stale = true, want false for a write the row accepted")
 	}
 	if !multi {
 		t.Fatal("ScanCopySafety() = false, want true for the conflicting-PPS stream")
@@ -181,12 +184,12 @@ func TestScanCopySafetyErrorRecordsNothing(t *testing.T) {
 
 	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
 
-	multi, err := ensurer.ScanCopySafety(context.Background(), file)
+	multi, stale, err := ensurer.ScanCopySafety(context.Background(), file)
 	if err == nil {
 		t.Fatal("ScanCopySafety() error = nil, want the scan failure surfaced to the caller")
 	}
-	if multi {
-		t.Fatal("ScanCopySafety() = true on error, want false")
+	if multi || stale {
+		t.Fatalf("ScanCopySafety() = (%t, %t) on error, want (false, false)", multi, stale)
 	}
 	if writes := writer.recorded(); len(writes) != 0 {
 		t.Fatalf("failed scan recorded %d verdicts, want 0", len(writes))

--- a/internal/scanner/probe_repair_copy_safety_cached_test.go
+++ b/internal/scanner/probe_repair_copy_safety_cached_test.go
@@ -73,7 +73,7 @@ func TestEnsureCopySafetyCachedStampsKnownVerdicts(t *testing.T) {
 		ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
 
 		file := copySafetyTestFile(mtime)
-		ensurer.storeCopySafety(file, false)
+		ensurer.storeCopySafety(file, false, true)
 
 		got, err := ensurer.EnsureCopySafetyCached(context.Background(), file)
 		if err != nil {
@@ -103,7 +103,7 @@ func TestNeedsCopySafetyScan(t *testing.T) {
 	t.Run("known verdict needs none", func(t *testing.T) {
 		ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
 		file := copySafetyTestFile(mtime)
-		ensurer.storeCopySafety(file, true)
+		ensurer.storeCopySafety(file, true, true)
 		if ensurer.NeedsCopySafetyScan(file) {
 			t.Fatal("NeedsCopySafetyScan() = true, want false once the verdict is known")
 		}

--- a/internal/scanner/probe_repair_copy_safety_cached_test.go
+++ b/internal/scanner/probe_repair_copy_safety_cached_test.go
@@ -1,0 +1,212 @@
+package scanner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// EnsureCopySafetyCached is the optimistic half of the remux race: a play must
+// never wait on the bitstream scan, so an unknown verdict is left unknown —
+// which the planner reads as "stream copy is allowed" — and no ffmpeg runs.
+func TestEnsureCopySafetyCachedNeverScans(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	got, err := ensurer.EnsureCopySafetyCached(context.Background(), file)
+	if err != nil {
+		t.Fatalf("EnsureCopySafetyCached() error = %v", err)
+	}
+	if runs() != 0 {
+		t.Fatalf("ffmpeg ran %d times, want 0 — the cached ensure must never exec", runs())
+	}
+	track := got.VideoTracks[0]
+	if track.MultiplePPS != nil {
+		t.Fatalf("MultiplePPS = %v, want nil so the planner may still remux optimistically", *track.MultiplePPS)
+	}
+	if track.VideoCopyUnsafe {
+		t.Fatal("VideoCopyUnsafe = true, want false: an unresolved verdict must not disqualify the copy route")
+	}
+	if writes := writer.recorded(); len(writes) != 0 {
+		t.Fatalf("cached ensure recorded %d verdicts, want 0", len(writes))
+	}
+}
+
+// A verdict that is already known is stamped without a scan, so a known-unsafe
+// file never gets an optimistic remux in the first place.
+func TestEnsureCopySafetyCachedStampsKnownVerdicts(t *testing.T) {
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+
+	t.Run("persisted", func(t *testing.T) {
+		ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+		ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+		file := copySafetyTestFile(mtime)
+		verdict := true
+		scanSize := file.FileSize
+		scanMtime := mtime
+		file.MultiplePPS = &verdict
+		file.MultiplePPSScanSize = &scanSize
+		file.MultiplePPSScanMtime = &scanMtime
+
+		got, err := ensurer.EnsureCopySafetyCached(context.Background(), file)
+		if err != nil {
+			t.Fatalf("EnsureCopySafetyCached() error = %v", err)
+		}
+		if runs() != 0 {
+			t.Fatalf("ffmpeg ran %d times, want 0", runs())
+		}
+		track := got.VideoTracks[0]
+		if track.MultiplePPS == nil || !*track.MultiplePPS || !track.VideoCopyUnsafe {
+			t.Fatalf("track = %+v, want the persisted multi-PPS verdict stamped copy-unsafe", track)
+		}
+	})
+
+	t.Run("memoized", func(t *testing.T) {
+		ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+		ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+		file := copySafetyTestFile(mtime)
+		ensurer.storeCopySafety(file, false)
+
+		got, err := ensurer.EnsureCopySafetyCached(context.Background(), file)
+		if err != nil {
+			t.Fatalf("EnsureCopySafetyCached() error = %v", err)
+		}
+		if runs() != 0 {
+			t.Fatalf("ffmpeg ran %d times, want 0", runs())
+		}
+		track := got.VideoTracks[0]
+		if track.MultiplePPS == nil || *track.MultiplePPS || track.VideoCopyUnsafe {
+			t.Fatalf("track = %+v, want the memoized copy-safe verdict", track)
+		}
+	})
+}
+
+func TestNeedsCopySafetyScan(t *testing.T) {
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	ffmpegPath, _ := fakeFFmpeg(t, "", 0)
+
+	t.Run("unknown h264 needs a scan", func(t *testing.T) {
+		ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+		if !ensurer.NeedsCopySafetyScan(copySafetyTestFile(mtime)) {
+			t.Fatal("NeedsCopySafetyScan() = false, want true for an unresolved H.264 file")
+		}
+	})
+
+	t.Run("known verdict needs none", func(t *testing.T) {
+		ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+		file := copySafetyTestFile(mtime)
+		ensurer.storeCopySafety(file, true)
+		if ensurer.NeedsCopySafetyScan(file) {
+			t.Fatal("NeedsCopySafetyScan() = true, want false once the verdict is known")
+		}
+	})
+
+	t.Run("non-h264 needs none", func(t *testing.T) {
+		ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+		file := copySafetyTestFile(mtime)
+		file.CodecVideo = "hevc"
+		file.VideoTracks[0].Codec = "hevc"
+		if ensurer.NeedsCopySafetyScan(file) {
+			t.Fatal("NeedsCopySafetyScan() = true, want false for a non-H.264 source")
+		}
+	})
+
+	t.Run("without ffmpeg needs none", func(t *testing.T) {
+		ensurer := &PlaybackProbeEnsurer{}
+		if ensurer.NeedsCopySafetyScan(copySafetyTestFile(mtime)) {
+			t.Fatal("NeedsCopySafetyScan() = true, want false without an ffmpeg to scan with")
+		}
+	})
+}
+
+// ScanCopySafety is the asynchronous half: it runs the scan, persists the
+// verdict, and memoizes it so the next plan for the file excludes the copy
+// route without touching the disk again.
+func TestScanCopySafetyPersistsAndMemoizes(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	file := copySafetyTestFile(mtime)
+
+	multi, err := ensurer.ScanCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ScanCopySafety() error = %v", err)
+	}
+	if !multi {
+		t.Fatal("ScanCopySafety() = false, want true for the conflicting-PPS stream")
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want 1", runs())
+	}
+	want := recordedPPSWrite{fileID: 42, multiplePPS: true, scanSize: 1234, scanMtime: mtime, scanMtimeSet: true}
+	if writes := writer.recorded(); len(writes) != 1 || writes[0] != want {
+		t.Fatalf("UpdateMultiplePPS writes = %+v, want exactly %+v", writes, want)
+	}
+	if ensurer.NeedsCopySafetyScan(file) {
+		t.Fatal("NeedsCopySafetyScan() = true after a completed scan, want false")
+	}
+
+	// The memoized verdict is what a later start reads, without re-execing.
+	got, err := ensurer.EnsureCopySafetyCached(context.Background(), file)
+	if err != nil {
+		t.Fatalf("EnsureCopySafetyCached() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times after the cached ensure, want 1", runs())
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS || !track.VideoCopyUnsafe {
+		t.Fatalf("track = %+v, want the scanned multi-PPS verdict", track)
+	}
+}
+
+// An inconclusive scan is not evidence: nothing is persisted, nothing is
+// memoized, and the caller learns the scan failed rather than being handed a
+// fabricated copy-unsafe verdict.
+func TestScanCopySafetyErrorRecordsNothing(t *testing.T) {
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{
+		ffmpegPath:     filepath.Join(t.TempDir(), "missing-ffmpeg"),
+		copySafetyRepo: writer,
+	}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	multi, err := ensurer.ScanCopySafety(context.Background(), file)
+	if err == nil {
+		t.Fatal("ScanCopySafety() error = nil, want the scan failure surfaced to the caller")
+	}
+	if multi {
+		t.Fatal("ScanCopySafety() = true on error, want false")
+	}
+	if writes := writer.recorded(); len(writes) != 0 {
+		t.Fatalf("failed scan recorded %d verdicts, want 0", len(writes))
+	}
+	if !ensurer.NeedsCopySafetyScan(file) {
+		t.Fatal("NeedsCopySafetyScan() = false after a failed scan, want true so a later request retries")
+	}
+
+	got, err := ensurer.EnsureCopySafetyCached(context.Background(), file)
+	if err != nil {
+		t.Fatalf("EnsureCopySafetyCached() error = %v", err)
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS != nil || track.VideoCopyUnsafe {
+		t.Fatalf("track = %+v, want the verdict left unknown after a failed scan", track)
+	}
+}
+
+func TestVideoCopySafetyUnknownIgnoresAudioOnlyFiles(t *testing.T) {
+	file := &models.MediaFile{ID: 7, CodecAudio: "flac"}
+	if file.VideoCopySafetyUnknown() {
+		t.Fatal("VideoCopySafetyUnknown() = true for an audio-only file, want false")
+	}
+}

--- a/internal/scanner/probe_repair_copy_safety_persist_test.go
+++ b/internal/scanner/probe_repair_copy_safety_persist_test.go
@@ -308,6 +308,79 @@ func TestEnsureCopySafetyRetriesAFailedPersistWithoutRescanning(t *testing.T) {
 	}
 }
 
+// A scan reads the opening seconds over storage that can be slow, so the file
+// can be rewritten in place while it runs. The row then refuses the write, and
+// the verdict is about bytes nobody is serving: it must not be memoized as
+// though it described the file, and the caller has to be told, because a
+// verdict that never reached the row must not be pushed at live sessions either.
+func TestScanCopySafetyReportsASupersededWriteAsStale(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{err: ErrStaleCopySafetyScan}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	file := copySafetyTestFile(mtime)
+
+	multi, stale, err := ensurer.ScanCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ScanCopySafety() error = %v, want a superseded write reported as stale, not failed", err)
+	}
+	if !stale {
+		t.Fatal("ScanCopySafety() stale = false, want true for a write the row refused")
+	}
+	if multi {
+		t.Fatal("ScanCopySafety() = true alongside stale, want no verdict claimed for a superseded generation")
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want 1", runs())
+	}
+	// Nothing was memoized, so the file is still unresolved: the next request
+	// for whatever generation the row now holds scans it properly.
+	if !ensurer.NeedsCopySafetyScan(file) {
+		t.Fatal("NeedsCopySafetyScan() = false after a superseded write, want the file still unresolved")
+	}
+	if _, known := ensurer.KnownCopySafetyVerdict(context.Background(), file); known {
+		t.Fatal("KnownCopySafetyVerdict() reported a verdict for a superseded generation")
+	}
+}
+
+// KnownCopySafetyVerdict is the question the serve gate and the race both ask.
+// It has to see the memo — a verdict whose write failed is authoritative here
+// and invisible on the row — and it must retry that write, without ffmpeg.
+func TestKnownCopySafetyVerdictSeesTheMemoAndRetriesTheWrite(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{err: fmt.Errorf("database unavailable")}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	file := copySafetyTestFile(mtime)
+
+	if _, _, err := ensurer.ScanCopySafety(context.Background(), file); err != nil {
+		t.Fatalf("ScanCopySafety() error = %v", err)
+	}
+	if writes := writer.recorded(); len(writes) != 1 {
+		t.Fatalf("UpdateMultiplePPS called %d times for the first scan, want 1", len(writes))
+	}
+
+	multi, known := ensurer.KnownCopySafetyVerdict(context.Background(), file)
+	if !known || !multi {
+		t.Fatalf("KnownCopySafetyVerdict() = (%t, %t), want the unpersisted unsafe verdict", multi, known)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want the known-verdict lookup to never scan", runs())
+	}
+	if writes := writer.recorded(); len(writes) != 2 {
+		t.Fatalf("UpdateMultiplePPS called %d times, want the unpersisted write retried", len(writes))
+	}
+
+	// An untouched file is simply unknown; the lookup never invents a verdict.
+	other := copySafetyTestFile(mtime)
+	other.ID = 43
+	if _, known := ensurer.KnownCopySafetyVerdict(context.Background(), other); known {
+		t.Fatal("KnownCopySafetyVerdict() reported a verdict for a file nothing has scanned")
+	}
+}
+
 // Rows predating the file_modified_at column carry no mtime. Their verdict is
 // still persisted and still honored on read — refusing to write it would leave
 // them permanently unverdicted, so every replica would rescan the same file and

--- a/internal/scanner/probe_repair_copy_safety_persist_test.go
+++ b/internal/scanner/probe_repair_copy_safety_persist_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,22 +35,51 @@ func fakeFFmpeg(t *testing.T, stdoutPayload string, delay time.Duration) (string
 	if err := os.WriteFile(ffmpegPath, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake ffmpeg: %v", err)
 	}
-	return ffmpegPath, func() int {
-		data, err := os.ReadFile(logPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return 0
-			}
-			t.Fatalf("read fake ffmpeg log: %v", err)
-		}
-		runs := 0
-		for _, b := range data {
-			if b == '\n' {
-				runs++
-			}
-		}
-		return runs
+	return ffmpegPath, func() int { return countFFmpegRuns(t, logPath) }
+}
+
+// fakeFFmpegGated is like fakeFFmpeg but blocks after recording its invocation
+// until the returned release func is called, so a test can observe that a scan
+// has actually started — rather than assume it via a fixed sleep — before
+// letting it complete.
+func fakeFFmpegGated(t *testing.T, stdoutPayload string) (ffmpegPath string, runs func() int, release func()) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "invocations.log")
+	releasePath := filepath.Join(dir, "release")
+	ffmpegPath = filepath.Join(dir, "ffmpeg")
+	// The invocation is logged before the gate so the log is the signal that
+	// this process has started, not that it has finished.
+	script := fmt.Sprintf("#!/bin/sh\necho run >> %q\nwhile [ ! -f %q ]; do sleep 0.01; done\nprintf '%s'\n", logPath, releasePath, stdoutPayload)
+	if err := os.WriteFile(ffmpegPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gated fake ffmpeg: %v", err)
 	}
+	runs = func() int { return countFFmpegRuns(t, logPath) }
+	release = func() {
+		if err := os.WriteFile(releasePath, nil, 0o644); err != nil {
+			t.Fatalf("write gated fake ffmpeg release file: %v", err)
+		}
+	}
+	return ffmpegPath, runs, release
+}
+
+// countFFmpegRuns reports how many invocations a fake ffmpeg has logged.
+func countFFmpegRuns(t *testing.T, logPath string) int {
+	t.Helper()
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read fake ffmpeg log: %v", err)
+	}
+	runs := 0
+	for _, b := range data {
+		if b == '\n' {
+			runs++
+		}
+	}
+	return runs
 }
 
 type recordedPPSWrite struct {
@@ -338,7 +368,7 @@ func TestEnsureProbeOnlySkipsCopySafetyScan(t *testing.T) {
 }
 
 func TestEnsureCopySafetyConcurrentCallsScanOnce(t *testing.T) {
-	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 200*time.Millisecond)
+	ffmpegPath, runs, release := fakeFFmpegGated(t, conflictingPPSAnnexB)
 	writer := &fakeCopySafetyWriter{}
 	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
 
@@ -346,6 +376,7 @@ func TestEnsureCopySafetyConcurrentCallsScanOnce(t *testing.T) {
 
 	const callers = 8
 	var wg sync.WaitGroup
+	var entered atomic.Int64
 	results := make([]*models.MediaFile, callers)
 	errs := make([]error, callers)
 	start := make(chan struct{})
@@ -354,11 +385,38 @@ func TestEnsureCopySafetyConcurrentCallsScanOnce(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			<-start
+			entered.Add(1)
 			results[i], errs[i] = ensurer.ensureCopySafety(context.Background(), copySafetyTestFile(mtime))
 		}(i)
 	}
 	close(start)
+
+	// Hold the winning ffmpeg inside its scan until observable state says the
+	// dedup path is genuinely under test: every caller has reached the
+	// ensureCopySafety call site, and exactly one ffmpeg process has started.
+	//
+	// ensureCopySafety dedupes through a singleflight.Group, which exposes no
+	// waiter count, so "all callers entered" is the strongest signal available
+	// from outside the package. It is sufficient here: between the call site
+	// and singleflight.Do, ensureCopySafety only does non-blocking work (a
+	// codec check and a sync.Map lookup), so a caller that has entered reaches
+	// the dedup point without waiting on anything — and the scan it would
+	// otherwise start for itself is still blocked when it gets there.
+	timeout := ""
+	deadline := time.Now().Add(5 * time.Second)
+	for int(entered.Load()) != callers || runs() != 1 {
+		if time.Now().After(deadline) {
+			timeout = fmt.Sprintf("timed out waiting for the deduped scan to start: %d/%d callers entered, %d ffmpeg runs", entered.Load(), callers, runs())
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// Always release, even on timeout, so the callers are not left blocked.
+	release()
 	wg.Wait()
+	if timeout != "" {
+		t.Fatal(timeout)
+	}
 
 	for i, err := range errs {
 		if err != nil {

--- a/internal/scanner/probe_repair_copy_safety_persist_test.go
+++ b/internal/scanner/probe_repair_copy_safety_persist_test.go
@@ -114,6 +114,14 @@ func (w *fakeCopySafetyWriter) UpdateMultiplePPS(_ context.Context, fileID int, 
 	return w.err
 }
 
+// setErr changes what the next write returns, so a test can bring a failed
+// backing store back up.
+func (w *fakeCopySafetyWriter) setErr(err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.err = err
+}
+
 func (w *fakeCopySafetyWriter) recorded() []recordedPPSWrite {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -245,6 +253,58 @@ func TestEnsureCopySafetyScanSurvivesPersistFailure(t *testing.T) {
 	}
 	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
 		t.Fatalf("MultiplePPS = %v, want the scan result despite the failed write", track.MultiplePPS)
+	}
+}
+
+// A verdict whose write failed is correct in this process but invisible to
+// every other replica, which keeps rescanning the file and keeps planning fresh
+// sessions onto the copy route it condemns. The next lookup has to retry the
+// write — and only the write: the answer is already memoized, so re-running
+// ffmpeg would pay the whole bitstream read again for nothing.
+func TestEnsureCopySafetyRetriesAFailedPersistWithoutRescanning(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{err: fmt.Errorf("database unavailable")}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	want := recordedPPSWrite{fileID: 42, multiplePPS: true, scanSize: 1234, scanMtime: mtime, scanMtimeSet: true}
+
+	if _, err := ensurer.ensureCopySafety(context.Background(), copySafetyTestFile(mtime)); err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times for the first call, want 1", runs())
+	}
+	if writes := writer.recorded(); len(writes) != 1 || writes[0] != want {
+		t.Fatalf("first-call writes = %+v, want exactly [%+v]", writes, want)
+	}
+
+	// The database comes back. The next lookup answers from the memo and
+	// retries the write behind it.
+	writer.setErr(nil)
+	got, err := ensurer.ensureCopySafety(context.Background(), copySafetyTestFile(mtime))
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want the retry to write only", runs())
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
+		t.Fatalf("MultiplePPS = %v, want the memoized verdict", track.MultiplePPS)
+	}
+	if writes := writer.recorded(); len(writes) != 2 || writes[1] != want {
+		t.Fatalf("writes after the retry = %+v, want the verdict written a second time as %+v", writes, want)
+	}
+
+	// The verdict has landed, so a third lookup must not touch the row again.
+	if _, err := ensurer.ensureCopySafety(context.Background(), copySafetyTestFile(mtime)); err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if writes := writer.recorded(); len(writes) != 2 {
+		t.Fatalf("UpdateMultiplePPS called %d times, want the successful write to stop the retries", len(writes))
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times overall, want 1", runs())
 	}
 }
 

--- a/internal/scanner/probe_repair_copy_safety_persist_test.go
+++ b/internal/scanner/probe_repair_copy_safety_persist_test.go
@@ -1,0 +1,380 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+// conflictingPPSAnnexB is a two-NAL Annex-B stream that redefines
+// pic_parameter_set_id 0 with two different payloads — what
+// DetectMultiplePPSH264 reports as multi-PPS. Written as printf octal escapes
+// so a /bin/sh stub can emit it: 00 00 01 68 80 | 00 00 01 68 C0.
+const conflictingPPSAnnexB = `\000\000\001\150\200\000\000\001\150\300`
+
+// fakeFFmpeg writes a stub ffmpeg that appends one line to a log file per
+// invocation and emits the given printf-escaped payload on stdout. It returns
+// the stub's path and a func reporting how many times it ran.
+func fakeFFmpeg(t *testing.T, stdoutPayload string, delay time.Duration) (string, func() int) {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "invocations.log")
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	sleep := ""
+	if delay > 0 {
+		sleep = fmt.Sprintf("sleep %.2f\n", delay.Seconds())
+	}
+	script := fmt.Sprintf("#!/bin/sh\necho run >> %q\n%sprintf '%s'\n", logPath, sleep, stdoutPayload)
+	if err := os.WriteFile(ffmpegPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+	return ffmpegPath, func() int {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return 0
+			}
+			t.Fatalf("read fake ffmpeg log: %v", err)
+		}
+		runs := 0
+		for _, b := range data {
+			if b == '\n' {
+				runs++
+			}
+		}
+		return runs
+	}
+}
+
+type recordedPPSWrite struct {
+	fileID      int
+	multiplePPS bool
+	scanSize    int64
+	scanMtime   time.Time
+}
+
+type fakeCopySafetyWriter struct {
+	mu     sync.Mutex
+	writes []recordedPPSWrite
+	err    error
+}
+
+func (w *fakeCopySafetyWriter) UpdateMultiplePPS(_ context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes = append(w.writes, recordedPPSWrite{
+		fileID:      fileID,
+		multiplePPS: multiplePPS,
+		scanSize:    scanSize,
+		scanMtime:   scanMtime,
+	})
+	return w.err
+}
+
+func (w *fakeCopySafetyWriter) recorded() []recordedPPSWrite {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]recordedPPSWrite(nil), w.writes...)
+}
+
+func copySafetyTestFile(mtime time.Time) *models.MediaFile {
+	modified := mtime
+	return &models.MediaFile{
+		ID:             42,
+		FilePath:       "/library/movie.mkv",
+		FileSize:       1234,
+		FileModifiedAt: &modified,
+		CodecVideo:     "h264",
+		VideoTracks:    []models.VideoTrack{{Codec: "h264"}},
+	}
+}
+
+func TestEnsureCopySafetyUsesPersistedVerdictWithoutScanning(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, "", 0)
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	file := copySafetyTestFile(mtime)
+	verdict := true
+	scanSize := file.FileSize
+	scanMtime := mtime
+	file.MultiplePPS = &verdict
+	file.MultiplePPSScanSize = &scanSize
+	file.MultiplePPSScanMtime = &scanMtime
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 0 {
+		t.Fatalf("ffmpeg ran %d times, want 0 for a valid persisted verdict", runs())
+	}
+	track := got.VideoTracks[0]
+	if track.MultiplePPS == nil || !*track.MultiplePPS {
+		t.Fatalf("MultiplePPS = %v, want true from the persisted verdict", track.MultiplePPS)
+	}
+	if !track.VideoCopyUnsafe {
+		t.Fatal("VideoCopyUnsafe = false, want true for a multi-PPS file")
+	}
+	if _, ok := ensurer.copySafety.Load(file.ID); !ok {
+		t.Fatal("persisted verdict was not promoted into the in-memory cache")
+	}
+}
+
+func TestEnsureCopySafetyRescansStaleVerdict(t *testing.T) {
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		scanSize  int64
+		scanMtime time.Time
+	}{
+		{name: "size mismatch", scanSize: 999, scanMtime: mtime},
+		{name: "mtime mismatch", scanSize: 1234, scanMtime: mtime.Add(time.Hour)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+			ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+			file := copySafetyTestFile(mtime)
+			verdict := false
+			scanSize := tc.scanSize
+			scanMtime := tc.scanMtime
+			file.MultiplePPS = &verdict
+			file.MultiplePPSScanSize = &scanSize
+			file.MultiplePPSScanMtime = &scanMtime
+
+			got, err := ensurer.ensureCopySafety(context.Background(), file)
+			if err != nil {
+				t.Fatalf("ensureCopySafety() error = %v", err)
+			}
+			if runs() != 1 {
+				t.Fatalf("ffmpeg ran %d times, want 1 for a stale persisted verdict", runs())
+			}
+			track := got.VideoTracks[0]
+			if track.MultiplePPS == nil || !*track.MultiplePPS {
+				t.Fatalf("MultiplePPS = %v, want the rescanned true, not the stale false", track.MultiplePPS)
+			}
+		})
+	}
+}
+
+func TestEnsureCopySafetyPersistsScanResult(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	file := copySafetyTestFile(mtime)
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want 1", runs())
+	}
+	writes := writer.recorded()
+	if len(writes) != 1 {
+		t.Fatalf("UpdateMultiplePPS called %d times, want 1", len(writes))
+	}
+	want := recordedPPSWrite{fileID: 42, multiplePPS: true, scanSize: 1234, scanMtime: mtime}
+	if writes[0] != want {
+		t.Fatalf("UpdateMultiplePPS(%+v), want %+v", writes[0], want)
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
+		t.Fatalf("MultiplePPS = %v, want true", track.MultiplePPS)
+	}
+}
+
+func TestEnsureCopySafetyScanSurvivesPersistFailure(t *testing.T) {
+	ffmpegPath, _ := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{err: fmt.Errorf("database unavailable")}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v, want the scan result to be used anyway", err)
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
+		t.Fatalf("MultiplePPS = %v, want the scan result despite the failed write", track.MultiplePPS)
+	}
+}
+
+func TestEnsureCopySafetyWithoutRepoDoesNotPanic(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	if _, err := ensurer.ensureCopySafety(context.Background(), file); err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want 1", runs())
+	}
+}
+
+// A failed scan must stay fail-closed and stateless: nothing is written, so a
+// transient error never becomes sticky state on the row and the next request
+// retries cleanly.
+func TestEnsureCopySafetyFailureRecordsNothing(t *testing.T) {
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{
+		ffmpegPath:     filepath.Join(t.TempDir(), "missing-ffmpeg"),
+		copySafetyRepo: writer,
+	}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	got, err := ensurer.ensureCopySafety(context.Background(), file)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if !got.VideoTracks[0].VideoCopyUnsafe {
+		t.Fatal("VideoCopyUnsafe = false, want true after an inconclusive scan")
+	}
+	if writes := writer.recorded(); len(writes) != 0 {
+		t.Fatalf("failed scan recorded %d verdicts, want 0", len(writes))
+	}
+}
+
+// Browse surfaces call EnsureProbeOnly. The copy-safety verdict never reaches
+// a client from those responses, so scanning there was pure warm-up — and the
+// read it costs is what made first-time browsing slow on remote storage.
+func TestEnsureProbeOnlySkipsCopySafetyScan(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	file := copySafetyTestFile(time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC))
+
+	got, err := ensurer.EnsureProbeOnly(context.Background(), file)
+	if err != nil {
+		t.Fatalf("EnsureProbeOnly() error = %v", err)
+	}
+	if runs() != 0 {
+		t.Fatalf("ffmpeg ran %d times for a browse-detail load, want 0", runs())
+	}
+	if got.VideoTracks[0].MultiplePPS != nil {
+		t.Fatal("EnsureProbeOnly() resolved the copy-safety verdict")
+	}
+	if got.VideoTracks[0].VideoCopyUnsafe {
+		t.Fatal("EnsureProbeOnly() marked the file copy-unsafe")
+	}
+	if writes := writer.recorded(); len(writes) != 0 {
+		t.Fatalf("EnsureProbeOnly() persisted %d verdicts, want 0", len(writes))
+	}
+
+	// The same ensurer still scans when a play is being prepared.
+	if _, err := ensurer.Ensure(context.Background(), file); err != nil {
+		t.Fatalf("Ensure() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times for a playback load, want 1", runs())
+	}
+}
+
+func TestEnsureCopySafetyConcurrentCallsScanOnce(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 200*time.Millisecond)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+
+	const callers = 8
+	var wg sync.WaitGroup
+	results := make([]*models.MediaFile, callers)
+	errs := make([]error, callers)
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = ensurer.ensureCopySafety(context.Background(), copySafetyTestFile(mtime))
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("ensureCopySafety() caller %d error = %v", i, err)
+		}
+		if track := results[i].VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
+			t.Fatalf("caller %d MultiplePPS = %v, want true", i, track.MultiplePPS)
+		}
+	}
+	if got := runs(); got != 1 {
+		t.Fatalf("ffmpeg ran %d times for %d concurrent callers, want 1", got, callers)
+	}
+	if writes := writer.recorded(); len(writes) != 1 {
+		t.Fatalf("UpdateMultiplePPS called %d times, want 1", len(writes))
+	}
+}
+
+func TestPersistedCopySafetyVerdict(t *testing.T) {
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	base := func() *models.MediaFile {
+		file := copySafetyTestFile(mtime)
+		verdict := true
+		scanSize := file.FileSize
+		scanMtime := mtime
+		file.MultiplePPS = &verdict
+		file.MultiplePPSScanSize = &scanSize
+		file.MultiplePPSScanMtime = &scanMtime
+		return file
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(*models.MediaFile)
+		wantMulti bool
+		wantOK    bool
+	}{
+		{name: "valid", mutate: func(*models.MediaFile) {}, wantMulti: true, wantOK: true},
+		{name: "never scanned", mutate: func(f *models.MediaFile) { f.MultiplePPS = nil }},
+		{name: "missing scan size", mutate: func(f *models.MediaFile) { f.MultiplePPSScanSize = nil }},
+		{name: "missing scan mtime", mutate: func(f *models.MediaFile) { f.MultiplePPSScanMtime = nil }},
+		{name: "size drifted", mutate: func(f *models.MediaFile) { f.FileSize = 4321 }},
+		{
+			name: "mtime drifted",
+			mutate: func(f *models.MediaFile) {
+				later := mtime.Add(time.Second)
+				f.FileModifiedAt = &later
+			},
+		},
+		{name: "file mtime unknown", mutate: func(f *models.MediaFile) { f.FileModifiedAt = nil }},
+		{
+			name: "sub-microsecond mtime drift is absorbed",
+			mutate: func(f *models.MediaFile) {
+				jittered := mtime.Add(17 * time.Nanosecond).Local()
+				f.FileModifiedAt = &jittered
+			},
+			wantMulti: true,
+			wantOK:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file := base()
+			tc.mutate(file)
+			multi, ok := persistedCopySafetyVerdict(file)
+			if ok != tc.wantOK || multi != tc.wantMulti {
+				t.Fatalf("persistedCopySafetyVerdict() = (%v, %v), want (%v, %v)", multi, ok, tc.wantMulti, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/scanner/probe_repair_copy_safety_persist_test.go
+++ b/internal/scanner/probe_repair_copy_safety_persist_test.go
@@ -56,7 +56,10 @@ type recordedPPSWrite struct {
 	fileID      int
 	multiplePPS bool
 	scanSize    int64
-	scanMtime   time.Time
+	// scanMtime is flattened to a comparable pair so a write for a row with no
+	// mtime is distinguishable from one that carries the zero time.
+	scanMtime    time.Time
+	scanMtimeSet bool
 }
 
 type fakeCopySafetyWriter struct {
@@ -65,15 +68,19 @@ type fakeCopySafetyWriter struct {
 	err    error
 }
 
-func (w *fakeCopySafetyWriter) UpdateMultiplePPS(_ context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime time.Time) error {
+func (w *fakeCopySafetyWriter) UpdateMultiplePPS(_ context.Context, fileID int, multiplePPS bool, scanSize int64, scanMtime *time.Time) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	w.writes = append(w.writes, recordedPPSWrite{
+	write := recordedPPSWrite{
 		fileID:      fileID,
 		multiplePPS: multiplePPS,
 		scanSize:    scanSize,
-		scanMtime:   scanMtime,
-	})
+	}
+	if scanMtime != nil {
+		write.scanMtime = *scanMtime
+		write.scanMtimeSet = true
+	}
+	w.writes = append(w.writes, write)
 	return w.err
 }
 
@@ -186,7 +193,7 @@ func TestEnsureCopySafetyPersistsScanResult(t *testing.T) {
 	if len(writes) != 1 {
 		t.Fatalf("UpdateMultiplePPS called %d times, want 1", len(writes))
 	}
-	want := recordedPPSWrite{fileID: 42, multiplePPS: true, scanSize: 1234, scanMtime: mtime}
+	want := recordedPPSWrite{fileID: 42, multiplePPS: true, scanSize: 1234, scanMtime: mtime, scanMtimeSet: true}
 	if writes[0] != want {
 		t.Fatalf("UpdateMultiplePPS(%+v), want %+v", writes[0], want)
 	}
@@ -208,6 +215,51 @@ func TestEnsureCopySafetyScanSurvivesPersistFailure(t *testing.T) {
 	}
 	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS {
 		t.Fatalf("MultiplePPS = %v, want the scan result despite the failed write", track.MultiplePPS)
+	}
+}
+
+// Rows predating the file_modified_at column carry no mtime. Their verdict is
+// still persisted and still honored on read — refusing to write it would leave
+// them permanently unverdicted, so every replica would rescan the same file and
+// tear down the same playback again.
+func TestEnsureCopySafetyPersistsVerdictForRowWithoutMtime(t *testing.T) {
+	ffmpegPath, runs := fakeFFmpeg(t, conflictingPPSAnnexB, 0)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	file := copySafetyTestFile(time.Now())
+	file.FileModifiedAt = nil
+
+	if _, err := ensurer.ensureCopySafety(context.Background(), file); err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if runs() != 1 {
+		t.Fatalf("ffmpeg ran %d times, want 1", runs())
+	}
+	writes := writer.recorded()
+	want := recordedPPSWrite{fileID: 42, multiplePPS: true, scanSize: 1234}
+	if len(writes) != 1 || writes[0] != want {
+		t.Fatalf("UpdateMultiplePPS writes = %+v, want exactly [%+v]", writes, want)
+	}
+
+	// A fresh process reading that row back must trust the verdict on size
+	// alone rather than rescanning.
+	reread := copySafetyTestFile(time.Now())
+	reread.FileModifiedAt = nil
+	verdict := true
+	scanSize := reread.FileSize
+	reread.MultiplePPS = &verdict
+	reread.MultiplePPSScanSize = &scanSize
+	cold := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath}
+	if cold.NeedsCopySafetyScan(reread) {
+		t.Fatal("NeedsCopySafetyScan() = true, want the persisted mtime-less verdict honored")
+	}
+	got, err := cold.ensureCopySafety(context.Background(), reread)
+	if err != nil {
+		t.Fatalf("ensureCopySafety() error = %v", err)
+	}
+	if track := got.VideoTracks[0]; track.MultiplePPS == nil || !*track.MultiplePPS || !track.VideoCopyUnsafe {
+		t.Fatalf("track = %+v, want the persisted multi-PPS verdict stamped", track)
 	}
 }
 

--- a/internal/scanner/probe_repair_copy_safety_persist_test.go
+++ b/internal/scanner/probe_repair_copy_safety_persist_test.go
@@ -494,6 +494,130 @@ func TestEnsureCopySafetyConcurrentCallsScanOnce(t *testing.T) {
 	}
 }
 
+// A file rewritten in place keeps its row ID and changes its bytes. Two callers
+// that disagree about the size and mtime are therefore looking at two different
+// bitstreams, and must not share a scan: the joiner would take the leader's
+// verdict for its own file — clearing the condemnation of a copy-unsafe
+// replacement, or condemning a copy-safe one.
+func TestCopySafetyScanDoesNotShareAFlightAcrossFileGenerations(t *testing.T) {
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*models.MediaFile)
+	}{
+		{
+			name:   "size changed",
+			mutate: func(f *models.MediaFile) { f.FileSize = 9999 },
+		},
+		{
+			name: "mtime changed",
+			mutate: func(f *models.MediaFile) {
+				later := mtime.Add(time.Hour)
+				f.FileModifiedAt = &later
+			},
+		},
+		{
+			name:   "mtime dropped",
+			mutate: func(f *models.MediaFile) { f.FileModifiedAt = nil },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ffmpegPath, runs, release := fakeFFmpegGated(t, conflictingPPSAnnexB)
+			writer := &fakeCopySafetyWriter{}
+			ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+			replaced := copySafetyTestFile(mtime)
+			tc.mutate(replaced)
+
+			var wg sync.WaitGroup
+			errs := make([]error, 2)
+			for i, file := range []*models.MediaFile{copySafetyTestFile(mtime), replaced} {
+				wg.Add(1)
+				go func(i int, file *models.MediaFile) {
+					defer wg.Done()
+					_, errs[i] = ensurer.ensureCopySafety(context.Background(), file)
+				}(i, file)
+			}
+
+			// Both scans are held inside the stub, so "two ffmpeg processes have
+			// started" is only reachable if the two generations were given
+			// separate flights. A shared flight leaves the second caller parked
+			// on the first and the count stuck at one.
+			timeout := ""
+			deadline := time.Now().Add(5 * time.Second)
+			for runs() != 2 {
+				if time.Now().After(deadline) {
+					timeout = fmt.Sprintf("timed out with %d ffmpeg runs, want one scan per file generation", runs())
+					break
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+			release()
+			wg.Wait()
+			if timeout != "" {
+				t.Fatal(timeout)
+			}
+			for i, err := range errs {
+				if err != nil {
+					t.Fatalf("ensureCopySafety() caller %d error = %v", i, err)
+				}
+			}
+			if writes := writer.recorded(); len(writes) != 2 {
+				t.Fatalf("UpdateMultiplePPS called %d times, want one verdict per generation: %+v", len(writes), writes)
+			}
+		})
+	}
+}
+
+// The same generation read twice — with the mtime differing only below the
+// precision the row can store — is one bitstream and must still share one scan.
+func TestCopySafetyScanSharesAFlightAcrossSubMicrosecondMtimeDrift(t *testing.T) {
+	ffmpegPath, runs, release := fakeFFmpegGated(t, conflictingPPSAnnexB)
+	writer := &fakeCopySafetyWriter{}
+	ensurer := &PlaybackProbeEnsurer{ffmpegPath: ffmpegPath, copySafetyRepo: writer}
+
+	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	jittered := copySafetyTestFile(mtime)
+	drifted := mtime.Add(17 * time.Nanosecond).Local()
+	jittered.FileModifiedAt = &drifted
+
+	var wg sync.WaitGroup
+	var entered atomic.Int64
+	errs := make([]error, 2)
+	for i, file := range []*models.MediaFile{copySafetyTestFile(mtime), jittered} {
+		wg.Add(1)
+		go func(i int, file *models.MediaFile) {
+			defer wg.Done()
+			entered.Add(1)
+			_, errs[i] = ensurer.ensureCopySafety(context.Background(), file)
+		}(i, file)
+	}
+
+	timeout := ""
+	deadline := time.Now().Add(5 * time.Second)
+	for entered.Load() != 2 || runs() != 1 {
+		if time.Now().After(deadline) {
+			timeout = fmt.Sprintf("timed out: %d callers entered, %d ffmpeg runs", entered.Load(), runs())
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	release()
+	wg.Wait()
+	if timeout != "" {
+		t.Fatal(timeout)
+	}
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("ensureCopySafety() caller %d error = %v", i, err)
+		}
+	}
+	if got := runs(); got != 1 {
+		t.Fatalf("ffmpeg ran %d times, want sub-microsecond mtime drift to share one scan", got)
+	}
+}
+
 func TestPersistedCopySafetyVerdict(t *testing.T) {
 	mtime := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
 	base := func() *models.MediaFile {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -3184,7 +3184,7 @@ func sameFileModifiedAt(existing *time.Time, current time.Time) bool {
 }
 
 func normalizeFileModifiedAt(ts time.Time) time.Time {
-	return ts.UTC().Truncate(time.Microsecond)
+	return models.NormalizeFileModifiedAt(ts)
 }
 
 func needsCriticalProbeRepairScanState(file *scanStateFile) bool {

--- a/migrations/sql/20260823182731_persist_multiple_pps_verdict.sql
+++ b/migrations/sql/20260823182731_persist_multiple_pps_verdict.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Persist the H.264 multi-PPS copy-safety verdict so the bitstream scan is not
+-- re-run on every process restart. The verdict is self-validating: it is only
+-- trusted when the recorded scan size and mtime still match the media_files
+-- row, so any rewrite of the file invalidates it without writer coordination.
+ALTER TABLE public.media_files
+    ADD COLUMN multiple_pps boolean,
+    ADD COLUMN multiple_pps_scan_size bigint,
+    ADD COLUMN multiple_pps_scan_mtime timestamptz;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE public.media_files
+    DROP COLUMN IF EXISTS multiple_pps_scan_mtime,
+    DROP COLUMN IF EXISTS multiple_pps_scan_size,
+    DROP COLUMN IF EXISTS multiple_pps;
+-- +goose StatementEnd

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -4,13 +4,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PlayerConfigProvider, type PlayerConfig } from "../context/PlayerConfigContext";
 import { fixturePlanV3 } from "../protocol-v3.fixtures";
-import type { PlaybackRealtimeEventEnvelope } from "../realtime-protocol";
+import type {
+  PlaybackRealtimeCommandEnvelope,
+  PlaybackRealtimeEventEnvelope,
+} from "../realtime-protocol";
 import type { PlayerSubtitleInfo } from "../types";
 import { HLS_STARTUP_TIMEOUT_MS } from "../utils/hlsStartupGuard";
 import { VideoPlayer } from "./VideoPlayer";
 
 const realtimeOptions = vi.hoisted(() => ({
-  current: null as null | { onEvent?: (event: PlaybackRealtimeEventEnvelope) => void },
+  current: null as null | {
+    onEvent?: (event: PlaybackRealtimeEventEnvelope) => void;
+    onCommand: (command: PlaybackRealtimeCommandEnvelope) => Promise<void> | void;
+  },
 }));
 const controls = vi.hoisted(() => ({
   current: null as null | {
@@ -118,6 +124,22 @@ function renderPlayer(overrides: Partial<Parameters<typeof VideoPlayer>[0]> = {}
     rerenderPlayer(next: Partial<Parameters<typeof VideoPlayer>[0]>) {
       rendered.rerender(createElement(VideoPlayer, { ...props, ...next }));
     },
+  };
+}
+
+function planInvalidatedCommand(
+  payload: Record<string, unknown> = {
+    reason: "video_copy_unsafe",
+    plan_id: directPlan.plan_id,
+  },
+): PlaybackRealtimeCommandEnvelope {
+  return {
+    type: "command",
+    command_id: "cmd-invalidate-1",
+    session_id: "session-1",
+    name: "plan_invalidated",
+    deadline_ms: 8_000,
+    payload,
   };
 }
 
@@ -232,6 +254,45 @@ describe("VideoPlayer plan failure recovery", () => {
 
     fireEvent.error(video);
     expect(onPlanFailure).toHaveBeenCalledTimes(2);
+  });
+
+  it("replans off a plan the server invalidated", async () => {
+    const onPlanInvalidated = vi.fn().mockResolvedValue(true);
+    renderPlayer({ onPlanInvalidated });
+    const onCommand = realtimeOptions.current?.onCommand;
+    if (!onCommand) throw new Error("expected the realtime command handler");
+
+    await act(async () => {
+      await onCommand(planInvalidatedCommand());
+    });
+
+    expect(onPlanInvalidated).toHaveBeenCalledWith(directPlan.plan_id, "video_copy_unsafe", 0);
+  });
+
+  // A rejected result is the server's cue to stop the session, which is what
+  // lets the client's own recovery mint a fresh attempt against the persisted
+  // verdict. Swallowing the failure here would leave the copy route playing.
+  it("rejects the invalidation command when no replacement plan is adopted", async () => {
+    const onPlanInvalidated = vi.fn().mockResolvedValue(false);
+    renderPlayer({ onPlanInvalidated });
+    const onCommand = realtimeOptions.current?.onCommand;
+    if (!onCommand) throw new Error("expected the realtime command handler");
+
+    await expect(onCommand(planInvalidatedCommand())).rejects.toThrow(
+      "plan_invalidation_replan_failed",
+    );
+  });
+
+  it("rejects an invalidation command that names no plan", async () => {
+    const onPlanInvalidated = vi.fn().mockResolvedValue(true);
+    renderPlayer({ onPlanInvalidated });
+    const onCommand = realtimeOptions.current?.onCommand;
+    if (!onCommand) throw new Error("expected the realtime command handler");
+
+    await expect(
+      onCommand(planInvalidatedCommand({ reason: "video_copy_unsafe" })),
+    ).rejects.toThrow("invalid_plan_invalidated_payload");
+    expect(onPlanInvalidated).not.toHaveBeenCalled();
   });
 
   it("does not retry an auto-selected subtitle after its replan is refused", async () => {

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -27,6 +27,7 @@ import { usePlayerConfig } from "../context/PlayerConfigContext";
 import { qualityOptionsFromPlanV3 } from "../playback-info";
 import { preconnectToStreamOrigin } from "../stream-url";
 import { WatchTogetherPanel } from "./WatchTogetherPanel";
+import { readPlanInvalidatedPayload, VIDEO_PLAYBACK_COMMANDS } from "../realtime-protocol";
 import type {
   PlaybackRealtimeCommandEnvelope,
   PlaybackRealtimeEventEnvelope,
@@ -109,6 +110,12 @@ interface VideoPlayerProps {
   onSubtitleTrackChange?: (combinedIndex: number | null, currentPosition: number) => void;
   /** `failure_recovery` replan after the client could not play the plan. */
   onPlanFailure?: (failure: FailureV3, currentPosition: number) => void;
+  /**
+   * Replan for a plan the server invalidated over the realtime
+   * `plan_invalidated` command. Resolving false rejects the command, which is
+   * what tells the server to stop the session instead.
+   */
+  onPlanInvalidated?: (planId: string, reason: string, currentPosition: number) => Promise<boolean>;
   /** `seek_reanchor` replan when a seek target falls outside the seekable window. */
   onReanchorSeek?: (positionSeconds: number) => void;
   preferredSubtitleLanguage?: string | null;
@@ -216,6 +223,7 @@ export function VideoPlayer({
   onQualitySelect,
   onSubtitleTrackChange,
   onPlanFailure,
+  onPlanInvalidated,
   onReanchorSeek,
   preferredSubtitleLanguage,
   preferredSubtitleTrackSignature,
@@ -2416,6 +2424,28 @@ export function VideoPlayer({
             tone: "warning",
           });
           return;
+        case "plan_invalidated": {
+          // The server decided the route it planned cannot serve this source
+          // after all. Ack (already sent by the transport), replan off it, and
+          // report the outcome: a rejection is the server's cue to stop the
+          // session so the client's own recovery can mint a fresh attempt.
+          const invalidated = readPlanInvalidatedPayload(command.payload);
+          if (!invalidated) {
+            throw new Error("invalid_plan_invalidated_payload");
+          }
+          if (!onPlanInvalidated) {
+            throw new Error("plan_invalidation_unsupported");
+          }
+          const replaced = await onPlanInvalidated(
+            invalidated.plan_id,
+            invalidated.reason,
+            currentTimeRef.current,
+          );
+          if (!replaced) {
+            throw new Error("plan_invalidation_replan_failed");
+          }
+          return;
+        }
         case "stop":
         case "terminate":
           if (command.payload) {
@@ -2436,13 +2466,14 @@ export function VideoPlayer({
           throw new Error("unsupported");
       }
     },
-    [handleExit, performPlayerSeek],
+    [handleExit, onPlanInvalidated, performPlayerSeek],
   );
 
   const realtime = usePlaybackRealtime({
     sessionId,
     onCommand: executeRealtimeCommand,
     onEvent: handleRealtimeEvent,
+    supportedCommands: VIDEO_PLAYBACK_COMMANDS,
   });
 
   useEffect(() => {

--- a/web/src/player/components/WatchPage.test.ts
+++ b/web/src/player/components/WatchPage.test.ts
@@ -87,6 +87,7 @@ function playbackSession(
     changeSubtitleTrack: vi.fn(),
     changeQuality: vi.fn(),
     recoverFromFailure: vi.fn(),
+    invalidatePlan: vi.fn().mockResolvedValue(true),
     reanchorSeek: vi.fn(),
     refreshSubtitles: vi.fn(),
     applySubtitleTrack: vi.fn(),

--- a/web/src/player/components/WatchPage.tsx
+++ b/web/src/player/components/WatchPage.tsx
@@ -450,6 +450,7 @@ export function WatchPage({
       onQualitySelect={session.changeQuality}
       onSubtitleTrackChange={session.changeSubtitleTrack}
       onPlanFailure={session.recoverFromFailure}
+      onPlanInvalidated={session.invalidatePlan}
       onReanchorSeek={session.reanchorSeek}
       onApplySubtitleTrack={session.applySubtitleTrack}
       preferredSubtitleLanguage={preferredSubtitleLanguage}

--- a/web/src/player/hooks/usePlaybackRealtime.ts
+++ b/web/src/player/hooks/usePlaybackRealtime.ts
@@ -5,6 +5,7 @@ import {
   buildPlaybackRealtimeHello,
   buildPlaybackRealtimeResult,
   parsePlaybackRealtimeMessage,
+  type PlaybackCommandName,
   type PlaybackRealtimeCommandEnvelope,
   type PlaybackRealtimeEventEnvelope,
 } from "../realtime-protocol";
@@ -15,6 +16,12 @@ interface UsePlaybackRealtimeOptions {
   sessionId: string | null;
   onCommand: (command: PlaybackRealtimeCommandEnvelope) => Promise<void> | void;
   onEvent?: (event: PlaybackRealtimeEventEnvelope) => void;
+  /**
+   * The commands this surface can execute, announced in the hello. Defaults to
+   * the shared set; a surface that handles more names them so it does not
+   * announce a command it would only reject.
+   */
+  supportedCommands?: PlaybackCommandName[];
 }
 
 interface UsePlaybackRealtimeResult {
@@ -39,16 +46,22 @@ export function usePlaybackRealtime({
   sessionId,
   onCommand,
   onEvent,
+  supportedCommands,
 }: UsePlaybackRealtimeOptions): UsePlaybackRealtimeResult {
   const config = usePlayerConfig();
   const [connectionState, setConnectionState] = useState<ConnectionState>("disconnected");
   const onCommandRef = useRef(onCommand);
   const onEventRef = useRef(onEvent);
+  const supportedCommandsRef = useRef(supportedCommands);
   const seenCommandsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     onCommandRef.current = onCommand;
   }, [onCommand]);
+
+  useEffect(() => {
+    supportedCommandsRef.current = supportedCommands;
+  }, [supportedCommands]);
 
   useEffect(() => {
     onEventRef.current = onEvent;
@@ -94,7 +107,9 @@ export function usePlaybackRealtime({
         attempt = 0;
         setConnectionState("connected");
         seenCommandsRef.current.clear();
-        socket.send(JSON.stringify(buildPlaybackRealtimeHello(sessionId)));
+        socket.send(
+          JSON.stringify(buildPlaybackRealtimeHello(sessionId, supportedCommandsRef.current)),
+        );
       });
 
       socket.addEventListener("message", (event) => {

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -1757,3 +1757,160 @@ describe("usePlaybackSession server-invalidated plans", () => {
     unmount();
   });
 });
+
+describe("usePlaybackSession server-invalidated plans", () => {
+  // An invalidation waits out whatever is still being adopted, so it decides
+  // against the plan that actually won rather than the one on screen. The wait
+  // has to be scoped to the request that can still own the session: a start
+  // abandoned by a version switch cannot install anything any more, and a hung
+  // one would otherwise hold the invalidation past the server's 8s deadline —
+  // which stops the very session that is playing fine.
+  it("does not wait on a superseded start that never settles", async () => {
+    let startCount = 0;
+    const replanBodies: Array<{ operation: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        startCount += 1;
+        if (startCount === 1) {
+          // The abandoned request: it never settles, and nothing will ever
+          // count it out.
+          return new Promise<Response>(() => {});
+        }
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "playable",
+            session_id: "session-2",
+            playback_plan: fixturePlanV3({ session_id: "session-2" }),
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/session-2/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as { operation: string });
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-2",
+          playback_plan: fixturePlanV3({
+            session_id: "session-2",
+            plan_id: "plan:2222222222222222",
+            plan_attempt_key: "v3:2222222222222222",
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender, unmount } = renderHook(
+      ({ requestKey, fileId }: { requestKey: string; fileId: number }) =>
+        usePlaybackSession(requestKey, [], [], fileId, 0, false, "auto"),
+      { wrapper, initialProps: { requestKey: "episode-1", fileId: 7 } },
+    );
+    await waitFor(() => expect(startCount).toBe(1));
+
+    rerender({ requestKey: "episode-2", fileId: 8 });
+    await waitFor(() => expect(result.current.plan).not.toBeNull());
+
+    const planId = result.current.plan?.plan_id;
+    if (!planId) throw new Error("expected an adopted plan");
+
+    const outcome = await act(async () =>
+      Promise.race([
+        result.current.invalidatePlan(planId, "video_copy_unsafe", 120),
+        new Promise<"blocked">((resolve) => {
+          setTimeout(() => resolve("blocked"), 500);
+        }),
+      ]),
+    );
+
+    expect(outcome).toBe(true);
+    expect(replanBodies.map(({ operation }) => operation)).toEqual(["failure_recovery"]);
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:2222222222222222"));
+
+    unmount();
+  });
+
+  // The scoping must not weaken the guarantee it was built for: an invalidation
+  // that arrives while the *current* start is still in flight still waits, so
+  // it decides against the plan that response installs rather than no-opping
+  // against the one already on screen.
+  it("still waits for the start that currently owns the session", async () => {
+    let releaseStart: ((response: Response) => void) | undefined;
+    const pendingStart = new Promise<Response>((resolve) => {
+      releaseStart = resolve;
+    });
+    let startCount = 0;
+    const replanBodies: Array<{ operation: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        startCount += 1;
+        return pendingStart;
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as { operation: string });
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-1",
+          playback_plan: fixturePlanV3({
+            session_id: "session-1",
+            plan_id: "plan:3333333333333333",
+            plan_attempt_key: "v3:3333333333333333",
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(startCount).toBe(1));
+
+    // The verdict names a plan this client has not read the response for yet.
+    let settled = false;
+    const invalidation = result.current
+      .invalidatePlan("plan:0123456789abcdef", "video_copy_unsafe", 120)
+      .then((adopted) => {
+        settled = true;
+        return adopted;
+      });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(settled).toBe(false);
+    expect(replanBodies).toHaveLength(0);
+
+    await act(async () => {
+      releaseStart?.(
+        jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "playable",
+            session_id: "session-1",
+            playback_plan: fixturePlanV3({ session_id: "session-1" }),
+          },
+          { status: 201 },
+        ),
+      );
+      await expect(invalidation).resolves.toBe(true);
+    });
+    expect(replanBodies.map(({ operation }) => operation)).toEqual(["failure_recovery"]);
+
+    unmount();
+  });
+});

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -12,6 +12,7 @@ import {
   buildReplanRequestV3,
   buildStartRequestV3,
   routeEventPlanIdentityV3,
+  VIDEO_CLIENT_FEATURES_V3,
 } from "../playback-session-wire-v3";
 import { usePlaybackSession } from "./usePlaybackSession";
 
@@ -67,6 +68,16 @@ const replanBase = {
 };
 
 describe("buildStartRequestV3", () => {
+  // Feature tokens are promises the server enforces, so a surface advertises
+  // only what it implements: the base set alone unless the caller names more.
+  it("advertises only the surface's own features", () => {
+    expect(
+      buildStartRequestV3({ ...startBase, extraClientFeatures: VIDEO_CLIENT_FEATURES_V3 })
+        .client_features,
+    ).toEqual(["playback_plan_v3", "plan_invalidated_v1"]);
+    expect(buildStartRequestV3(startBase).client_features).toEqual(["playback_plan_v3"]);
+  });
+
   it("declares the protocol version and the plan feature", () => {
     expect(buildStartRequestV3(startBase)).toMatchObject({
       protocol_version: 3,
@@ -143,6 +154,19 @@ describe("buildReplanRequestV3", () => {
       plan_attempt_key: "v3:0123456789abcdef",
       position_seconds: 120,
     });
+  });
+
+  // A replan that sends `client_features` replaces the negotiated list, so a
+  // replan which advertised less than the start did would silently withdraw the
+  // promise the server gates the invalidation command on.
+  it("re-advertises the same features a start negotiated", () => {
+    expect(
+      buildReplanRequestV3({
+        ...replanBase,
+        operation: "failure_recovery",
+        extraClientFeatures: VIDEO_CLIENT_FEATURES_V3,
+      }).client_features,
+    ).toEqual(["playback_plan_v3", "plan_invalidated_v1"]);
   });
 
   it("names a new audio track by index alone", () => {
@@ -1391,6 +1415,155 @@ describe("usePlaybackSession replans", () => {
       expect(result.current.error).toBe("Playback failed after repeated recovery attempts.");
     });
     expect(replanCount).toBe(8);
+
+    unmount();
+  });
+});
+
+describe("usePlaybackSession server-invalidated plans", () => {
+  function invalidationFetchMock(replanBodies: Array<Record<string, unknown>>, replan: unknown) {
+    return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "playable",
+            session_id: "session-1",
+            playback_plan: fixturePlanV3(),
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return jsonResponse(replan);
+      }
+      if (url.endsWith("/playback/route-events")) {
+        return new Response(null, { status: 202 });
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+  }
+
+  it("recovers off the invalidated plan and excludes its attempt key", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    vi.stubGlobal(
+      "fetch",
+      invalidationFetchMock(replanBodies, {
+        protocol_version: 3,
+        server_features: ["playback_plan_v3"],
+        outcome: "playable",
+        session_id: "session-1",
+        playback_plan: fixturePlanV3({
+          plan_id: "plan:2222222222222222",
+          plan_attempt_key: "v3:2222222222222222",
+          delivery: "server_transcode_hls",
+        }),
+      }),
+    );
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.invalidatePlan(
+        "plan:0123456789abcdef",
+        "video_copy_unsafe",
+        450,
+      );
+    });
+
+    // The server only pushes the command to a session that promised to handle
+    // it, so the promise has to be on the wire for any of this to be reachable.
+    const startCall = vi
+      .mocked(fetch)
+      .mock.calls.find(([url]) => String(url).endsWith("/playback/start"));
+    const startBody = JSON.parse(String(startCall?.[1]?.body)) as { client_features: string[] };
+    expect(startBody.client_features).toContain("plan_invalidated_v1");
+
+    expect(outcome).toBe(true);
+    expect(replanBodies).toHaveLength(1);
+    expect(replanBodies[0]).toMatchObject({
+      operation: "failure_recovery",
+      failed_plan_id: "plan:0123456789abcdef",
+      position_seconds: 450,
+      // The invalidated route is excluded by key, so the replacement plan
+      // cannot be the same copy route the server just disqualified.
+      attempted_plan_keys: ["v3:0123456789abcdef"],
+      failure: { classification: "video_copy_unsafe" },
+    });
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:2222222222222222"));
+
+    unmount();
+  });
+
+  it("does nothing for a plan the session already moved past", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    vi.stubGlobal("fetch", invalidationFetchMock(replanBodies, {}));
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.invalidatePlan("plan:superseded", "video_copy_unsafe", 12);
+    });
+
+    // Reported as handled: the invalidated route is already gone, and replanning
+    // would evict a plan the server never complained about.
+    expect(outcome).toBe(true);
+    expect(replanBodies).toHaveLength(0);
+
+    unmount();
+  });
+
+  it("reports failure when the replan produces no replacement plan", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    vi.stubGlobal(
+      "fetch",
+      invalidationFetchMock(replanBodies, {
+        protocol_version: 3,
+        server_features: ["playback_plan_v3"],
+        outcome: "adaptation_unavailable",
+        terminal: {
+          reason: "video_conversion_unsupported",
+          message: "No executor can transcode this source.",
+          retryable: false,
+        },
+      }),
+    );
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.invalidatePlan(
+        "plan:0123456789abcdef",
+        "video_copy_unsafe",
+        30,
+      );
+    });
+
+    // The caller rejects the realtime command on false, which is what makes the
+    // server stop the session instead of leaving the copy route playing.
+    expect(outcome).toBe(false);
+    expect(replanBodies).toHaveLength(1);
 
     unmount();
   });

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -1529,6 +1529,195 @@ describe("usePlaybackSession server-invalidated plans", () => {
     unmount();
   });
 
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((settle) => {
+      resolve = settle;
+    });
+    return { promise, resolve };
+  }
+
+  /**
+   * A start and a replan whose response is held open, so a test can act while
+   * the client has a decision in flight — the state the server is always in
+   * when it pushes an invalidation: it commits the replacement plan and starts
+   * the copy-safety scan behind it before the response is on the wire.
+   */
+  function gatedReplanFetchMock(
+    replanBodies: Array<Record<string, unknown>>,
+    replans: unknown[],
+    gate: Promise<void>,
+  ) {
+    return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "playable",
+            session_id: "session-1",
+            playback_plan: fixturePlanV3(),
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        if (replanBodies.length === 1) await gate;
+        return jsonResponse(replans.shift());
+      }
+      if (url.endsWith("/playback/route-events")) {
+        return new Response(null, { status: 202 });
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+  }
+
+  function playableDecision(plan: ReturnType<typeof fixturePlanV3>) {
+    return {
+      protocol_version: 3,
+      server_features: ["playback_plan_v3"],
+      outcome: "playable",
+      session_id: "session-1",
+      playback_plan: plan,
+    };
+  }
+
+  // The server commits the replacement plan and starts the scan behind it
+  // before the client can read the response, so the invalidation can name a
+  // plan this client has not adopted yet. Deciding against the plan on screen
+  // would complete the command as a no-op and then let the pending response
+  // install the very route the server withdrew.
+  it("waits out an in-flight replan and recovers off the plan it adopts", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    const gate = deferred<void>();
+    vi.stubGlobal(
+      "fetch",
+      gatedReplanFetchMock(
+        replanBodies,
+        [
+          playableDecision(
+            fixturePlanV3({
+              plan_id: "plan:2222222222222222",
+              plan_attempt_key: "v3:2222222222222222",
+            }),
+          ),
+          playableDecision(
+            fixturePlanV3({
+              plan_id: "plan:3333333333333333",
+              plan_attempt_key: "v3:3333333333333333",
+              delivery: "server_transcode_hls",
+            }),
+          ),
+        ],
+        gate.promise,
+      ),
+    );
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    act(() => {
+      result.current.changeQuality("720p", 100);
+    });
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+
+    let invalidation: Promise<boolean> | undefined;
+    act(() => {
+      invalidation = result.current.invalidatePlan(
+        "plan:2222222222222222",
+        "video_copy_unsafe",
+        100,
+      );
+    });
+    // Nothing may be decided yet: the plan the command names is still in the
+    // response the client has not read.
+    expect(replanBodies).toHaveLength(1);
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      gate.resolve();
+      outcome = await invalidation;
+    });
+
+    expect(outcome).toBe(true);
+    expect(replanBodies).toHaveLength(2);
+    expect(replanBodies[1]).toMatchObject({
+      operation: "failure_recovery",
+      failed_plan_id: "plan:2222222222222222",
+      // The plan that was invalidated mid-adoption is the one excluded, not the
+      // one that was on screen when the command arrived.
+      attempted_plan_keys: ["v3:2222222222222222"],
+      failure: { classification: "video_copy_unsafe" },
+    });
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:3333333333333333"));
+
+    unmount();
+  });
+
+  // The mirror image: the client really did move past the invalidated plan
+  // while the command was in flight. Waiting must not turn that into a replan —
+  // it would evict a route the server never complained about.
+  it("stays a no-op for a plan the in-flight replan replaced", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    const gate = deferred<void>();
+    vi.stubGlobal(
+      "fetch",
+      gatedReplanFetchMock(
+        replanBodies,
+        [
+          playableDecision(
+            fixturePlanV3({
+              plan_id: "plan:2222222222222222",
+              plan_attempt_key: "v3:2222222222222222",
+            }),
+          ),
+        ],
+        gate.promise,
+      ),
+    );
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    act(() => {
+      result.current.changeQuality("720p", 100);
+    });
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+
+    let invalidation: Promise<boolean> | undefined;
+    act(() => {
+      invalidation = result.current.invalidatePlan(
+        "plan:0123456789abcdef",
+        "video_copy_unsafe",
+        100,
+      );
+    });
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      gate.resolve();
+      outcome = await invalidation;
+    });
+
+    // Reported as handled, with no second replan: the invalidated route is gone.
+    expect(outcome).toBe(true);
+    expect(replanBodies).toHaveLength(1);
+    expect(result.current.plan?.plan_id).toBe("plan:2222222222222222");
+
+    unmount();
+  });
+
   it("reports failure when the replan produces no replacement plan", async () => {
     const replanBodies: Array<Record<string, unknown>> = [];
     vi.stubGlobal(

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -28,6 +28,7 @@ import {
   buildReplanRequestV3,
   buildStartRequestV3,
   routeEventPlanIdentityV3,
+  VIDEO_CLIENT_FEATURES_V3,
   type ReplanOptions,
 } from "../playback-session-wire-v3";
 import type {
@@ -87,6 +88,12 @@ export interface UsePlaybackSessionResult extends PlaybackSessionState {
   changeQuality: (label: string, currentPosition: number) => void;
   /** `failure_recovery` replan after the client could not play the plan. */
   recoverFromFailure: (failure: FailureV3, currentPosition: number) => void;
+  /**
+   * `failure_recovery` replan for a plan the *server* invalidated over the
+   * realtime `plan_invalidated` command. Resolves to whether a replacement plan
+   * is now playing; the caller reports that back as the command's result.
+   */
+  invalidatePlan: (planId: string, reason: string, currentPosition: number) => Promise<boolean>;
   /** `seek_reanchor` replan when the target lies outside the seekable window. */
   reanchorSeek: (positionSeconds: number) => void;
   /** Re-reads the subtitle inventory by replanning with the selection unchanged. */
@@ -416,6 +423,7 @@ export function usePlaybackSession(
       playbackAttemptId: string,
     ): Promise<DecisionResponseV3> => {
       const body = buildStartRequestV3({
+        extraClientFeatures: VIDEO_CLIENT_FEATURES_V3,
         fileId: targetFileId,
         profileId: config.getProfileId() ?? "",
         playbackAttemptId,
@@ -793,6 +801,7 @@ export function usePlaybackSession(
 
       const body = buildReplanRequestV3({
         ...options,
+        extraClientFeatures: VIDEO_CLIENT_FEATURES_V3,
         plan,
         playbackAttemptId,
         replanRequestId: randomUUID(),
@@ -1008,6 +1017,35 @@ export function usePlaybackSession(
     [replan, reportEvent],
   );
 
+  /**
+   * Replans off a plan the server invalidated mid-playback.
+   *
+   * This is an ordinary `failure_recovery`, deliberately: that operation is
+   * what folds the current plan's attempt key into `attempted_plan_keys`, so
+   * the route the server just disqualified is excluded from the replacement
+   * plan without the client reasoning about deliveries at all. The plan
+   * revision the adopted plan bumps rebuilds the transport and restores the
+   * position, exactly as it does after a client-detected failure.
+   */
+  const invalidatePlan = useCallback(
+    async (planId: string, reason: string, currentPosition: number): Promise<boolean> => {
+      const plan = planRef.current;
+      if (!plan) return false;
+      // The command names the plan the server invalidated. Once the client has
+      // moved past it there is nothing to recover from, and replanning anyway
+      // would evict a route the server never complained about.
+      if (plan.plan_id !== planId) return true;
+      const classification = reason.trim().slice(0, 64) || "plan_invalidated";
+      reportEvent("plan_invalidated", { fallbackReason: classification });
+      return replan({
+        operation: "failure_recovery",
+        positionSeconds: currentPosition,
+        failure: { classification, message: "The server invalidated this plan." },
+      });
+    },
+    [replan, reportEvent],
+  );
+
   const reanchorSeek = useCallback(
     (positionSeconds: number) => {
       playbackPositionRef.current = positionSeconds;
@@ -1111,6 +1149,7 @@ export function usePlaybackSession(
     changeSubtitleTrack,
     changeQuality,
     recoverFromFailure,
+    invalidatePlan,
     reanchorSeek,
     refreshSubtitles,
     applySubtitleTrack,

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -316,14 +316,23 @@ export function usePlaybackSession(
   const attemptedPlanKeysRef = useRef<string[]>([]);
   const attemptCountRef = useRef(1);
   const replanInFlightRef = useRef(false);
-  // Adoptions in flight: a start or a replan whose decision has not been
-  // applied yet. The server commits a replacement plan — and starts the
-  // copy-safety scan behind it — before the client can read the response, so a
-  // `plan_invalidated` command can name a plan this client is still adopting.
-  // Waiters registered here are woken once nothing is in flight, which lets an
-  // invalidation decide against the plan that actually won.
-  const adoptionsInFlightRef = useRef(0);
-  const adoptionWaitersRef = useRef<Array<() => void>>([]);
+  // Adoptions in flight, counted per load sequence: a start or a replan whose
+  // decision has not been applied yet. The server commits a replacement plan —
+  // and starts the copy-safety scan behind it — before the client can read the
+  // response, so a `plan_invalidated` command can name a plan this client is
+  // still adopting. Waiters registered here are woken once their own sequence
+  // has nothing in flight, which lets an invalidation decide against the plan
+  // that actually won.
+  //
+  // The key is what makes the wait bounded. A superseded request — a version
+  // switch abandoned mid-flight, a start whose `fetch` never settles — is not a
+  // candidate to own the session any more, so waiting for it decides nothing
+  // and is worse than not waiting: the server's invalidation deadline is 8s,
+  // and a session that misses it is stopped outright. Only the sequence that
+  // currently owns the session can still change what the invalidation should
+  // decide against, so only it is waited on.
+  const adoptionsInFlightRef = useRef(new Map<number, number>());
+  const adoptionWaitersRef = useRef<Array<{ loadSequence: number; resolve: () => void }>>([]);
   const pendingReplanRef = useRef<{
     options: ReplanOptions;
     loadSequence: number;
@@ -340,34 +349,51 @@ export function usePlaybackSession(
     stateRef.current = state;
   }, [state]);
 
-  const beginAdoption = useCallback(() => {
-    adoptionsInFlightRef.current += 1;
+  const beginAdoption = useCallback((loadSequence: number) => {
+    const inFlight = adoptionsInFlightRef.current;
+    inFlight.set(loadSequence, (inFlight.get(loadSequence) ?? 0) + 1);
   }, []);
 
   /**
-   * Counts one in-flight adoption out.
+   * Counts one in-flight adoption out of its load sequence.
    *
-   * Waiters are woken only when nothing is left in flight: a queued replan is
-   * dispatched from its predecessor's `finally` before the predecessor is
-   * counted out, so the count tracks the whole chain rather than one request.
+   * A sequence's waiters are woken only when nothing is left in flight for it:
+   * a queued replan is dispatched from its predecessor's `finally` before the
+   * predecessor is counted out, so the count tracks the whole chain rather than
+   * one request.
    */
-  const endAdoption = useCallback(() => {
-    adoptionsInFlightRef.current = Math.max(0, adoptionsInFlightRef.current - 1);
-    if (adoptionsInFlightRef.current > 0) return;
+  const endAdoption = useCallback((loadSequence: number) => {
+    const inFlight = adoptionsInFlightRef.current;
+    const remaining = (inFlight.get(loadSequence) ?? 0) - 1;
+    if (remaining > 0) {
+      inFlight.set(loadSequence, remaining);
+      return;
+    }
+    inFlight.delete(loadSequence);
     const waiters = adoptionWaitersRef.current;
     if (waiters.length === 0) return;
-    adoptionWaitersRef.current = [];
-    for (const wake of waiters) wake();
+    const settled = waiters.filter((waiter) => !inFlight.has(waiter.loadSequence));
+    if (settled.length === 0) return;
+    adoptionWaitersRef.current = waiters.filter((waiter) => inFlight.has(waiter.loadSequence));
+    for (const waiter of settled) waiter.resolve();
   }, []);
 
   /**
-   * Resolves once no start or replan is in flight, or null when none is —
-   * callers act synchronously in the common case rather than deferring a turn.
+   * Resolves once the sequence that currently owns the session has no start or
+   * replan in flight, or null when it has none — callers act synchronously in
+   * the common case rather than deferring a turn.
+   *
+   * A request from a superseded sequence is deliberately not waited for. It can
+   * no longer install a plan (every path re-checks the sequence before adopting
+   * one), so it has nothing left to say about what an invalidation should
+   * decide against, and a hung one would otherwise hold the wait open past the
+   * server's deadline and cost the live session its stream.
    */
   const awaitAdoptionSettled = useCallback((): Promise<void> | null => {
-    if (adoptionsInFlightRef.current === 0) return null;
+    const loadSequence = loadSequenceRef.current;
+    if (!adoptionsInFlightRef.current.has(loadSequence)) return null;
     return new Promise<void>((resolve) => {
-      adoptionWaitersRef.current.push(resolve);
+      adoptionWaitersRef.current.push({ loadSequence, resolve });
     });
   }, []);
 
@@ -619,7 +645,7 @@ export function usePlaybackSession(
         }));
       };
 
-      beginAdoption();
+      beginAdoption(loadSequence);
       try {
         const selectedFileId = selectFileId(preferredFileId);
         if (!selectedFileId) {
@@ -683,7 +709,7 @@ export function usePlaybackSession(
         const nextError = describePlaybackSessionError(err, initialErrorMessage);
         retirePreviousSession(nextError);
       } finally {
-        endAdoption();
+        endAdoption(loadSequence);
       }
     },
     [adoptDecision, beginAdoption, endAdoption, requestStart, selectFileId, stopSession],
@@ -860,7 +886,7 @@ export function usePlaybackSession(
 
       const loadSequence = loadSequenceRef.current;
       replanInFlightRef.current = true;
-      beginAdoption();
+      beginAdoption(loadSequence);
       setState((current) => ({
         ...current,
         replanning: true,
@@ -950,7 +976,7 @@ export function usePlaybackSession(
         }
         // Last: a queued replan dispatched just above has already counted
         // itself in, so waiters are not woken between the two links of a chain.
-        endAdoption();
+        endAdoption(loadSequence);
       }
     },
     [

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -316,6 +316,14 @@ export function usePlaybackSession(
   const attemptedPlanKeysRef = useRef<string[]>([]);
   const attemptCountRef = useRef(1);
   const replanInFlightRef = useRef(false);
+  // Adoptions in flight: a start or a replan whose decision has not been
+  // applied yet. The server commits a replacement plan — and starts the
+  // copy-safety scan behind it — before the client can read the response, so a
+  // `plan_invalidated` command can name a plan this client is still adopting.
+  // Waiters registered here are woken once nothing is in flight, which lets an
+  // invalidation decide against the plan that actually won.
+  const adoptionsInFlightRef = useRef(0);
+  const adoptionWaitersRef = useRef<Array<() => void>>([]);
   const pendingReplanRef = useRef<{
     options: ReplanOptions;
     loadSequence: number;
@@ -331,6 +339,37 @@ export function usePlaybackSession(
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+
+  const beginAdoption = useCallback(() => {
+    adoptionsInFlightRef.current += 1;
+  }, []);
+
+  /**
+   * Counts one in-flight adoption out.
+   *
+   * Waiters are woken only when nothing is left in flight: a queued replan is
+   * dispatched from its predecessor's `finally` before the predecessor is
+   * counted out, so the count tracks the whole chain rather than one request.
+   */
+  const endAdoption = useCallback(() => {
+    adoptionsInFlightRef.current = Math.max(0, adoptionsInFlightRef.current - 1);
+    if (adoptionsInFlightRef.current > 0) return;
+    const waiters = adoptionWaitersRef.current;
+    if (waiters.length === 0) return;
+    adoptionWaitersRef.current = [];
+    for (const wake of waiters) wake();
+  }, []);
+
+  /**
+   * Resolves once no start or replan is in flight, or null when none is —
+   * callers act synchronously in the common case rather than deferring a turn.
+   */
+  const awaitAdoptionSettled = useCallback((): Promise<void> | null => {
+    if (adoptionsInFlightRef.current === 0) return null;
+    return new Promise<void>((resolve) => {
+      adoptionWaitersRef.current.push(resolve);
+    });
+  }, []);
 
   const reportEvent = useCallback(
     (
@@ -580,6 +619,7 @@ export function usePlaybackSession(
         }));
       };
 
+      beginAdoption();
       try {
         const selectedFileId = selectFileId(preferredFileId);
         if (!selectedFileId) {
@@ -642,9 +682,11 @@ export function usePlaybackSession(
 
         const nextError = describePlaybackSessionError(err, initialErrorMessage);
         retirePreviousSession(nextError);
+      } finally {
+        endAdoption();
       }
     },
-    [adoptDecision, requestStart, selectFileId, stopSession],
+    [adoptDecision, beginAdoption, endAdoption, requestStart, selectFileId, stopSession],
   );
 
   useEffect(() => {
@@ -818,6 +860,7 @@ export function usePlaybackSession(
 
       const loadSequence = loadSequenceRef.current;
       replanInFlightRef.current = true;
+      beginAdoption();
       setState((current) => ({
         ...current,
         replanning: true,
@@ -905,13 +948,18 @@ export function usePlaybackSession(
         } else {
           pendingReplan?.resolve(false);
         }
+        // Last: a queued replan dispatched just above has already counted
+        // itself in, so waiters are not woken between the two links of a chain.
+        endAdoption();
       }
     },
     [
       adoptDecision,
+      beginAdoption,
       clientCapabilities,
       clientPlaybackContext,
       config,
+      endAdoption,
       maxBitrateKbps,
       retireActiveSession,
     ],
@@ -1026,14 +1074,25 @@ export function usePlaybackSession(
    * plan without the client reasoning about deliveries at all. The plan
    * revision the adopted plan bumps rebuilds the transport and restores the
    * position, exactly as it does after a client-detected failure.
+   *
+   * A start or replan already in flight is waited out first. The server commits
+   * a replacement plan and starts the copy-safety scan behind it *before* the
+   * response reaches the client, so an invalidation can name a plan this client
+   * has not adopted yet. Deciding against the plan currently on screen would
+   * complete the command as a no-op and then let the pending response install
+   * the very route the server just withdrew.
    */
   const invalidatePlan = useCallback(
     async (planId: string, reason: string, currentPosition: number): Promise<boolean> => {
+      const settling = awaitAdoptionSettled();
+      if (settling) await settling;
       const plan = planRef.current;
       if (!plan) return false;
       // The command names the plan the server invalidated. Once the client has
       // moved past it there is nothing to recover from, and replanning anyway
-      // would evict a route the server never complained about.
+      // would evict a route the server never complained about. That stays true
+      // for a plan id this client has never seen: it is a verdict for a route
+      // that has already been replaced, not a reason to tear the session down.
       if (plan.plan_id !== planId) return true;
       const classification = reason.trim().slice(0, 64) || "plan_invalidated";
       reportEvent("plan_invalidated", { fallbackReason: classification });
@@ -1043,7 +1102,7 @@ export function usePlaybackSession(
         failure: { classification, message: "The server invalidated this plan." },
       });
     },
-    [replan, reportEvent],
+    [awaitAdoptionSettled, replan, reportEvent],
   );
 
   const reanchorSeek = useCallback(

--- a/web/src/player/playback-session-wire-v3.ts
+++ b/web/src/player/playback-session-wire-v3.ts
@@ -1,4 +1,5 @@
 import {
+  FEATURE_PLAN_INVALIDATED_V3,
   FEATURE_PLAYBACK_PLAN_V3,
   PROTOCOL_V3,
   type ClientCodecCapabilitiesV3,
@@ -16,6 +17,34 @@ import {
 /** Contract bound on `position_seconds` and `start_position`. */
 const MAX_POSITION_SECONDS = 31_536_000;
 
+/**
+ * What every v3 surface in this app can do.
+ *
+ * Anything beyond it is named by the caller through `extraClientFeatures`,
+ * because a feature token is a promise the server holds the client to and then
+ * enforces destructively — a session that advertises the plan-invalidation
+ * command and then rejects it gets stopped. The video player and the audiobook
+ * player share these builders but do not execute the same realtime commands, so
+ * neither may inherit the other's promises.
+ */
+const BASE_CLIENT_FEATURES_V3 = [FEATURE_PLAYBACK_PLAN_V3];
+
+/**
+ * The features the video watch page adds: it executes the realtime
+ * `plan_invalidated` command (see `VideoPlayer`) and replans off the plan the
+ * server names.
+ */
+export const VIDEO_CLIENT_FEATURES_V3 = [FEATURE_PLAN_INVALIDATED_V3];
+
+/**
+ * `client_features` is the contract's single advertisement location, and a
+ * replan that sends it replaces the negotiated list — so start and replan build
+ * it identically rather than letting a replan silently withdraw a promise.
+ */
+function clientFeaturesV3(extra: string[] | undefined): string[] {
+  return [...BASE_CLIENT_FEATURES_V3, ...(extra ?? [])];
+}
+
 function clampPosition(seconds: number): number {
   if (!Number.isFinite(seconds) || seconds < 0) return 0;
   return Math.min(seconds, MAX_POSITION_SECONDS);
@@ -31,6 +60,8 @@ export interface ReplanOptions {
 }
 
 export interface StartRequestInput {
+  /** Features this surface implements beyond {@link BASE_CLIENT_FEATURES_V3}. */
+  extraClientFeatures?: string[];
   fileId: number;
   profileId: string;
   playbackAttemptId: string;
@@ -60,7 +91,7 @@ export interface StartRequestInput {
 export function buildStartRequestV3(input: StartRequestInput): StartRequestV3 {
   return {
     protocol_version: PROTOCOL_V3,
-    client_features: [FEATURE_PLAYBACK_PLAN_V3],
+    client_features: clientFeaturesV3(input.extraClientFeatures),
     file_id: input.fileId,
     profile_id: input.profileId,
     playback_attempt_id: input.playbackAttemptId,
@@ -86,6 +117,8 @@ export function buildStartRequestV3(input: StartRequestInput): StartRequestV3 {
 }
 
 export interface ReplanRequestInput extends ReplanOptions {
+  /** Features this surface implements beyond {@link BASE_CLIENT_FEATURES_V3}. */
+  extraClientFeatures?: string[];
   plan: PlanV3;
   playbackAttemptId: string;
   replanRequestId: string;
@@ -123,7 +156,7 @@ export function buildReplanRequestV3(input: ReplanRequestInput): ReplanRequestV3
 
   return {
     protocol_version: PROTOCOL_V3,
-    client_features: [FEATURE_PLAYBACK_PLAN_V3],
+    client_features: clientFeaturesV3(input.extraClientFeatures),
     operation: input.operation,
     playback_attempt_id: input.playbackAttemptId,
     replan_request_id: input.replanRequestId,

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -126,6 +126,17 @@ export const FEATURE_NEUTRAL_PLAYBACK_V3_CONTRACT = "neutral_playback_v3_contrac
 /** Server accepts output-capability refreshes without treating the route as failed. */
 export const FEATURE_OUTPUT_CHANGE_V3 = "output_change_v1";
 
+/**
+ * The client can be told mid-session that the plan it is playing is no longer
+ * valid, over the realtime `plan_invalidated` command.
+ *
+ * Advertising it is a promise: the client acks the command and replans off the
+ * named plan. A server that does not see the token, or has no realtime
+ * connection to the session, stops the session instead — so a client that sends
+ * this must actually implement the command.
+ */
+export const FEATURE_PLAN_INVALIDATED_V3 = "plan_invalidated_v1";
+
 /** The `original` rung label, which always preserves the source. */
 export const QUALITY_ORIGINAL_V3 = "original";
 

--- a/web/src/player/realtime-protocol.test.ts
+++ b/web/src/player/realtime-protocol.test.ts
@@ -6,7 +6,9 @@ import {
   buildPlaybackRealtimeResult,
   parsePlaybackRealtimeMessage,
   parsePlaybackRealtimeCommand,
+  readPlanInvalidatedPayload,
   SUPPORTED_PLAYBACK_COMMANDS,
+  VIDEO_PLAYBACK_COMMANDS,
 } from "./realtime-protocol";
 
 describe("realtime protocol", () => {
@@ -31,6 +33,49 @@ describe("realtime protocol", () => {
       deadline_ms: undefined,
       payload: { message: "Restarting soon" },
     });
+  });
+
+  it("parses a plan invalidation command and its payload", () => {
+    const command = parsePlaybackRealtimeCommand(
+      JSON.stringify({
+        type: "command",
+        command_id: "cmd-9",
+        session_id: "session-1",
+        name: "plan_invalidated",
+        deadline_ms: 8_000,
+        payload: { reason: "video_copy_unsafe", plan_id: "plan:0123456789abcdef" },
+      }),
+    );
+
+    expect(command).toMatchObject({
+      type: "command",
+      command_id: "cmd-9",
+      name: "plan_invalidated",
+      deadline_ms: 8_000,
+    });
+    expect(readPlanInvalidatedPayload(command?.payload)).toEqual({
+      reason: "video_copy_unsafe",
+      plan_id: "plan:0123456789abcdef",
+    });
+  });
+
+  it("rejects a plan invalidation payload missing the invalidated plan", () => {
+    // Without the plan id the client cannot tell whether the plan it is playing
+    // is the one that was invalidated, so acting on it is never correct.
+    expect(readPlanInvalidatedPayload({ reason: "video_copy_unsafe" })).toBeNull();
+    expect(readPlanInvalidatedPayload({ reason: "", plan_id: "plan:1" })).toBeNull();
+    expect(readPlanInvalidatedPayload({ reason: "video_copy_unsafe", plan_id: 42 })).toBeNull();
+    expect(readPlanInvalidatedPayload(undefined)).toBeNull();
+  });
+
+  // The audiobook surface shares this module and cannot replan off an
+  // invalidated plan, so only the video command set announces it.
+  it("announces plan invalidation only for the video surface", () => {
+    expect(SUPPORTED_PLAYBACK_COMMANDS).not.toContain("plan_invalidated");
+    expect(VIDEO_PLAYBACK_COMMANDS).toContain("plan_invalidated");
+    expect(
+      buildPlaybackRealtimeHello("session-1", VIDEO_PLAYBACK_COMMANDS).capabilities.commands,
+    ).toContain("plan_invalidated");
   });
 
   it("rejects unknown commands", () => {

--- a/web/src/player/realtime-protocol.ts
+++ b/web/src/player/realtime-protocol.ts
@@ -15,7 +15,8 @@ export type PlaybackCommandName =
   | "server_shutting_down"
   | "play_media"
   | "set_audio_track"
-  | "set_subtitle_track";
+  | "set_subtitle_track"
+  | "plan_invalidated";
 
 export type PlaybackRealtimeAckStatus = "accepted";
 export type PlaybackRealtimeResultStatus = "completed" | "rejected";
@@ -39,6 +40,18 @@ export interface PlaybackRealtimeCommandEnvelope {
   };
   deadline_ms?: number;
   payload?: Record<string, unknown>;
+}
+
+/**
+ * Payload of the `plan_invalidated` command: the server decided, after the plan
+ * was already playing, that the route it names cannot serve this source.
+ *
+ * `plan_id` is the invalidated plan, not necessarily the one on screen — a
+ * client that has already replanned past it has nothing left to do.
+ */
+export interface PlaybackPlanInvalidatedPayload {
+  reason: string;
+  plan_id: string;
 }
 
 export interface PlaybackRealtimeHelloEnvelope {
@@ -206,8 +219,10 @@ export const ALL_PLAYBACK_COMMANDS: PlaybackCommandName[] = [
   "play_media",
   "set_audio_track",
   "set_subtitle_track",
+  "plan_invalidated",
 ];
 
+/** The commands every realtime surface in this app executes. */
 export const SUPPORTED_PLAYBACK_COMMANDS: PlaybackCommandName[] = [
   "pause",
   "unpause",
@@ -221,12 +236,39 @@ export const SUPPORTED_PLAYBACK_COMMANDS: PlaybackCommandName[] = [
   "server_shutting_down",
 ];
 
+/**
+ * What the video player executes on top of the shared set. `plan_invalidated`
+ * needs a replan the audiobook surface has no route ladder for, so the hello is
+ * per-surface rather than one list both over-claim.
+ */
+export const VIDEO_PLAYBACK_COMMANDS: PlaybackCommandName[] = [
+  ...SUPPORTED_PLAYBACK_COMMANDS,
+  "plan_invalidated",
+];
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
 function isCommandName(value: unknown): value is PlaybackCommandName {
   return typeof value === "string" && ALL_PLAYBACK_COMMANDS.includes(value as PlaybackCommandName);
+}
+
+/**
+ * Reads a `plan_invalidated` payload, or null when it is not well formed.
+ *
+ * Both fields are required: without `plan_id` the client cannot tell whether
+ * the invalidated plan is still the one playing, and acting anyway would evict
+ * a route the server never complained about.
+ */
+export function readPlanInvalidatedPayload(
+  payload: Record<string, unknown> | undefined,
+): PlaybackPlanInvalidatedPayload | null {
+  if (!isRecord(payload)) return null;
+  const { reason, plan_id: planId } = payload;
+  if (typeof reason !== "string" || reason.trim() === "") return null;
+  if (typeof planId !== "string" || planId.trim() === "") return null;
+  return { reason, plan_id: planId };
 }
 
 function isChapterThumbnailReadyPayload(
@@ -486,7 +528,10 @@ export function parsePlaybackRealtimeCommand(data: string): PlaybackRealtimeComm
   return message?.type === "command" ? message : null;
 }
 
-export function buildPlaybackRealtimeHello(sessionId: string): PlaybackRealtimeHelloEnvelope {
+export function buildPlaybackRealtimeHello(
+  sessionId: string,
+  commands: PlaybackCommandName[] = SUPPORTED_PLAYBACK_COMMANDS,
+): PlaybackRealtimeHelloEnvelope {
   return {
     type: "hello",
     session_id: sessionId,
@@ -495,7 +540,7 @@ export function buildPlaybackRealtimeHello(sessionId: string): PlaybackRealtimeH
       version: "1",
     },
     capabilities: {
-      commands: [...SUPPORTED_PLAYBACK_COMMANDS],
+      commands: [...commands],
     },
   };
 }


### PR DESCRIPTION
Single PR covering the full copy-safety rework (consolidates #733 at maintainer request): verdict persistence + the optimistic remux race, reviewed and merged together.

## Problem

The H.264 multi-PPS copy-safety scan (which decides whether a file can be stream-copied into fMP4 HLS without corrupting VideoToolbox decoders) ran while media detail pages loaded and was forgotten every restart — re-reading the opening seconds of every browsed H.264 file, which made first-time browsing take seconds per page on remote/cloud storage (Discord report; reproduced on shared dev's ceph-backed library). Even with a remembered verdict, the first-ever play of a file would still block 1–5 s on the scan.

## Part 1 — persist the verdict, get scans off browse paths

- Three nullable `media_files` columns: `multiple_pps` plus the file size and mtime it was computed from. **Self-validating**: trusted only while stored size/mtime match the row, so a replaced or re-encoded file invalidates its verdict with zero writer coordination. `Upsert` never touches the columns (it has side effects a scan must not trigger); writes go through a narrow targeted UPDATE.
- Deliberately *not* stored in the `video_tracks` jsonb: `models.VideoTrack` marshals straight into v1 detail responses, and several paths rebuild that jsonb from ffprobe — a tag change would leak the field to clients and lose it on reprobe.
- Browse/detail pages use a new `EnsureProbeOnly` (probe repair only) and never scan; the verdict is invisible in their responses anyway.
- Scan window 15 s → 5 s (affected encoders emit every PPS variant within the opening GOPs; the cost is bytes read off storage), and singleflight collapses concurrent first scans.

## Part 2 — optimistic remux race

- **Playback start and watch pages never wait.** Unknown verdict → the planner issues the stream-copy plan optimistically and the scan runs behind it (app-scoped context, per-file dedupe). Known verdicts route deterministically on every path, including replans.
- **Unsafe verdict → plan withdrawal.** New negotiated feature `plan_invalidated_v1`: a session that advertised it and holds a live realtime connection gets a pushed `plan_invalidated` command — the protocol's first server-initiated control message (doc §6.1) — acks, runs its normal `failure_recovery` replan with the withdrawn plan's attempt key excluded, and rebuilds at position. Same UX as a quality switch. Implemented end to end in the web player.
- **Backwards compatibility = the stop fallback.** No feature, no connection, no `completed` result within 8 s, or `rejected` → session stopped; the client's existing recovery replans against the persisted verdict and lands on transcode. Current mobile apps need zero changes to stay correct. App adoption tracked in Silo-Server/silo-android#244 and Silo-Server/silo-apple#183.
- **Scoping guards** (from adversarial review + live testing): verdicts apply only to the file a session actually streams; new sessions get a settle window; a post-settle file-wide sweep catches sessions that register in the milliseconds after a verdict lands (found live on shared dev — plan decided at t, verdict at t+4 ms, session registered after both; regression-tested); jellycompat sessions are exempt because their route selection never consults the verdict (documented follow-up); inconclusive scans touch nothing and persist nothing.

## Accepted tradeoff

On the first-ever play of a genuinely multi-PPS file, VideoToolbox clients may briefly show corruption before the withdrawal lands. Explicit maintainer decision, weighed against blocking every unknown first play. Such files are rare — 2 found in shared dev's 1.76M-file library on day one.

## Validation

Deployed live to shared dev: migration applied cleanly; detail/watch endpoints return in ~400–500 ms on cold unscanned h264 files while scans complete asynchronously and persist with valid size/mtime bindings; revisits reuse verdicts with no re-scan; capability endpoint advertises `plan_invalidated_v1`; the detector flagged two real multi-PPS files. Live testing surfaced the registration race fixed in the final commit. Full gate: build, scanner/playback/catalog/api suites, race detector on notifier/dispatcher tests, `golangci-lint --new-from-merge-base` (0 issues), `make migrate-validate`, `make test-web` (2035 tests), plus a from-zero migration chain + round-trip check against a scratch Postgres.

## Risks / follow-ups

- jellycompat route selection still ignores the verdict (pre-existing gap, documented).
- Apple/Android `plan_invalidated_v1` adoption: silo-android#244, silo-apple#183.
- Possible polish: defer the scan further, to only when the planner actually selects a copy route.

Related issue: #135

## AI use disclosure

Implemented by Claude Code (maintainer-directed, multi-agent workflow with adversarial review); design decisions, live validation, and incident diagnosis supervised by @Quick104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback starts without waiting for H.264 copy-safety analysis.
  * Background results are cached, validated against media changes, and refreshed as needed.
  * Active sessions can be notified when stream copying becomes unsafe and automatically replan.
  * Added realtime plan-invalidation support for compatible video clients.

* **Bug Fixes**
  * Browsing no longer triggers copy-safety analysis.
  * Preserves playback when analysis fails or is inconclusive.
  * Prevents stale verdicts from affecting playback decisions.
  * Stops unsafe remux playback during session recovery or termination.

* **Documentation**
  * Documented plan invalidation, capability negotiation, acknowledgements, timeouts, and compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->