### PR TITLE
feat(home): add profile option to hide watched items

### DIFF
--- a/contracts/settings/v1/conformance.json
+++ b/contracts/settings/v1/conformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 7,
+  "manifest_revision": 8,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {

--- a/contracts/settings/v1/manifest.json
+++ b/contracts/settings/v1/manifest.json
@@ -1,6 +1,6 @@
 {
   "api_version": 1,
-  "revision": 7,
+  "revision": 8,
   "option_sets": {
     "playback_audio_languages": {
       "type": "language_tag",
@@ -758,6 +758,20 @@
       "description": "How clock times are written across the interface.",
       "recommended_control": "select",
       "notes": "Moved from account to profile scope; the account row is copied to every profile during migration."
+    },
+    {
+      "key": "home.hide_watched_items",
+      "introduced_in": 8,
+      "persistence": "remote",
+      "allowed_scopes": ["profile"],
+      "resolution_order": ["profile", "default"],
+      "value_schema": { "type": "boolean" },
+      "default_value": false,
+      "platforms": ["web", "ios", "tvos", "macos", "android", "android_tv"],
+      "category": "navigation",
+      "label": "Hide watched items from Home",
+      "description": "Remove watched items from ordinary Home sections while keeping Featured and watch-history sections unchanged.",
+      "recommended_control": "switch"
     },
     {
       "key": "ui.library_page_state",

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -1,5 +1,10 @@
 # Feature Changelog
 
+## 2026-08-24
+
+### Let each profile hide watched items from Home
+Profiles can now remove watched items from ordinary Home sections without hiding them from library pages, search, collections, or other browsing surfaces. Featured sections and sections whose purpose depends on watch history — Most Watched, profile activity, and Forgotten Favorites — keep watched items. The preference is off by default and watched indicators remain available everywhere an item is shown.
+
 ## 2026-08-23
 
 ### Never wait on H.264 stream-copy analysis to start playing

--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -586,7 +586,7 @@ func (h *SectionHandler) HandleHomeSections(w http.ResponseWriter, r *http.Reque
 	withItems := h.fetcher.FetchAll(r.Context(), resolved, nil, libraryIDs, userID, profileID, accessFilter)
 	withItems = applyDiversityFilter(withItems)
 	withItems = dropEmptySeasonalSections(withItems)
-	writeJSON(w, http.StatusOK, h.buildSectionsResponse(r, withItems))
+	writeJSON(w, http.StatusOK, h.buildHomeSectionsResponse(r, withItems))
 }
 
 // HandleHomeSectionItems handles GET /home/sections/{id}/items
@@ -619,7 +619,7 @@ func (h *SectionHandler) HandleHomeSectionItems(w http.ResponseWriter, r *http.R
 			}
 		}
 
-		resp := h.buildSectionsResponse(r, []sections.SectionWithItems{withItems})
+		resp := h.buildHomeSectionsResponse(r, []sections.SectionWithItems{withItems})
 		if len(resp.Sections) == 0 {
 			resp.Sections = append(resp.Sections, resolvedSectionResponse{
 				ID:          withItems.ID,
@@ -1224,6 +1224,38 @@ type sectionItemImageURLs struct {
 }
 
 func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sections.SectionWithItems) homeSectionsResponse {
+	return h.buildSectionsResponseWithOptions(r, withItems, sectionResponseOptions{})
+}
+
+type sectionResponseOptions struct {
+	hideWatchedHomeItems bool
+}
+
+func (h *SectionHandler) buildHomeSectionsResponse(r *http.Request, withItems []sections.SectionWithItems) homeSectionsResponse {
+	options := sectionResponseOptions{}
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if h.StoreProvider != nil && userID > 0 && profileID != "" {
+		store, err := h.StoreProvider.ForUser(r.Context(), userID)
+		if err == nil {
+			options.hideWatchedHomeItems = sections.HideWatchedItemsFromHome(r.Context(), store, profileID)
+		}
+	}
+	return h.buildSectionsResponseWithOptions(r, withItems, options)
+}
+
+func (h *SectionHandler) buildSectionsResponseWithOptions(
+	r *http.Request,
+	withItems []sections.SectionWithItems,
+	options sectionResponseOptions,
+) homeSectionsResponse {
+	allItems := sectionMediaItems(withItems)
+	userStates := h.listSectionItemUserStates(r, allItems)
+	if options.hideWatchedHomeItems {
+		withItems = filterWatchedHomeSectionItems(withItems, userStates)
+		allItems = sectionMediaItems(withItems)
+	}
+
 	overlaySummaries := make(map[string]*models.OverlaySummary)
 	contentIDs := make([]string, 0)
 	seen := make(map[string]struct{})
@@ -1251,11 +1283,6 @@ func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sect
 	resp := homeSectionsResponse{
 		Sections: make([]resolvedSectionResponse, 0, len(withItems)),
 	}
-	allItems := make([]*models.MediaItem, 0)
-	for _, s := range withItems {
-		allItems = append(allItems, s.Items...)
-	}
-	userStates := h.listSectionItemUserStates(r, allItems)
 	imageURLs := h.resolveSectionItemImageURLs(r.Context(), withItems)
 	episodeMeta := h.listSectionEpisodeItemMeta(r.Context(), withItems, requestAccessFilter(r))
 	mangaChapterMeta := h.listSectionMangaChapterItemMeta(r.Context(), allItems)
@@ -1300,6 +1327,38 @@ func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sect
 		})
 	}
 	return resp
+}
+
+func sectionMediaItems(withItems []sections.SectionWithItems) []*models.MediaItem {
+	items := make([]*models.MediaItem, 0)
+	for _, section := range withItems {
+		items = append(items, section.Items...)
+	}
+	return items
+}
+
+func filterWatchedHomeSectionItems(
+	withItems []sections.SectionWithItems,
+	userStates map[string]*itemUserStateResponse,
+) []sections.SectionWithItems {
+	filtered := make([]sections.SectionWithItems, len(withItems))
+	copy(filtered, withItems)
+	for i := range filtered {
+		section := &filtered[i]
+		if section.Featured || sections.PreserveWatchedItemsOnHome(section.SectionType) {
+			continue
+		}
+
+		items := make([]*models.MediaItem, 0, len(section.Items))
+		for _, item := range section.Items {
+			if item != nil && userStates[item.ContentID] != nil && userStates[item.ContentID].Played {
+				continue
+			}
+			items = append(items, item)
+		}
+		section.Items = items
+	}
+	return filtered
 }
 
 // listSectionMangaChapterItemMeta resolves series linkage for every manga

--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -583,10 +583,14 @@ func (h *SectionHandler) HandleHomeSections(w http.ResponseWriter, r *http.Reque
 
 	userID := apimw.GetUserID(r.Context())
 	resolved = h.maybeInjectNextUp(r.Context(), resolved, userID)
-	withItems := h.fetcher.FetchAll(r.Context(), resolved, nil, libraryIDs, userID, profileID, accessFilter)
+	responseOptions := h.homeSectionResponseOptions(r)
+	fetchSections := homeSectionsForFetch(resolved, responseOptions)
+	withItems := h.fetcher.FetchAll(r.Context(), fetchSections, nil, libraryIDs, userID, profileID, accessFilter)
+	withItems = restoreHomeSectionDisplayLimits(withItems, resolved)
+	withItems, responseOptions = h.prepareHomeSectionsResponse(r, withItems, responseOptions)
 	withItems = applyDiversityFilter(withItems)
 	withItems = dropEmptySeasonalSections(withItems)
-	writeJSON(w, http.StatusOK, h.buildHomeSectionsResponse(r, withItems))
+	writeJSON(w, http.StatusOK, h.buildSectionsResponseWithOptions(r, withItems, responseOptions))
 }
 
 // HandleHomeSectionItems handles GET /home/sections/{id}/items
@@ -604,13 +608,15 @@ func (h *SectionHandler) HandleHomeSectionItems(w http.ResponseWriter, r *http.R
 	}
 	userID := apimw.GetUserID(r.Context())
 	resolved = h.maybeInjectNextUp(r.Context(), resolved, userID)
+	responseOptions := h.homeSectionResponseOptions(r)
 
 	for _, s := range resolved {
 		if s.ID != sectionID {
 			continue
 		}
 
-		withItems, fetchErr := h.fetcher.FetchOne(r.Context(), s, nil, libraryIDs, userID, profileID, accessFilter)
+		fetchSection := homeSectionsForFetch([]sections.ResolvedSection{s}, responseOptions)[0]
+		withItems, fetchErr := h.fetcher.FetchOne(r.Context(), fetchSection, nil, libraryIDs, userID, profileID, accessFilter)
 		if fetchErr != nil {
 			slog.ErrorContext(r.Context(), "fetching section items", "component", "api", "section_id", s.ID, "type", s.SectionType, "error", fetchErr)
 			withItems = sections.SectionWithItems{
@@ -618,8 +624,10 @@ func (h *SectionHandler) HandleHomeSectionItems(w http.ResponseWriter, r *http.R
 				Items:           []*models.MediaItem{},
 			}
 		}
+		withItems.ItemLimit = s.ItemLimit
+		prepared, preparedOptions := h.prepareHomeSectionsResponse(r, []sections.SectionWithItems{withItems}, responseOptions)
 
-		resp := h.buildHomeSectionsResponse(r, []sections.SectionWithItems{withItems})
+		resp := h.buildSectionsResponseWithOptions(r, prepared, preparedOptions)
 		if len(resp.Sections) == 0 {
 			resp.Sections = append(resp.Sections, resolvedSectionResponse{
 				ID:          withItems.ID,
@@ -1229,9 +1237,17 @@ func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sect
 
 type sectionResponseOptions struct {
 	hideWatchedHomeItems bool
+	userStates           map[string]*itemUserStateResponse
 }
 
-func (h *SectionHandler) buildHomeSectionsResponse(r *http.Request, withItems []sections.SectionWithItems) homeSectionsResponse {
+const (
+	homeWatchedCandidateMultiplier = 5
+	// Series and season watched state requires episode lookups, so keep the
+	// refill window bounded rather than scanning the whole section.
+	homeWatchedMaxExpandedCandidates = 200
+)
+
+func (h *SectionHandler) homeSectionResponseOptions(r *http.Request) sectionResponseOptions {
 	options := sectionResponseOptions{}
 	userID := apimw.GetUserID(r.Context())
 	profileID := apimw.GetProfileID(r.Context())
@@ -1241,7 +1257,72 @@ func (h *SectionHandler) buildHomeSectionsResponse(r *http.Request, withItems []
 			options.hideWatchedHomeItems = sections.HideWatchedItemsFromHome(r.Context(), store, profileID)
 		}
 	}
+	return options
+}
+
+func (h *SectionHandler) buildHomeSectionsResponse(r *http.Request, withItems []sections.SectionWithItems) homeSectionsResponse {
+	options := h.homeSectionResponseOptions(r)
+	withItems, options = h.prepareHomeSectionsResponse(r, withItems, options)
 	return h.buildSectionsResponseWithOptions(r, withItems, options)
+}
+
+func (h *SectionHandler) prepareHomeSectionsResponse(
+	r *http.Request,
+	withItems []sections.SectionWithItems,
+	options sectionResponseOptions,
+) ([]sections.SectionWithItems, sectionResponseOptions) {
+	if !options.hideWatchedHomeItems {
+		return withItems, options
+	}
+
+	options.userStates = h.listSectionItemUserStates(r, sectionMediaItems(withItems))
+	return filterWatchedHomeSectionItems(withItems, options.userStates), options
+}
+
+func homeSectionsForFetch(
+	resolved []sections.ResolvedSection,
+	options sectionResponseOptions,
+) []sections.ResolvedSection {
+	if !options.hideWatchedHomeItems {
+		return resolved
+	}
+
+	fetchSections := make([]sections.ResolvedSection, len(resolved))
+	copy(fetchSections, resolved)
+	for i := range fetchSections {
+		section := &fetchSections[i]
+		if section.Featured || sections.PreserveWatchedItemsOnHome(section.SectionType) {
+			continue
+		}
+		section.ItemLimit = homeWatchedCandidateLimit(section.ItemLimit)
+	}
+	return fetchSections
+}
+
+func homeWatchedCandidateLimit(displayLimit int) int {
+	if displayLimit <= 0 || displayLimit >= homeWatchedMaxExpandedCandidates {
+		return displayLimit
+	}
+	if displayLimit > homeWatchedMaxExpandedCandidates/homeWatchedCandidateMultiplier {
+		return homeWatchedMaxExpandedCandidates
+	}
+	return displayLimit * homeWatchedCandidateMultiplier
+}
+
+func restoreHomeSectionDisplayLimits(
+	withItems []sections.SectionWithItems,
+	resolved []sections.ResolvedSection,
+) []sections.SectionWithItems {
+	displayLimits := make(map[string]int, len(resolved))
+	for _, section := range resolved {
+		displayLimits[section.ID] = section.ItemLimit
+	}
+	for i := range withItems {
+		if displayLimit, ok := displayLimits[withItems[i].ID]; ok {
+			withItems[i].ItemLimit = displayLimit
+		}
+	}
+	return withItems
 }
 
 func (h *SectionHandler) buildSectionsResponseWithOptions(
@@ -1250,10 +1331,9 @@ func (h *SectionHandler) buildSectionsResponseWithOptions(
 	options sectionResponseOptions,
 ) homeSectionsResponse {
 	allItems := sectionMediaItems(withItems)
-	userStates := h.listSectionItemUserStates(r, allItems)
-	if options.hideWatchedHomeItems {
-		withItems = filterWatchedHomeSectionItems(withItems, userStates)
-		allItems = sectionMediaItems(withItems)
+	userStates := options.userStates
+	if userStates == nil {
+		userStates = h.listSectionItemUserStates(r, allItems)
 	}
 
 	overlaySummaries := make(map[string]*models.OverlaySummary)
@@ -1355,6 +1435,9 @@ func filterWatchedHomeSectionItems(
 				continue
 			}
 			items = append(items, item)
+			if section.ItemLimit > 0 && len(items) == section.ItemLimit {
+				break
+			}
 		}
 		section.Items = items
 	}

--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -588,6 +588,9 @@ func (h *SectionHandler) HandleHomeSections(w http.ResponseWriter, r *http.Reque
 	withItems := h.fetcher.FetchAll(r.Context(), fetchSections, nil, libraryIDs, userID, profileID, accessFilter)
 	withItems = restoreHomeSectionDisplayLimits(withItems, resolved)
 	withItems, responseOptions = h.prepareHomeSectionsResponse(r, withItems, responseOptions)
+	if responseOptions.hideWatchedHomeItems {
+		withItems = dropEmptyWatchedHomeSections(withItems)
+	}
 	withItems = applyDiversityFilter(withItems)
 	withItems = dropEmptySeasonalSections(withItems)
 	writeJSON(w, http.StatusOK, h.buildSectionsResponseWithOptions(r, withItems, responseOptions))
@@ -1260,12 +1263,6 @@ func (h *SectionHandler) homeSectionResponseOptions(r *http.Request) sectionResp
 	return options
 }
 
-func (h *SectionHandler) buildHomeSectionsResponse(r *http.Request, withItems []sections.SectionWithItems) homeSectionsResponse {
-	options := h.homeSectionResponseOptions(r)
-	withItems, options = h.prepareHomeSectionsResponse(r, withItems, options)
-	return h.buildSectionsResponseWithOptions(r, withItems, options)
-}
-
 func (h *SectionHandler) prepareHomeSectionsResponse(
 	r *http.Request,
 	withItems []sections.SectionWithItems,
@@ -1277,6 +1274,21 @@ func (h *SectionHandler) prepareHomeSectionsResponse(
 
 	options.userStates = h.listSectionItemUserStates(r, sectionMediaItems(withItems))
 	return filterWatchedHomeSectionItems(withItems, options.userStates), options
+}
+
+// dropEmptyWatchedHomeSections removes ordinary sections whose source contains
+// items but whose bounded candidate window was emptied by watched filtering.
+// The direct section endpoint still returns the empty section when requested.
+func dropEmptyWatchedHomeSections(withItems []sections.SectionWithItems) []sections.SectionWithItems {
+	out := withItems[:0]
+	for _, section := range withItems {
+		if len(section.Items) == 0 && section.TotalCount > 0 &&
+			!section.Featured && !sections.PreserveWatchedItemsOnHome(section.SectionType) {
+			continue
+		}
+		out = append(out, section)
+	}
+	return out
 }
 
 func homeSectionsForFetch(

--- a/internal/api/handlers/sections_home_watched_test.go
+++ b/internal/api/handlers/sections_home_watched_test.go
@@ -1,0 +1,128 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/sections"
+	"github.com/Silo-Server/silo-server/internal/settingscontract"
+	"github.com/Silo-Server/silo-server/internal/settingskeys"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+func TestFilterWatchedHomeSectionItems(t *testing.T) {
+	watched := &models.MediaItem{ContentID: "watched", Title: "Watched"}
+	unwatched := &models.MediaItem{ContentID: "unwatched", Title: "Unwatched"}
+	states := map[string]*itemUserStateResponse{
+		"watched":   {Played: true},
+		"unwatched": {Played: false},
+	}
+
+	input := []sections.SectionWithItems{
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "ordinary", SectionType: sections.SectionRecentlyAdded},
+			Items:           []*models.MediaItem{watched, unwatched},
+			TotalCount:      2,
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "featured", SectionType: sections.SectionRecentlyAdded, Featured: true},
+			Items:           []*models.MediaItem{watched, unwatched},
+			TotalCount:      2,
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "most-watched", SectionType: sections.SectionMostWatched},
+			Items:           []*models.MediaItem{watched, unwatched},
+			TotalCount:      2,
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "activity", SectionType: sections.SectionProfileActivityFeed},
+			Items:           []*models.MediaItem{watched, unwatched},
+			TotalCount:      2,
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "forgotten", SectionType: sections.SectionForgottenFavorites},
+			Items:           []*models.MediaItem{watched, unwatched},
+			TotalCount:      2,
+		},
+	}
+
+	filtered := filterWatchedHomeSectionItems(input, states)
+	if got := filtered[0].Items; len(got) != 1 || got[0].ContentID != "unwatched" {
+		t.Fatalf("ordinary section items = %#v, want only unwatched", got)
+	}
+	if filtered[0].TotalCount != 2 {
+		t.Errorf("ordinary TotalCount = %d, want original section count 2", filtered[0].TotalCount)
+	}
+	for _, index := range []int{1, 2, 3, 4} {
+		if got := len(filtered[index].Items); got != 2 {
+			t.Errorf("exempt section %q has %d items, want 2", filtered[index].ID, got)
+		}
+	}
+	if got := len(input[0].Items); got != 2 {
+		t.Errorf("input section mutated to %d items", got)
+	}
+}
+
+func TestFilterWatchedHomeSectionItemsKeepsUnknownState(t *testing.T) {
+	item := &models.MediaItem{ContentID: "unknown", Title: "Unknown"}
+	input := []sections.SectionWithItems{{
+		ResolvedSection: sections.ResolvedSection{ID: "ordinary", SectionType: sections.SectionRecentlyAdded},
+		Items:           []*models.MediaItem{item},
+		TotalCount:      1,
+	}}
+
+	filtered := filterWatchedHomeSectionItems(input, nil)
+	if len(filtered[0].Items) != 1 {
+		t.Fatal("item with unavailable user state was hidden")
+	}
+}
+
+func TestHomePreferenceFiltersOnlyHomeResponses(t *testing.T) {
+	ctx := context.Background()
+	store := newPlaybackTestStore(t)
+	if _, err := store.UpsertSettingValue(ctx, userstore.SettingIdentity{
+		Key:       settingskeys.HomeHideWatchedItems,
+		Scope:     settingscontract.ScopeProfile,
+		ProfileID: "profile-1",
+	}, json.RawMessage(`true`)); err != nil {
+		t.Fatalf("enable Home preference: %v", err)
+	}
+	if err := store.AddHistory(ctx, userstore.WatchHistoryEntry{
+		ProfileID:   "profile-1",
+		MediaItemID: "watched",
+		Completed:   true,
+		Source:      userstore.WatchHistorySourceManual,
+	}); err != nil {
+		t.Fatalf("mark item watched: %v", err)
+	}
+
+	items := []*models.MediaItem{
+		{ContentID: "watched", Type: "movie", Title: "Watched"},
+		{ContentID: "unwatched", Type: "movie", Title: "Unwatched"},
+	}
+	sectionItems := []sections.SectionWithItems{{
+		ResolvedSection: sections.ResolvedSection{ID: "ordinary", SectionType: sections.SectionRecentlyAdded},
+		Items:           items,
+		TotalCount:      len(items),
+	}}
+	handler := &SectionHandler{StoreProvider: testUserStoreProvider{store: store}}
+	req := httptest.NewRequest(http.MethodGet, "/home/sections/ordinary/items", nil)
+	reqCtx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 1})
+	req = req.WithContext(apimw.SetProfileID(reqCtx, "profile-1"))
+
+	home := handler.buildHomeSectionsResponse(req, sectionItems)
+	if got := home.Sections[0].Items; len(got) != 1 || got[0].ContentID != "unwatched" {
+		t.Fatalf("Home response items = %#v, want only unwatched", got)
+	}
+
+	library := handler.buildSectionsResponse(req, sectionItems)
+	if got := len(library.Sections[0].Items); got != 2 {
+		t.Fatalf("non-Home response has %d items, want 2", got)
+	}
+}

--- a/internal/api/handlers/sections_home_watched_test.go
+++ b/internal/api/handlers/sections_home_watched_test.go
@@ -158,6 +158,46 @@ func TestHomeWatchedCandidateLimitCapsExpandedWindow(t *testing.T) {
 	}
 }
 
+func TestDropEmptyWatchedHomeSections(t *testing.T) {
+	input := []sections.SectionWithItems{
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "filtered", SectionType: sections.SectionRecentlyAdded},
+			TotalCount:      10,
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "naturally-empty", SectionType: sections.SectionRecentlyAdded},
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{
+				ID:          "featured",
+				SectionType: sections.SectionRecentlyAdded,
+				Featured:    true,
+			},
+			TotalCount: 10,
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "most-watched", SectionType: sections.SectionMostWatched},
+			TotalCount:      10,
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "non-empty", SectionType: sections.SectionRecentlyAdded},
+			Items:           []*models.MediaItem{{ContentID: "visible"}},
+			TotalCount:      10,
+		},
+	}
+
+	filtered := dropEmptyWatchedHomeSections(input)
+	wantIDs := []string{"naturally-empty", "featured", "most-watched", "non-empty"}
+	if len(filtered) != len(wantIDs) {
+		t.Fatalf("filtered sections = %d, want %d", len(filtered), len(wantIDs))
+	}
+	for i, want := range wantIDs {
+		if got := filtered[i].ID; got != want {
+			t.Errorf("filtered[%d].ID = %q, want %q", i, got, want)
+		}
+	}
+}
+
 func TestWatchedRefillRunsBeforeDiversity(t *testing.T) {
 	visible := &models.MediaItem{ContentID: "visible"}
 	overflow := &models.MediaItem{ContentID: "overflow"}
@@ -226,7 +266,9 @@ func TestHomePreferenceFiltersOnlyHomeResponses(t *testing.T) {
 	reqCtx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 1})
 	req = req.WithContext(apimw.SetProfileID(reqCtx, "profile-1"))
 
-	home := handler.buildHomeSectionsResponse(req, sectionItems)
+	options := handler.homeSectionResponseOptions(req)
+	prepared, options := handler.prepareHomeSectionsResponse(req, sectionItems, options)
+	home := handler.buildSectionsResponseWithOptions(req, prepared, options)
 	if got := home.Sections[0].Items; len(got) != 1 || got[0].ContentID != "unwatched" {
 		t.Fatalf("Home response items = %#v, want only unwatched", got)
 	}

--- a/internal/api/handlers/sections_home_watched_test.go
+++ b/internal/api/handlers/sections_home_watched_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -80,6 +81,115 @@ func TestFilterWatchedHomeSectionItemsKeepsUnknownState(t *testing.T) {
 	filtered := filterWatchedHomeSectionItems(input, nil)
 	if len(filtered[0].Items) != 1 {
 		t.Fatal("item with unavailable user state was hidden")
+	}
+}
+
+func TestFilterWatchedHomeSectionItemsRefillsDisplayLimit(t *testing.T) {
+	items := make([]*models.MediaItem, 0, 23)
+	states := make(map[string]*itemUserStateResponse, 23)
+	for i := 0; i < 23; i++ {
+		id := fmt.Sprintf("item-%02d", i+1)
+		items = append(items, &models.MediaItem{ContentID: id})
+		states[id] = &itemUserStateResponse{Played: i < 3}
+	}
+	input := []sections.SectionWithItems{{
+		ResolvedSection: sections.ResolvedSection{
+			ID:          "ordinary",
+			SectionType: sections.SectionRecentlyAdded,
+			ItemLimit:   20,
+		},
+		Items:      items,
+		TotalCount: 50,
+	}}
+
+	filtered := filterWatchedHomeSectionItems(input, states)
+	if got := len(filtered[0].Items); got != 20 {
+		t.Fatalf("filtered section has %d items, want configured limit 20", got)
+	}
+	if got := filtered[0].Items[19].ContentID; got != "item-23" {
+		t.Errorf("last displayed item = %q, want refill candidate item-23", got)
+	}
+	if got := filtered[0].TotalCount; got != 50 {
+		t.Errorf("TotalCount = %d, want source count 50", got)
+	}
+	if got := len(input[0].Items); got != 23 {
+		t.Errorf("input section mutated to %d items", got)
+	}
+}
+
+func TestHomeSectionsForFetchExpandsOnlyFilteredSections(t *testing.T) {
+	resolved := []sections.ResolvedSection{
+		{ID: "ordinary", SectionType: sections.SectionRecentlyAdded, ItemLimit: 20},
+		{ID: "featured", SectionType: sections.SectionRecentlyAdded, Featured: true, ItemLimit: 20},
+		{ID: "most-watched", SectionType: sections.SectionMostWatched, ItemLimit: 20},
+		{ID: "large", SectionType: sections.SectionRecentlyAdded, ItemLimit: 250},
+	}
+
+	unchanged := homeSectionsForFetch(resolved, sectionResponseOptions{})
+	if unchanged[0].ItemLimit != 20 {
+		t.Fatalf("disabled preference changed limit to %d", unchanged[0].ItemLimit)
+	}
+
+	expanded := homeSectionsForFetch(resolved, sectionResponseOptions{hideWatchedHomeItems: true})
+	wantLimits := []int{100, 20, 20, 250}
+	for i, want := range wantLimits {
+		if got := expanded[i].ItemLimit; got != want {
+			t.Errorf("section %q fetch limit = %d, want %d", expanded[i].ID, got, want)
+		}
+	}
+	if got := resolved[0].ItemLimit; got != 20 {
+		t.Errorf("input limit mutated to %d", got)
+	}
+}
+
+func TestHomeWatchedCandidateLimitCapsExpandedWindow(t *testing.T) {
+	for _, test := range []struct {
+		display int
+		want    int
+	}{
+		{display: 0, want: 0},
+		{display: 20, want: 100},
+		{display: 50, want: 200},
+		{display: 250, want: 250},
+	} {
+		if got := homeWatchedCandidateLimit(test.display); got != test.want {
+			t.Errorf("homeWatchedCandidateLimit(%d) = %d, want %d", test.display, got, test.want)
+		}
+	}
+}
+
+func TestWatchedRefillRunsBeforeDiversity(t *testing.T) {
+	visible := &models.MediaItem{ContentID: "visible"}
+	overflow := &models.MediaItem{ContentID: "overflow"}
+	sectionsWithItems := []sections.SectionWithItems{
+		{
+			ResolvedSection: sections.ResolvedSection{
+				ID:          "ordinary",
+				SectionType: sections.SectionRecentlyAdded,
+				ItemLimit:   1,
+			},
+			Items: []*models.MediaItem{visible, overflow},
+		},
+		{
+			ResolvedSection: sections.ResolvedSection{
+				ID:          "avoid-duplicates",
+				SectionType: sections.SectionHiddenGems,
+			},
+			Items: []*models.MediaItem{overflow},
+		},
+	}
+
+	filtered := filterWatchedHomeSectionItems(sectionsWithItems, map[string]*itemUserStateResponse{
+		"visible":  {Played: false},
+		"overflow": {Played: false},
+	})
+	diverse := applyDiversityFilter(filtered)
+
+	if got := diverse[0].Items; len(got) != 1 || got[0].ContentID != "visible" {
+		t.Fatalf("first section items = %#v, want visible refill", got)
+	}
+	if got := diverse[1].Items; len(got) != 1 || got[0].ContentID != "overflow" {
+		t.Fatalf("hidden overflow candidate affected downstream diversity: %#v", got)
 	}
 }
 

--- a/internal/sections/home_watched_items.go
+++ b/internal/sections/home_watched_items.go
@@ -1,0 +1,57 @@
+package sections
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/Silo-Server/silo-server/internal/settingscontract"
+	"github.com/Silo-Server/silo-server/internal/settingskeys"
+	"github.com/Silo-Server/silo-server/internal/settingsresolve"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+// HideWatchedItemsFromHome resolves the acting profile's Home preference.
+// Failure is fail-open: an unavailable preference store must not make media
+// disappear from Home unexpectedly.
+func HideWatchedItemsFromHome(ctx context.Context, store userstore.UserStore, profileID string) bool {
+	if store == nil || profileID == "" {
+		return false
+	}
+
+	contract, err := settingscontract.Load()
+	if err != nil {
+		slog.WarnContext(ctx, "hide-watched Home preference unavailable: loading settings contract failed",
+			"component", "sections", "profile_id", profileID, "error", err)
+		return false
+	}
+	resolved, err := settingsresolve.New(contract).Resolve(ctx, store,
+		settingsresolve.Context{ProfileID: profileID},
+		[]string{settingskeys.HomeHideWatchedItems}, nil)
+	if err != nil {
+		slog.WarnContext(ctx, "hide-watched Home preference unavailable: reading setting values failed",
+			"component", "sections", "profile_id", profileID, "error", err)
+		return false
+	}
+	if len(resolved) != 1 {
+		return false
+	}
+
+	var enabled bool
+	if err := json.Unmarshal(resolved[0].Value, &enabled); err != nil {
+		return false
+	}
+	return enabled
+}
+
+// PreserveWatchedItemsOnHome identifies sections whose meaning depends on
+// watched history. Featured sections are handled separately because Featured
+// is section configuration rather than a section type.
+func PreserveWatchedItemsOnHome(sectionType SectionType) bool {
+	switch sectionType {
+	case SectionMostWatched, SectionProfileActivityFeed, SectionForgottenFavorites:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/sections/home_watched_items_test.go
+++ b/internal/sections/home_watched_items_test.go
@@ -1,0 +1,64 @@
+package sections
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/settingscontract"
+	"github.com/Silo-Server/silo-server/internal/settingskeys"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+func setHideWatchedItemsFromHome(t *testing.T, store userstore.UserStore, profileID string, enabled bool) {
+	t.Helper()
+	value, err := json.Marshal(enabled)
+	if err != nil {
+		t.Fatalf("marshal preference: %v", err)
+	}
+	if _, err := store.UpsertSettingValue(context.Background(), userstore.SettingIdentity{
+		Key:       settingskeys.HomeHideWatchedItems,
+		Scope:     settingscontract.ScopeProfile,
+		ProfileID: profileID,
+	}, value); err != nil {
+		t.Fatalf("upsert Home preference: %v", err)
+	}
+}
+
+func TestHideWatchedItemsFromHomeDefaultsOff(t *testing.T) {
+	store := newNextUpModeTestStore(t)
+	if HideWatchedItemsFromHome(context.Background(), store, "profile-1") {
+		t.Fatal("HideWatchedItemsFromHome = true, want false by default")
+	}
+}
+
+func TestHideWatchedItemsFromHomeIsProfileScoped(t *testing.T) {
+	ctx := context.Background()
+	store := newNextUpModeTestStore(t)
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: "profile-2", Name: "Kids"}); err != nil {
+		t.Fatalf("create second profile: %v", err)
+	}
+	setHideWatchedItemsFromHome(t, store, "profile-1", true)
+
+	if !HideWatchedItemsFromHome(ctx, store, "profile-1") {
+		t.Error("HideWatchedItemsFromHome for profile-1 = false, want true")
+	}
+	if HideWatchedItemsFromHome(ctx, store, "profile-2") {
+		t.Error("HideWatchedItemsFromHome leaked to profile-2")
+	}
+}
+
+func TestPreserveWatchedItemsOnHome(t *testing.T) {
+	for _, sectionType := range []SectionType{
+		SectionMostWatched,
+		SectionProfileActivityFeed,
+		SectionForgottenFavorites,
+	} {
+		if !PreserveWatchedItemsOnHome(sectionType) {
+			t.Errorf("PreserveWatchedItemsOnHome(%q) = false, want true", sectionType)
+		}
+	}
+	if PreserveWatchedItemsOnHome(SectionRecentlyAdded) {
+		t.Error("PreserveWatchedItemsOnHome(recently_added) = true, want false")
+	}
+}

--- a/internal/settingskeys/keys.go
+++ b/internal/settingskeys/keys.go
@@ -9,7 +9,7 @@
 package settingskeys
 
 // Revision is the manifest revision these bindings were generated from.
-const Revision = 7
+const Revision = 8
 
 // Setting keys, one constant per definition.
 const (
@@ -23,6 +23,8 @@ const (
 	DownloadsKeepWatched = "downloads.keep_watched"
 	// Download over Wi-Fi only
 	DownloadsWifiOnly = "downloads.wifi_only"
+	// Hide watched items from Home
+	HomeHideWatchedItems = "home.hide_watched_items"
 	// Primary menu
 	NavPrimaryMenu = "nav.primary_menu"
 	// Navigation shortcuts
@@ -127,6 +129,7 @@ const (
 var Remote = []string{
 	CatalogMetadataLanguage,
 	CatalogMetadataLanguageOverrides,
+	HomeHideWatchedItems,
 	NavPrimaryMenu,
 	NavShortcuts,
 	PlaybackAudioLanguage,

--- a/web/src/lib/settingsConformance.json
+++ b/web/src/lib/settingsConformance.json
@@ -1,6 +1,6 @@
 {
   "fixture_version": 1,
-  "manifest_revision": 7,
+  "manifest_revision": 8,
   "description": "Cross-platform conformance cases for settings resolution. Every case runs against the shipped manifest in this directory: definitions are referenced by key, never restated, so an expectation can only be satisfied by resolving the real contract. Each platform's resolver (Go in internal/settingsresolve, TypeScript in web/src/lib/settingsResolve.ts, Kotlin and Swift in the client repos) runs every case through a hand-written runner; a runner must fail on any fixture field it does not know, because schema drift in the fixture itself is drift. A case's constraint_bindings attach a constraint to a copy of a real definition so constraint semantics stay testable even while no shipped definition carries that constraint kind. In expected entries, constrained:true requires stored_value and constraint_kind to be present, and stored_value may be null to mean the authored value was JSON null.",
   "cases": [
     {

--- a/web/src/lib/settingsContract.ts
+++ b/web/src/lib/settingsContract.ts
@@ -9,7 +9,7 @@
  */
 
 export const SETTINGS_API_VERSION = 1;
-export const SETTINGS_REVISION = 7;
+export const SETTINGS_REVISION = 8;
 
 export interface SettingSuggestedOption {
   value: string;
@@ -163,6 +163,8 @@ export const SETTING_KEYS = {
   DOWNLOADS_KEEP_WATCHED: "downloads.keep_watched",
   /** Download over Wi-Fi only */
   DOWNLOADS_WIFI_ONLY: "downloads.wifi_only",
+  /** Hide watched items from Home */
+  HOME_HIDE_WATCHED_ITEMS: "home.hide_watched_items",
   /** Primary menu */
   NAV_PRIMARY_MENU: "nav.primary_menu",
   /** Navigation shortcuts */
@@ -403,6 +405,23 @@ export const SETTING_DEFINITIONS: Record<SettingKey, SettingDefinition> = {
     category: "downloads",
     control: "switch",
     platforms: ["ios", "android"],
+  },
+  "home.hide_watched_items": {
+    key: "home.hide_watched_items",
+    type: "boolean",
+    nullable: false,
+    persistence: "remote",
+    introducedIn: 8,
+    scopes: ["profile"],
+    scopeIntroducedIn: [8],
+    resolutionOrder: ["profile", "default"],
+    defaultValue: false,
+    label: "Hide watched items from Home",
+    description:
+      "Remove watched items from ordinary Home sections while keeping Featured and watch-history sections unchanged.",
+    category: "navigation",
+    control: "switch",
+    platforms: ["web", "ios", "tvos", "macos", "android", "android_tv"],
   },
   "nav.primary_menu": {
     key: "nav.primary_menu",

--- a/web/src/pages/settings/HomeScreenSettings.tsx
+++ b/web/src/pages/settings/HomeScreenSettings.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useState, useEffect, useRef } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { SettingsGroup } from "@/components/settings/SettingsGroup";
 import {
@@ -14,6 +14,7 @@ import type { SettingsSectionEntry, SectionOverride } from "@/api/types";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -47,6 +48,17 @@ import type { DragStartEvent, DragEndEvent } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { toast } from "sonner";
+import {
+  useEffectiveSettings,
+  useSetSettingValue,
+  type SettingIdentity,
+} from "@/hooks/queries/settingValues";
+import { SETTING_KEYS } from "@/lib/settingsContract";
+import { sectionKeys } from "@/hooks/queries/keys";
+import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
+
+const PROFILE_SCOPE: SettingIdentity = { scope: "profile" };
+const HOME_PREFERENCE_KEYS = [SETTING_KEYS.HOME_HIDE_WATCHED_ITEMS] as const;
 
 interface RemovedSystemOverride {
   id: string;
@@ -180,6 +192,7 @@ export function buildProfileGallerySection(
 }
 
 export default function HomeScreenSettings() {
+  const queryClient = useQueryClient();
   const { data: libraries } = useUserLibraries();
   const { data: recipeCatalog } = useQuery({
     queryKey: ["recipe-catalog"],
@@ -200,6 +213,10 @@ export default function HomeScreenSettings() {
   const saveMutation = useSaveProfileOverrides();
   const resetMutation = useResetProfileOverrides();
   const canEditSections = canMutateSectionSettings(settingsQuery, rawOverridesQuery);
+  const homePreferences = useEffectiveSettings({ keys: HOME_PREFERENCE_KEYS });
+  const saveHomePreference = useSetSettingValue();
+  const hideWatchedItems =
+    homePreferences.data?.[SETTING_KEYS.HOME_HIDE_WATCHED_ITEMS]?.value === true;
   const activeSelectionValue = scopeValue;
   const activeSelectionRef = useRef(activeSelectionValue);
   const latestSaveAttemptRef = useRef(0);
@@ -425,6 +442,23 @@ export default function HomeScreenSettings() {
     saveOverrides(next);
   }
 
+  function handleHideWatchedItemsChange(enabled: boolean) {
+    saveHomePreference.mutate(
+      {
+        key: SETTING_KEYS.HOME_HIDE_WATCHED_ITEMS,
+        value: enabled,
+        identity: PROFILE_SCOPE,
+      },
+      {
+        onSuccess: () => {
+          queryClient.removeQueries({ queryKey: sectionKeys.homeItemsRoot() });
+          bumpHomeRefreshSignal(queryClient);
+        },
+        onError: () => toast.error("Failed to save Home preference"),
+      },
+    );
+  }
+
   return (
     <div className="space-y-6">
       <div className="space-y-3">
@@ -465,6 +499,29 @@ export default function HomeScreenSettings() {
         variant="destructive"
         onConfirm={handleConfirmDelete}
       />
+
+      <SettingsGroup
+        title="Home preferences"
+        description="Choose how this profile's Home screen handles completed media."
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-0.5">
+            <Label htmlFor="hide-watched-home" className="text-sm font-medium">
+              Hide watched items
+            </Label>
+            <p className="text-muted-foreground text-[13px] leading-relaxed">
+              Remove watched items from ordinary Home sections. Featured and watch-history sections
+              keep them.
+            </p>
+          </div>
+          <Switch
+            id="hide-watched-home"
+            checked={hideWatchedItems}
+            disabled={homePreferences.isLoading || saveHomePreference.isPending}
+            onCheckedChange={handleHideWatchedItemsChange}
+          />
+        </div>
+      </SettingsGroup>
 
       <SettingsGroup
         title="Scope"


### PR DESCRIPTION
## Why I wanted this

Related work: #714

PR #714 adds the watched controls and indicators. This PR builds on that work with an optional way to make Home feel more like a discovery screen.

I still want watched indicators and history everywhere in Silo, but I do not always want completed titles taking up space in ordinary Home rows. The important part is that this is a **profile preference**, not a server-wide rule: one profile can hide watched items from Home while another profile keeps the normal layout.

This only changes Home. Watched items and their indicators remain available in libraries, search, collections, sidebar pages, and every other normal browsing surface.

## Where the setting is

In the Web app, go to:

**Settings → Home & Discovery → Home Screen → Home preferences → Hide watched items**

The switch is off by default. Its description is: “Remove watched items from ordinary Home sections. Featured and watch-history sections keep them.”

Saving the preference refreshes Home immediately for the active profile.

## What it does

When enabled for a profile:

- Watched titles disappear from ordinary Home sections.
- The row refills with the next unwatched titles where possible, so a 20-item section still displays 20 items instead of shrinking to 17 after three watched titles are removed.
- Featured sections keep watched content because they are editorially selected.
- `Most Watched`, `Profile Activity Feed`, and `Forgotten Favorites` keep watched content because removing it would break the meaning of those sections.
- Watched indicators remain shared and accurate across every sidebar tab and page.
- “View all” still opens the normal unfiltered browsing surface.

The result is a cleaner Home screen without weakening or hiding Silo’s watched-state system anywhere else.

## Implementation

The preference is stored through the canonical settings contract as profile-scoped `home.hide_watched_items`.

Ordinary Home sections fetch a bounded candidate window at five times their display limit, capped at 200 expanded candidates. Silo resolves the profile’s item state once, removes watched candidates, trims the result back to the configured row size, and only then applies cross-section duplicate handling.

That ordering matters: candidates that are filtered out or fall beyond the visible row cannot suppress content in later sections. The source count is preserved so “View all” continues to behave normally.

The refill window is intentionally bounded because determining whether a series or season is watched also requires episode-state lookups. If every item in that bounded window is watched, a row can still be shorter instead of causing an unbounded scan.

## Validation

I tested the first version on my own Silo server. That live test confirmed the profile behavior worked and also exposed the refill issue: removing three watched titles from a 20-item row initially left only 17 visible. I reported that case and guided the follow-up so the row now pulls in replacement candidates.

Passed locally on the upstream-based branch:

- `go test ./internal/sections ./internal/settingscontract ./internal/settingsresolve -run 'Test(HideWatchedItemsFromHome|PreserveWatchedItemsOnHome|.*HomeHideWatched.*)' -count=1`
- `go test ./internal/api/handlers -run 'Test(FilterWatchedHomeSectionItems|HomeSectionsForFetch|HomeWatchedCandidateLimit|WatchedRefillRunsBeforeDiversity|HomePreferenceFiltersOnlyHomeResponses)' -count=1`
- `make verify-local-paths`
- `git diff --check upstream/main...HEAD`

The same commits passed Go, Web, and Docs GitHub Actions on the fork. The corrected build is deployed there and reports healthy readiness. The full upstream matrix is left to GitHub Actions.

No screenshot is included because the visible change is a single switch in the existing Home Screen settings page.

## Risks and compatibility

- No database migration is required; the existing generic settings store holds the value.
- Default behavior is unchanged until an individual profile enables the switch.
- Enabled profiles trade bounded extra section and item-state work for refilled Home rows.
- The server behavior applies to native clients once the setting is enabled. This PR adds the setting control to Web; the canonical contract makes it available for native settings UIs as well.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted, human-directed and human-verified
- Human contribution: I defined the product behavior, chose the per-profile scope, specified the Featured and watch-history exemptions, tested the feature on my live Silo fork, found the incomplete-row regression, and guided the refill behavior and final review. Codex traced the affected server paths, implemented the focused changes, added regressions, and ran the technical validation under my direction.
- Adversarial review: We reviewed Home versus non-Home routing, profile isolation, watched-indicator preservation, Featured/history exemptions, cache safety, source counts, bounded state-resolution work, and diversity ordering. The review found and fixed an incorrect source-count rewrite in the first iteration and the risk that over-fetched candidates could suppress items in later duplicate-avoiding sections. External Codex review was not retried because the environment blocked transmitting the private diff. No actionable local findings remain.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a profile-specific Home setting to hide watched items.
  * Watched items are removed from eligible Home sections while remaining available in libraries, search, collections, featured sections, and watch-history-based sections.
  * Home sections refill where possible, and watched indicators remain visible.
  * The setting is disabled by default and available on web, iOS, tvOS, macOS, Android, and Android TV.

* **Bug Fixes**
  * Home refreshes automatically after the preference changes, with an error notification if saving fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
