### PR TITLE
perf(metadata): avoid no-op artwork GC healing

### DIFF
--- a/internal/metadata/artwork_revision_gc.go
+++ b/internal/metadata/artwork_revision_gc.go
@@ -103,10 +103,15 @@ func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevis
 		}
 	}
 
+	pendingHeals := make([]artworkRevisionGCPendingHeal, 0, len(due))
 	batchStats, err := processArtworkRevisionGCBatch(
 		due,
 		func(candidate artworkRevisionGCCandidate) (artworkRevisionGCOutcome, error) {
-			return g.processCandidate(ctx, candidate, workerID)
+			outcome, pending, processErr := g.processCandidateToHeal(ctx, candidate, workerID)
+			if pending != nil {
+				pendingHeals = append(pendingHeals, *pending)
+			}
+			return outcome, processErr
 		},
 		func(candidate artworkRevisionGCCandidate, cause error) error {
 			return g.retry(ctx, candidate, workerID, cause)
@@ -117,6 +122,26 @@ func (g *ArtworkRevisionGarbageCollector) Run(ctx context.Context) (ArtworkRevis
 	stats.Referenced += batchStats.Referenced
 	stats.Retried = batchStats.Retried
 	stats.Healed = batchStats.Healed
+	if len(pendingHeals) > 0 {
+		healResult, healErr := g.finishPendingHeals(ctx, pendingHeals, workerID)
+		if healErr != nil {
+			stats.Deleted += len(healResult.finalizedIDs)
+			stats.Healed += len(healResult.healedPaths)
+			for _, pending := range pendingHeals {
+				retried, retryErr := g.retryDeletedCandidate(ctx, pending, workerID, healErr)
+				if retried {
+					stats.Retried++
+				}
+				if retryErr != nil && err == nil {
+					err = retryErr
+				}
+			}
+		} else {
+			stats.Deleted += len(healResult.finalizedIDs)
+			stats.Healed += len(healResult.healedPaths)
+			stats.Retried += len(healResult.rearmedIDs)
+		}
+	}
 
 	checked, requeued, sweepErr := g.sweepDormant(ctx, artworkRevisionGCBatchSize)
 	stats.DormantChecked = checked
@@ -172,6 +197,25 @@ type artworkRevisionGCCandidate struct {
 	objectKeys   []string
 	attemptCount int
 	deletedAt    *time.Time
+}
+
+type artworkRevisionGCPendingHeal struct {
+	candidate    artworkRevisionGCCandidate
+	originalPath string
+}
+
+type artworkRevisionGCHealResult struct {
+	healedPaths  map[string]struct{}
+	finalizedIDs map[int64]struct{}
+	rearmedIDs   map[int64]struct{}
+}
+
+func newArtworkRevisionGCHealResult() artworkRevisionGCHealResult {
+	return artworkRevisionGCHealResult{
+		healedPaths:  make(map[string]struct{}),
+		finalizedIDs: make(map[int64]struct{}),
+		rearmedIDs:   make(map[int64]struct{}),
+	}
 }
 
 func candidatePaths(candidates []artworkRevisionGCCandidate) []string {
@@ -237,18 +281,18 @@ func (g *ArtworkRevisionGarbageCollector) parkClaimed(ctx context.Context, ids [
 	return nil
 }
 
-// processCandidate holds the registry row lock across the last reference check
-// and object deletion. A concurrent cache attempt registers the revision before
-// uploading and therefore waits here; once deletion commits, that attempt can
-// safely recreate the complete object set before publication.
-func (g *ArtworkRevisionGarbageCollector) processCandidate(
+// processCandidateToHeal holds the registry row lock across the last reference
+// check and object deletion, then leaves the durable row for batched healing.
+// A concurrent cache attempt registers before uploading and therefore waits
+// here; once deletion commits, it can recreate the complete object set.
+func (g *ArtworkRevisionGarbageCollector) processCandidateToHeal(
 	ctx context.Context,
 	candidate artworkRevisionGCCandidate,
 	workerID string,
-) (artworkRevisionGCOutcome, error) {
+) (artworkRevisionGCOutcome, *artworkRevisionGCPendingHeal, error) {
 	tx, err := g.pool.Begin(ctx)
 	if err != nil {
-		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: begin deletion: %w", err)
+		return artworkRevisionGCSuperseded, nil, fmt.Errorf("artwork revision GC: begin deletion: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -261,18 +305,18 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 		WHERE id = $1 AND locked_by = $2
 		FOR UPDATE`, candidate.id, workerID).Scan(&originalPath, &imageType, &objectKeys, &deletedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return artworkRevisionGCSuperseded, nil
+		return artworkRevisionGCSuperseded, nil, nil
 	}
 	if err != nil {
-		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: lock candidate: %w", err)
+		return artworkRevisionGCSuperseded, nil, fmt.Errorf("artwork revision GC: lock candidate: %w", err)
 	}
 
 	// Once objects are deleted, a lingering reference is broken rather than
-	// live: skip parking and finish the pending heal instead.
+	// live: skip parking and finish the durable pending heal instead.
 	if deletedAt == nil {
 		referenced, err := g.isReferenced(ctx, tx, originalPath)
 		if err != nil {
-			return artworkRevisionGCSuperseded, err
+			return artworkRevisionGCSuperseded, nil, err
 		}
 		if referenced {
 			if _, err := tx.Exec(ctx, `
@@ -284,12 +328,12 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 					last_error = '',
 					updated_at = NOW()
 				WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
-				return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: park referenced revision: %w", err)
+				return artworkRevisionGCSuperseded, nil, fmt.Errorf("artwork revision GC: park referenced revision: %w", err)
 			}
 			if err := tx.Commit(ctx); err != nil {
-				return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit referenced revision: %w", err)
+				return artworkRevisionGCSuperseded, nil, fmt.Errorf("artwork revision GC: commit referenced revision: %w", err)
 			}
-			return artworkRevisionGCReferenced, nil
+			return artworkRevisionGCReferenced, nil, nil
 		}
 	}
 
@@ -305,65 +349,131 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 			err = fmt.Errorf("deleted %d of %d artwork objects", deleted, len(objectKeys))
 		}
 		if err != nil {
-			return artworkRevisionGCSuperseded, err
+			return artworkRevisionGCSuperseded, nil, err
 		}
 	}
 	// Keep the row until the post-delete heal succeeds: marking deleted_at
-	// (instead of deleting the row) preserves a durable retry if healing or
-	// the final row removal fails after the objects are already gone.
+	// preserves a durable retry if healing or the final row removal fails after
+	// the objects are already gone.
 	if _, err := tx.Exec(ctx, `
 		UPDATE artwork_revision_gc_candidates
-		SET deleted_at = COALESCE(deleted_at, NOW()), updated_at = NOW()
+		SET deleted_at = COALESCE(deleted_at, NOW()), locked_at = NOW(), updated_at = NOW()
 		WHERE id = $1 AND locked_by = $2`, candidate.id, workerID); err != nil {
-		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: mark deleted: %w", err)
+		return artworkRevisionGCSuperseded, nil, fmt.Errorf("artwork revision GC: mark deleted: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: commit deletion: %w", err)
+		return artworkRevisionGCSuperseded, nil, fmt.Errorf("artwork revision GC: commit deletion: %w", err)
 	}
+	return artworkRevisionGCSuperseded, &artworkRevisionGCPendingHeal{
+		candidate:    candidate,
+		originalPath: originalPath,
+	}, nil
+}
 
-	// Writers that assign an existing path without registering a revision
-	// (bulk upserts copying previously-read values) do not serialize with the
-	// row lock above. Detect that narrow race after the fact and reset the
-	// affected rows the same way the artwork reconciler handles missing
-	// objects, so pipelines re-cache instead of serving 404 artwork.
-	healed, healErr := g.healDeletedReferences(ctx, originalPath)
-	if healErr != nil {
-		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: post-delete heal: %w", healErr)
+func (g *ArtworkRevisionGarbageCollector) processCandidate(
+	ctx context.Context,
+	candidate artworkRevisionGCCandidate,
+	workerID string,
+) (artworkRevisionGCOutcome, error) {
+	outcome, pending, err := g.processCandidateToHeal(ctx, candidate, workerID)
+	if err != nil || pending == nil {
+		return outcome, err
 	}
-	// Healing can itself displace the path again (clearing a referencing row
-	// fires the trigger, which re-arms this row and drops our lease), so gate
-	// the removal on deleted_at instead of the lease: a concurrent tracker
-	// re-registration clears deleted_at and must survive; anything else with
-	// deleted_at set is a finished deletion.
-	if _, err := g.pool.Exec(ctx, `
-		DELETE FROM artwork_revision_gc_candidates
-		WHERE id = $1 AND deleted_at IS NOT NULL`, candidate.id); err != nil {
-		return artworkRevisionGCSuperseded, fmt.Errorf("artwork revision GC: finish: %w", err)
+	healResult, err := g.finishPendingHeals(ctx, []artworkRevisionGCPendingHeal{*pending}, workerID)
+	if err != nil {
+		return artworkRevisionGCSuperseded, err
 	}
-	if healed {
-		slog.WarnContext(ctx, "artwork revision GC: deleted revision was re-referenced concurrently; reset rows for re-cache",
-			"component", "metadata", "original_path", originalPath)
+	if _, healed := healResult.healedPaths[pending.originalPath]; healed {
 		return artworkRevisionGCDeletedAndHealed, nil
 	}
 	return artworkRevisionGCDeleted, nil
+}
+
+// finishPendingHeals uses one guarded, batched reference sweep to finalize the
+// normal unreferenced paths immediately. Only survivors that raced back into
+// use need the legacy one-path surface healing. Each required surface update
+// stays in its own short transaction before one bounded confirmation sweep.
+func (g *ArtworkRevisionGarbageCollector) finishPendingHeals(
+	ctx context.Context,
+	pending []artworkRevisionGCPendingHeal,
+	workerID string,
+) (artworkRevisionGCHealResult, error) {
+	result := newArtworkRevisionGCHealResult()
+	if len(pending) == 0 {
+		return result, nil
+	}
+
+	ids := make([]int64, 0, len(pending))
+	paths := make([]string, 0, len(pending))
+	for _, item := range pending {
+		ids = append(ids, item.candidate.id)
+		paths = append(paths, item.originalPath)
+	}
+	finalizedIDs, rearmedIDs, err := g.finalizePendingHeals(ctx, ids, paths, workerID, false)
+	if err != nil {
+		return result, err
+	}
+	result.finalizedIDs = finalizedIDs
+
+	// Heal paths that the finalization snapshot proved are still referenced,
+	// then confirm once. A continuously changing path remains durably rearmed
+	// instead of making this background task spin without a bound.
+	if len(rearmedIDs) > 0 {
+		survivors := make([]artworkRevisionGCPendingHeal, 0, len(rearmedIDs))
+		for _, item := range pending {
+			if _, ok := rearmedIDs[item.candidate.id]; ok {
+				survivors = append(survivors, item)
+			}
+		}
+		healedPaths, healErr := g.healDeletedReferences(ctx, g.pool, survivors, workerID)
+		for path := range healedPaths {
+			result.healedPaths[path] = struct{}{}
+		}
+		if healErr != nil {
+			return result, fmt.Errorf("artwork revision GC: post-delete heal: %w", healErr)
+		}
+		survivorIDs := make([]int64, 0, len(survivors))
+		survivorPaths := make([]string, 0, len(survivors))
+		for _, item := range survivors {
+			survivorIDs = append(survivorIDs, item.candidate.id)
+			survivorPaths = append(survivorPaths, item.originalPath)
+		}
+		secondFinalized, secondRearmed, secondErr := g.finalizePendingHeals(
+			ctx, survivorIDs, survivorPaths, workerID, true,
+		)
+		if secondErr != nil {
+			return result, secondErr
+		}
+		for id := range secondFinalized {
+			result.finalizedIDs[id] = struct{}{}
+		}
+		rearmedIDs = secondRearmed
+	}
+	result.rearmedIDs = rearmedIDs
+	for path := range result.healedPaths {
+		slog.WarnContext(ctx, "artwork revision GC: deleted revision was re-referenced concurrently; reset rows for re-cache",
+			"component", "metadata", "original_path", path)
+	}
+	return result, nil
 }
 
 type artworkReferenceQuerier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
-func artworkReferenceUnionSQL() string {
+func artworkReferenceUnionSQL(pathsParameter string) string {
 	surfaces := artworkSweepSurfaces()
 	parts := make([]string, 0, len(surfaces))
 	for _, surface := range surfaces {
-		parts = append(parts, fmt.Sprintf("SELECT %s AS path FROM %s WHERE %s = ANY($1)", surface.pathCol, surface.table, surface.pathCol))
+		parts = append(parts, fmt.Sprintf("SELECT %s AS path FROM %s WHERE %s = ANY(%s)",
+			surface.pathCol, surface.table, surface.pathCol, pathsParameter))
 	}
 	return strings.Join(parts, " UNION ALL ")
 }
 
 func (g *ArtworkRevisionGarbageCollector) isReferenced(ctx context.Context, q artworkReferenceQuerier, originalPath string) (bool, error) {
 	var referenced bool
-	query := "SELECT EXISTS(" + artworkReferenceUnionSQL() + ")"
+	query := "SELECT EXISTS(" + artworkReferenceUnionSQL("$1") + ")"
 	if err := q.QueryRow(ctx, query, []string{originalPath}).Scan(&referenced); err != nil {
 		return false, fmt.Errorf("artwork revision GC: check references: %w", err)
 	}
@@ -377,7 +487,7 @@ func (g *ArtworkRevisionGarbageCollector) referencedPaths(ctx context.Context, p
 	if len(paths) == 0 {
 		return referenced, nil
 	}
-	rows, err := g.pool.Query(ctx, "SELECT DISTINCT path FROM ("+artworkReferenceUnionSQL()+") refs", paths)
+	rows, err := g.pool.Query(ctx, "SELECT DISTINCT path FROM ("+artworkReferenceUnionSQL("$1")+") refs", paths)
 	if err != nil {
 		return nil, fmt.Errorf("artwork revision GC: batch reference check: %w", err)
 	}
@@ -465,31 +575,184 @@ func (g *ArtworkRevisionGarbageCollector) sweepDormant(ctx context.Context, limi
 	return checked, requeued, nil
 }
 
-// healDeletedReferences resets any row still pointing at a just-deleted
-// revision, mirroring the reconciler: rows with a re-downloadable source are
-// repointed at it (the image cache pipeline re-caches them); the rest are
-// cleared for their owning pipeline to refill.
-func (g *ArtworkRevisionGarbageCollector) healDeletedReferences(ctx context.Context, originalPath string) (bool, error) {
-	healed := false
-	for _, surface := range artworkSweepSurfaces() {
-		if surface.sourceCol != "" {
-			resetSQL := fmt.Sprintf(`UPDATE %s SET %s WHERE %s = $1 AND %s`,
-				surface.table, surface.resetSet(), surface.pathCol, surface.remoteSourcePredicate())
-			tag, err := g.pool.Exec(ctx, resetSQL, originalPath)
-			if err != nil {
-				return healed, fmt.Errorf("artwork revision GC: heal %s: %w", surface.name, err)
-			}
-			healed = healed || tag.RowsAffected() > 0
-		}
-		clearSQL := fmt.Sprintf(`UPDATE %s SET %s WHERE %s = $1 AND NOT (%s)`,
-			surface.table, surface.clearSet, surface.pathCol, surface.remoteSourcePredicate())
-		tag, err := g.pool.Exec(ctx, clearSQL, originalPath)
+type artworkRevisionGCTransactionBeginner interface {
+	Begin(ctx context.Context) (pgx.Tx, error)
+}
+
+func artworkRevisionGCHealingSQL(surface artworkSweepSurface, set, predicate string) string {
+	return fmt.Sprintf(`UPDATE %s AS target
+		SET %s
+		FROM artwork_revision_gc_candidates AS candidate
+		WHERE target.%s = $1
+		  AND candidate.id = $2
+		  AND candidate.original_path = $1
+		  AND candidate.deleted_at IS NOT NULL
+		  AND candidate.locked_by IN ('', $3)
+		  AND %s`, surface.table, set, surface.pathCol, predicate)
+}
+
+func healArtworkRevisionRows(
+	ctx context.Context,
+	db artworkRevisionGCTransactionBeginner,
+	surface artworkSweepSurface,
+	query string,
+	pending artworkRevisionGCPendingHeal,
+	workerID string,
+	healed map[string]struct{},
+) error {
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("artwork revision GC: begin heal %s: %w", surface.name, err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	tag, err := tx.Exec(ctx, query, pending.originalPath, pending.candidate.id, workerID)
+	if err != nil {
+		return fmt.Errorf("artwork revision GC: heal %s: %w", surface.name, err)
+	}
+	healedRows := tag.RowsAffected()
+	if healedRows > 0 {
+		tag, err = tx.Exec(ctx, `
+			UPDATE artwork_revision_gc_candidates AS candidate
+			SET not_before = LEAST(candidate.not_before, NOW()),
+				next_attempt_at = NOW(),
+				locked_at = NOW(),
+				locked_by = $3,
+				updated_at = NOW()
+			WHERE candidate.id = $1
+			  AND candidate.original_path = $2
+			  AND candidate.deleted_at IS NOT NULL
+			  AND candidate.locked_by IN ('', $3)`, pending.candidate.id, pending.originalPath, workerID)
 		if err != nil {
-			return healed, fmt.Errorf("artwork revision GC: heal %s: %w", surface.name, err)
+			return fmt.Errorf("artwork revision GC: restore %s heal lease: %w", surface.name, err)
 		}
-		healed = healed || tag.RowsAffected() > 0
+		if tag.RowsAffected() != 1 {
+			return fmt.Errorf("artwork revision GC: restore %s heal lease: candidate changed concurrently", surface.name)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("artwork revision GC: commit heal %s: %w", surface.name, err)
+	}
+	if healedRows > 0 {
+		healed[pending.originalPath] = struct{}{}
+	}
+	return nil
+}
+
+// healDeletedReferences repairs paths that the guarded finalization sweep just
+// proved are still referenced. The common path never calls this function.
+// Exceptional paths are healed one at a time to retain the previous lock
+// width: rows with a re-downloadable source are repointed; the rest are cleared.
+func (g *ArtworkRevisionGarbageCollector) healDeletedReferences(
+	ctx context.Context,
+	db artworkRevisionGCTransactionBeginner,
+	pending []artworkRevisionGCPendingHeal,
+	workerID string,
+) (map[string]struct{}, error) {
+	healed := make(map[string]struct{})
+	if len(pending) == 0 {
+		return healed, nil
+	}
+	for _, item := range pending {
+		for _, surface := range artworkSweepSurfaces() {
+			if surface.sourceCol != "" {
+				resetSQL := artworkRevisionGCHealingSQL(surface, surface.resetSet(), surface.remoteSourcePredicate())
+				if err := healArtworkRevisionRows(ctx, db, surface, resetSQL, item, workerID, healed); err != nil {
+					return healed, err
+				}
+			}
+			clearSQL := artworkRevisionGCHealingSQL(surface, surface.clearSet, "NOT ("+surface.remoteSourcePredicate()+")")
+			if err := healArtworkRevisionRows(ctx, db, surface, clearSQL, item, workerID, healed); err != nil {
+				return healed, err
+			}
+		}
 	}
 	return healed, nil
+}
+
+func artworkRevisionGCFinalizeSQL() string {
+	return `
+		WITH referenced AS MATERIALIZED (` + artworkReferenceUnionSQL("$2") + `)
+		DELETE FROM artwork_revision_gc_candidates AS candidate
+		USING unnest($1::bigint[], $2::text[]) AS deleted(candidate_id, original_path)
+		WHERE candidate.id = deleted.candidate_id
+		  AND candidate.original_path = deleted.original_path
+		  AND candidate.deleted_at IS NOT NULL
+		  AND candidate.locked_by IN ('', $3)
+		  AND NOT EXISTS (
+			SELECT 1 FROM referenced WHERE referenced.path = deleted.original_path
+		  )
+		RETURNING candidate.id`
+}
+
+func (g *ArtworkRevisionGarbageCollector) finalizePendingHeals(
+	ctx context.Context,
+	candidateIDs []int64,
+	originalPaths []string,
+	workerID string,
+	releaseSurvivors bool,
+) (map[int64]struct{}, map[int64]struct{}, error) {
+	finalizedIDs := make(map[int64]struct{})
+	rearmedIDs := make(map[int64]struct{})
+	tx, err := g.pool.Begin(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("artwork revision GC: begin finish: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, artworkRevisionGCFinalizeSQL(), candidateIDs, originalPaths, workerID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("artwork revision GC: finish: %w", err)
+	}
+	for rows.Next() {
+		var candidateID int64
+		if err := rows.Scan(&candidateID); err != nil {
+			rows.Close()
+			return nil, nil, fmt.Errorf("artwork revision GC: scan finished candidate: %w", err)
+		}
+		finalizedIDs[candidateID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, nil, fmt.Errorf("artwork revision GC: finished candidates: %w", err)
+	}
+	rows.Close()
+
+	rows, err = tx.Query(ctx, `
+		UPDATE artwork_revision_gc_candidates AS candidate
+		SET not_before = LEAST(candidate.not_before, NOW()),
+			next_attempt_at = NOW(),
+			locked_at = CASE WHEN $4 THEN NULL ELSE NOW() END,
+			locked_by = CASE WHEN $4 THEN '' ELSE $3 END,
+			updated_at = NOW()
+		FROM unnest($1::bigint[], $2::text[]) AS pending(candidate_id, original_path)
+		WHERE candidate.id = pending.candidate_id
+		  AND candidate.original_path = pending.original_path
+		  AND candidate.deleted_at IS NOT NULL
+		  AND candidate.locked_by IN ('', $3)
+		RETURNING candidate.id`, candidateIDs, originalPaths, workerID, releaseSurvivors)
+	if err != nil {
+		return nil, nil, fmt.Errorf("artwork revision GC: rearm unfinished heals: %w", err)
+	}
+	for rows.Next() {
+		var candidateID int64
+		if err := rows.Scan(&candidateID); err != nil {
+			rows.Close()
+			return nil, nil, fmt.Errorf("artwork revision GC: scan rearmed heal: %w", err)
+		}
+		rearmedIDs[candidateID] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, nil, fmt.Errorf("artwork revision GC: rearmed heals: %w", err)
+	}
+	rows.Close()
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, fmt.Errorf("artwork revision GC: commit finish: %w", err)
+	}
+	return finalizedIDs, rearmedIDs, nil
 }
 
 func (g *ArtworkRevisionGarbageCollector) retry(ctx context.Context, candidate artworkRevisionGCCandidate, workerID string, cause error) error {
@@ -507,6 +770,37 @@ func (g *ArtworkRevisionGarbageCollector) retry(ctx context.Context, candidate a
 		return fmt.Errorf("artwork revision GC: schedule retry: %w", err)
 	}
 	return nil
+}
+
+// retryDeletedCandidate repairs the lease changes made by displacement
+// triggers during a partially completed heal. It may reclaim an unlocked
+// tombstone from this same batch, but never steals one from another worker or
+// a true retrack (which clears deleted_at).
+func (g *ArtworkRevisionGarbageCollector) retryDeletedCandidate(
+	ctx context.Context,
+	pending artworkRevisionGCPendingHeal,
+	workerID string,
+	cause error,
+) (bool, error) {
+	delay := time.Minute << min(pending.candidate.attemptCount, 10)
+	tag, err := g.pool.Exec(ctx, `
+		UPDATE artwork_revision_gc_candidates
+		SET not_before = LEAST(not_before, NOW()),
+			attempt_count = attempt_count + 1,
+			next_attempt_at = NOW() + ($4 * interval '1 second'),
+			locked_at = NULL,
+			locked_by = '',
+			last_error = $5,
+			updated_at = NOW()
+		WHERE id = $1
+		  AND original_path = $2
+		  AND deleted_at IS NOT NULL
+		  AND locked_by IN ('', $3)`, pending.candidate.id, pending.originalPath, workerID,
+		int64(delay/time.Second), cause.Error())
+	if err != nil {
+		return false, fmt.Errorf("artwork revision GC: schedule heal retry: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
 }
 
 func (s ArtworkRevisionGCStats) JSON() []byte {

--- a/internal/metadata/artwork_revision_gc.go
+++ b/internal/metadata/artwork_revision_gc.go
@@ -171,6 +171,10 @@ func processArtworkRevisionGCBatch(
 		switch outcome {
 		case artworkRevisionGCReferenced:
 			stats.Referenced++
+		case artworkRevisionGCDeletionPendingHeal:
+			// Run accounts this deletion only after the shared final guard
+			// confirms that the durable tombstone can be removed.
+			continue
 		case artworkRevisionGCDeleted:
 			stats.Deleted++
 		case artworkRevisionGCDeletedAndHealed:
@@ -186,6 +190,7 @@ type artworkRevisionGCOutcome int
 const (
 	artworkRevisionGCSuperseded artworkRevisionGCOutcome = iota
 	artworkRevisionGCReferenced
+	artworkRevisionGCDeletionPendingHeal
 	artworkRevisionGCDeleted
 	artworkRevisionGCDeletedAndHealed
 )
@@ -364,7 +369,7 @@ func (g *ArtworkRevisionGarbageCollector) processCandidateToHeal(
 	if err := tx.Commit(ctx); err != nil {
 		return artworkRevisionGCSuperseded, nil, fmt.Errorf("artwork revision GC: commit deletion: %w", err)
 	}
-	return artworkRevisionGCSuperseded, &artworkRevisionGCPendingHeal{
+	return artworkRevisionGCDeletionPendingHeal, &artworkRevisionGCPendingHeal{
 		candidate:    candidate,
 		originalPath: originalPath,
 	}, nil
@@ -393,6 +398,8 @@ func (g *ArtworkRevisionGarbageCollector) processCandidate(
 // normal unreferenced paths immediately. Only survivors that raced back into
 // use need the legacy one-path surface healing. Each required surface update
 // stays in its own short transaction before one bounded confirmation sweep.
+// Run caps the interval between object deletion and this guard at the fixed
+// artworkRevisionGCBatchSize rather than accumulating an unbounded work list.
 func (g *ArtworkRevisionGarbageCollector) finishPendingHeals(
 	ctx context.Context,
 	pending []artworkRevisionGCPendingHeal,

--- a/internal/metadata/artwork_revision_gc_test.go
+++ b/internal/metadata/artwork_revision_gc_test.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/artworkkey"
@@ -56,6 +59,35 @@ func artworkRevisionGCTestPool(t *testing.T) *pgxpool.Pool {
 	return pool
 }
 
+type failingArtworkRevisionGCExecBeginner struct {
+	pool *pgxpool.Pool
+}
+
+func (b failingArtworkRevisionGCExecBeginner) Begin(ctx context.Context) (pgx.Tx, error) {
+	tx, err := b.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &failingArtworkRevisionGCExecTx{Tx: tx}, nil
+}
+
+type failingArtworkRevisionGCExecTx struct {
+	pgx.Tx
+	execs int
+}
+
+func (tx *failingArtworkRevisionGCExecTx) Exec(
+	ctx context.Context,
+	sql string,
+	args ...any,
+) (pgconn.CommandTag, error) {
+	tx.execs++
+	if tx.execs == 2 {
+		return pgconn.CommandTag{}, errors.New("injected heal lease failure")
+	}
+	return tx.Tx.Exec(ctx, sql, args...)
+}
+
 func TestProcessArtworkRevisionGCBatchContinuesAfterRetryFailure(t *testing.T) {
 	candidates := []artworkRevisionGCCandidate{{id: 1}, {id: 2}, {id: 3}}
 	processed := make([]int64, 0, len(candidates))
@@ -91,6 +123,48 @@ func TestProcessArtworkRevisionGCBatchContinuesAfterRetryFailure(t *testing.T) {
 	want := ArtworkRevisionGCStats{Claimed: 3, Deleted: 1, Referenced: 1, Retried: 1}
 	if stats != want {
 		t.Fatalf("stats = %+v, want %+v", stats, want)
+	}
+}
+
+func TestArtworkRevisionGCHealingSQLTargetsOneReferencedPath(t *testing.T) {
+	surface := artworkSweepSurfaces()[0]
+	query := artworkRevisionGCHealingSQL(surface, surface.resetSet(), surface.remoteSourcePredicate())
+	for _, want := range []string{
+		"UPDATE " + surface.table,
+		"target." + surface.pathCol + " = $1",
+		"candidate.id = $2",
+		"candidate.deleted_at IS NOT NULL",
+		"candidate.locked_by IN ('', $3)",
+		surface.remoteSourcePredicate(),
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("heal query missing %q: %s", want, query)
+		}
+	}
+	if strings.Contains(query, "unnest(") {
+		t.Fatalf("exceptional healing must retain one-path lock width: %s", query)
+	}
+	if strings.Contains(query, "FOR UPDATE") {
+		t.Fatalf("heal query must not invert source-to-candidate lock ordering: %s", query)
+	}
+}
+
+func TestArtworkRevisionGCFinalizeSQLMaterializesReferenceSweep(t *testing.T) {
+	query := artworkRevisionGCFinalizeSQL()
+	for _, want := range []string{
+		"WITH referenced AS MATERIALIZED",
+		"unnest($1::bigint[], $2::text[])",
+		"candidate.deleted_at IS NOT NULL",
+		"candidate.locked_by IN ('', $3)",
+		"NOT EXISTS",
+		"RETURNING candidate.id",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("finalize query missing %q: %s", want, query)
+		}
+	}
+	if got := strings.Count(query, " = ANY($2)"); got != len(artworkSweepSurfaces()) {
+		t.Fatalf("final reference sweep covers %d surfaces, want %d", got, len(artworkSweepSurfaces()))
 	}
 }
 
@@ -422,6 +496,438 @@ func TestArtworkRevisionGCExpandsTriggerManifestFromImageType(t *testing.T) {
 	want := artworkkey.ObjectKeys(originalPath, "backdrop")
 	if !slices.Equal(deleted[0], want) {
 		t.Fatalf("deleted keys = %v, want expanded manifest %v", deleted[0], want)
+	}
+}
+
+func TestArtworkRevisionGCBatchReferenceGateHealsRaces(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	workerID := fmt.Sprintf("gc-batch-heal-worker-%d", suffix)
+	type healCase struct {
+		contentID string
+		path      string
+		source    string
+		want      string
+		id        int64
+	}
+	cases := []healCase{
+		{
+			contentID: fmt.Sprintf("gc-batch-heal-remote-%d", suffix),
+			path:      fmt.Sprintf("tmdb/movies/%d/poster/original.remote-gone.webp", suffix),
+			source:    fmt.Sprintf("https://images.example/%d/poster.jpg", suffix),
+			want:      fmt.Sprintf("https://images.example/%d/poster.jpg", suffix),
+		},
+		{
+			contentID: fmt.Sprintf("gc-batch-heal-clear-%d", suffix),
+			path:      fmt.Sprintf("tmdb/movies/%d/poster/original.local-gone.webp", suffix),
+		},
+	}
+	contentIDs := make([]string, 0, len(cases))
+	paths := make([]string, 0, len(cases))
+	for i := range cases {
+		item := &cases[i]
+		contentIDs = append(contentIDs, item.contentID)
+		paths = append(paths, item.path)
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_items (
+				content_id, type, title, status, genres, poster_path, poster_source_path
+			) VALUES ($1, 'movie', 'GC Batch Heal', 'matched', '{}'::text[], $2, $3)`,
+			item.contentID, item.path, item.source); err != nil {
+			t.Fatalf("seed batch heal item: %v", err)
+		}
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO artwork_revision_gc_candidates (
+				original_path, image_type, object_keys, not_before, next_attempt_at,
+				deleted_at, locked_at, locked_by
+			) VALUES ($1, 'poster', '{}', NOW() - interval '1 hour', NOW() - interval '1 hour',
+				NOW() - interval '1 hour', NOW(), $2)
+			RETURNING id`, item.path, workerID).Scan(&item.id); err != nil {
+			t.Fatalf("seed batch heal candidate: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = ANY($1)`, contentIDs)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path = ANY($1)`, paths)
+	})
+
+	pending := make([]artworkRevisionGCPendingHeal, 0, len(cases))
+	for _, item := range cases {
+		pending = append(pending, artworkRevisionGCPendingHeal{
+			candidate:    artworkRevisionGCCandidate{id: item.id, originalPath: item.path},
+			originalPath: item.path,
+		})
+	}
+	collector := NewArtworkRevisionGarbageCollector(pool, &blockingArtworkRevisionDeleter{started: make(chan struct{})})
+	result, err := collector.finishPendingHeals(ctx, pending, workerID)
+	if err != nil {
+		t.Fatalf("finishPendingHeals: %v", err)
+	}
+	healed := result.healedPaths
+	if len(healed) != len(cases) {
+		t.Fatalf("healed paths = %v, want both deleted revisions", healed)
+	}
+	for _, item := range cases {
+		if _, ok := healed[item.path]; !ok {
+			t.Fatalf("healed paths missing %q: %v", item.path, healed)
+		}
+		var got string
+		if err := pool.QueryRow(ctx, `SELECT poster_path FROM media_items WHERE content_id = $1`, item.contentID).Scan(&got); err != nil {
+			t.Fatalf("load batch healed item: %v", err)
+		}
+		if got != item.want {
+			t.Fatalf("poster_path = %q, want %q", got, item.want)
+		}
+	}
+	var remaining int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM artwork_revision_gc_candidates WHERE original_path = ANY($1)`, paths).Scan(&remaining); err != nil {
+		t.Fatalf("count batch heal candidates: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("candidate rows remaining = %d, want 0", remaining)
+	}
+}
+
+func TestArtworkRevisionGCHealStatementRollsBackBeforeRetry(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-heal-rollback-%d", suffix)
+	originalPath := fmt.Sprintf("tmdb/movies/%d/poster/original.rollback.webp", suffix)
+	sourcePath := fmt.Sprintf("https://images.example/%d/poster.jpg", suffix)
+	workerID := fmt.Sprintf("gc-heal-rollback-worker-%d", suffix)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (
+			content_id, type, title, status, genres, poster_path, poster_source_path
+		) VALUES ($1, 'movie', 'GC Heal Rollback', 'matched', '{}'::text[], $2, $3)`,
+		contentID, originalPath, sourcePath); err != nil {
+		t.Fatalf("seed rollback item: %v", err)
+	}
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, image_type, object_keys, not_before, next_attempt_at,
+			deleted_at, locked_at, locked_by
+		) VALUES ($1, 'poster', '{}', NOW() - interval '1 hour', NOW() - interval '1 hour',
+			NOW() - interval '1 hour', NOW(), $2)
+		RETURNING id`, originalPath, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed rollback candidate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	surface := artworkSweepSurfaces()[0]
+	query := artworkRevisionGCHealingSQL(surface, surface.resetSet(), surface.remoteSourcePredicate())
+	healed := make(map[string]struct{})
+	err := healArtworkRevisionRows(
+		ctx,
+		failingArtworkRevisionGCExecBeginner{pool: pool},
+		surface,
+		query,
+		artworkRevisionGCPendingHeal{
+			candidate:    artworkRevisionGCCandidate{id: candidateID, originalPath: originalPath},
+			originalPath: originalPath,
+		},
+		workerID,
+		healed,
+	)
+	if err == nil || !strings.Contains(err.Error(), "injected heal lease failure") {
+		t.Fatalf("heal error = %v, want injected lease failure", err)
+	}
+	if len(healed) != 0 {
+		t.Fatalf("rolled-back heal reported success: %v", healed)
+	}
+
+	var posterPath, lockedBy string
+	var nextAttempt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT item.poster_path, candidate.locked_by, candidate.next_attempt_at
+		FROM media_items AS item
+		JOIN artwork_revision_gc_candidates AS candidate ON candidate.original_path = item.poster_path
+		WHERE item.content_id = $1`, contentID).Scan(&posterPath, &lockedBy, &nextAttempt); err != nil {
+		t.Fatalf("load rolled-back state: %v", err)
+	}
+	if posterPath != originalPath {
+		t.Fatalf("poster_path = %q, want rolled-back path %q", posterPath, originalPath)
+	}
+	if lockedBy != workerID {
+		t.Fatalf("locked_by = %q, want original worker lease", lockedBy)
+	}
+	if nextAttempt.After(time.Now()) {
+		t.Fatalf("next_attempt_at = %v, want original due time after rollback", nextAttempt)
+	}
+
+	collector := NewArtworkRevisionGarbageCollector(pool, &blockingArtworkRevisionDeleter{started: make(chan struct{})})
+	retried, retryErr := collector.retryDeletedCandidate(ctx, artworkRevisionGCPendingHeal{
+		candidate: artworkRevisionGCCandidate{
+			id:           candidateID,
+			originalPath: originalPath,
+		},
+		originalPath: originalPath,
+	}, workerID, err)
+	if retryErr != nil {
+		t.Fatalf("retryDeletedCandidate: %v", retryErr)
+	}
+	if !retried {
+		t.Fatal("rolled-back heal was not scheduled for retry")
+	}
+	var notBefore time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT not_before, next_attempt_at, locked_by
+		FROM artwork_revision_gc_candidates
+		WHERE id = $1`, candidateID).Scan(&notBefore, &nextAttempt, &lockedBy); err != nil {
+		t.Fatalf("load retry state: %v", err)
+	}
+	if notBefore.After(time.Now()) {
+		t.Fatalf("not_before = %v, want immediate heal eligibility", notBefore)
+	}
+	if nextAttempt.After(time.Now().Add(2 * time.Minute)) {
+		t.Fatalf("next_attempt_at = %v, want bounded retry delay", nextAttempt)
+	}
+	if lockedBy != "" {
+		t.Fatalf("locked_by = %q, want retry lease released", lockedBy)
+	}
+}
+
+func TestArtworkRevisionGCFinalGuardRearmsVisibleReference(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-final-guard-%d", suffix)
+	originalPath := fmt.Sprintf("tmdb/movies/%d/poster/original.final-guard.webp", suffix)
+	workerID := fmt.Sprintf("gc-final-guard-worker-%d", suffix)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path)
+		VALUES ($1, 'movie', 'GC Final Guard', 'matched', '{}'::text[], $2)`, contentID, originalPath); err != nil {
+		t.Fatalf("seed final guard item: %v", err)
+	}
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, image_type, object_keys, not_before, next_attempt_at,
+			deleted_at, locked_at, locked_by
+		) VALUES ($1, 'poster', '{}', NOW() - interval '1 hour', NOW() - interval '1 hour',
+			NOW() - interval '1 hour', NOW(), $2)
+		RETURNING id`, originalPath, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed final guard candidate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	collector := NewArtworkRevisionGarbageCollector(pool, &blockingArtworkRevisionDeleter{started: make(chan struct{})})
+	finalizedIDs, rearmedIDs, err := collector.finalizePendingHeals(
+		ctx,
+		[]int64{candidateID},
+		[]string{originalPath},
+		workerID,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("finalizePendingHeals: %v", err)
+	}
+	if len(finalizedIDs) != 0 {
+		t.Fatalf("visible reference finalized as unreferenced: %v", finalizedIDs)
+	}
+	if _, ok := rearmedIDs[candidateID]; !ok {
+		t.Fatalf("guarded candidate was not rearmed: %v", rearmedIDs)
+	}
+
+	var deletedAt *time.Time
+	var nextAttempt time.Time
+	var lockedBy string
+	if err := pool.QueryRow(ctx, `
+		SELECT deleted_at, next_attempt_at, locked_by
+		FROM artwork_revision_gc_candidates
+		WHERE id = $1`, candidateID).Scan(&deletedAt, &nextAttempt, &lockedBy); err != nil {
+		t.Fatalf("load guarded candidate: %v", err)
+	}
+	if deletedAt == nil {
+		t.Fatal("guarded candidate lost its durable deleted_at marker")
+	}
+	if nextAttempt.After(time.Now()) {
+		t.Fatalf("next_attempt_at = %v, want immediate follow-up", nextAttempt)
+	}
+	if lockedBy != "" {
+		t.Fatalf("locked_by = %q, want guarded candidate released", lockedBy)
+	}
+}
+
+func TestArtworkRevisionGCBatchHealPreservesRetrackedRevision(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-batch-heal-retracked-%d", suffix)
+	originalPath := fmt.Sprintf("tmdb/movies/%d/poster/original.retracked.webp", suffix)
+	workerID := fmt.Sprintf("gc-batch-heal-retracked-worker-%d", suffix)
+	newKeys := []string{originalPath, fmt.Sprintf("tmdb/movies/%d/poster/w500.retracked.webp", suffix)}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres, poster_path)
+		VALUES ($1, 'movie', 'GC Retracked Heal', 'matched', '{}'::text[], $2)`, contentID, originalPath); err != nil {
+		t.Fatalf("seed retracked item: %v", err)
+	}
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, image_type, object_keys, not_before, next_attempt_at,
+			deleted_at, locked_at, locked_by
+		) VALUES ($1, 'poster', '{}', NOW() - interval '1 hour', NOW() - interval '1 hour',
+			NOW() - interval '1 hour', NOW(), $2)
+		RETURNING id`, originalPath, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed retracked candidate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	tracker := catalog.NewArtworkRevisionTracker(pool)
+	if err := tracker.TrackArtworkRevision(ctx, originalPath, "poster", newKeys); err != nil {
+		t.Fatalf("retrack revision: %v", err)
+	}
+	collector := NewArtworkRevisionGarbageCollector(pool, &blockingArtworkRevisionDeleter{started: make(chan struct{})})
+	result, err := collector.finishPendingHeals(ctx, []artworkRevisionGCPendingHeal{{
+		candidate:    artworkRevisionGCCandidate{id: candidateID, originalPath: originalPath},
+		originalPath: originalPath,
+	}}, workerID)
+	if err != nil {
+		t.Fatalf("finishPendingHeals: %v", err)
+	}
+	if len(result.healedPaths) != 0 || len(result.finalizedIDs) != 0 {
+		t.Fatalf("retracked revision was healed or finalized: %+v", result)
+	}
+
+	var posterPath string
+	if err := pool.QueryRow(ctx, `SELECT poster_path FROM media_items WHERE content_id = $1`, contentID).Scan(&posterPath); err != nil {
+		t.Fatalf("load retracked item: %v", err)
+	}
+	if posterPath != originalPath {
+		t.Fatalf("poster_path = %q, want retracked path %q preserved", posterPath, originalPath)
+	}
+	var deletedAt *time.Time
+	var objectKeys []string
+	if err := pool.QueryRow(ctx, `
+		SELECT deleted_at, object_keys
+		FROM artwork_revision_gc_candidates
+		WHERE id = $1`, candidateID).Scan(&deletedAt, &objectKeys); err != nil {
+		t.Fatalf("load retracked candidate: %v", err)
+	}
+	if deletedAt != nil {
+		t.Fatalf("deleted_at = %v, want retracker to clear it", *deletedAt)
+	}
+	if !slices.Equal(objectKeys, newKeys) {
+		t.Fatalf("object_keys = %v, want retracked manifest %v", objectKeys, newKeys)
+	}
+}
+
+func TestArtworkRevisionGCBatchHealRechecksRetrackBetweenSurfaces(t *testing.T) {
+	pool := artworkRevisionGCTestPool(t)
+	ctx := context.Background()
+	suffix := time.Now().UnixNano()
+	contentID := fmt.Sprintf("gc-batch-heal-mid-retrack-%d", suffix)
+	originalPath := fmt.Sprintf("tmdb/movies/%d/poster/original.mid-retrack.webp", suffix)
+	posterSource := fmt.Sprintf("https://images.example/%d/poster.jpg", suffix)
+	backdropSource := fmt.Sprintf("https://images.example/%d/backdrop.jpg", suffix)
+	workerID := fmt.Sprintf("gc-batch-heal-mid-retrack-worker-%d", suffix)
+	newKeys := []string{originalPath, fmt.Sprintf("tmdb/movies/%d/poster/w500.mid-retrack.webp", suffix)}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (
+			content_id, type, title, status, genres, poster_path, poster_source_path,
+			backdrop_path, backdrop_source_path
+		) VALUES ($1, 'movie', 'GC Mid-Heal Retrack', 'matched', '{}'::text[], $2, $3, $2, $4)`,
+		contentID, originalPath, posterSource, backdropSource); err != nil {
+		t.Fatalf("seed mid-heal retrack item: %v", err)
+	}
+	var candidateID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO artwork_revision_gc_candidates (
+			original_path, image_type, object_keys, not_before, next_attempt_at,
+			deleted_at, locked_at, locked_by
+		) VALUES ($1, 'poster', '{}', NOW() - interval '1 hour', NOW() - interval '1 hour',
+			NOW() - interval '1 hour', NOW(), $2)
+		RETURNING id`, originalPath, workerID).Scan(&candidateID); err != nil {
+		t.Fatalf("seed mid-heal retrack candidate: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path = $1`, originalPath)
+	})
+
+	posterSurface := artworkSweepSurfaces()[0]
+	posterReset := artworkRevisionGCHealingSQL(
+		posterSurface,
+		posterSurface.resetSet(),
+		posterSurface.remoteSourcePredicate(),
+	)
+	firstHealed := make(map[string]struct{})
+	if err := healArtworkRevisionRows(
+		ctx,
+		pool,
+		posterSurface,
+		posterReset,
+		artworkRevisionGCPendingHeal{
+			candidate:    artworkRevisionGCCandidate{id: candidateID, originalPath: originalPath},
+			originalPath: originalPath,
+		},
+		workerID,
+		firstHealed,
+	); err != nil {
+		t.Fatalf("heal first surface: %v", err)
+	}
+	if _, ok := firstHealed[originalPath]; !ok {
+		t.Fatalf("first surface did not heal %q", originalPath)
+	}
+
+	tracker := catalog.NewArtworkRevisionTracker(pool)
+	if err := tracker.TrackArtworkRevision(ctx, originalPath, "poster", newKeys); err != nil {
+		t.Fatalf("retrack between heal surfaces: %v", err)
+	}
+	collector := NewArtworkRevisionGarbageCollector(pool, &blockingArtworkRevisionDeleter{started: make(chan struct{})})
+	result, err := collector.finishPendingHeals(ctx, []artworkRevisionGCPendingHeal{{
+		candidate:    artworkRevisionGCCandidate{id: candidateID, originalPath: originalPath},
+		originalPath: originalPath,
+	}}, workerID)
+	if err != nil {
+		t.Fatalf("finishPendingHeals after retrack: %v", err)
+	}
+	if len(result.healedPaths) != 0 || len(result.finalizedIDs) != 0 {
+		t.Fatalf("later surfaces ignored cleared deleted_at: %+v", result)
+	}
+
+	var posterPath, backdropPath string
+	if err := pool.QueryRow(ctx, `
+		SELECT poster_path, backdrop_path
+		FROM media_items
+		WHERE content_id = $1`, contentID).Scan(&posterPath, &backdropPath); err != nil {
+		t.Fatalf("load mid-heal retrack item: %v", err)
+	}
+	if posterPath != posterSource {
+		t.Fatalf("poster_path = %q, want first surface reset %q", posterPath, posterSource)
+	}
+	if backdropPath != originalPath {
+		t.Fatalf("backdrop_path = %q, want retracked path %q preserved", backdropPath, originalPath)
+	}
+	var deletedAt *time.Time
+	var objectKeys []string
+	if err := pool.QueryRow(ctx, `
+		SELECT deleted_at, object_keys
+		FROM artwork_revision_gc_candidates
+		WHERE id = $1`, candidateID).Scan(&deletedAt, &objectKeys); err != nil {
+		t.Fatalf("load mid-heal retracked candidate: %v", err)
+	}
+	if deletedAt != nil {
+		t.Fatalf("deleted_at = %v, want retracker to clear it", *deletedAt)
+	}
+	if !slices.Equal(objectKeys, newKeys) {
+		t.Fatalf("object_keys = %v, want retracked manifest %v", objectKeys, newKeys)
 	}
 }
 

--- a/internal/metadata/artwork_revision_gc_test.go
+++ b/internal/metadata/artwork_revision_gc_test.go
@@ -89,7 +89,7 @@ func (tx *failingArtworkRevisionGCExecTx) Exec(
 }
 
 func TestProcessArtworkRevisionGCBatchContinuesAfterRetryFailure(t *testing.T) {
-	candidates := []artworkRevisionGCCandidate{{id: 1}, {id: 2}, {id: 3}}
+	candidates := []artworkRevisionGCCandidate{{id: 1}, {id: 2}, {id: 3}, {id: 4}}
 	processed := make([]int64, 0, len(candidates))
 	retryErr := errors.New("schedule retry")
 
@@ -102,6 +102,8 @@ func TestProcessArtworkRevisionGCBatchContinuesAfterRetryFailure(t *testing.T) {
 				return artworkRevisionGCSuperseded, errors.New("delete object")
 			case 2:
 				return artworkRevisionGCReferenced, nil
+			case 3:
+				return artworkRevisionGCDeletionPendingHeal, nil
 			default:
 				return artworkRevisionGCDeleted, nil
 			}
@@ -117,10 +119,10 @@ func TestProcessArtworkRevisionGCBatchContinuesAfterRetryFailure(t *testing.T) {
 	if !errors.Is(err, retryErr) {
 		t.Fatalf("process batch error = %v, want %v", err, retryErr)
 	}
-	if !slices.Equal(processed, []int64{1, 2, 3}) {
+	if !slices.Equal(processed, []int64{1, 2, 3, 4}) {
 		t.Fatalf("processed candidates = %v, want all candidates", processed)
 	}
-	want := ArtworkRevisionGCStats{Claimed: 3, Deleted: 1, Referenced: 1, Retried: 1}
+	want := ArtworkRevisionGCStats{Claimed: 4, Deleted: 1, Referenced: 1, Retried: 1}
 	if stats != want {
 		t.Fatalf("stats = %+v, want %+v", stats, want)
 	}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Artwork revision GC was doing healing work even when there was nothing to heal. After deleting an object set, it could run 24 `UPDATE`s across 14 artwork surfaces for every candidate, whether anything still referenced that path or not.

Over a 46.6-hour production sample, the final reference check and two `people.photo_path` healing statements alone accumulated about 83 minutes of database execution and 619 million shared-block hits.

This is background/recovery cost, not the normal browsing path.

## Approach

Keep the existing correctness gates and remove the no-op healing work:

- Retain the final under-lock reference check, object deletion, and durable tombstone for each candidate.
- Run one materialized reference sweep for the completed batch.
- Finalize unreferenced tombstones without running surface healing statements.
- Heal survivors one path at a time, preserving the existing lock scope.
- Keep each source update and candidate lease restoration in the same transaction.
- Run one confirmation sweep, then rearm candidates that remain referenced instead of spinning.

The batch remains capped at 100 candidates. There is no migration or API change.

## Validation

Production validation of this exact patch:

- 9 hourly runs processed 900 candidates.
- All 900 were deleted, with zero heals, retries, or task errors.
- The matched eight-run average fell from 127.3 seconds to 68.2 seconds, a 46.4% reduction.
- In a fresh 100-candidate sample, batch finalization and rearm took 298.6 ms with 45,592 shared-block hits.
- No guarded or legacy healing statement ran in that sample.
- No tombstones or expired leases were left behind.

The exact implementation also passed the Docs hygiene, Go, and Web GitHub Actions jobs on [fork PR #42](https://github.com/blurbery/silo-server/pull/42).

The generated `DELETE` statements parsed and passed plain `EXPLAIN` inside a read-only transaction. `EXPLAIN ANALYZE` was not used because it would execute the deletes.

Added coverage for batch healing, lease rollback, visible-reference rearm, retracking before and during the surface sweep, and the SQL shape of the materialized reference check.

Local checks:

```text
git diff --check upstream/main...HEAD
make verify-local-paths
```

Both pass. Database-backed tests skip in GitHub Actions unless `SILO_TEST_DATABASE_URL` is available.

## Risks

Object deletion now precedes the shared reference sweep for a bounded batch of up to 100 candidates. This widens the delete-to-heal window within that batch. The final under-lock check still runs before each object deletion, and survivors still go through the guarded one-path heal.

The tombstone refreshes its lease once, so the 15-minute lease must cover the remaining object deletions and finalization. Observed runs completed in 63–75 seconds.

No schema, migration, configuration, compatibility, or security change is involved.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: Reviewed the upstream-only diff for lock ordering, retry behavior, retracking, lease rollback, and race conditions. No material findings. Two pre-existing theoretical races remain outside this change: a same-path trigger deadlock and an untracked writer after the final reference snapshot. Neither has a deterministic reproduction; this change retains the under-lock check and guarded final sweep.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of outdated artwork revisions while preserving revisions that become referenced or tracked again.
  * Added safeguards to prevent active artwork paths from being removed during concurrent updates.
  * Improved recovery when cleanup encounters temporary failures, with targeted retries and rollback protection.
  * Enhanced batch processing so one failed cleanup does not interrupt processing of other revisions.
* **Reliability**
  * Added broader coverage for reference changes, retries, and concurrent artwork updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->