### PR TITLE
fix(catalog): reject disabled dual-library items

### DIFF
--- a/internal/access/types.go
+++ b/internal/access/types.go
@@ -5,7 +5,7 @@ type Scope struct {
 	UserID              int
 	ProfileID           string
 	AllowedLibraryIDs   []int
-	DisabledLibraryIDs  []int // user-disabled libraries (only set when AllowedLibraryIDs is nil)
+	DisabledLibraryIDs  []int // libraries whose membership globally hides an item
 	LibrariesRestricted bool
 	MaxContentRating    string
 	MaxPlaybackQuality  string

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -622,30 +622,19 @@ func (h *CatalogHandler) HandlePostCatalogQuery(w http.ResponseWriter, r *http.R
 
 	disabledLibraryIDs := accessFilter.DisabledLibraryIDs
 	fromClause := "media_items mi"
-	if libraryIDs != nil || req.LibraryID > 0 || len(disabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
+	libraryConditions, libraryArgs, nextArgIdx, earlyEmpty := buildPostCatalogLibraryScope(
+		req.LibraryID,
+		libraryIDs,
+		disabledLibraryIDs,
+		argIdx,
+	)
+	if earlyEmpty {
+		writeJSON(w, http.StatusOK, browseResponse{Items: []itemListResponse{}, Total: 0})
+		return
 	}
-
-	if req.LibraryID > 0 {
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = $%d", argIdx))
-		args = append(args, req.LibraryID)
-		argIdx++
-	}
-
-	if libraryIDs != nil {
-		if len(libraryIDs) == 0 {
-			writeJSON(w, http.StatusOK, browseResponse{Items: []itemListResponse{}, Total: 0})
-			return
-		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = ANY($%d)", argIdx))
-		args = append(args, libraryIDs)
-		argIdx++
-	}
-	if len(disabledLibraryIDs) > 0 {
-		conditions = append(conditions, fmt.Sprintf("NOT (mil.media_folder_id = ANY($%d))", argIdx))
-		args = append(args, disabledLibraryIDs)
-		argIdx++
-	}
+	conditions = append(conditions, libraryConditions...)
+	args = append(args, libraryArgs...)
+	argIdx = nextArgIdx
 	catalog.ApplySectionAccessFilter("mi", catalog.AccessFilter{MaxContentRating: accessFilter.MaxContentRating}, &conditions, &args, &argIdx)
 
 	whereClause := ""
@@ -733,6 +722,54 @@ func (h *CatalogHandler) HandlePostCatalogQuery(w http.ResponseWriter, r *http.R
 		HasMore: req.Offset+req.Limit < total,
 		Items:   items,
 	})
+}
+
+func buildPostCatalogLibraryScope(
+	libraryID int,
+	allowedLibraryIDs []int,
+	disabledLibraryIDs []int,
+	argIdx int,
+) (conditions []string, args []any, nextArgIdx int, earlyEmpty bool) {
+	nextArgIdx = argIdx
+	if allowedLibraryIDs != nil && len(allowedLibraryIDs) == 0 {
+		return nil, nil, nextArgIdx, true
+	}
+
+	positiveConditions := []string{"mil_scope_in.content_id = mi.content_id"}
+	hasPositiveScope := false
+	if libraryID > 0 {
+		positiveConditions = append(positiveConditions, fmt.Sprintf("mil_scope_in.media_folder_id = $%d", nextArgIdx))
+		args = append(args, libraryID)
+		nextArgIdx++
+		hasPositiveScope = true
+	}
+	if allowedLibraryIDs != nil {
+		positiveConditions = append(positiveConditions, fmt.Sprintf("mil_scope_in.media_folder_id = ANY($%d)", nextArgIdx))
+		args = append(args, allowedLibraryIDs)
+		nextArgIdx++
+		hasPositiveScope = true
+	}
+	if hasPositiveScope {
+		conditions = append(conditions, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in WHERE %s)",
+			strings.Join(positiveConditions, " AND "),
+		))
+	} else if len(disabledLibraryIDs) > 0 {
+		conditions = append(conditions,
+			"EXISTS (SELECT 1 FROM media_item_libraries mil_scope_any WHERE mil_scope_any.content_id = mi.content_id)",
+		)
+	}
+
+	if len(disabledLibraryIDs) > 0 {
+		conditions = append(conditions, fmt.Sprintf(
+			"NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out WHERE mil_scope_out.content_id = mi.content_id AND mil_scope_out.media_folder_id = ANY($%d))",
+			nextArgIdx,
+		))
+		args = append(args, disabledLibraryIDs)
+		nextArgIdx++
+	}
+
+	return conditions, args, nextArgIdx, false
 }
 
 func (h *CatalogHandler) HandleLegacySearch(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/catalog_library_scope_test.go
+++ b/internal/api/handlers/catalog_library_scope_test.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPostCatalogLibraryScopeDisabledOnlyUsesItemLevelExclusion(t *testing.T) {
+	conditions, args, nextArgIdx, earlyEmpty := buildPostCatalogLibraryScope(0, nil, []int{9}, 3)
+	if earlyEmpty {
+		t.Fatal("disabled-only scope must not be treated as empty")
+	}
+	sql := strings.Join(conditions, " AND ")
+	if !strings.Contains(sql, "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_any") {
+		t.Fatalf("disabled-only scope must require positive membership; got %s", sql)
+	}
+	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out") {
+		t.Fatalf("disabled membership must be rejected with NOT EXISTS; got %s", sql)
+	}
+	if strings.Contains(sql, "NOT (mil.media_folder_id = ANY(") {
+		t.Fatalf("row-local disabled-library predicate leaks dual-membership items; got %s", sql)
+	}
+	if len(args) != 1 || nextArgIdx != 4 {
+		t.Fatalf("args = %v, nextArgIdx = %d; want one disabled-list arg and 4", args, nextArgIdx)
+	}
+}
+
+func TestBuildPostCatalogLibraryScopeCombinesRequestedAndAllowedLibraries(t *testing.T) {
+	conditions, args, _, earlyEmpty := buildPostCatalogLibraryScope(7, []int{1, 2}, []int{9}, 1)
+	if earlyEmpty {
+		t.Fatal("non-empty allowlist must not be treated as empty")
+	}
+	sql := strings.Join(conditions, " AND ")
+	if got := strings.Count(sql, "EXISTS (SELECT 1 FROM media_item_libraries mil_scope_in"); got != 1 {
+		t.Fatalf("requested library and allowlist must share one positive membership EXISTS; got %d in %s", got, sql)
+	}
+	for _, want := range []string{
+		"mil_scope_in.media_folder_id = $1",
+		"mil_scope_in.media_folder_id = ANY($2)",
+		"mil_scope_out.media_folder_id = ANY($3)",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("library scope missing %q: %s", want, sql)
+		}
+	}
+	if len(args) != 3 {
+		t.Fatalf("args = %v, want requested, allowed, and disabled scopes", args)
+	}
+}
+
+func TestBuildPostCatalogLibraryScopeEmptyAllowedLibrariesIsEmpty(t *testing.T) {
+	_, _, _, earlyEmpty := buildPostCatalogLibraryScope(0, []int{}, nil, 1)
+	if !earlyEmpty {
+		t.Fatal("empty non-nil allowlist must produce an empty result")
+	}
+}

--- a/internal/catalog/access_filter.go
+++ b/internal/catalog/access_filter.go
@@ -14,7 +14,7 @@ const LibraryCollectionVisibilityVisible = "visible"
 type AccessFilter struct {
 	AllowedLibraryIDs     []int
 	AllowedContentIDs     []string
-	DisabledLibraryIDs    []int // user-disabled libraries (only set when AllowedLibraryIDs is nil)
+	DisabledLibraryIDs    []int // libraries whose membership globally hides an item
 	PresentationLibraryID *int
 	PresentationLanguage  string
 	// ProfilePreferredLanguage is the viewer profile's preferred metadata

--- a/internal/catalog/access_filter.go
+++ b/internal/catalog/access_filter.go
@@ -142,6 +142,13 @@ func appendLibraryAccessConditions(keyColumn string, filter AccessFilter, condit
 	*conditions = append(*conditions, libraryAccessConditions(keyColumn, allowedIdx, disabledIdx)...)
 }
 
+// ApplyLibraryAccessFilter appends the canonical item-level library allow/deny
+// predicates for keyColumn. It is exported for query builders outside the
+// catalog package that must enforce the same dual-membership invariant.
+func ApplyLibraryAccessFilter(keyColumn string, filter AccessFilter, conditions *[]string, args *[]any, argIdx *int) {
+	appendLibraryAccessConditions(keyColumn, filter, conditions, args, argIdx)
+}
+
 // ApplySectionAccessFilter applies non-library access constraints to section queries.
 func ApplySectionAccessFilter(alias string, filter AccessFilter, conditions *[]string, args *[]any, argIdx *int) {
 	applyAccessFilter(alias, filter, conditions, args, argIdx)

--- a/internal/catalog/browse.go
+++ b/internal/catalog/browse.go
@@ -25,7 +25,7 @@ type BrowseFilters struct {
 	ContentIDs         []string // optional allowlist of exact content IDs
 	LibraryID          int      // filter by specific library
 	LibraryIDs         []int    // accessible library IDs (nil = all)
-	DisabledLibraryIDs []int    // user-disabled libraries to exclude (only used when LibraryIDs is nil)
+	DisabledLibraryIDs []int    // libraries whose membership globally hides an item
 	MaxContentRating   string   // maximum allowed content rating ceiling
 	YearMin            int      // minimum year (inclusive)
 	YearMax            int      // maximum year (inclusive)

--- a/internal/catalog/browse.go
+++ b/internal/catalog/browse.go
@@ -169,14 +169,7 @@ func (r *BrowseRepository) BrowseRecentlyAddedAcrossLibraries(ctx context.Contex
 	perLibrary := make([][]*models.MediaItem, 0, len(libraryIDs))
 	anyLibraryHasMore := false
 	for _, id := range libraryIDs {
-		sub := base
-		sub.LibraryID = id
-		// Clearing the multi-library scopes is what selects the
-		// singleLibraryNoDedup fast path in buildBrowsePlan.
-		sub.LibraryIDs = nil
-		sub.DisabledLibraryIDs = nil
-		sub.Offset = 0
-		sub.Limit = limit
+		sub := recentlyAddedLibraryBrowseFilters(base, id, limit)
 		res, err := r.BrowsePage(ctx, sub, false)
 		if err != nil {
 			return nil, fmt.Errorf("browse recently added in library %d: %w", id, err)
@@ -206,6 +199,17 @@ func (r *BrowseRepository) BrowseRecentlyAddedAcrossLibraries(ctx context.Contex
 	}
 
 	return &BrowseResult{Items: merged, Total: total, HasMore: hasMore}, nil
+}
+
+func recentlyAddedLibraryBrowseFilters(base BrowseFilters, libraryID, limit int) BrowseFilters {
+	base.LibraryID = libraryID
+	// Clear the multi-library allowlist to select the direct single-library
+	// index path. Keep the global deny list: an item also linked to a disabled
+	// library must remain hidden even while this subquery walks an enabled one.
+	base.LibraryIDs = nil
+	base.Offset = 0
+	base.Limit = limit
+	return base
 }
 
 // mergeRecentlyAddedItems merges per-library recently_added result slices — each
@@ -455,7 +459,7 @@ func (r *BrowseRepository) buildBrowsePlan(filters BrowseFilters) (browseQueryPl
 	}
 
 	// Library access control: restrict to user's accessible libraries.
-	needsLibJoin := filters.LibraryID > 0 || filters.LibraryIDs != nil || len(filters.DisabledLibraryIDs) > 0 || filters.Sort == "recently_added"
+	needsLibJoin := filters.LibraryID > 0 || filters.LibraryIDs != nil || filters.Sort == "recently_added"
 	needsPersonJoin := filters.PersonID > 0
 	// When filtering by exactly one library and no person join, each
 	// content_id matches at most one mil row, so the GROUP BY usually added
@@ -463,7 +467,7 @@ func (r *BrowseRepository) buildBrowsePlan(filters BrowseFilters) (browseQueryPl
 	// mil.first_seen_at exploit idx_item_libraries_folder_seen_content
 	// directly — turning a full-library scan + heapsort into a top-N index
 	// walk.
-	singleLibraryNoDedup := filters.LibraryID > 0 && filters.LibraryIDs == nil && len(filters.DisabledLibraryIDs) == 0 && !needsPersonJoin
+	singleLibraryNoDedup := filters.LibraryID > 0 && filters.LibraryIDs == nil && !needsPersonJoin
 
 	if filters.PersonID > 0 {
 		conditions = append(conditions, fmt.Sprintf("ip.person_id = $%d", argIdx))
@@ -488,7 +492,15 @@ func (r *BrowseRepository) buildBrowsePlan(filters BrowseFilters) (browseQueryPl
 	}
 
 	if len(filters.DisabledLibraryIDs) > 0 {
-		conditions = append(conditions, fmt.Sprintf("NOT (mil.media_folder_id = ANY($%d))", argIdx))
+		if !needsLibJoin {
+			conditions = append(conditions,
+				"EXISTS (SELECT 1 FROM media_item_libraries mil_scope_any WHERE mil_scope_any.content_id = mi.content_id)",
+			)
+		}
+		conditions = append(conditions, fmt.Sprintf(
+			"NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out WHERE mil_scope_out.content_id = mi.content_id AND mil_scope_out.media_folder_id = ANY($%d))",
+			argIdx,
+		))
 		args = append(args, filters.DisabledLibraryIDs)
 		argIdx++
 	}
@@ -580,6 +592,8 @@ func filterWhereClause(filters BrowseFilters) (fromClause, whereClause string, a
 func filterWhereClauseForSource(filters BrowseFilters, baseRelation string, mediaScope string) (fromClause, whereClause string, args []any, earlyEmpty bool) {
 	var conditions []string
 	argIdx := 1
+	libraryContentExpr := catalogLibraryContentExprForScope(mediaScope, "mi")
+	membershipTable, membershipKey := catalogLibraryMembershipTableAndKeyForScope(mediaScope)
 
 	if filters.Type != "" {
 		types := splitTypes(filters.Type)
@@ -613,8 +627,9 @@ func filterWhereClauseForSource(filters BrowseFilters, baseRelation string, medi
 		args = append(args, filters.PersonID)
 		argIdx++
 	}
+	var positiveLibraryConditions []string
 	if filters.LibraryID > 0 {
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = $%d", argIdx))
+		positiveLibraryConditions = append(positiveLibraryConditions, fmt.Sprintf("mil_scope_in.media_folder_id = $%d", argIdx))
 		args = append(args, filters.LibraryID)
 		argIdx++
 	}
@@ -630,13 +645,36 @@ func filterWhereClauseForSource(filters BrowseFilters, baseRelation string, medi
 		if len(filters.LibraryIDs) == 0 {
 			return "", "", nil, true
 		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = ANY($%d)", argIdx))
+		positiveLibraryConditions = append(positiveLibraryConditions, fmt.Sprintf("mil_scope_in.media_folder_id = ANY($%d)", argIdx))
 		args = append(args, filters.LibraryIDs)
 		argIdx++
 	}
+	if len(positiveLibraryConditions) > 0 {
+		conditions = append(conditions, fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM %s mil_scope_in WHERE mil_scope_in.%s = %s AND %s)",
+			membershipTable,
+			membershipKey,
+			libraryContentExpr,
+			strings.Join(positiveLibraryConditions, " AND "),
+		))
+	}
 
 	if len(filters.DisabledLibraryIDs) > 0 {
-		conditions = append(conditions, fmt.Sprintf("NOT (mil.media_folder_id = ANY($%d))", argIdx))
+		if len(positiveLibraryConditions) == 0 {
+			conditions = append(conditions, fmt.Sprintf(
+				"EXISTS (SELECT 1 FROM %s mil_scope_any WHERE mil_scope_any.%s = %s)",
+				membershipTable,
+				membershipKey,
+				libraryContentExpr,
+			))
+		}
+		conditions = append(conditions, fmt.Sprintf(
+			"NOT EXISTS (SELECT 1 FROM %s mil_scope_out WHERE mil_scope_out.%s = %s AND mil_scope_out.media_folder_id = ANY($%d))",
+			membershipTable,
+			membershipKey,
+			libraryContentExpr,
+			argIdx,
+		))
 		args = append(args, filters.DisabledLibraryIDs)
 		argIdx++
 	}
@@ -644,11 +682,6 @@ func filterWhereClauseForSource(filters BrowseFilters, baseRelation string, medi
 	applyAccessFilter("mi", AccessFilter{MaxContentRating: filters.MaxContentRating}, &conditions, &args, &argIdx)
 
 	fromClause = baseRelation
-	libraryContentExpr := catalogLibraryContentExprForScope(mediaScope, "mi")
-	if filters.LibraryID > 0 || filters.LibraryIDs != nil || len(filters.DisabledLibraryIDs) > 0 {
-		membershipTable, membershipKey := catalogLibraryMembershipTableAndKeyForScope(mediaScope)
-		fromClause += " JOIN " + membershipTable + " mil ON " + libraryContentExpr + " = mil." + membershipKey
-	}
 	if filters.PersonID > 0 {
 		fromClause += " JOIN item_people ip ON ip.content_id = mi.content_id"
 	}

--- a/internal/catalog/browse.go
+++ b/internal/catalog/browse.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+const browseSortRecentlyAdded = "recently_added"
+
 // BrowseFilters represents all supported filter, sort, and pagination parameters
 // for the /items browse endpoint.
 type BrowseFilters struct {
@@ -459,7 +461,7 @@ func (r *BrowseRepository) buildBrowsePlan(filters BrowseFilters) (browseQueryPl
 	}
 
 	// Library access control: restrict to user's accessible libraries.
-	needsLibJoin := filters.LibraryID > 0 || filters.LibraryIDs != nil || filters.Sort == "recently_added"
+	needsLibJoin := filters.LibraryID > 0 || filters.LibraryIDs != nil || filters.Sort == browseSortRecentlyAdded
 	needsPersonJoin := filters.PersonID > 0
 	// When filtering by exactly one library and no person join, each
 	// content_id matches at most one mil row, so the GROUP BY usually added
@@ -1540,7 +1542,7 @@ func buildOrderByPlan(sort, order string, snapshot *time.Time, argIdx int, singl
 			direction,
 			direction,
 		), nil
-	case "recently_added":
+	case browseSortRecentlyAdded:
 		// Without GROUP BY (single-library filter), reference mil.first_seen_at
 		// directly so the planner can drive the order from
 		// idx_item_libraries_folder_seen_content instead of materializing

--- a/internal/catalog/browse_library_scope_test.go
+++ b/internal/catalog/browse_library_scope_test.go
@@ -1,0 +1,106 @@
+package catalog
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildBrowsePlanDisabledLibrariesUseItemLevelExclusion(t *testing.T) {
+	plan, earlyEmpty, err := (&BrowseRepository{}).buildBrowsePlan(BrowseFilters{
+		DisabledLibraryIDs: []int{9},
+		Limit:              20,
+	})
+	if err != nil {
+		t.Fatalf("buildBrowsePlan: %v", err)
+	}
+	if earlyEmpty {
+		t.Fatal("disabled-library scope must not be treated as empty")
+	}
+
+	sql, _ := plan.pagedSQL(false)
+	assertDisabledLibraryItemScope(t, sql, "media_item_libraries", "content_id", "mi.content_id")
+	if strings.Contains(plan.fromClause, "JOIN media_item_libraries") {
+		t.Fatalf("disabled-only browse must not fan out through a membership JOIN; got:\n%s", sql)
+	}
+	if plan.groupByClause != "" {
+		t.Fatalf("disabled-only browse must not need GROUP BY after item-level filtering; got %q", plan.groupByClause)
+	}
+}
+
+func TestBuildBrowsePlanSingleLibraryKeepsFastPathWithDisabledLibraries(t *testing.T) {
+	plan, earlyEmpty, err := (&BrowseRepository{}).buildBrowsePlan(BrowseFilters{
+		LibraryID:          7,
+		DisabledLibraryIDs: []int{9},
+		Sort:               "recently_added",
+		Limit:              20,
+	})
+	if err != nil {
+		t.Fatalf("buildBrowsePlan: %v", err)
+	}
+	if earlyEmpty {
+		t.Fatal("single enabled library plus a deny list must not be treated as empty")
+	}
+
+	sql, _ := plan.pagedSQL(false)
+	if !strings.Contains(sql, "JOIN media_item_libraries mil") || !strings.Contains(sql, "mil.media_folder_id = $1") {
+		t.Fatalf("single-library browse must retain its direct indexed membership path; got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out") {
+		t.Fatalf("single-library browse must independently reject disabled membership; got:\n%s", sql)
+	}
+	if plan.groupByClause != "" {
+		t.Fatalf("single-library browse must not add a GROUP BY for the independent deny check; got %q", plan.groupByClause)
+	}
+}
+
+func TestFilterWhereClauseDisabledLibrariesUseItemLevelExclusion(t *testing.T) {
+	fromClause, whereClause, _, earlyEmpty := filterWhereClauseForSource(
+		BrowseFilters{DisabledLibraryIDs: []int{9}},
+		"media_items mi",
+		"",
+	)
+	if earlyEmpty {
+		t.Fatal("disabled-library scope must not be treated as empty")
+	}
+
+	assertDisabledLibraryItemScope(t, whereClause, "media_item_libraries", "content_id", "mi.content_id")
+	if strings.Contains(fromClause, "JOIN media_item_libraries") {
+		t.Fatalf("disabled-only facet query must not fan out through a membership JOIN; got FROM %s %s", fromClause, whereClause)
+	}
+}
+
+func TestFilterWhereClauseDisabledLibrariesUseScopeMembershipTable(t *testing.T) {
+	fromClause, whereClause, _, earlyEmpty := filterWhereClauseForSource(
+		BrowseFilters{DisabledLibraryIDs: []int{9}},
+		"episodes e JOIN media_items mi ON mi.content_id = e.content_id",
+		"episode",
+	)
+	if earlyEmpty {
+		t.Fatal("disabled-library scope must not be treated as empty")
+	}
+
+	assertDisabledLibraryItemScope(t, whereClause, "episode_libraries", "episode_id", "mi.content_id")
+	if strings.Contains(fromClause, "JOIN episode_libraries") {
+		t.Fatalf("disabled-only episode facet query must not fan out through a membership JOIN; got FROM %s %s", fromClause, whereClause)
+	}
+}
+
+func assertDisabledLibraryItemScope(t *testing.T, sql, table, keyColumn, itemExpr string) {
+	t.Helper()
+	positive := "EXISTS (SELECT 1 FROM " + table
+	negative := "NOT EXISTS (SELECT 1 FROM " + table
+	correlation := "." + keyColumn + " = " + itemExpr
+
+	if !strings.Contains(sql, positive) {
+		t.Fatalf("disabled-only scope must still require positive membership; got:\n%s", sql)
+	}
+	if !strings.Contains(sql, negative) {
+		t.Fatalf("disabled membership must be rejected with NOT EXISTS; got:\n%s", sql)
+	}
+	if !strings.Contains(sql, correlation) {
+		t.Fatalf("library predicates must correlate %s to %s; got:\n%s", keyColumn, itemExpr, sql)
+	}
+	if strings.Contains(sql, "NOT (mil.media_folder_id = ANY(") {
+		t.Fatalf("row-local disabled-library predicate leaks dual-membership items; got:\n%s", sql)
+	}
+}

--- a/internal/catalog/browse_recently_added_merge_test.go
+++ b/internal/catalog/browse_recently_added_merge_test.go
@@ -1,11 +1,35 @@
 package catalog
 
 import (
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
+
+func TestRecentlyAddedLibraryBrowseFiltersPreserveDisabledLibraries(t *testing.T) {
+	base := BrowseFilters{
+		LibraryIDs:         []int{1, 2},
+		DisabledLibraryIDs: []int{9},
+		Offset:             25,
+		Limit:              50,
+	}
+
+	got := recentlyAddedLibraryBrowseFilters(base, 7, 20)
+	if got.LibraryID != 7 {
+		t.Fatalf("LibraryID = %d, want 7", got.LibraryID)
+	}
+	if got.LibraryIDs != nil {
+		t.Fatalf("LibraryIDs = %v, want nil for the single-library fast path", got.LibraryIDs)
+	}
+	if !slices.Equal(got.DisabledLibraryIDs, []int{9}) {
+		t.Fatalf("DisabledLibraryIDs = %v, want [9]", got.DisabledLibraryIDs)
+	}
+	if got.Offset != 0 || got.Limit != 20 {
+		t.Fatalf("Offset/Limit = %d/%d, want 0/20", got.Offset, got.Limit)
+	}
+}
 
 func tsPtr(t time.Time) *time.Time { return &t }
 

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -2120,7 +2120,7 @@ func catalogSearchAccess(req CatalogRequest, access AccessFilter) (AccessFilter,
 
 	searchAccess := AccessFilter{
 		AllowedLibraryIDs:  allowedLibraryIDs,
-		DisabledLibraryIDs: effectiveCatalogDisabledLibraryIDs(req.Query.LibraryIDs, access.DisabledLibraryIDs),
+		DisabledLibraryIDs: slices.Clone(access.DisabledLibraryIDs),
 		MaxContentRating:   access.MaxContentRating,
 	}
 
@@ -2138,7 +2138,7 @@ func catalogBrowseFilters(req CatalogRequest, access AccessFilter) (BrowseFilter
 		// scopes like "video" expand here rather than leaking downstream.
 		Type:               strings.Join(MediaScopeItemTypes(req.Query.MediaScope), ","),
 		NamePrefix:         req.NamePrefix,
-		DisabledLibraryIDs: effectiveCatalogDisabledLibraryIDs(req.Query.LibraryIDs, access.DisabledLibraryIDs),
+		DisabledLibraryIDs: slices.Clone(access.DisabledLibraryIDs),
 		MaxContentRating:   access.MaxContentRating,
 	}
 	applyCatalogBrowseOverlayRules(&filters, req.Query)
@@ -2244,13 +2244,6 @@ func effectiveCatalogLibraryIDs(requestIDs []int, access AccessFilter) ([]int, b
 		return nil, true
 	}
 	return ids, false
-}
-
-func effectiveCatalogDisabledLibraryIDs(requestIDs, disabled []int) []int {
-	if len(requestIDs) > 0 {
-		return nil
-	}
-	return append([]int(nil), disabled...)
 }
 
 func removeCatalogLibraryIDs(ids, remove []int) []int {

--- a/internal/catalog/catalog_resolver_test.go
+++ b/internal/catalog/catalog_resolver_test.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -9,6 +10,36 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
+
+func TestCatalogScopedLibraryRequestPreservesGlobalDisabledLibraries(t *testing.T) {
+	req := CatalogRequest{Query: QueryDefinition{LibraryIDs: []int{7}}}
+	viewerAccess := AccessFilter{DisabledLibraryIDs: []int{9}}
+
+	searchAccess, _, earlyEmpty := catalogSearchAccess(req, viewerAccess)
+	if earlyEmpty {
+		t.Fatal("catalogSearchAccess returned early empty for an enabled requested library")
+	}
+	if !slices.Equal(searchAccess.AllowedLibraryIDs, []int{7}) {
+		t.Fatalf("search allowed libraries = %v, want [7]", searchAccess.AllowedLibraryIDs)
+	}
+	if !slices.Equal(searchAccess.DisabledLibraryIDs, []int{9}) {
+		t.Fatalf("search disabled libraries = %v, want [9]", searchAccess.DisabledLibraryIDs)
+	}
+
+	browseFilters, earlyEmpty, err := catalogBrowseFilters(req, viewerAccess)
+	if err != nil {
+		t.Fatalf("catalogBrowseFilters: %v", err)
+	}
+	if earlyEmpty {
+		t.Fatal("catalogBrowseFilters returned early empty for an enabled requested library")
+	}
+	if browseFilters.LibraryID != 7 {
+		t.Fatalf("browse library = %d, want 7", browseFilters.LibraryID)
+	}
+	if !slices.Equal(browseFilters.DisabledLibraryIDs, []int{9}) {
+		t.Fatalf("browse disabled libraries = %v, want [9]", browseFilters.DisabledLibraryIDs)
+	}
+}
 
 func TestValidateCatalogQueryRequest_AllowsLastAirDateSort(t *testing.T) {
 	req := CatalogRequest{

--- a/internal/catalog/episode_catalog_entries_executor.go
+++ b/internal/catalog/episode_catalog_entries_executor.go
@@ -53,6 +53,9 @@ type episodeCatalogUserStatePlan struct {
 // the entry-scan level so both queries stay aligned with hydration.
 func applyEpisodeCatalogAccessFilter(access AccessFilter, whereParts *[]string, args *[]any, argIdx *int) {
 	if len(access.DisabledLibraryIDs) > 0 {
+		*whereParts = append(*whereParts,
+			"EXISTS (SELECT 1 FROM episode_libraries el_scope_any WHERE el_scope_any.episode_id = ece.episode_id)",
+		)
 		*whereParts = append(*whereParts, fmt.Sprintf(
 			"NOT EXISTS (SELECT 1 FROM episode_libraries el_scope_out WHERE el_scope_out.episode_id = ece.episode_id AND el_scope_out.media_folder_id = ANY($%d))",
 			*argIdx,

--- a/internal/catalog/episode_catalog_entries_executor.go
+++ b/internal/catalog/episode_catalog_entries_executor.go
@@ -52,6 +52,14 @@ type episodeCatalogUserStatePlan struct {
 // render. episodeCatalogSeriesParentGuard re-expresses that same constraint at
 // the entry-scan level so both queries stay aligned with hydration.
 func applyEpisodeCatalogAccessFilter(access AccessFilter, whereParts *[]string, args *[]any, argIdx *int) {
+	if len(access.DisabledLibraryIDs) > 0 {
+		*whereParts = append(*whereParts, fmt.Sprintf(
+			"NOT EXISTS (SELECT 1 FROM episode_libraries el_scope_out WHERE el_scope_out.episode_id = ece.episode_id AND el_scope_out.media_folder_id = ANY($%d))",
+			*argIdx,
+		))
+		*args = append(*args, access.DisabledLibraryIDs)
+		*argIdx++
+	}
 	access.ExcludedMediaTypes = nil // access is a value param; caller unaffected
 	ApplySectionAccessFilter("ece", access, whereParts, args, argIdx)
 	*whereParts = append(*whereParts, episodeCatalogSeriesParentGuard)

--- a/internal/catalog/episode_catalog_entries_executor_test.go
+++ b/internal/catalog/episode_catalog_entries_executor_test.go
@@ -5,6 +5,29 @@ import (
 	"testing"
 )
 
+func TestApplyEpisodeCatalogAccessFilterRejectsAnyDisabledMembership(t *testing.T) {
+	var whereParts []string
+	var args []any
+	argIdx := 2
+	applyEpisodeCatalogAccessFilter(
+		AccessFilter{DisabledLibraryIDs: []int{9}},
+		&whereParts,
+		&args,
+		&argIdx,
+	)
+
+	where := strings.Join(whereParts, " AND ")
+	if !strings.Contains(where, "NOT EXISTS (SELECT 1 FROM episode_libraries el_scope_out") {
+		t.Fatalf("optimized episode catalog path must reject any disabled membership, got %s", where)
+	}
+	if !strings.Contains(where, "el_scope_out.media_folder_id = ANY($2)") {
+		t.Fatalf("disabled libraries must bind at $2, got %s", where)
+	}
+	if len(args) != 1 || argIdx != 3 {
+		t.Fatalf("args = %v, argIdx = %d; want one disabled-list arg and 3", args, argIdx)
+	}
+}
+
 func TestEpisodeCatalogEntryOrderByUsesReadModelColumns(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/catalog/episode_catalog_entries_executor_test.go
+++ b/internal/catalog/episode_catalog_entries_executor_test.go
@@ -17,6 +17,9 @@ func TestApplyEpisodeCatalogAccessFilterRejectsAnyDisabledMembership(t *testing.
 	)
 
 	where := strings.Join(whereParts, " AND ")
+	if !strings.Contains(where, "EXISTS (SELECT 1 FROM episode_libraries el_scope_any") {
+		t.Fatalf("optimized episode catalog path must require current episode membership, got %s", where)
+	}
 	if !strings.Contains(where, "NOT EXISTS (SELECT 1 FROM episode_libraries el_scope_out") {
 		t.Fatalf("optimized episode catalog path must reject any disabled membership, got %s", where)
 	}

--- a/internal/catalog/episode_catalog_source.go
+++ b/internal/catalog/episode_catalog_source.go
@@ -124,39 +124,36 @@ func episodeCatalogBaseRelationForLibraries(
 		return episodeCatalogBaseRelation, nil, false
 	}
 
-	libraryConditions := []string{
-		"el.episode_id = e.content_id",
-	}
+	var libraryPredicates []string
 	args := make([]any, 0, len(allowedLibraryIDs)+len(disabledLibraryIDs))
 
 	if len(allowedLibraryIDs) > 0 {
-		libraryConditions = append(
-			libraryConditions,
-			fmt.Sprintf("el.media_folder_id = ANY($%d)", argIdx),
-		)
+		libraryPredicates = append(libraryPredicates, fmt.Sprintf(`EXISTS (
+		SELECT 1
+		FROM episode_libraries el_scope_in
+		WHERE el_scope_in.episode_id = e.content_id
+		  AND el_scope_in.media_folder_id = ANY($%d)
+	)`, argIdx))
 		args = append(args, allowedLibraryIDs)
 		argIdx++
+	} else if len(disabledLibraryIDs) > 0 {
+		libraryPredicates = append(libraryPredicates, episodeCatalogActiveLibraryExists)
 	}
 
 	if len(disabledLibraryIDs) > 0 {
-		libraryConditions = append(
-			libraryConditions,
-			fmt.Sprintf("NOT (el.media_folder_id = ANY($%d))", argIdx),
-		)
+		libraryPredicates = append(libraryPredicates, fmt.Sprintf(`NOT EXISTS (
+		SELECT 1
+		FROM episode_libraries el_scope_out
+		WHERE el_scope_out.episode_id = e.content_id
+		  AND el_scope_out.media_folder_id = ANY($%d)
+	)`, argIdx))
 		args = append(args, disabledLibraryIDs)
 		argIdx++
 	}
 
 	relation := fmt.Sprintf(
 		episodeCatalogSelectBody,
-		fmt.Sprintf(
-			`EXISTS (
-		SELECT 1
-		FROM episode_libraries el
-		WHERE %s
-	)`,
-			strings.Join(libraryConditions, "\n\t\t  AND "),
-		),
+		strings.Join(libraryPredicates, "\n\tAND "),
 	)
 	return relation, args, true
 }

--- a/internal/catalog/item_repo_access_db_test.go
+++ b/internal/catalog/item_repo_access_db_test.go
@@ -35,7 +35,7 @@ func TestDualLibraryItemDeniedByDisabledLibraryDB(t *testing.T) {
 		t.Fatalf("seed disabled folder: %v", err)
 	}
 	batchEquivExec(t, pool, `
-		INSERT INTO media_items (content_id, type, title) VALUES ($1, 'movie', 'Dual Library Item')`, item)
+		INSERT INTO media_items (content_id, type, title, genres) VALUES ($1, 'movie', 'Dual Library Item', ARRAY['Dual Library Leak'])`, item)
 	batchEquivExec(t, pool, `
 		INSERT INTO media_item_libraries (content_id, media_folder_id) VALUES ($1, $2), ($1, $3)`,
 		item, enabledLib, disabledLib)
@@ -46,6 +46,7 @@ func TestDualLibraryItemDeniedByDisabledLibraryDB(t *testing.T) {
 
 	itemRepo := NewItemRepository(pool)
 	libraryRepo := NewLibraryItemRepository(pool)
+	browseRepo := NewBrowseRepository(pool)
 
 	scopes := []struct {
 		name   string
@@ -53,6 +54,42 @@ func TestDualLibraryItemDeniedByDisabledLibraryDB(t *testing.T) {
 	}{
 		{"disabled list", AccessFilter{DisabledLibraryIDs: []int{disabledLib}}},
 		{"allowlist excluding disabled", AccessFilter{AllowedLibraryIDs: []int{enabledLib}, DisabledLibraryIDs: []int{disabledLib}}},
+	}
+
+	browseResult, err := browseRepo.Browse(ctx, BrowseFilters{
+		ContentIDs:         []string{item},
+		DisabledLibraryIDs: []int{disabledLib},
+		Limit:              20,
+	})
+	if err != nil {
+		t.Fatalf("Browse dual-library scope: %v", err)
+	}
+	if len(browseResult.Items) != 0 || browseResult.Total != 0 {
+		t.Fatalf("Browse returned disabled dual-library item: %+v", browseResult)
+	}
+
+	genres, err := browseRepo.ListGenres(ctx, BrowseFilters{
+		ContentIDs:         []string{item},
+		DisabledLibraryIDs: []int{disabledLib},
+	})
+	if err != nil {
+		t.Fatalf("ListGenres dual-library scope: %v", err)
+	}
+	if len(genres) != 0 {
+		t.Fatalf("ListGenres exposed disabled dual-library metadata: %v", genres)
+	}
+
+	recent, err := browseRepo.BrowseRecentlyAddedAcrossLibraries(ctx, BrowseFilters{
+		ContentIDs:         []string{item},
+		DisabledLibraryIDs: []int{disabledLib},
+		Sort:               "recently_added",
+		Limit:              20,
+	}, []int{enabledLib})
+	if err != nil {
+		t.Fatalf("BrowseRecentlyAddedAcrossLibraries dual-library scope: %v", err)
+	}
+	if len(recent.Items) != 0 {
+		t.Fatalf("recently-added fanout returned disabled dual-library item: %+v", recent.Items)
 	}
 	for _, scope := range scopes {
 		t.Run(scope.name, func(t *testing.T) {
@@ -91,5 +128,16 @@ func TestDualLibraryItemDeniedByDisabledLibraryDB(t *testing.T) {
 	// accessible through the membership EXISTS.
 	if err := itemRepo.EnsureAccessible(ctx, item, AccessFilter{DisabledLibraryIDs: []int{disabledLib + 100000}}); err != nil {
 		t.Fatalf("EnsureAccessible with unrelated disabled library = %v, want nil", err)
+	}
+	controlBrowse, err := browseRepo.Browse(ctx, BrowseFilters{
+		ContentIDs:         []string{item},
+		DisabledLibraryIDs: []int{disabledLib + 100000},
+		Limit:              20,
+	})
+	if err != nil {
+		t.Fatalf("Browse with unrelated disabled library: %v", err)
+	}
+	if len(controlBrowse.Items) != 1 || controlBrowse.Total != 1 {
+		t.Fatalf("Browse with unrelated disabled library = %+v, want one visible item", controlBrowse)
 	}
 }

--- a/internal/catalog/query_executor_test.go
+++ b/internal/catalog/query_executor_test.go
@@ -153,17 +153,36 @@ func TestEpisodeCatalogBaseRelationForLibraries_UsesEpisodeLibraries(t *testing.
 	if got, ok := args[1].([]int); !ok || len(got) != 1 || got[0] != 9 {
 		t.Fatalf("args[1] = %v, want []int{9}", args[1])
 	}
-	if !strings.Contains(relation, "el.episode_id = e.content_id") {
-		t.Fatalf("expected episode library join in relation, got %q", relation)
+	if !strings.Contains(relation, "el_scope_in.episode_id = e.content_id") {
+		t.Fatalf("expected allowed episode membership in relation, got %q", relation)
 	}
-	if !strings.Contains(relation, "el.media_folder_id = ANY($3)") {
+	if !strings.Contains(relation, "el_scope_in.media_folder_id = ANY($3)") {
 		t.Fatalf("expected allowed library = ANY filter, got %q", relation)
 	}
-	if !strings.Contains(relation, "NOT (el.media_folder_id = ANY($4))") {
-		t.Fatalf("expected disabled library NOT (= ANY) filter, got %q", relation)
+	if !strings.Contains(relation, "NOT EXISTS (") || !strings.Contains(relation, "el_scope_out.media_folder_id = ANY($4)") {
+		t.Fatalf("expected independent disabled-library NOT EXISTS filter, got %q", relation)
+	}
+	if strings.Contains(relation, "NOT (el.media_folder_id = ANY(") {
+		t.Fatalf("row-local disabled-library predicate leaks dual-membership episodes, got %q", relation)
 	}
 	if strings.Contains(relation, "media_files mf") {
 		t.Fatalf("expected relation to avoid media_files, got %q", relation)
+	}
+}
+
+func TestEpisodeCatalogBaseRelationForLibraries_DisabledOnlyRequiresMembership(t *testing.T) {
+	relation, args, handled := episodeCatalogBaseRelationForLibraries(nil, []int{9}, 1)
+	if !handled {
+		t.Fatal("expected disabled episode library scope to be handled")
+	}
+	if !strings.Contains(relation, episodeCatalogActiveLibraryExists) {
+		t.Fatalf("disabled-only episode scope must require positive membership, got %q", relation)
+	}
+	if !strings.Contains(relation, "NOT EXISTS (") || !strings.Contains(relation, "el_scope_out.media_folder_id = ANY($1)") {
+		t.Fatalf("disabled-only episode scope must reject any disabled membership, got %q", relation)
+	}
+	if len(args) != 1 {
+		t.Fatalf("args = %v, want one disabled-library argument", args)
 	}
 }
 

--- a/internal/jellycompat/batch_loaders.go
+++ b/internal/jellycompat/batch_loaders.go
@@ -62,32 +62,13 @@ func (h *ItemsHandler) fetchCompatItemsByContentIDs(ctx context.Context, session
 	conditions := []string{"mi.content_id = ANY($1)"}
 	args := []any{normalized}
 	argIdx := 2
-
-	if libraryID != nil || access.AllowedLibraryIDs != nil || len(access.DisabledLibraryIDs) > 0 {
-		fromClause = "media_items mi JOIN media_item_libraries mil ON mi.content_id = mil.content_id"
-	}
-	if libraryID != nil {
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = $%d", argIdx))
-		args = append(args, *libraryID)
-		argIdx++
-	}
-	if access.AllowedLibraryIDs != nil {
-		if len(access.AllowedLibraryIDs) == 0 {
-			return map[string]upstreamListItem{}, nil
-		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = ANY($%d)", argIdx))
-		args = append(args, access.AllowedLibraryIDs)
-		argIdx++
-	}
-	if len(access.DisabledLibraryIDs) > 0 {
-		conditions = append(conditions, fmt.Sprintf("NOT (mil.media_folder_id = ANY($%d))", argIdx))
-		args = append(args, access.DisabledLibraryIDs)
-		argIdx++
+	if !applyCompatLibraryAccess(&access, libraryID, "mi.content_id", &conditions, &args, &argIdx) {
+		return map[string]upstreamListItem{}, nil
 	}
 	catalog.ApplySectionAccessFilter("mi", access, &conditions, &args, &argIdx)
 
 	query := fmt.Sprintf(
-		`SELECT DISTINCT ON (mi.content_id) %s FROM %s WHERE %s ORDER BY mi.content_id`,
+		`SELECT %s FROM %s WHERE %s`,
 		compatItemColumns("mi"), fromClause, strings.Join(conditions, " AND "),
 	)
 
@@ -165,6 +146,24 @@ func narrowAccessToLibrary(access *catalog.AccessFilter, libraryID int) bool {
 	return true
 }
 
+func applyCompatLibraryAccess(
+	access *catalog.AccessFilter,
+	libraryID *int,
+	keyColumn string,
+	conditions *[]string,
+	args *[]any,
+	argIdx *int,
+) bool {
+	if libraryID != nil && !narrowAccessToLibrary(access, *libraryID) {
+		return false
+	}
+	if access.AllowedLibraryIDs != nil && len(access.AllowedLibraryIDs) == 0 {
+		return false
+	}
+	catalog.ApplyLibraryAccessFilter(keyColumn, *access, conditions, args, argIdx)
+	return true
+}
+
 func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDs(ctx context.Context, session *Session, contentIDs []string, libraryID *int) (map[string]compatEpisodeTarget, error) {
 	normalized := normalizeContentIDs(contentIDs)
 	if len(normalized) == 0 {
@@ -185,32 +184,13 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDs(ctx context.Context
 	conditions := []string{"e.content_id = ANY($1)"}
 	args := []any{normalized}
 	argIdx := 2
-
-	if libraryID != nil || access.AllowedLibraryIDs != nil || len(access.DisabledLibraryIDs) > 0 {
-		fromClause += " JOIN media_item_libraries mil ON si.content_id = mil.content_id"
-	}
-	if libraryID != nil {
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = $%d", argIdx))
-		args = append(args, *libraryID)
-		argIdx++
-	}
-	if access.AllowedLibraryIDs != nil {
-		if len(access.AllowedLibraryIDs) == 0 {
-			return map[string]compatEpisodeTarget{}, nil
-		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = ANY($%d)", argIdx))
-		args = append(args, access.AllowedLibraryIDs)
-		argIdx++
-	}
-	if len(access.DisabledLibraryIDs) > 0 {
-		conditions = append(conditions, fmt.Sprintf("NOT (mil.media_folder_id = ANY($%d))", argIdx))
-		args = append(args, access.DisabledLibraryIDs)
-		argIdx++
+	if !applyCompatLibraryAccess(&access, libraryID, "si.content_id", &conditions, &args, &argIdx) {
+		return map[string]compatEpisodeTarget{}, nil
 	}
 	catalog.ApplySectionAccessFilter("si", access, &conditions, &args, &argIdx)
 
 	query := fmt.Sprintf(`
-		SELECT DISTINCT ON (e.content_id)
+		SELECT
 			e.content_id,
 			e.title,
 			e.overview,
@@ -242,7 +222,6 @@ func (h *ItemsHandler) fetchCompatEpisodeTargetsByContentIDs(ctx context.Context
 			)
 		FROM %s
 		WHERE %s
-		ORDER BY e.content_id
 	`, fromClause, strings.Join(conditions, " AND "))
 
 	rows, err := pool.Query(ctx, query, args...)

--- a/internal/jellycompat/batch_loaders_test.go
+++ b/internal/jellycompat/batch_loaders_test.go
@@ -4,11 +4,57 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
+
+func TestApplyCompatLibraryAccessUsesItemLevelDisabledExclusion(t *testing.T) {
+	access := catalog.AccessFilter{DisabledLibraryIDs: []int{9}}
+	var conditions []string
+	var args []any
+	argIdx := 2
+	if !applyCompatLibraryAccess(&access, nil, "mi.content_id", &conditions, &args, &argIdx) {
+		t.Fatal("disabled-only scope must remain queryable")
+	}
+
+	sql := strings.Join(conditions, " AND ")
+	if !strings.Contains(sql, "EXISTS (SELECT 1 FROM media_item_libraries mil WHERE mil.content_id = mi.content_id)") {
+		t.Fatalf("disabled-only scope must require positive membership, got %s", sql)
+	}
+	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil WHERE mil.content_id = mi.content_id AND mil.media_folder_id = ANY($2))") {
+		t.Fatalf("dual-membership items must be rejected with NOT EXISTS, got %s", sql)
+	}
+	if len(args) != 1 || argIdx != 3 {
+		t.Fatalf("args = %v, argIdx = %d; want one disabled-list arg and 3", args, argIdx)
+	}
+}
+
+func TestApplyCompatLibraryAccessNarrowsRequestedLibraryBeforeDeny(t *testing.T) {
+	libraryID := 7
+	access := catalog.AccessFilter{
+		AllowedLibraryIDs:  []int{7, 8},
+		DisabledLibraryIDs: []int{9},
+	}
+	var conditions []string
+	var args []any
+	argIdx := 1
+	if !applyCompatLibraryAccess(&access, &libraryID, "si.content_id", &conditions, &args, &argIdx) {
+		t.Fatal("requested allowed library must remain queryable")
+	}
+
+	if !reflect.DeepEqual(access.AllowedLibraryIDs, []int{7}) {
+		t.Fatalf("allowed libraries = %v, want requested library only", access.AllowedLibraryIDs)
+	}
+	sql := strings.Join(conditions, " AND ")
+	if !strings.Contains(sql, "mil.media_folder_id = ANY($1)") ||
+		!strings.Contains(sql, "NOT EXISTS") ||
+		!strings.Contains(sql, "mil.media_folder_id = ANY($2)") {
+		t.Fatalf("requested library and global deny must be independent predicates, got %s", sql)
+	}
+}
 
 type stubLibraryMembershipChecker struct {
 	membership map[string]bool

--- a/internal/recommendations/repo.go
+++ b/internal/recommendations/repo.go
@@ -364,28 +364,8 @@ func (r *Repo) findTasteProfileCandidates(
 		if len(filter.AllowedLibraryIDs) == 0 {
 			return []ScoredItem{}, map[string][]string{}, nil
 		}
-		conditions = append(conditions, fmt.Sprintf(`
-			EXISTS (
-				SELECT 1
-				FROM media_item_libraries mil
-				WHERE mil.content_id = mi.content_id
-				  AND mil.media_folder_id = ANY($%d)
-			)`, argIdx))
-		args = append(args, filter.AllowedLibraryIDs)
-		argIdx++
 	}
-
-	if len(filter.DisabledLibraryIDs) > 0 {
-		conditions = append(conditions, fmt.Sprintf(`
-			EXISTS (
-				SELECT 1
-				FROM media_item_libraries mil
-				WHERE mil.content_id = mi.content_id
-				  AND mil.media_folder_id != ALL($%d)
-			)`, argIdx))
-		args = append(args, filter.DisabledLibraryIDs)
-		argIdx++
-	}
+	catalog.ApplyLibraryAccessFilter("mi.content_id", filter, &conditions, &args, &argIdx)
 
 	if filter.MaxContentRating != "" {
 		allowedRatings := access.AllowedRatingsUpTo(filter.MaxContentRating)
@@ -1600,30 +1580,10 @@ func (r *Repo) FilterAccessibleItemIDs(ctx context.Context, itemIDs []string, fi
 		argIdx++
 	}
 
-	if filter.AllowedLibraryIDs != nil {
-		if len(filter.AllowedLibraryIDs) == 0 {
-			return map[string]struct{}{}, nil
-		}
-		conditions = append(conditions, fmt.Sprintf(`
-			EXISTS (
-				SELECT 1
-				FROM media_item_libraries mil
-				WHERE mil.content_id = mi.content_id
-				  AND mil.media_folder_id = ANY($%d)
-			)`, argIdx))
-		args = append(args, filter.AllowedLibraryIDs)
-		argIdx++
-	} else if len(filter.DisabledLibraryIDs) > 0 {
-		conditions = append(conditions, fmt.Sprintf(`
-			EXISTS (
-				SELECT 1
-				FROM media_item_libraries mil
-				WHERE mil.content_id = mi.content_id
-				  AND mil.media_folder_id != ALL($%d)
-			)`, argIdx))
-		args = append(args, filter.DisabledLibraryIDs)
-		argIdx++
+	if filter.AllowedLibraryIDs != nil && len(filter.AllowedLibraryIDs) == 0 {
+		return map[string]struct{}{}, nil
 	}
+	catalog.ApplyLibraryAccessFilter("mi.content_id", filter, &conditions, &args, &argIdx)
 
 	if filter.MaxContentRating != "" {
 		allowedRatings := access.AllowedRatingsUpTo(filter.MaxContentRating)

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -2423,13 +2423,12 @@ func buildRecentlyAddedSingleLibraryQuery(s ResolvedSection, cfgFilters SectionC
 	}
 
 	if len(filter.DisabledLibraryIDs) > 0 {
-		placeholders := make([]string, len(filter.DisabledLibraryIDs))
-		for i, id := range filter.DisabledLibraryIDs {
-			placeholders[i] = fmt.Sprintf("$%d", argIdx)
-			args = append(args, id)
-			argIdx++
-		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id NOT IN (%s)", strings.Join(placeholders, ", ")))
+		conditions = append(conditions, fmt.Sprintf(
+			"NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out WHERE mil_scope_out.content_id = mi.content_id AND mil_scope_out.media_folder_id = ANY($%d))",
+			argIdx,
+		))
+		args = append(args, append([]int(nil), filter.DisabledLibraryIDs...))
+		argIdx++
 	}
 
 	applyConfigTypeFilter("mi", cfgFilters.FilterType, &conditions, &args, &argIdx)

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -2676,30 +2676,9 @@ func (f *Fetcher) fetchEpisodeTargetsByContentIDs(ctx context.Context, contentID
 	}
 	conditions = append(conditions, fmt.Sprintf("e.content_id IN (%s)", strings.Join(placeholders, ", ")))
 
-	effectiveLibraryIDs := effectiveFetchLibraryIDs(libraryIDs, filter)
-
 	fromClause := "episodes e JOIN media_items si ON e.series_id = si.content_id LEFT JOIN seasons s ON s.content_id = e.season_id"
-	if libraryID != nil || effectiveLibraryIDs != nil {
-		fromClause += " JOIN media_item_libraries mil ON si.content_id = mil.content_id"
-	}
-
-	if libraryID != nil {
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id = $%d", argIdx))
-		args = append(args, *libraryID)
-		argIdx++
-	}
-
-	if effectiveLibraryIDs != nil {
-		if len(effectiveLibraryIDs) == 0 {
-			return []*models.MediaItem{}, map[string]SectionItemMeta{}, nil
-		}
-		placeholders = make([]string, len(effectiveLibraryIDs))
-		for i, id := range effectiveLibraryIDs {
-			placeholders[i] = fmt.Sprintf("$%d", argIdx)
-			args = append(args, id)
-			argIdx++
-		}
-		conditions = append(conditions, fmt.Sprintf("mil.media_folder_id IN (%s)", strings.Join(placeholders, ", ")))
+	if !applyEpisodeTargetLibraryAccess(filter, libraryID, libraryIDs, &conditions, &args, &argIdx) {
+		return []*models.MediaItem{}, map[string]SectionItemMeta{}, nil
 	}
 
 	catalog.ApplySectionAccessFilter("si", filter, &conditions, &args, &argIdx)
@@ -2793,6 +2772,22 @@ func effectiveFetchLibraryIDs(libraryIDs []int, filter catalog.AccessFilter) []i
 		return filter.AllowedLibraryIDs
 	}
 	return nil
+}
+
+func applyEpisodeTargetLibraryAccess(
+	filter catalog.AccessFilter,
+	libraryID *int,
+	libraryIDs []int,
+	conditions *[]string,
+	args *[]any,
+	argIdx *int,
+) bool {
+	scoped := collectionRailQueryAccess(filter, libraryID, libraryIDs)
+	if scoped.AllowedLibraryIDs != nil && len(scoped.AllowedLibraryIDs) == 0 {
+		return false
+	}
+	catalog.ApplyLibraryAccessFilter("si.content_id", scoped, conditions, args, argIdx)
+	return true
 }
 
 // collectionRailQueryAccess expresses the section's explicit library scope as

--- a/internal/sections/fetcher_access_test.go
+++ b/internal/sections/fetcher_access_test.go
@@ -2,6 +2,7 @@ package sections
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -37,5 +38,63 @@ func TestEffectiveFetchLibraryIDsPreservesEmptyAllowedScope(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Fatalf("effective library IDs = %#v, want empty slice", got)
+	}
+}
+
+func TestApplyEpisodeTargetLibraryAccessRejectsAnyDisabledSeriesMembership(t *testing.T) {
+	var conditions []string
+	var args []any
+	argIdx := 2
+
+	ok := applyEpisodeTargetLibraryAccess(
+		catalog.AccessFilter{DisabledLibraryIDs: []int{9}},
+		nil,
+		nil,
+		&conditions,
+		&args,
+		&argIdx,
+	)
+	if !ok {
+		t.Fatal("disabled-only access unexpectedly returned an empty scope")
+	}
+
+	where := strings.Join(conditions, " AND ")
+	if !strings.Contains(where, "EXISTS (SELECT 1 FROM media_item_libraries mil WHERE mil.content_id = si.content_id)") {
+		t.Fatalf("episode hydration must require positive series membership, got %s", where)
+	}
+	if !strings.Contains(where, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil WHERE mil.content_id = si.content_id AND mil.media_folder_id = ANY($2))") {
+		t.Fatalf("episode hydration must reject any disabled series membership, got %s", where)
+	}
+	if len(args) != 1 || !slices.Equal(args[0].([]int), []int{9}) || argIdx != 3 {
+		t.Fatalf("args = %v, argIdx = %d; want disabled list at $2 and next index 3", args, argIdx)
+	}
+}
+
+func TestApplyEpisodeTargetLibraryAccessComposesAllowedAndDisabledMembership(t *testing.T) {
+	var conditions []string
+	var args []any
+	argIdx := 1
+
+	ok := applyEpisodeTargetLibraryAccess(
+		catalog.AccessFilter{AllowedLibraryIDs: []int{7}, DisabledLibraryIDs: []int{9}},
+		nil,
+		nil,
+		&conditions,
+		&args,
+		&argIdx,
+	)
+	if !ok {
+		t.Fatal("allowed library unexpectedly returned an empty scope")
+	}
+
+	where := strings.Join(conditions, " AND ")
+	if !strings.Contains(where, "mil.media_folder_id = ANY($1)") {
+		t.Fatalf("episode hydration must require allowed series membership, got %s", where)
+	}
+	if !strings.Contains(where, "NOT EXISTS") || !strings.Contains(where, "mil.media_folder_id = ANY($2)") {
+		t.Fatalf("episode hydration must independently reject disabled series membership, got %s", where)
+	}
+	if len(args) != 2 || argIdx != 3 {
+		t.Fatalf("args = %v, argIdx = %d; want allowed and disabled lists with next index 3", args, argIdx)
 	}
 }

--- a/internal/sections/recently_added_query_test.go
+++ b/internal/sections/recently_added_query_test.go
@@ -58,3 +58,22 @@ func TestBuildRecentlyAddedQueryKeepsGenericPathForMultiLibraryConfig(t *testing
 		t.Fatalf("multi-library generic path should not use the single-library first_seen_at sort:\n%s", query)
 	}
 }
+
+func TestBuildRecentlyAddedSingleLibraryQueryRejectsAnyDisabledMembership(t *testing.T) {
+	t.Parallel()
+
+	query, _ := buildRecentlyAddedQuery(ResolvedSection{
+		ItemLimit: 12,
+		Config:    json.RawMessage(`{"generated_source":"home_library_recent","filter_library_id":1,"filter_type":"movie"}`),
+	}, nil, nil, catalog.AccessFilter{DisabledLibraryIDs: []int{9}})
+
+	if !strings.Contains(query, "mil.media_folder_id = $1") {
+		t.Fatalf("single-library fast path must keep its direct indexed membership, got:\n%s", query)
+	}
+	if !strings.Contains(query, "NOT EXISTS (SELECT 1 FROM media_item_libraries mil_scope_out") {
+		t.Fatalf("single-library fast path must reject any disabled membership, got:\n%s", query)
+	}
+	if strings.Contains(query, "mil.media_folder_id NOT IN") {
+		t.Fatalf("row-local deny leaks dual-membership items, got:\n%s", query)
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Disabled-library filters were evaluated against a joined membership row. An item linked to both an enabled library and a disabled library could pass through its enabled row, even though the disabled membership should veto it globally.

Current `main` had the same row-local pattern in native catalog browse and facets, recommendations, Jellyfin batch loaders, episode catalog queries, and section hydration. Scoped catalog requests and recently-added fanout could also discard the global deny list.

Before porting the fix, these focused regressions failed on current upstream and showed the vulnerable SQL shape:

```text
GOWORK=off go test ./internal/catalog -run 'TestBuildBrowsePlanDisabledLibrariesUseItemLevelExclusion|TestBuildBrowsePlanSingleLibraryKeepsFastPathWithDisabledLibraries' -count=1
--- FAIL: TestBuildBrowsePlanDisabledLibrariesUseItemLevelExclusion
--- FAIL: TestBuildBrowsePlanSingleLibraryKeepsFastPathWithDisabledLibraries
FAIL
```

## Approach

Library access now uses independent correlated `EXISTS` and `NOT EXISTS` predicates. A positive allowed membership may admit an item, but any disabled membership rejects it. Disabled-only filters also require a positive membership so orphan catalog rows do not pass through a vacuous anti-join.

The same invariant is applied when IDs are hydrated into catalog, Jellyfin, recommendation, and episode/section records. Single-library recently-added queries keep their indexed membership join and add the deny as a separate anti-probe, so the fix does not introduce a new `GROUP BY` or discard the existing fast path.

This is the complete portable patch from blurbery/silo-server#43. Stable patch IDs match all three reviewed fork commits. No fork configuration, deployment changes, migrations, dependencies, or unrelated fixes are included.

## Validation

Focused regressions after the port:

```text
GOWORK=off go test ./internal/catalog -run 'TestBuildBrowsePlanDisabledLibrariesUseItemLevelExclusion|TestBuildBrowsePlanSingleLibraryKeepsFastPathWithDisabledLibraries' -count=1
ok  github.com/Silo-Server/silo-server/internal/catalog

GOWORK=off go test ./internal/api/handlers ./internal/catalog ./internal/jellycompat ./internal/sections -run '^(TestBuildPostCatalogLibraryScopeDisabledOnlyUsesItemLevelExclusion|TestBuildPostCatalogLibraryScopeCombinesRequestedAndAllowedLibraries|TestBuildPostCatalogLibraryScopeEmptyAllowedLibrariesIsEmpty|TestBuildBrowsePlanDisabledLibrariesUseItemLevelExclusion|TestBuildBrowsePlanSingleLibraryKeepsFastPathWithDisabledLibraries|TestFilterWhereClauseDisabledLibrariesUseItemLevelExclusion|TestFilterWhereClauseDisabledLibrariesUseScopeMembershipTable|TestRecentlyAddedLibraryBrowseFiltersPreserveDisabledLibraries|TestCatalogScopedLibraryRequestPreservesGlobalDisabledLibraries|TestApplyEpisodeCatalogAccessFilterRejectsAnyDisabledMembership|TestEpisodeCatalogBaseRelationForLibraries_DisabledOnlyRequiresMembership|TestApplyCompatLibraryAccessUsesItemLevelDisabledExclusion|TestApplyCompatLibraryAccessNarrowsRequestedLibraryBeforeDeny|TestApplyEpisodeTargetLibraryAccessRejectsAnyDisabledSeriesMembership|TestApplyEpisodeTargetLibraryAccessComposesAllowedAndDisabledMembership|TestBuildRecentlyAddedSingleLibraryQueryRejectsAnyDisabledMembership|TestDualLibraryItemDeniedByDisabledLibraryDB)$' -count=1
ok  github.com/Silo-Server/silo-server/internal/api/handlers
ok  github.com/Silo-Server/silo-server/internal/catalog
ok  github.com/Silo-Server/silo-server/internal/jellycompat
ok  github.com/Silo-Server/silo-server/internal/sections

GOWORK=off go test ./internal/recommendations -count=1
ok  github.com/Silo-Server/silo-server/internal/recommendations

GOWORK=off go vet ./internal/api/handlers ./internal/catalog ./internal/jellycompat ./internal/recommendations ./internal/sections
pass

git diff --name-only -z origin/main...HEAD -- '*.go' | xargs -0 gofmt -l
no output

make verify-local-paths
pass

git diff --check origin/main...HEAD
pass
```

`TestDualLibraryItemDeniedByDisabledLibraryDB` is included but skips locally when `SILO_TEST_DATABASE_URL` is unset. A broader local package run also encountered sandbox-only DNS and `httptest` listener restrictions in unrelated tests, so GitHub Actions is the full build, lint, vet, and test gate.

## Risks

The deny check adds indexed correlated anti-probes, while several paths remove membership fanout and its `DISTINCT`/`GROUP BY` cost. Independent SQL review found no material query-plan regression. There is no API, schema, migration, client, or deployment change; no silo-android or silo-apple follow-up is needed.

## AI Disclosure

- Tool(s): OpenAI Codex desktop; Codex Security diff scan
- Model(s): GPT-5; gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: Complete 20-file Codex Security diff scan plus independent correctness and SQL-performance reviews. All three reviews found no material issue; the scan recorded full changed-file coverage with zero findings.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected library access filtering across catalog search, browsing, recommendations, compatibility views, and recently added content.
  - Items associated with disabled libraries are now consistently hidden, even when also linked to an allowed library.
  - Improved episode filtering to exclude content with disabled-library associations and handle unassigned episodes correctly.
  - Empty library access scopes now return no results instead of potentially showing unintended content.
- **Documentation**
  - Clarified that disabled-library membership globally hides items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->