### PR TITLE
fix(web): avoid duplicate audiobook playback starts

### DIFF
--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,9 @@
 
 ## 2026-08-24
 
+### Start audiobook playback once after browser capability detection
+The web audiobook player now waits for the browser's capability check to finish before requesting a playback session. It previously reacted to each intermediate capability result, creating and immediately replacing multiple sessions when one play request should have produced only one.
+
 ### Play HDR video on SDR-only devices
 An HDR source used to be a dead end for a device that cannot display HDR: Silo had no recipe that could convert one, so the plan refused rather than washing the picture out. Silo can now tone-map HDR to SDR, on streaming and on prepared downloads alike, so those devices get a watchable picture with the colors mapped rather than clipped.
 

--- a/web/src/pages/audiobooks/player/useAudiobookPlayback.test.ts
+++ b/web/src/pages/audiobooks/player/useAudiobookPlayback.test.ts
@@ -251,6 +251,38 @@ describe("useAudiobookPlayback", () => {
     });
   });
 
+  it("waits for the capability probe before starting playback", async () => {
+    let resolveProbe!: (value: MediaCapabilitiesDecodingInfo) => void;
+    const probeResult = new Promise<MediaCapabilitiesDecodingInfo>((resolve) => {
+      resolveProbe = resolve;
+    });
+    vi.stubGlobal("navigator", {
+      userAgent: "test-browser",
+      mediaCapabilities: { decodingInfo: vi.fn(() => probeResult) },
+    });
+
+    const { result } = renderAudiobookPlayback();
+    await act(async () => Promise.resolve());
+    expect(
+      vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith("/playback/start")),
+    ).toHaveLength(0);
+
+    await act(async () => {
+      resolveProbe({
+        supported: false,
+        smooth: false,
+        powerEfficient: false,
+        keySystemAccess: null,
+      });
+      await probeResult;
+    });
+    await flushAsyncWork();
+    expect(result.current.streamUrl).toBe("/api/v1/stream/session-1?token=token");
+    expect(
+      vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith("/playback/start")),
+    ).toHaveLength(1);
+  });
+
   it("advertises the delivery classes the audio-only planner routes to", async () => {
     renderAudiobookPlayback();
 

--- a/web/src/pages/audiobooks/player/useAudiobookPlayback.ts
+++ b/web/src/pages/audiobooks/player/useAudiobookPlayback.ts
@@ -218,6 +218,7 @@ export function useAudiobookPlayback({
   // against `audio/mp4` as well as `video/mp4`, so an audio-only source is
   // described honestly without a second detection path.
   const capabilityProbe = useCodecDetection();
+  const capabilitiesSettled = capabilityProbe.settled;
   const clientCapabilities = useMemo(
     () => buildClientCapabilitiesV3(capabilityProbe),
     [capabilityProbe],
@@ -530,6 +531,7 @@ export function useAudiobookPlayback({
       playbackAttemptIdRef.current = null;
       return;
     }
+    if (!capabilitiesSettled) return;
 
     let canceled = false;
     let startedSessionId: string | null = null;
@@ -634,6 +636,7 @@ export function useAudiobookPlayback({
     adoptPlan,
     clientCapabilities,
     clientPlaybackContext,
+    capabilitiesSettled,
     config,
     fileId,
     sourceRevision,


### PR DESCRIPTION
## Summary

- wait for the shared browser capability probe to settle before starting audiobook playback
- cover the startup lifecycle with a regression test that holds the async probe open and proves exactly one session is created
- record the user-visible fix in the feature changelog

## Cause

Commit `4b6c05e18` in PR #634 made the shared codec probe publish an explicit unsettled state and a final settled state. The video player waited for the final state, but the audiobook hook still started on every capability object change. One render therefore issued three `POST /playback/start` requests in CI.

This change applies the same settled gate to audiobook startup while preserving the existing cleanup when no active file exists.

## Validation

Passed:

- `pnpm exec vitest run src/pages/audiobooks/player/useAudiobookPlayback.test.ts` — 16 tests
- `pnpm run lint` — 0 errors; 155 existing warnings
- `pnpm run format:check`
- `pnpm run build`
- `make test-web` — 285 files, 2,067 tests
- `go build ./...`
- tracked-file `gofmt` check
- `go vet ./...`
- `golangci-lint run --new-from-merge-base="origin/main" ./...` — 0 issues
- `make verify-settings-bindings-all`
- `make verify-playback-fixtures`
- `make verify-local-paths`

`make test-go` completed all packages except two existing macOS process-lock tests in `internal/jellycompat`: `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`. Both failures reproduce unchanged in a detached clean `origin/main` worktree. The main-branch GitHub Actions Go job at `a0a31e891` passed on Linux.

Manual browser playback was not run; the session-start lifecycle is covered at hook level.

Related issue: N/A — narrow regression after #634

## AI Disclosure

- Tool(s): T3 Code with Codex
- Model(s): gpt-5.6-sol
- Involvement: Fully AI-generated; human verification pending
- Adversarial review: Traced the codec-probe and session-effect lifecycle, compared the video and audiobook consumers, checked the no-active-file cleanup path, and added a controlled async-probe regression test. The review found and corrected an early-return ordering edge case before publication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audiobook playback startup by waiting for browser capability detection to complete before beginning playback.
  * Prevented repeated playback session creation and replacement during startup.

* **Tests**
  * Added coverage confirming playback starts exactly once after capability detection finishes.

* **Documentation**
  * Documented the updated audiobook playback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->