### PR TITLE
fix(scanner): scope file reconciliation to changed path

### DIFF
--- a/internal/scanner/present_file_state_test.go
+++ b/internal/scanner/present_file_state_test.go
@@ -10,12 +10,26 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func TestSyncPresentFileStateScopesMembershipRepairToFile(t *testing.T) {
+// presentStateFixture seeds one folder holding a series episode file and an
+// unrelated movie file, both present, with no memberships yet.
+type presentStateFixture struct {
+	pool          *pgxpool.Pool
+	folderID      int
+	seriesID      string
+	episodeID     string
+	unrelatedID   string
+	targetPath    string
+	unrelatedPath string
+	firstSeen     time.Time
+}
+
+func seedPresentStateFixture(ctx context.Context, t *testing.T, label string) presentStateFixture {
+	t.Helper()
+
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
 		t.Skip("SILO_TEST_DATABASE_URL is not set")
 	}
-	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, dsn)
 	if err != nil {
 		t.Fatalf("connect test database: %v", err)
@@ -23,23 +37,26 @@ func TestSyncPresentFileStateScopesMembershipRepairToFile(t *testing.T) {
 	t.Cleanup(pool.Close)
 
 	suffix := time.Now().UnixNano()
-	seriesID := fmt.Sprintf("present-file-series-%d", suffix)
-	episodeID := fmt.Sprintf("present-file-episode-%d", suffix)
-	unrelatedID := fmt.Sprintf("present-file-unrelated-%d", suffix)
-	targetPath := fmt.Sprintf("/tmp/present-file-%d/episode.mkv", suffix)
-	unrelatedPath := fmt.Sprintf("/tmp/present-file-%d/unrelated.mkv", suffix)
+	fx := presentStateFixture{
+		pool:          pool,
+		seriesID:      fmt.Sprintf("present-%s-series-%d", label, suffix),
+		episodeID:     fmt.Sprintf("present-%s-episode-%d", label, suffix),
+		unrelatedID:   fmt.Sprintf("present-%s-unrelated-%d", label, suffix),
+		targetPath:    fmt.Sprintf("/tmp/present-%s-%d/episode.mkv", label, suffix),
+		unrelatedPath: fmt.Sprintf("/tmp/present-%s-%d/unrelated.mkv", label, suffix),
+		firstSeen:     time.Now().Add(-time.Hour).UTC().Truncate(time.Second),
+	}
 
-	var folderID int
 	if err := pool.QueryRow(ctx, `
 		INSERT INTO media_folders (type, name, enabled)
-		VALUES ('series', 'Present File State Test', true)
+		VALUES ('series', 'Present State Test', true)
 		RETURNING id
-	`).Scan(&folderID); err != nil {
+	`).Scan(&fx.folderID); err != nil {
 		t.Fatalf("seed folder: %v", err)
 	}
 	t.Cleanup(func() {
-		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
-		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{seriesID, unrelatedID})
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, fx.folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{fx.seriesID, fx.unrelatedID})
 	})
 
 	if _, err := pool.Exec(ctx, `
@@ -47,16 +64,15 @@ func TestSyncPresentFileStateScopesMembershipRepairToFile(t *testing.T) {
 		VALUES
 			($1, 'series', 'Target Series', 'matched', '{}'::text[]),
 			($2, 'movie', 'Unrelated Movie', 'matched', '{}'::text[])
-	`, seriesID, unrelatedID); err != nil {
+	`, fx.seriesID, fx.unrelatedID); err != nil {
 		t.Fatalf("seed media items: %v", err)
 	}
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO episodes (content_id, series_id, season_number, episode_number, title)
 		VALUES ($1, $2, 1, 1, 'Episode')
-	`, episodeID, seriesID); err != nil {
+	`, fx.episodeID, fx.seriesID); err != nil {
 		t.Fatalf("seed episode: %v", err)
 	}
-	firstSeen := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
 	if _, err := pool.Exec(ctx, `
 		INSERT INTO media_files (
 			content_id, episode_id, media_folder_id, file_path, file_size,
@@ -65,60 +81,153 @@ func TestSyncPresentFileStateScopesMembershipRepairToFile(t *testing.T) {
 		VALUES
 			($1, $2, $3, $4, 1024, 1, 1, $5),
 			($6, NULL, $3, $7, 1024, NULL, NULL, NOW())
-	`, seriesID, episodeID, folderID, targetPath, firstSeen, unrelatedID, unrelatedPath); err != nil {
+	`, fx.seriesID, fx.episodeID, fx.folderID, fx.targetPath, fx.firstSeen, fx.unrelatedID, fx.unrelatedPath); err != nil {
 		t.Fatalf("seed media files: %v", err)
 	}
 
-	scanner := &Scanner{fileRepo: NewFileRepository(pool)}
-	if err := scanner.syncPresentFileState(ctx, folderID, targetPath); err != nil {
-		t.Fatalf("syncPresentFileState: %v", err)
-	}
+	return fx
+}
 
-	var targetMembership bool
-	if err := pool.QueryRow(ctx, `
+func (fx presentStateFixture) hasItemMembership(ctx context.Context, t *testing.T, contentID string) bool {
+	t.Helper()
+	var exists bool
+	if err := fx.pool.QueryRow(ctx, `
 		SELECT EXISTS (
 			SELECT 1 FROM media_item_libraries
 			WHERE content_id = $1 AND media_folder_id = $2
 		)
-	`, seriesID, folderID).Scan(&targetMembership); err != nil {
-		t.Fatalf("read target membership: %v", err)
+	`, contentID, fx.folderID).Scan(&exists); err != nil {
+		t.Fatalf("read membership for %s: %v", contentID, err)
 	}
-	if !targetMembership {
-		t.Fatal("target media item membership was not restored")
-	}
+	return exists
+}
 
-	var unrelatedMembership bool
-	if err := pool.QueryRow(ctx, `
-		SELECT EXISTS (
-			SELECT 1 FROM media_item_libraries
-			WHERE content_id = $1 AND media_folder_id = $2
-		)
-	`, unrelatedID, folderID).Scan(&unrelatedMembership); err != nil {
-		t.Fatalf("read unrelated membership: %v", err)
-	}
-	if unrelatedMembership {
-		t.Fatal("unrelated media item membership was repaired by a single-file sync")
-	}
+// assertEpisodeRepaired checks the parts both scopes must agree on: the
+// episode membership exists with first_seen_at aggregated over all of the
+// episode's active files, and the series denorm was bumped to match.
+func (fx presentStateFixture) assertEpisodeRepaired(ctx context.Context, t *testing.T) {
+	t.Helper()
 
 	var episodeFirstSeen time.Time
-	if err := pool.QueryRow(ctx, `
+	if err := fx.pool.QueryRow(ctx, `
 		SELECT first_seen_at
 		FROM episode_libraries
 		WHERE episode_id = $1 AND media_folder_id = $2
-	`, episodeID, folderID).Scan(&episodeFirstSeen); err != nil {
+	`, fx.episodeID, fx.folderID).Scan(&episodeFirstSeen); err != nil {
 		t.Fatalf("read episode membership: %v", err)
 	}
-	if !episodeFirstSeen.Equal(firstSeen) {
-		t.Fatalf("episode first_seen_at = %v, want %v", episodeFirstSeen, firstSeen)
+	if !episodeFirstSeen.Equal(fx.firstSeen) {
+		t.Fatalf("episode first_seen_at = %v, want %v", episodeFirstSeen, fx.firstSeen)
 	}
 
 	var latestEpisodeAdded *time.Time
-	if err := pool.QueryRow(ctx, `
+	if err := fx.pool.QueryRow(ctx, `
 		SELECT latest_episode_added_at FROM media_items WHERE content_id = $1
-	`, seriesID).Scan(&latestEpisodeAdded); err != nil {
+	`, fx.seriesID).Scan(&latestEpisodeAdded); err != nil {
 		t.Fatalf("read latest episode timestamp: %v", err)
 	}
-	if latestEpisodeAdded == nil || !latestEpisodeAdded.Equal(firstSeen) {
-		t.Fatalf("latest_episode_added_at = %v, want %v", latestEpisodeAdded, firstSeen)
+	if latestEpisodeAdded == nil || !latestEpisodeAdded.Equal(fx.firstSeen) {
+		t.Fatalf("latest_episode_added_at = %v, want %v", latestEpisodeAdded, fx.firstSeen)
+	}
+
+	if !fx.hasItemMembership(ctx, t, fx.seriesID) {
+		t.Fatal("target media item membership was not restored")
+	}
+}
+
+func TestSyncPresentFileStateScopesMembershipRepairToFile(t *testing.T) {
+	ctx := context.Background()
+	fx := seedPresentStateFixture(ctx, t, "file")
+
+	scanner := &Scanner{fileRepo: NewFileRepository(fx.pool)}
+	if err := scanner.syncPresentFileState(ctx, fx.folderID, fx.targetPath); err != nil {
+		t.Fatalf("syncPresentFileState: %v", err)
+	}
+
+	fx.assertEpisodeRepaired(ctx, t)
+	if fx.hasItemMembership(ctx, t, fx.unrelatedID) {
+		t.Fatal("unrelated media item membership was repaired by a single-file sync")
+	}
+}
+
+// TestSyncPresentLibraryStateRepairsWholeFolder drives the same unified body
+// through the folder-wide scope: the file-scoped assertions must still hold,
+// and the unrelated file in the folder must be repaired too.
+func TestSyncPresentLibraryStateRepairsWholeFolder(t *testing.T) {
+	ctx := context.Background()
+	fx := seedPresentStateFixture(ctx, t, "folder")
+
+	scanner := &Scanner{fileRepo: NewFileRepository(fx.pool)}
+	if err := scanner.syncPresentLibraryState(ctx, fx.folderID); err != nil {
+		t.Fatalf("syncPresentLibraryState: %v", err)
+	}
+
+	fx.assertEpisodeRepaired(ctx, t)
+	if !fx.hasItemMembership(ctx, t, fx.unrelatedID) {
+		t.Fatal("unrelated media item membership was not repaired by a folder-wide sync")
+	}
+}
+
+// TestSyncPresentStateClearsDanglingLinks covers the dangling-link statement
+// through both scopes: a file pointing at a deleted item must have its
+// content_id nulled. Only content_id can dangle — media_files.episode_id has
+// an ON DELETE SET NULL foreign key, so the episode variant of the repair is
+// defensive and cannot be seeded here.
+func TestSyncPresentStateClearsDanglingLinks(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name  string
+		label string
+		scope func(s *Scanner, fx presentStateFixture) error
+	}{
+		{
+			name:  "file scope",
+			label: "dangling-file",
+			scope: func(s *Scanner, fx presentStateFixture) error {
+				return s.syncPresentFileState(ctx, fx.folderID, fx.targetPath)
+			},
+		},
+		{
+			name:  "folder scope",
+			label: "dangling-folder",
+			scope: func(s *Scanner, fx presentStateFixture) error {
+				return s.syncPresentLibraryState(ctx, fx.folderID)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := seedPresentStateFixture(ctx, t, tc.label)
+
+			// Point the target file at content that does not exist, leaving
+			// the row's content link dangling.
+			if _, err := fx.pool.Exec(ctx, `
+				UPDATE media_files
+				SET content_id = $1, episode_id = NULL
+				WHERE media_folder_id = $2 AND file_path = $3
+			`, fx.seriesID+"-missing", fx.folderID, fx.targetPath); err != nil {
+				t.Fatalf("dangle target link: %v", err)
+			}
+
+			scanner := &Scanner{fileRepo: NewFileRepository(fx.pool)}
+			if err := tc.scope(scanner, fx); err != nil {
+				t.Fatalf("sync present state: %v", err)
+			}
+
+			var contentID, episodeID *string
+			if err := fx.pool.QueryRow(ctx, `
+				SELECT content_id, episode_id
+				FROM media_files
+				WHERE media_folder_id = $1 AND file_path = $2
+			`, fx.folderID, fx.targetPath).Scan(&contentID, &episodeID); err != nil {
+				t.Fatalf("read repaired file: %v", err)
+			}
+			if contentID != nil {
+				t.Fatalf("dangling content_id was not cleared: %v", *contentID)
+			}
+			if episodeID != nil {
+				t.Fatalf("episode_id unexpectedly set: %v", *episodeID)
+			}
+		})
 	}
 }

--- a/internal/scanner/present_file_state_test.go
+++ b/internal/scanner/present_file_state_test.go
@@ -1,0 +1,124 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestSyncPresentFileStateScopesMembershipRepairToFile(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	seriesID := fmt.Sprintf("present-file-series-%d", suffix)
+	episodeID := fmt.Sprintf("present-file-episode-%d", suffix)
+	unrelatedID := fmt.Sprintf("present-file-unrelated-%d", suffix)
+	targetPath := fmt.Sprintf("/tmp/present-file-%d/episode.mkv", suffix)
+	unrelatedPath := fmt.Sprintf("/tmp/present-file-%d/unrelated.mkv", suffix)
+
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled)
+		VALUES ('series', 'Present File State Test', true)
+		RETURNING id
+	`).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, []string{seriesID, unrelatedID})
+	})
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres)
+		VALUES
+			($1, 'series', 'Target Series', 'matched', '{}'::text[]),
+			($2, 'movie', 'Unrelated Movie', 'matched', '{}'::text[])
+	`, seriesID, unrelatedID); err != nil {
+		t.Fatalf("seed media items: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO episodes (content_id, series_id, season_number, episode_number, title)
+		VALUES ($1, $2, 1, 1, 'Episode')
+	`, episodeID, seriesID); err != nil {
+		t.Fatalf("seed episode: %v", err)
+	}
+	firstSeen := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO media_files (
+			content_id, episode_id, media_folder_id, file_path, file_size,
+			season_number, episode_number, created_at
+		)
+		VALUES
+			($1, $2, $3, $4, 1024, 1, 1, $5),
+			($6, NULL, $3, $7, 1024, NULL, NULL, NOW())
+	`, seriesID, episodeID, folderID, targetPath, firstSeen, unrelatedID, unrelatedPath); err != nil {
+		t.Fatalf("seed media files: %v", err)
+	}
+
+	scanner := &Scanner{fileRepo: NewFileRepository(pool)}
+	if err := scanner.syncPresentFileState(ctx, folderID, targetPath); err != nil {
+		t.Fatalf("syncPresentFileState: %v", err)
+	}
+
+	var targetMembership bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM media_item_libraries
+			WHERE content_id = $1 AND media_folder_id = $2
+		)
+	`, seriesID, folderID).Scan(&targetMembership); err != nil {
+		t.Fatalf("read target membership: %v", err)
+	}
+	if !targetMembership {
+		t.Fatal("target media item membership was not restored")
+	}
+
+	var unrelatedMembership bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM media_item_libraries
+			WHERE content_id = $1 AND media_folder_id = $2
+		)
+	`, unrelatedID, folderID).Scan(&unrelatedMembership); err != nil {
+		t.Fatalf("read unrelated membership: %v", err)
+	}
+	if unrelatedMembership {
+		t.Fatal("unrelated media item membership was repaired by a single-file sync")
+	}
+
+	var episodeFirstSeen time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT first_seen_at
+		FROM episode_libraries
+		WHERE episode_id = $1 AND media_folder_id = $2
+	`, episodeID, folderID).Scan(&episodeFirstSeen); err != nil {
+		t.Fatalf("read episode membership: %v", err)
+	}
+	if !episodeFirstSeen.Equal(firstSeen) {
+		t.Fatalf("episode first_seen_at = %v, want %v", episodeFirstSeen, firstSeen)
+	}
+
+	var latestEpisodeAdded *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT latest_episode_added_at FROM media_items WHERE content_id = $1
+	`, seriesID).Scan(&latestEpisodeAdded); err != nil {
+		t.Fatalf("read latest episode timestamp: %v", err)
+	}
+	if latestEpisodeAdded == nil || !latestEpisodeAdded.Equal(firstSeen) {
+		t.Fatalf("latest_episode_added_at = %v, want %v", latestEpisodeAdded, firstSeen)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2111,82 +2111,10 @@ func compactScanRoots(paths []string) []string {
 	return out
 }
 
+// syncPresentLibraryState repairs the catalog memberships owned by every
+// present media file in a folder.
 func (s *Scanner) syncPresentLibraryState(ctx context.Context, folderID int) error {
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
-		UPDATE media_files mf
-		SET content_id = NULL,
-			updated_at = NOW()
-		WHERE mf.media_folder_id = $1
-		  AND mf.missing_since IS NULL
-		  AND mf.content_id IS NOT NULL
-		  AND NOT EXISTS (
-			SELECT 1
-			FROM media_items mi
-			WHERE mi.content_id = mf.content_id
-		  )
-	`, folderID); err != nil {
-		return fmt.Errorf("clearing dangling content links: %w", err)
-	}
-
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
-		UPDATE media_files mf
-		SET episode_id = NULL,
-			updated_at = NOW()
-		WHERE mf.media_folder_id = $1
-		  AND mf.missing_since IS NULL
-		  AND mf.episode_id IS NOT NULL
-		  AND NOT EXISTS (
-			SELECT 1
-			FROM episodes e
-			WHERE e.content_id = mf.episode_id
-		  )
-	`, folderID); err != nil {
-		return fmt.Errorf("clearing dangling episode links: %w", err)
-	}
-
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
-		INSERT INTO media_item_libraries (content_id, media_folder_id, first_seen_at)
-		SELECT DISTINCT mf.content_id, mf.media_folder_id, NOW()
-		FROM media_files mf
-		JOIN media_items mi ON mi.content_id = mf.content_id
-		WHERE mf.media_folder_id = $1
-		  AND mf.missing_since IS NULL
-		  AND mf.content_id IS NOT NULL
-		ON CONFLICT (content_id, media_folder_id) DO NOTHING
-	`, folderID); err != nil {
-		return fmt.Errorf("restoring folder memberships: %w", err)
-	}
-
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
-		WITH inserted AS (
-			INSERT INTO episode_libraries (episode_id, media_folder_id, first_seen_at)
-			SELECT mf.episode_id, mf.media_folder_id, MIN(mf.created_at)
-			FROM media_files mf
-			JOIN episodes e ON e.content_id = mf.episode_id
-			WHERE mf.media_folder_id = $1
-			  AND mf.missing_since IS NULL
-			  AND mf.episode_id IS NOT NULL
-			GROUP BY mf.episode_id, mf.media_folder_id
-			ON CONFLICT (episode_id, media_folder_id) DO NOTHING
-			RETURNING episode_id, first_seen_at
-		)
-		-- Bump each parent series' latest-episode-added denorm for the
-		-- genuinely new links ("Latest Episodes" sort, issue #202).
-		UPDATE media_items mi
-		SET latest_episode_added_at = GREATEST(COALESCE(mi.latest_episode_added_at, sub.latest_added), sub.latest_added)
-		FROM (
-			SELECT e.series_id, MAX(i.first_seen_at) AS latest_added
-			FROM inserted i
-			JOIN episodes e ON e.content_id = i.episode_id
-			GROUP BY e.series_id
-		) sub
-		WHERE mi.content_id = sub.series_id
-		  AND mi.type = 'series'
-	`, folderID); err != nil {
-		return fmt.Errorf("restoring episode folder memberships: %w", err)
-	}
-
-	return nil
+	return s.syncPresentState(ctx, folderID, nil)
 }
 
 // syncPresentFileState repairs the catalog memberships owned by one present
@@ -2194,12 +2122,38 @@ func (s *Scanner) syncPresentLibraryState(ctx context.Context, folderID int) err
 // syncPresentLibraryState: a large library can contain hundreds of thousands
 // of files while this path has exactly one changed row to reconcile.
 func (s *Scanner) syncPresentFileState(ctx context.Context, folderID int, filePath string) error {
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
+	if strings.TrimSpace(filePath) == "" {
+		return fmt.Errorf("syncing present file state: empty file path")
+	}
+	return s.syncPresentState(ctx, folderID, &filePath)
+}
+
+// syncPresentState is the single implementation behind both entry points. When
+// filePath is nil the repair covers every present file in the folder; when it
+// is set the exact same statements are narrowed to that one row.
+//
+// The path predicate is appended in Go rather than expressed as
+// "($2::text IS NULL OR mf.file_path = $2)" so the folder-wide plan is not
+// forced onto a filter the planner cannot use an index for.
+func (s *Scanner) syncPresentState(ctx context.Context, folderID int, filePath *string) error {
+	args := []any{folderID}
+	filePredicate := ""
+	if filePath != nil {
+		args = append(args, *filePath)
+		filePredicate = "\n\t\t  AND mf.file_path = $2"
+	}
+
+	statements := []struct {
+		desc string
+		sql  string
+	}{
+		{
+			desc: "clearing dangling content links",
+			sql: `
 		UPDATE media_files mf
 		SET content_id = NULL,
 			updated_at = NOW()
-		WHERE mf.media_folder_id = $1
-		  AND mf.file_path = $2
+		WHERE mf.media_folder_id = $1` + filePredicate + `
 		  AND mf.missing_since IS NULL
 		  AND mf.content_id IS NOT NULL
 		  AND NOT EXISTS (
@@ -2207,16 +2161,15 @@ func (s *Scanner) syncPresentFileState(ctx context.Context, folderID int, filePa
 			FROM media_items mi
 			WHERE mi.content_id = mf.content_id
 		  )
-	`, folderID, filePath); err != nil {
-		return fmt.Errorf("clearing dangling content link for file: %w", err)
-	}
-
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
+	`,
+		},
+		{
+			desc: "clearing dangling episode links",
+			sql: `
 		UPDATE media_files mf
 		SET episode_id = NULL,
 			updated_at = NOW()
-		WHERE mf.media_folder_id = $1
-		  AND mf.file_path = $2
+		WHERE mf.media_folder_id = $1` + filePredicate + `
 		  AND mf.missing_since IS NULL
 		  AND mf.episode_id IS NOT NULL
 		  AND NOT EXISTS (
@@ -2224,31 +2177,32 @@ func (s *Scanner) syncPresentFileState(ctx context.Context, folderID int, filePa
 			FROM episodes e
 			WHERE e.content_id = mf.episode_id
 		  )
-	`, folderID, filePath); err != nil {
-		return fmt.Errorf("clearing dangling episode link for file: %w", err)
-	}
-
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
+	`,
+		},
+		{
+			desc: "restoring folder memberships",
+			sql: `
 		INSERT INTO media_item_libraries (content_id, media_folder_id, first_seen_at)
-		SELECT mf.content_id, mf.media_folder_id, NOW()
+		SELECT DISTINCT mf.content_id, mf.media_folder_id, NOW()
 		FROM media_files mf
 		JOIN media_items mi ON mi.content_id = mf.content_id
-		WHERE mf.media_folder_id = $1
-		  AND mf.file_path = $2
+		WHERE mf.media_folder_id = $1` + filePredicate + `
 		  AND mf.missing_since IS NULL
 		  AND mf.content_id IS NOT NULL
 		ON CONFLICT (content_id, media_folder_id) DO NOTHING
-	`, folderID, filePath); err != nil {
-		return fmt.Errorf("restoring folder membership for file: %w", err)
-	}
-
-	if _, err := s.fileRepo.Pool().Exec(ctx, `
+	`,
+		},
+		{
+			// target_episode selects the episodes in scope; candidate then
+			// re-joins every active file of those episodes so first_seen_at
+			// aggregates over the whole episode, not just the scanned path.
+			desc: "restoring episode folder memberships",
+			sql: `
 		WITH target_episode AS (
-			SELECT mf.episode_id, mf.media_folder_id
+			SELECT DISTINCT mf.episode_id, mf.media_folder_id
 			FROM media_files mf
 			JOIN episodes e ON e.content_id = mf.episode_id
-			WHERE mf.media_folder_id = $1
-			  AND mf.file_path = $2
+			WHERE mf.media_folder_id = $1` + filePredicate + `
 			  AND mf.missing_since IS NULL
 			  AND mf.episode_id IS NOT NULL
 		),
@@ -2270,8 +2224,10 @@ func (s *Scanner) syncPresentFileState(ctx context.Context, folderID int, filePa
 			ON CONFLICT (episode_id, media_folder_id) DO NOTHING
 			RETURNING episode_id, first_seen_at
 		)
+		-- Bump each parent series' latest-episode-added denorm for the
+		-- genuinely new links ("Latest Episodes" sort, issue #202).
 		UPDATE media_items mi
-		SET latest_episode_added_at = GREATEST(COALESCE(mi.latest_episode_added_at, sub.latest_added), sub.latest_added)
+		SET latest_episode_added_at = GREATEST(mi.latest_episode_added_at, sub.latest_added)
 		FROM (
 			SELECT e.series_id, MAX(i.first_seen_at) AS latest_added
 			FROM inserted i
@@ -2280,10 +2236,27 @@ func (s *Scanner) syncPresentFileState(ctx context.Context, folderID int, filePa
 		) sub
 		WHERE mi.content_id = sub.series_id
 		  AND mi.type = 'series'
-	`, folderID, filePath); err != nil {
-		return fmt.Errorf("restoring episode folder membership for file: %w", err)
+	`,
+		},
 	}
 
+	// One transaction: a crash part-way through must not leave a row with some
+	// links cleared and its memberships unrepaired.
+	tx, err := s.fileRepo.Pool().Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning present state repair: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	for _, stmt := range statements {
+		if _, err := tx.Exec(ctx, stmt.sql, args...); err != nil {
+			return fmt.Errorf("%s: %w", stmt.desc, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("committing present state repair: %w", err)
+	}
 	return nil
 }
 
@@ -2501,12 +2474,11 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		if stats.Errors > 0 {
 			return fmt.Errorf("processing extra file %s failed", cleanFile)
 		}
-		// Converting a previously-primary row into an extra clears its
-		// content linkage; run the same membership cleanup a full scan would
-		// so stale library membership doesn't linger until the next scan.
-		if err := s.syncPresentFileState(ctx, folder.ID, cleanFile); err != nil {
-			return fmt.Errorf("syncing present library state for extra file: %w", err)
-		}
+		// The Upsert above already nulled this row's content/episode links as
+		// part of converting it into an extra. What still needs repair is the
+		// library membership: if this was the last primary file behind an
+		// item, the folder membership must go away too, which is what
+		// reconcileLibraryMemberships below does.
 		protectedRoots, err := s.protectedConfiguredRoots(ctx, folder)
 		if err != nil {
 			return err

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2189,6 +2189,104 @@ func (s *Scanner) syncPresentLibraryState(ctx context.Context, folderID int) err
 	return nil
 }
 
+// syncPresentFileState repairs the catalog memberships owned by one present
+// media file. Single-file Autoscan work must not pay the folder-wide cost of
+// syncPresentLibraryState: a large library can contain hundreds of thousands
+// of files while this path has exactly one changed row to reconcile.
+func (s *Scanner) syncPresentFileState(ctx context.Context, folderID int, filePath string) error {
+	if _, err := s.fileRepo.Pool().Exec(ctx, `
+		UPDATE media_files mf
+		SET content_id = NULL,
+			updated_at = NOW()
+		WHERE mf.media_folder_id = $1
+		  AND mf.file_path = $2
+		  AND mf.missing_since IS NULL
+		  AND mf.content_id IS NOT NULL
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM media_items mi
+			WHERE mi.content_id = mf.content_id
+		  )
+	`, folderID, filePath); err != nil {
+		return fmt.Errorf("clearing dangling content link for file: %w", err)
+	}
+
+	if _, err := s.fileRepo.Pool().Exec(ctx, `
+		UPDATE media_files mf
+		SET episode_id = NULL,
+			updated_at = NOW()
+		WHERE mf.media_folder_id = $1
+		  AND mf.file_path = $2
+		  AND mf.missing_since IS NULL
+		  AND mf.episode_id IS NOT NULL
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM episodes e
+			WHERE e.content_id = mf.episode_id
+		  )
+	`, folderID, filePath); err != nil {
+		return fmt.Errorf("clearing dangling episode link for file: %w", err)
+	}
+
+	if _, err := s.fileRepo.Pool().Exec(ctx, `
+		INSERT INTO media_item_libraries (content_id, media_folder_id, first_seen_at)
+		SELECT mf.content_id, mf.media_folder_id, NOW()
+		FROM media_files mf
+		JOIN media_items mi ON mi.content_id = mf.content_id
+		WHERE mf.media_folder_id = $1
+		  AND mf.file_path = $2
+		  AND mf.missing_since IS NULL
+		  AND mf.content_id IS NOT NULL
+		ON CONFLICT (content_id, media_folder_id) DO NOTHING
+	`, folderID, filePath); err != nil {
+		return fmt.Errorf("restoring folder membership for file: %w", err)
+	}
+
+	if _, err := s.fileRepo.Pool().Exec(ctx, `
+		WITH target_episode AS (
+			SELECT mf.episode_id, mf.media_folder_id
+			FROM media_files mf
+			JOIN episodes e ON e.content_id = mf.episode_id
+			WHERE mf.media_folder_id = $1
+			  AND mf.file_path = $2
+			  AND mf.missing_since IS NULL
+			  AND mf.episode_id IS NOT NULL
+		),
+		candidate AS (
+			SELECT target.episode_id,
+			       target.media_folder_id,
+			       MIN(mf.created_at) AS first_seen_at
+			FROM target_episode target
+			JOIN media_files mf
+			  ON mf.episode_id = target.episode_id
+			 AND mf.media_folder_id = target.media_folder_id
+			 AND mf.missing_since IS NULL
+			GROUP BY target.episode_id, target.media_folder_id
+		),
+		inserted AS (
+			INSERT INTO episode_libraries (episode_id, media_folder_id, first_seen_at)
+			SELECT episode_id, media_folder_id, first_seen_at
+			FROM candidate
+			ON CONFLICT (episode_id, media_folder_id) DO NOTHING
+			RETURNING episode_id, first_seen_at
+		)
+		UPDATE media_items mi
+		SET latest_episode_added_at = GREATEST(COALESCE(mi.latest_episode_added_at, sub.latest_added), sub.latest_added)
+		FROM (
+			SELECT e.series_id, MAX(i.first_seen_at) AS latest_added
+			FROM inserted i
+			JOIN episodes e ON e.content_id = i.episode_id
+			GROUP BY e.series_id
+		) sub
+		WHERE mi.content_id = sub.series_id
+		  AND mi.type = 'series'
+	`, folderID, filePath); err != nil {
+		return fmt.Errorf("restoring episode folder membership for file: %w", err)
+	}
+
+	return nil
+}
+
 func (s *Scanner) syncFolderScopedAudioLibraryState(ctx context.Context, folderID int) error {
 	if err := s.syncPresentLibraryState(ctx, folderID); err != nil {
 		return err
@@ -2406,7 +2504,7 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		// Converting a previously-primary row into an extra clears its
 		// content linkage; run the same membership cleanup a full scan would
 		// so stale library membership doesn't linger until the next scan.
-		if err := s.syncPresentLibraryState(ctx, folder.ID); err != nil {
+		if err := s.syncPresentFileState(ctx, folder.ID, cleanFile); err != nil {
 			return fmt.Errorf("syncing present library state for extra file: %w", err)
 		}
 		protectedRoots, err := s.protectedConfiguredRoots(ctx, folder)
@@ -2473,7 +2571,7 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 	if err := s.reconcileScannedGroups(ctx, folder.ID, false, []string{scopePath}, false, groupInference); err != nil {
 		return fmt.Errorf("reconciling scanned groups for file: %w", err)
 	}
-	if err := s.syncPresentLibraryState(ctx, folder.ID); err != nil {
+	if err := s.syncPresentFileState(ctx, folder.ID, filePath); err != nil {
 		return fmt.Errorf("syncing present library state for file: %w", err)
 	}
 	if s.seriesQueueSyncer != nil {


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

A file-scoped Autoscan request ended by calling `syncPresentLibraryState`, which reconciles every catalog membership in the media folder. On a library with about 865,000 active files, production plans scanned roughly 754,000 `media_files` rows and 2.15 million `episodes` rows for each changed file. Bursts of subtitle sidecar updates therefore kept PostgreSQL busy with folder-wide work even though each request named one path.

## Approach

Both scopes now share one implementation, `syncPresentState(ctx, folderID, filePath *string)`: `syncPresentLibraryState` and `syncPresentFileState` are thin wrappers, and the exact-path predicate is appended in Go so the folder-wide plan is unchanged. The repair performs, in a single transaction:

- clear dangling content links (episode links have an `ON DELETE SET NULL` FK, so that statement is defensive);
- restore media-item membership;
- restore episode membership, aggregating `first_seen_at` over all of the episode's active files rather than just the scanned path;
- bump the parent series' `latest_episode_added_at` only for genuinely new links.

The transaction replaces four autocommit round-trips, so a crash mid-repair can no longer leave a row with its links cleared but its memberships unrestored.

The extras-conversion branch no longer calls the sync at all: the `Upsert` that converts a row into an extra already nulls its content/episode links, which made every statement of the sync a no-op there. The membership cleanup on that path comes from the unchanged folder-wide `reconcileLibraryMemberships` call. (An earlier revision of this PR kept a file-scoped sync call there and described it as retaining cleanup; review showed it was dead code.)

## Validation

Passed:

- `go test ./internal/scanner ./internal/autoscan ./internal/libraryingest -count=1`
- `go test ./internal/scanner -count=1` with `SILO_TEST_DATABASE_URL` against a local migrated Postgres — the DB-backed regression tests executed (not skipped), covering the file scope, the folder-wide scope through the same unified body, and dangling content-link repair in both scopes
- `go build ./...`
- `go vet ./...`
- `gofmt -l .` (no output)
- `pnpm install --frozen-lockfile`
- `pnpm run lint` (0 errors; 155 existing warnings)
- `pnpm run format:check`
- `pnpm run build` (existing font and chunk-size warnings)
- `make test-web` (283 files, 2,039 tests)
- `make verify-settings-bindings-all`
- `make verify-playback-fixtures`
- `make verify-local-paths`

`make test-go` ran the full suite. All scanner tests passed, but the command failed on two unrelated macOS Jellycompat process-lock tests:

- `TestBeginWebOperationRecoversDeadProcessLock`
- `TestBeginWebOperationRejectsLiveProcessLock`

The same path was exercised on shared-dev through a real file scan: the scan completed in 2.07 seconds, and `EXPLAIN ANALYZE` used the exact-path and active-episode indexes with 3.19 ms execution time and no broad sequential scan. During CephFS batches of 33 and 37 file scans, PostgreSQL sampled at 0.67–2.23% CPU; health and readiness remained green.

`golangci-lint run --new-from-merge-base="origin/main" ./...` was not run because `golangci-lint` is not installed in this environment.

## Risks

A single-file scan no longer repairs unrelated stale memberships in the same folder. Full folder scans retain that cleanup, and the extra-conversion path still runs `reconcileLibraryMemberships`. There are no migrations or API changes.

Pre-existing and unchanged by this PR: the plain single-file scan path never deletes a stale membership left behind when a file is re-identified from one content ID to another (neither sync variant issues DELETEs; that cleanup belongs to `reconcileLibraryMemberships`, which the plain path does not call). Worth a follow-up issue.

## AI Disclosure

- Tool(s): Codex; Claude Code
- Model(s): gpt-5.6-sol; Claude Fable 5 (orchestration) with Opus 5 implementation subagents
- Involvement: AI-assisted
- Adversarial review: A multi-agent Claude review of the merge-base diff (8 finder angles, adversarial verification votes) found the dead extras-branch sync call, the duplicated SQL bodies, and the non-transactional repair sequence; this revision addresses those findings. The DB-backed regression tests were executed against a real migrated Postgres as part of validating the revision.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
