### PR TITLE
fix(playback): keep requested version while capabilities warm

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -193,7 +193,9 @@ the same replay/conflict rules and gives terminal route events an addressable
 authorization record.
 
 A client generates a fresh `playback_attempt_id` per user-initiated playback and
-reuses it only to retry a request whose response it did not receive.
+reuses it only to retry a request whose response it did not receive. After any
+response is received, including a retryable terminal, a follow-up start mints a
+new ID so the server does not replay the durable response.
 
 **Omission is a request, not a default.** Two start fields mean "you decide" when
 absent, and the server answers from stored user state rather than from a
@@ -945,7 +947,10 @@ The plan will play, but something the user might notice was given up.
 ### 7.3 Terminal reasons
 
 Playback will not proceed. `terminal.retryable` says whether trying again could
-help. Delivered inside a `201` (start) or `200` (replan), never a 4xx.
+help. A retryable terminal may include `retry_after_ms`; each retry of a start
+must mint a fresh `playback_attempt_id`, because an attempt decision is
+idempotently replayed. Delivered inside a `201` (start) or `200` (replan), never
+a 4xx.
 
 *Planner:* `adaptation_exhausted`, `adaptation_unavailable`,
 `client_hls_unsupported`, `conversion_tool_unavailable`,
@@ -966,12 +971,17 @@ HDR, 4K, or transcode-policy reason — deselecting the subtitle restores playba
 `subtitle_artifact_unavailable`, `capacity_unavailable`,
 `local_transcode_disabled`,
 `audio_transcoding_disabled`,
-`transcode_start_failed`, `transcode_node_unavailable`,
+`capability_warming`, `transcode_start_failed`, `transcode_node_unavailable`,
 `transcode_node_capability_unavailable`, `track_unavailable`,
 `invalid_seek_position`, `invalid_replan`, `seek_reanchor_route_changed`,
 `seek_reanchor_recipe_unavailable`,
 `seek_reanchor_intent_mismatch`, `seek_failure_recovery_intent_mismatch`,
 `policy_denied`.
+
+`capability_warming` means the bounded planning request ended before the shared
+tone-map inventory became definitive. It is retryable and never authorizes an
+alternate media-file selection; a client should keep the requested file pinned
+while retrying.
 
 ### 7.4 Route event names
 

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -106,13 +106,13 @@ the document is always the full one:
   "features": ["playback_plan_v3", "neutral_playback_v3_contract_v1", "layout_aware_passthrough", "playback_route_diagnostics",
                "device_quirks_v1", "seek_reanchor_v1", "output_change_v1", "direct_stream_resume_v1",
                "header_authenticated_media_v1", "authorized_media_origins_v1", "software_video_decode_v1",
-               "plan_invalidated_v1", "plan_source_duration_v1"],
+               "plan_invalidated_v1", "capability_warming_v1", "plan_source_duration_v1"],
   "deliveries": ["original_http", "server_remux_progressive", "server_remux_hls", "server_transcode_hls"],
   "transformations": [{"name": "audio_to_aac", "executor": "server", "recipe_version": "1", "validated_claims": ["audio_decode"]}]
 }
 ```
 
-The thirteen feature strings above are the full set this server version advertises:
+The fourteen feature strings above are the full set this server version advertises:
 
 | Feature | What it promises |
 | --- | --- |
@@ -128,6 +128,7 @@ The thirteen feature strings above are the full set this server version advertis
 | `authorized_media_origins_v1` | Meaningful only with the token above: the client also honors credential-free absolute media URLs on server-designated proxy origins, which restores distributed egress for a header-authenticated attempt (§4.1) |
 | `software_video_decode_v1` | Exact/platform-attested clients may qualify bounded `video_decode[]` entries with `hardware: false` for direct/original delivery; without the opt-in those evidence tiers remain hardware-only (§3) |
 | `plan_invalidated_v1` | The client can be told mid-session that the plan it is playing was withdrawn, over the realtime `plan_invalidated` command, and replans off it. A session that did not negotiate it is stopped instead (§6.1) |
+| `capability_warming_v1` | Decisions may return the retryable `capability_warming` terminal with `retry_after_ms`; clients may wait and retry the same requested file instead of treating the incomplete inventory as definitive (§7.3) |
 | `plan_source_duration_v1` | `source.duration_seconds` is populated when known, so its absence means *unknown* rather than *unsupported* (§5) |
 
 That last one is the reason feature detection is a list and not a version
@@ -986,7 +987,9 @@ HDR, 4K, or transcode-policy reason — deselecting the subtitle restores playba
 `capability_warming` means the bounded planning request ended before the shared
 tone-map inventory became definitive. It is retryable and never authorizes an
 alternate media-file selection; a client should keep the requested file pinned
-while retrying.
+while retrying. Automatic retry requires the server-advertised
+`capability_warming_v1` feature; without it, a client treats the terminal as a
+normal adaptation refusal and surfaces the server message.
 
 ### 7.4 Route event names
 

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -73,14 +73,19 @@ All paths are relative to `/api/v1`. Every endpoint requires an authenticated
 user. The mutation endpoints additionally require a profile, supplied as the
 `X-Profile-Id` header.
 
-Every non-2xx response body is the standard error envelope:
+Every non-2xx response body includes the standard error envelope:
 
 ```json
 {"error": "<machine_code>", "message": "<human sentence>"}
 ```
 
 The `error` code is the stable part; the `message` is for logs and is not
-contract.
+contract. An endpoint may add fields that help the client recover. In
+particular, a replan rejected after the server can prove `failed_plan_id` is no
+longer current includes `current_decision`, a complete playable
+`DecisionResponseV3` for the session's durably committed plan. A client can
+adopt that decision instead of stopping a session whose replacement completed
+while its response was in flight.
 
 ### 2.1 `GET /playback/capability`
 
@@ -236,7 +241,7 @@ body cap: 256 KiB. Body: `ReplanRequestV3`
 | `401` | `unauthorized` | No authenticated user, or no `X-Profile-Id` |
 | `403` | `forbidden` | The session belongs to another user or profile |
 | `404` | `playback_session_not_found` | No such session, or its session has ended |
-| `409` | `stale_playback_plan` | `failed_plan_id` is not the session's current plan, `playback_attempt_id` is not the session's attempt, or a newer replacement is already active |
+| `409` | `stale_playback_plan` | `failed_plan_id` is not the session's current plan, `playback_attempt_id` is not the session's attempt, or a newer replacement is already active. When the server rejects a superseded `failed_plan_id` or completed request against a known current plan, the body also carries its playable `current_decision`. |
 | `409` | `idempotency_key_reused` | This `replan_request_id` was used for a different replan |
 | `409` | `replan_in_progress` | A replan for this session holds the lease right now |
 | `503` | `replan_capacity_exhausted` | Server-wide concurrent replan limit (8) reached; retryable |

--- a/docs/design/schemas/playback-v3/v3/decision-response.schema.json
+++ b/docs/design/schemas/playback-v3/v3/decision-response.schema.json
@@ -101,6 +101,11 @@
         },
         "retryable": {
           "type": "boolean"
+        },
+        "retry_after_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional server hint for the delay before retrying this terminal decision."
         }
       },
       "additionalProperties": true

--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
@@ -16,6 +16,7 @@
     "authorized_media_origins_v1",
     "software_video_decode_v1",
     "plan_invalidated_v1",
+    "capability_warming_v1",
     "plan_source_duration_v1"
   ],
   "deliveries": [

--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/decision_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/decision_response.json
@@ -13,6 +13,7 @@
     "authorized_media_origins_v1",
     "software_video_decode_v1",
     "plan_invalidated_v1",
+    "capability_warming_v1",
     "plan_source_duration_v1"
   ],
   "outcome": "playable",

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,16 @@
 
 ## 2026-08-24
 
+### Keep the selected media version while the transcoder warms up
+The first HDR playback after a server restart no longer treats a still-running
+tone-map capability check as proof that the selected 4K version cannot play.
+Silo warms the capability inventory in the background, keeps the requested file
+pinned while discovery is incomplete, and lets the web player retry briefly
+with a visible preparing state. A lower-resolution version is considered only
+after a definitive result says the selected version has no route. Subtitle
+remapping between versions also uses the track's descriptive metadata and
+refuses ambiguous duplicate tracks instead of silently choosing the first one.
+
 ### Start audiobook playback once after browser capability detection
 The web audiobook player now waits for the browser's capability check to finish before requesting a playback session. It previously reacted to each intermediate capability result, creating and immediately replacing multiple sessions when one play request should have produced only one.
 

--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -6,9 +6,10 @@
 The first HDR playback after a server restart no longer treats a still-running
 tone-map capability check as proof that the selected 4K version cannot play.
 Silo warms the capability inventory in the background, keeps the requested file
-pinned while discovery is incomplete, and lets the web player retry briefly
-with a visible preparing state. A lower-resolution version is considered only
-after a definitive result says the selected version has no route. Subtitle
+pinned while discovery is incomplete, and advertises the retry contract so the
+web player can wait through the bounded probe window with a visible preparing
+state. A lower-resolution version is considered only after a definitive result
+says the selected version has no route. Subtitle
 remapping between versions also uses the track's descriptive metadata and
 refuses ambiguous duplicate tracks instead of silently choosing the first one.
 

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -251,6 +251,11 @@ type PlaybackHandler struct {
 	v3Registry           *playback.TransformationRegistryV3
 	v3RegistryProbe      func(context.Context, string, tonemap.Capabilities) (*playback.TransformationRegistryV3, error)
 	v3ToneMapProbe       func(context.Context, string, string, string) (tonemap.Capabilities, error)
+	v3HWAccelMu          sync.Mutex
+	v3HWAccelKey         string
+	v3HWAccelResolved    string
+	v3HWAccelExpiresAt   time.Time
+	v3HWAccelResolver    func(context.Context, string, string) string
 	v3NodeCapabilitiesMu sync.Mutex
 	v3NodeCapabilities   map[string]v3NodeCapabilityCache
 	v3EventOnce          sync.Once

--- a/internal/api/handlers/playback_transport.go
+++ b/internal/api/handlers/playback_transport.go
@@ -95,6 +95,13 @@ func fetchRemoteTranscodeCapabilities(ctx context.Context, nodeURL, jwtSecret st
 		return playback.HWAccelInfo{}, err
 	}
 	if status != http.StatusOK {
+		// A cold node reports 503 while its live capability probe is still
+		// resolving. Preserve that as an incomplete snapshot so planning pins the
+		// requested version and lets the client retry instead of treating the node
+		// as definitively incapable.
+		if status == http.StatusServiceUnavailable {
+			return playback.HWAccelInfo{}, fmt.Errorf("%w: node returned %d", errRemoteCapabilityWarmingV3, status)
+		}
 		return playback.HWAccelInfo{}, fmt.Errorf("node returned %d", status)
 	}
 	info.Source = "transcode_node"

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -48,6 +48,7 @@ const (
 	capabilityWarmingReasonV3    = "capability_warming"
 	capabilityWarmRetryAfterV3   = 250 * time.Millisecond
 	probePositiveTTLForHWAccelV3 = 5 * time.Minute
+	probeNegativeTTLForHWAccelV3 = 15 * time.Second
 	seekRestorationPlayerV3      = "player_position"
 	// Failed capability fetches are memoized briefly so an unreachable node
 	// costs one timeout per window instead of one per planning request.
@@ -272,10 +273,17 @@ func (h *PlaybackHandler) resolveLocalHWAccelV3(ctx context.Context, cfg config.
 	if ctx.Err() != nil {
 		return resolved
 	}
+	ttl := probePositiveTTLForHWAccelV3
+	if strings.EqualFold(strings.TrimSpace(cfg.HWAccel), "auto") && resolved == playback.HWAccelNone {
+		// Auto-detection can return none after a transient driver/encoder probe
+		// failure. Match the detector's own short negative cache instead of
+		// promoting that result to a five-minute positive.
+		ttl = probeNegativeTTLForHWAccelV3
+	}
 	h.v3HWAccelMu.Lock()
 	h.v3HWAccelKey = key
 	h.v3HWAccelResolved = resolved
-	h.v3HWAccelExpiresAt = now.Add(probePositiveTTLForHWAccelV3)
+	h.v3HWAccelExpiresAt = now.Add(ttl)
 	h.v3HWAccelMu.Unlock()
 	return resolved
 }

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -45,6 +45,9 @@ const (
 	subtitleMIMEVTTV3            = "text/vtt"
 	subtitleUnavailableReasonV3  = "subtitle_artifact_unavailable"
 	transcodeStartFailedReasonV3 = "transcode_start_failed"
+	capabilityWarmingReasonV3    = "capability_warming"
+	capabilityWarmRetryAfterV3   = 250 * time.Millisecond
+	probePositiveTTLForHWAccelV3 = 5 * time.Minute
 	seekRestorationPlayerV3      = "player_position"
 	// Failed capability fetches are memoized briefly so an unreachable node
 	// costs one timeout per window instead of one per planning request.
@@ -228,7 +231,7 @@ func (h *PlaybackHandler) transformationRegistryV3(ctx context.Context) *playbac
 func (h *PlaybackHandler) localToneMapCapabilitiesV3(ctx context.Context) (tonemap.Capabilities, error) {
 	cfg := h.playbackConfig()
 	ffmpegPath := playback.ResolveFFmpegPath(cfg.FFmpegPath)
-	resolved := playback.ResolveHWAccelWithFFmpegContext(ctx, cfg.HWAccel, cfg.FFmpegPath)
+	resolved := h.resolveLocalHWAccelV3(ctx, cfg, ffmpegPath)
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -239,6 +242,33 @@ func (h *PlaybackHandler) localToneMapCapabilitiesV3(ctx context.Context) (tonem
 	}
 	capabilities, err := probe(ctx, ffmpegPath, resolved, hwDevice)
 	return append(tonemap.Capabilities(nil), capabilities...), err
+}
+
+func (h *PlaybackHandler) resolveLocalHWAccelV3(ctx context.Context, cfg config.PlaybackConfig, ffmpegPath string) string {
+	key := strings.Join([]string{ffmpegPath, strings.TrimSpace(cfg.HWAccel), strings.TrimSpace(cfg.HWDevice)}, "\x00")
+	now := time.Now()
+	h.v3HWAccelMu.Lock()
+	if h.v3HWAccelKey == key && now.Before(h.v3HWAccelExpiresAt) {
+		resolved := h.v3HWAccelResolved
+		h.v3HWAccelMu.Unlock()
+		return resolved
+	}
+	h.v3HWAccelMu.Unlock()
+
+	resolver := playback.ResolveHWAccelWithFFmpegContext
+	if h.v3HWAccelResolver != nil {
+		resolver = h.v3HWAccelResolver
+	}
+	resolved := resolver(ctx, cfg.HWAccel, cfg.FFmpegPath)
+	if ctx.Err() != nil {
+		return resolved
+	}
+	h.v3HWAccelMu.Lock()
+	h.v3HWAccelKey = key
+	h.v3HWAccelResolved = resolved
+	h.v3HWAccelExpiresAt = now.Add(probePositiveTTLForHWAccelV3)
+	h.v3HWAccelMu.Unlock()
+	return resolved
 }
 
 func (h *PlaybackHandler) localToneMapCapabilitiesForTransportV3(ctx context.Context) (tonemap.Capabilities, error) {
@@ -267,6 +297,61 @@ func (h *PlaybackHandler) toneMapPlanningTimeoutV3(localFallbackAllowed bool) ti
 		return v3NodeCapabilityPlanTimeout
 	}
 	return remoteNodeProbeFallbackTimeout
+}
+
+// StartToneMapCapabilityWarmup begins a best-effort capability inventory after
+// runtime config, settings, and node planning have been wired. It deliberately
+// does not gate global readiness: a cold or unavailable transcoder is a
+// playback-subsystem state, not an API-server outage.
+func (h *PlaybackHandler) StartToneMapCapabilityWarmup(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	go h.warmToneMapCapabilitiesV3(ctx)
+}
+
+func (h *PlaybackHandler) warmToneMapCapabilitiesV3(ctx context.Context) {
+	settings, err := h.plannerSettingsV3Result(ctx)
+	if err != nil {
+		slog.DebugContext(ctx, "tone-map capability warmup skipped while playback settings are unavailable", logComponentKey, "playback", "error", err)
+		return
+	}
+	if tonemap.NewPolicy(settings.HardwareToneMapEnabled, settings.SoftwareToneMapEnabled) == tonemap.PolicyNone {
+		return
+	}
+
+	localAllowed := h.NodePlanner == nil || nodepool.LocalTranscodeFallbackAllowed(ctx, h.SettingsRepo)
+	var nodeURLs []string
+	if enumerator, ok := h.NodePlanner.(transcodeNodeEnumeratorV3); ok {
+		nodeURLs = enumerator.TranscodeNodeURLs()
+	}
+
+	var wg sync.WaitGroup
+	if localAllowed {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, probeErr := h.localToneMapCapabilitiesForTransportV3(ctx); probeErr != nil && ctx.Err() == nil {
+				slog.DebugContext(ctx, "local tone-map capability warmup incomplete", logComponentKey, "playback", "error", probeErr)
+			}
+		}()
+	}
+	for _, nodeURL := range nodeURLs {
+		nodeURL := nodeURL
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			probeCtx, cancel := context.WithTimeout(ctx, h.remoteToneMapProbeTimeoutV3(nodeURL))
+			defer cancel()
+			if _, probeErr := h.remoteToneMapCapabilitiesV3(probeCtx, nodeURL, false); probeErr != nil && ctx.Err() == nil {
+				slog.DebugContext(ctx, "remote tone-map capability warmup incomplete", logComponentKey, "playback", "node", logredact.SanitizeURL(nodeURL), "error", probeErr)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // remoteTransformationsV3 is the transport-time capability lookup for a
@@ -542,7 +627,9 @@ func (h *PlaybackHandler) hlsToneMapCapabilityInventoryV3(ctx context.Context) (
 	var probeErr error
 	if localAllowed {
 		if localResult.err != nil {
-			probeErr = errors.Join(probeErr, localResult.err)
+			if toneMapCapabilityDiscoveryIncompleteV3(localResult.err) {
+				probeErr = errors.Join(probeErr, localResult.err)
+			}
 		} else {
 			inventory.local = localResult.capabilities
 			inventory.union = append(inventory.union, localResult.capabilities...)
@@ -550,7 +637,13 @@ func (h *PlaybackHandler) hlsToneMapCapabilityInventoryV3(ctx context.Context) (
 	}
 	for _, remote := range results {
 		if remote.err != nil {
-			probeErr = errors.Join(probeErr, remote.err)
+			// A node that completed with an ordinary transport or protocol
+			// failure is definitively unavailable for this snapshot. Only a
+			// canceled/deadline-bounded lookup means discovery is still in
+			// progress and must defer an irreversible version fallback.
+			if toneMapCapabilityDiscoveryIncompleteV3(remote.err) {
+				probeErr = errors.Join(probeErr, remote.err)
+			}
 			continue
 		}
 		inventory.union = append(inventory.union, remote.capabilities...)
@@ -573,12 +666,10 @@ type hlsPlanningSnapshotV3 struct {
 	registry  *playback.TransformationRegistryV3
 	inventory hlsToneMapCapabilityInventoryV3
 	err       error
-	resolved  bool
 }
 
 func (snapshot *hlsPlanningSnapshotV3) resolve() {
 	snapshot.once.Do(func() {
-		snapshot.resolved = true
 		policy := tonemap.NewPolicy(snapshot.settings.HardwareToneMapEnabled, snapshot.settings.SoftwareToneMapEnabled)
 		if policy != tonemap.PolicyNone {
 			snapshot.inventory, snapshot.err = snapshot.handler.hlsToneMapCapabilityInventoryV3(snapshot.ctx)
@@ -598,27 +689,48 @@ func (snapshot *hlsPlanningSnapshotV3) toneMapCapabilities() tonemap.Capabilitie
 }
 
 func (snapshot *hlsPlanningSnapshotV3) capabilityError() error {
-	if !snapshot.resolved {
-		return nil
-	}
 	return snapshot.err
 }
 
-func retryIncompleteToneMapPlanningV3(result playback.PlannerResultV3, capabilityErr error) playback.PlannerResultV3 {
-	if capabilityErr == nil || result.Terminal == nil {
-		return result
+func toneMapCapabilityDiscoveryIncompleteV3(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func terminalDependsOnToneMapCapabilitiesV3(terminal *playback.TerminalV3) bool {
+	if terminal == nil {
+		return false
 	}
-	switch result.Terminal.Reason {
-	case playback.TerminalHDRTranscodeUnsupportedV3, terminalSubtitleConversionUnsupportedV3:
-	default:
+	return terminal.Reason == playback.TerminalHDRTranscodeUnsupportedV3 ||
+		(terminal.Reason == terminalSubtitleConversionUnsupportedV3 && strings.Contains(terminal.Message, "this HDR source"))
+}
+
+func retryIncompleteToneMapPlanningV3(result playback.PlannerResultV3, capabilityErr error) playback.PlannerResultV3 {
+	if capabilityErr == nil || !terminalDependsOnToneMapCapabilitiesV3(result.Terminal) {
 		return result
 	}
 	result.Terminal = &playback.TerminalV3{
-		Reason:    transcodeStartFailedReasonV3,
-		Message:   "Tone-map capability discovery is temporarily unavailable.",
-		Retryable: true,
+		Reason:           capabilityWarmingReasonV3,
+		Message:          "Tone-map capability discovery is still warming.",
+		Retryable:        true,
+		RetryAfterMillis: capabilityWarmRetryAfterV3.Milliseconds(),
 	}
 	return result
+}
+
+// fallbackPlanningInputsCompleteV3 prevents a transiently incomplete settings
+// or executor snapshot from becoming an irreversible media-version choice.
+// A definitive terminal may still select a compatible alternate.
+func fallbackPlanningInputsCompleteV3(toneMapCapabilityErr, settingsErr error) bool {
+	return toneMapCapabilityErr == nil && settingsErr == nil
+}
+
+func terminalDecisionResponseV3(terminal *playback.TerminalV3) playback.DecisionResponseV3 {
+	if terminal == nil {
+		return playback.DecisionResponseV3{}
+	}
+	response := playback.NewTerminalResponseV3(terminal.Reason, terminal.Message, terminal.Retryable)
+	response.Terminal.RetryAfterMillis = terminal.RetryAfterMillis
+	return response
 }
 
 func retryIncompletePlaybackSettingsV3(result playback.PlannerResultV3, settingsErr error) playback.PlannerResultV3 {
@@ -646,11 +758,8 @@ func (h *PlaybackHandler) planPlaybackWithCapabilitiesV3(ctx context.Context, in
 	input.HLSRegistry = snapshot.hlsRegistry
 	input.HLSToneMapCapabilities = snapshot.toneMapCapabilities
 	result := playback.PlanPlaybackV3(input)
-	if result.Terminal != nil {
-		switch result.Terminal.Reason {
-		case playback.TerminalHDRTranscodeUnsupportedV3, terminalSubtitleConversionUnsupportedV3:
-			return result, snapshot.capabilityError()
-		}
+	if terminalDependsOnToneMapCapabilitiesV3(result.Terminal) {
+		return result, snapshot.capabilityError()
 	}
 	return result, nil
 }
@@ -970,7 +1079,7 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 		Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(),
 		AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile),
 	})
-	if terminalAllowsAlternateFileV3(result.Terminal) && shouldTryAlternateFileV3(req.QualityPreference) {
+	if fallbackPlanningInputsCompleteV3(toneMapCapabilityErr, settingsErr) && terminalAllowsAlternateFileV3(result.Terminal) && shouldTryAlternateFileV3(req.QualityPreference) {
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			effectiveFile = h.ensurePlaybackProbe(r.Context(), alternate)
 			audioIndex = remapAudioIndexV3(requestedFile, effectiveFile, audioIndex)
@@ -1005,7 +1114,7 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 			"file_id", effectiveFile.ID,
 			"quality_preference", req.QualityPreference,
 		}, clientInfo.LogAttrs()...)...)
-		response, persistErr := h.persistTerminalStartDecisionV3(r.Context(), userID, profileID, req, requestDigests, requestedFile.ID, effectiveFile.ID, playback.NewTerminalResponseV3(result.Terminal.Reason, result.Terminal.Message, result.Terminal.Retryable))
+		response, persistErr := h.persistTerminalStartDecisionV3(r.Context(), userID, profileID, req, requestDigests, requestedFile.ID, effectiveFile.ID, terminalDecisionResponseV3(result.Terminal))
 		if persistErr != nil {
 			writeStartAttemptPersistenceErrorV3(w, persistErr)
 			return
@@ -3293,7 +3402,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	} else {
 		result, toneMapCapabilityErr = h.planPlaybackWithCapabilitiesV3(r.Context(), playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: plannerSettings, Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
 	}
-	if outputChange && result.Terminal != nil && effectiveFile.ID != currentEffectiveFile.ID {
+	if fallbackPlanningInputsCompleteV3(toneMapCapabilityErr, plannerSettingsErr) && outputChange && result.Terminal != nil && effectiveFile.ID != currentEffectiveFile.ID {
 		// Returning to the requested edition is speculative during an output
 		// refresh. Any terminal from that probe must fall back to the edition
 		// already playing, not only HDR/alternate-selection terminals: its audio,
@@ -3307,7 +3416,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		}
 		result, toneMapCapabilityErr = h.planPlaybackWithCapabilitiesV3(r.Context(), playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: plannerSettings, Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
 	}
-	if terminalAllowsAlternateFileV3(result.Terminal) && replanAllowsAlternateFileV3(operation, start.QualityPreference) {
+	if fallbackPlanningInputsCompleteV3(toneMapCapabilityErr, plannerSettingsErr) && terminalAllowsAlternateFileV3(result.Terminal) && replanAllowsAlternateFileV3(operation, start.QualityPreference) {
 		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
 			alternate = h.ensurePlaybackProbe(r.Context(), alternate)
 			remappedAudio := remapAudioIndexV3(effectiveFile, alternate, audioIndex)
@@ -3349,7 +3458,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		result = escalated
 	}
 	if result.Terminal != nil {
-		return playback.NewTerminalResponseV3(result.Terminal.Reason, result.Terminal.Message, result.Terminal.Retryable), *record, nil, nil
+		return terminalDecisionResponseV3(result.Terminal), *record, nil, nil
 	}
 	session, err := h.sessionMgr.GetSession(record.SessionID)
 	if err != nil {
@@ -4329,6 +4438,42 @@ func remapAudioSelectionV3(source, target *models.MediaFile, request *playback.S
 	return nil
 }
 
+func selectSubtitleRemapCandidateV3(baseMatches, exactMatches []int) (int, bool) {
+	if len(exactMatches) == 1 {
+		return exactMatches[0], false
+	}
+	if len(exactMatches) > 1 {
+		return -1, true
+	}
+	if len(baseMatches) == 1 {
+		return baseMatches[0], false
+	}
+	return -1, len(baseMatches) > 1
+}
+
+func sameEmbeddedSubtitleMetadataV3(left, right models.SubtitleTrack) bool {
+	return strings.EqualFold(strings.TrimSpace(left.Title), strings.TrimSpace(right.Title)) &&
+		strings.EqualFold(strings.TrimSpace(left.EmbeddedTitle), strings.TrimSpace(right.EmbeddedTitle)) &&
+		strings.EqualFold(strings.TrimSpace(left.Resolution), strings.TrimSpace(right.Resolution)) &&
+		left.Default == right.Default &&
+		left.HearingImpaired == right.HearingImpaired &&
+		left.External == right.External
+}
+
+func sameExternalSubtitleMetadataV3(left, right models.ExternalSubtitle) bool {
+	return strings.EqualFold(strings.TrimSpace(left.Title), strings.TrimSpace(right.Title)) &&
+		strings.EqualFold(strings.TrimSpace(left.EmbeddedTitle), strings.TrimSpace(right.EmbeddedTitle)) &&
+		strings.EqualFold(strings.TrimSpace(left.Resolution), strings.TrimSpace(right.Resolution)) &&
+		left.Default == right.Default &&
+		left.HearingImpaired == right.HearingImpaired
+}
+
+func sameDownloadedSubtitleMetadataV3(left, right subtitles.DownloadedSubtitle) bool {
+	return strings.EqualFold(strings.TrimSpace(left.ReleaseName), strings.TrimSpace(right.ReleaseName)) &&
+		strings.EqualFold(strings.TrimSpace(left.Provider), strings.TrimSpace(right.Provider)) &&
+		left.HearingImpaired == right.HearingImpaired
+}
+
 func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, target *models.MediaFile, request *playback.StartRequestV3) error {
 	if request == nil || source == nil || target == nil || source.ID == target.ID {
 		return nil
@@ -4351,23 +4496,35 @@ func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, 
 		return errors.New("The selected subtitle track index is invalid.")
 	}
 	targetIndex := -1
+	ambiguous := false
 	switch {
 	case index < len(source.ExternalSubtitles):
 		wanted := source.ExternalSubtitles[index]
+		baseMatches := make([]int, 0)
+		exactMatches := make([]int, 0)
 		for candidateIndex, candidate := range target.ExternalSubtitles {
 			if strings.EqualFold(candidate.Language, wanted.Language) && strings.EqualFold(candidate.Format, wanted.Format) && candidate.Forced == wanted.Forced {
-				targetIndex = candidateIndex
-				break
+				baseMatches = append(baseMatches, candidateIndex)
+				if sameExternalSubtitleMetadataV3(candidate, wanted) {
+					exactMatches = append(exactMatches, candidateIndex)
+				}
 			}
 		}
+		targetIndex, ambiguous = selectSubtitleRemapCandidateV3(baseMatches, exactMatches)
 	case index < len(source.ExternalSubtitles)+len(source.SubtitleTracks):
 		wanted := source.SubtitleTracks[index-len(source.ExternalSubtitles)]
+		baseMatches := make([]int, 0)
+		exactMatches := make([]int, 0)
 		for candidateIndex, candidate := range target.SubtitleTracks {
 			if strings.EqualFold(candidate.Language, wanted.Language) && strings.EqualFold(candidate.Codec, wanted.Codec) && candidate.Forced == wanted.Forced {
-				targetIndex = len(target.ExternalSubtitles) + candidateIndex
-				break
+				combinedIndex := len(target.ExternalSubtitles) + candidateIndex
+				baseMatches = append(baseMatches, combinedIndex)
+				if sameEmbeddedSubtitleMetadataV3(candidate, wanted) {
+					exactMatches = append(exactMatches, combinedIndex)
+				}
 			}
 		}
+		targetIndex, ambiguous = selectSubtitleRemapCandidateV3(baseMatches, exactMatches)
 	default:
 		if h.SubtitleRepo != nil {
 			sourceDownloaded, sourceErr := h.SubtitleRepo.ListDownloadedSubtitles(ctx, source.ID)
@@ -4375,14 +4532,23 @@ func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, 
 			downloadedIndex := index - len(source.ExternalSubtitles) - len(source.SubtitleTracks)
 			if sourceErr == nil && targetErr == nil && downloadedIndex >= 0 && downloadedIndex < len(sourceDownloaded) {
 				wanted := sourceDownloaded[downloadedIndex]
+				baseMatches := make([]int, 0)
+				exactMatches := make([]int, 0)
 				for candidateIndex, candidate := range targetDownloaded {
-					if strings.EqualFold(candidate.Language, wanted.Language) && strings.EqualFold(string(candidate.Format), string(wanted.Format)) && strings.EqualFold(candidate.ReleaseName, wanted.ReleaseName) {
-						targetIndex = len(target.ExternalSubtitles) + len(target.SubtitleTracks) + candidateIndex
-						break
+					if strings.EqualFold(candidate.Language, wanted.Language) && strings.EqualFold(string(candidate.Format), string(wanted.Format)) {
+						combinedIndex := len(target.ExternalSubtitles) + len(target.SubtitleTracks) + candidateIndex
+						baseMatches = append(baseMatches, combinedIndex)
+						if sameDownloadedSubtitleMetadataV3(candidate, wanted) {
+							exactMatches = append(exactMatches, combinedIndex)
+						}
 					}
 				}
+				targetIndex, ambiguous = selectSubtitleRemapCandidateV3(baseMatches, exactMatches)
 			}
 		}
+	}
+	if ambiguous {
+		return errors.New("selected subtitle track cannot be mapped unambiguously to the effective file version")
 	}
 	if targetIndex < 0 {
 		return errors.New("The selected subtitle track is unavailable in the effective file version.")

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -68,7 +68,10 @@ const (
 	nodeRecipeWriteTimeoutV3 = 2 * time.Second
 )
 
-var errSubtitleStoreUnavailableV3 = errors.New("subtitle store unavailable")
+var (
+	errSubtitleStoreUnavailableV3 = errors.New("subtitle store unavailable")
+	errRemoteCapabilityWarmingV3  = errors.New("remote capability discovery is still warming")
+)
 
 type v3NodeCapabilityCache struct {
 	transformations     []playback.TransformationV3
@@ -408,6 +411,13 @@ func (h *PlaybackHandler) lookupRemoteCapabilitiesV3(ctx context.Context, nodeUR
 			h.v3NodeCapabilitiesMu.Unlock()
 			return current, nil
 		}
+		// A planning deadline or an explicit warming response says nothing
+		// definitive about the node. Caching it for the ordinary failure TTL
+		// would make every bounded client retry replay the same stale error.
+		if toneMapCapabilityDiscoveryIncompleteV3(err) {
+			h.v3NodeCapabilitiesMu.Unlock()
+			return v3NodeCapabilityCache{}, err
+		}
 		h.v3NodeCapabilities[nodeURL] = v3NodeCapabilityCache{err: err, expiresAt: completedAt.Add(v3NodeCapabilityErrorTTL), probeRequestTimeout: entry.probeRequestTimeout}
 		h.v3NodeCapabilitiesMu.Unlock()
 		return v3NodeCapabilityCache{}, err
@@ -693,7 +703,7 @@ func (snapshot *hlsPlanningSnapshotV3) capabilityError() error {
 }
 
 func toneMapCapabilityDiscoveryIncompleteV3(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, errRemoteCapabilityWarmingV3)
 }
 
 func terminalDependsOnToneMapCapabilitiesV3(terminal *playback.TerminalV3) bool {
@@ -737,12 +747,11 @@ func retryIncompletePlaybackSettingsV3(result playback.PlannerResultV3, settings
 	if settingsErr == nil || result.Terminal == nil {
 		return result
 	}
-	terminal := result.Terminal
-	settingsDependent := terminal.Reason == playback.TerminalHDRTranscodeUnsupportedV3 ||
-		(terminal.Reason == terminalNoAlternateVersionV3 && terminal.Message == playback.TerminalMessage4KTranscodeDisabledV3) ||
-		(terminal.Reason == terminalSubtitleConversionUnsupportedV3 &&
-			(strings.Contains(terminal.Message, "this HDR source") || strings.Contains(terminal.Message, "4K transcoding is disabled")))
-	if !settingsDependent {
+	// A settings failure suppresses alternate-version planning above. Any
+	// terminal that would otherwise be eligible for that fallback is therefore
+	// provisional, even when its wording is about subtitles rather than HDR or
+	// the 4K policy directly.
+	if !terminalAllowsAlternateFileV3(result.Terminal) {
 		return result
 	}
 	result.Terminal = &playback.TerminalV3{

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -81,6 +81,12 @@ type v3NodeCapabilityCache struct {
 	probeRequestTimeout time.Duration
 }
 
+type stalePlaybackPlanResponseV3 struct {
+	Error           string                      `json:"error"`
+	Message         string                      `json:"message"`
+	CurrentDecision playback.DecisionResponseV3 `json:"current_decision"`
+}
+
 type preparedTransportV3 struct {
 	url                string
 	nodeURL            string
@@ -2935,6 +2941,25 @@ func downloadedSubtitleLabelV3(value subtitles.DownloadedSubtitle) string {
 	return value.ReleaseName + " (" + value.Provider + ")"
 }
 
+func writeStalePlaybackPlanV3(w http.ResponseWriter, record *playback.AttemptRecordV3) {
+	if record == nil || record.SessionID == "" || record.CurrentPlan.PlanID == "" {
+		writeError(w, http.StatusConflict, "stale_playback_plan", "The failed plan is no longer current")
+		return
+	}
+	plan := record.CurrentPlan
+	writeJSON(w, http.StatusConflict, stalePlaybackPlanResponseV3{
+		Error:   "stale_playback_plan",
+		Message: "The failed plan is no longer current",
+		CurrentDecision: playback.DecisionResponseV3{
+			ProtocolVersion: playback.ProtocolV3,
+			ServerFeatures:  playback.ServerFeaturesV3(),
+			Outcome:         playback.OutcomePlayableV3,
+			SessionID:       record.SessionID,
+			PlaybackPlan:    &plan,
+		},
+	})
+}
+
 // HandleReplanPlaybackV3 provides persistent idempotency and preserves the old
 // transport until a successor has entered its startup state and the new plan is
 // durably committed.
@@ -3056,7 +3081,7 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 	}
 	if lease.State == playback.ReplanLeaseCompletedV3 {
 		if record.CurrentReplanRequestID != req.ReplanRequestID || !completedReplanResponseMatchesAttemptV3(lease.Response, record) {
-			writeError(w, http.StatusConflict, "stale_playback_plan", "A newer replacement plan is already active")
+			writeStalePlaybackPlanV3(w, record)
 			return
 		}
 		if _, err := h.sessionMgr.GetSession(sessionID); err != nil {
@@ -3080,7 +3105,7 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 		}
 	}()
 	if record.CurrentPlanID != req.FailedPlanID {
-		writeError(w, http.StatusConflict, "stale_playback_plan", "The failed plan is no longer current")
+		writeStalePlaybackPlanV3(w, record)
 		return
 	}
 	response, updated, transport, replanErr := h.executeReplanV3(r, record, req)

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -4502,8 +4502,35 @@ func sameEmbeddedSubtitleMetadataV3(left, right models.SubtitleTrack) bool {
 		left.External == right.External
 }
 
-func sameExternalSubtitleMetadataV3(left, right models.ExternalSubtitle) bool {
-	return strings.EqualFold(strings.TrimSpace(left.Title), strings.TrimSpace(right.Title)) &&
+func externalSubtitleStableSuffixV3(file *models.MediaFile, subtitle models.ExternalSubtitle) (string, bool) {
+	if file == nil {
+		return "", false
+	}
+	mediaName := filepath.Base(strings.TrimSpace(file.FilePath))
+	mediaStem := strings.TrimSuffix(mediaName, filepath.Ext(mediaName))
+	subtitleName := filepath.Base(strings.TrimSpace(subtitle.Title))
+	if subtitleName == "." || subtitleName == "" {
+		subtitleName = filepath.Base(strings.TrimSpace(subtitle.Path))
+	}
+	subtitleStem := strings.TrimSuffix(subtitleName, filepath.Ext(subtitleName))
+	if mediaStem == "" || len(subtitleStem) < len(mediaStem) || !strings.EqualFold(subtitleStem[:len(mediaStem)], mediaStem) {
+		return "", false
+	}
+	suffix := subtitleStem[len(mediaStem):]
+	if suffix != "" && !strings.HasPrefix(suffix, ".") {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimPrefix(suffix, ".")), true
+}
+
+func sameExternalSubtitleMetadataV3(leftFile *models.MediaFile, left models.ExternalSubtitle, rightFile *models.MediaFile, right models.ExternalSubtitle) bool {
+	leftSuffix, leftHasSuffix := externalSubtitleStableSuffixV3(leftFile, left)
+	rightSuffix, rightHasSuffix := externalSubtitleStableSuffixV3(rightFile, right)
+	titleMatches := strings.EqualFold(strings.TrimSpace(left.Title), strings.TrimSpace(right.Title))
+	if leftHasSuffix && rightHasSuffix {
+		titleMatches = leftSuffix == rightSuffix
+	}
+	return titleMatches &&
 		strings.EqualFold(strings.TrimSpace(left.EmbeddedTitle), strings.TrimSpace(right.EmbeddedTitle)) &&
 		strings.EqualFold(strings.TrimSpace(left.Resolution), strings.TrimSpace(right.Resolution)) &&
 		left.Default == right.Default &&
@@ -4547,7 +4574,7 @@ func (h *PlaybackHandler) remapSubtitleSelectionV3(ctx context.Context, source, 
 		for candidateIndex, candidate := range target.ExternalSubtitles {
 			if strings.EqualFold(candidate.Language, wanted.Language) && strings.EqualFold(candidate.Format, wanted.Format) && candidate.Forced == wanted.Forced {
 				baseMatches = append(baseMatches, candidateIndex)
-				if sameExternalSubtitleMetadataV3(candidate, wanted) {
+				if sameExternalSubtitleMetadataV3(target, candidate, source, wanted) {
 					exactMatches = append(exactMatches, candidateIndex)
 				}
 			}

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -40,6 +40,39 @@ type mutablePlaybackSettingsV3 struct {
 	getErrors map[string]error
 }
 
+func TestResolveLocalHWAccelV3CachesFailedAutoDetectionBriefly(t *testing.T) {
+	handler := &PlaybackHandler{}
+	var calls int
+	handler.v3HWAccelResolver = func(context.Context, string, string) string {
+		calls++
+		if calls == 1 {
+			return playback.HWAccelNone
+		}
+		return tonemap.BackendNVENC
+	}
+	cfg := config.PlaybackConfig{HWAccel: "auto"}
+
+	if got := handler.resolveLocalHWAccelV3(context.Background(), cfg, "/ffmpeg"); got != playback.HWAccelNone {
+		t.Fatalf("first resolution = %q, want none", got)
+	}
+	handler.v3HWAccelMu.Lock()
+	negativeTTL := time.Until(handler.v3HWAccelExpiresAt)
+	handler.v3HWAccelMu.Unlock()
+	if negativeTTL <= 0 || negativeTTL > probeNegativeTTLForHWAccelV3+time.Second {
+		t.Fatalf("negative auto-detection TTL = %s, want about %s", negativeTTL, probeNegativeTTLForHWAccelV3)
+	}
+	if got := handler.resolveLocalHWAccelV3(context.Background(), cfg, "/ffmpeg"); got != playback.HWAccelNone || calls != 1 {
+		t.Fatalf("cached resolution = %q after %d calls, want none after one call", got, calls)
+	}
+
+	handler.v3HWAccelMu.Lock()
+	handler.v3HWAccelExpiresAt = time.Now().Add(-time.Second)
+	handler.v3HWAccelMu.Unlock()
+	if got := handler.resolveLocalHWAccelV3(context.Background(), cfg, "/ffmpeg"); got != tonemap.BackendNVENC || calls != 2 {
+		t.Fatalf("refreshed resolution = %q after %d calls, want nvenc after two calls", got, calls)
+	}
+}
+
 type failingAudioPreferenceStoreV3 struct {
 	userstore.UserStore
 	err error

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -259,6 +259,72 @@ func TestHandleStartPlaybackV3TriesAlternateAfterHDRTerminal(t *testing.T) {
 	}
 }
 
+func TestHandleStartPlaybackV3DoesNotTryAlternateWhileToneMapCapabilitiesAreIncomplete(t *testing.T) {
+	source := v3HandlerFixtureFile(t)
+	source.CodecVideo = "hevc"
+	source.Resolution = "2160p"
+	source.Bitrate = 32_000
+	source.VideoTracks[0] = models.VideoTrack{
+		Codec: "hevc", Profile: "main 10", Level: 150, Width: 3840, Height: 2160,
+		FrameRate: "24000/1001", Bitrate: 32_000, BitDepth: 10,
+		VideoRange: "DolbyVision", VideoRangeType: "DOVIWithHDR10", DVProfile: 8, DVBLCompatID: 1,
+	}
+	alternateValue := *source
+	alternate := &alternateValue
+	alternate.ID = 84
+	alternate.CodecVideo = "h264"
+	alternate.Resolution = "1080p"
+	alternate.Bitrate = 8_000
+	alternate.VideoTracks = []models.VideoTrack{{
+		Codec: "h264", Profile: "high", Level: 41, Width: 1920, Height: 1080,
+		FrameRate: "24000/1001", Bitrate: 8_000, BitDepth: 8, VideoRange: "SDR", VideoRangeType: "SDR",
+	}}
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), testPlaybackFileResolver{file: source})
+	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{
+		source.ContentID: {source, alternate},
+	}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{
+		config.Allow4KTranscodeSettingKey:                 "true",
+		config.PlaybackTranscodeHardwareToneMapSettingKey: "true",
+		config.PlaybackTranscodeSoftwareToneMapSettingKey: "true",
+	}}
+	handler.PlaybackConfig = playbackTestConfig("", "none")
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	handler.v3ToneMapProbe = func(context.Context, string, string, string) (tonemap.Capabilities, error) {
+		return nil, context.DeadlineExceeded
+	}
+	presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{
+		{Name: playback.TransformationVideoToH264V3, RecipeVersion: playback.TransformationVideoToH264RecipeVersionV3, Available: true},
+		{Name: playback.TransformationAudioToAACV3, RecipeVersion: "1", Available: true},
+		{Name: playback.TransformationHDRToSDRToneMapV3, RecipeVersion: playback.TransformationHDRToSDRToneMapRecipeVersionV3},
+	}))
+
+	start := v3HandlerStartRequest()
+	start.QualityPreference = "auto"
+	start.ClientPlaybackContext.Deliveries[playback.DeliveryClassHLSV3] = playback.DeliveryCapabilityV3{
+		Enabled: true, SupportedOnDevice: true, Containers: []string{"hls"},
+		VideoCodecs: []string{"h264"}, AudioDecodeCodecs: []string{"aac"},
+	}
+	recorder := httptest.NewRecorder()
+	handler.HandleStartPlayback(recorder, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, start))).WithContext(newAuthorizedPlaybackContext()))
+
+	var response playback.DecisionResponseV3
+	if recorder.Code != http.StatusCreated || json.Unmarshal(recorder.Body.Bytes(), &response) != nil || response.Terminal == nil {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if response.Terminal.Reason != "capability_warming" || !response.Terminal.Retryable || response.Terminal.RetryAfterMillis <= 0 {
+		t.Fatalf("terminal = %#v, want retryable capability_warming", response.Terminal)
+	}
+	record, err := handler.PlanStoreV3.GetAttemptByPlaybackAttemptID(context.Background(), start.PlaybackAttemptID)
+	if err != nil {
+		t.Fatalf("load playback attempt: %v", err)
+	}
+	if record.RequestedMediaFileID != source.ID || record.EffectiveMediaFileID != source.ID {
+		t.Fatalf("attempt files = requested %d effective %d, want source %d pinned", record.RequestedMediaFileID, record.EffectiveMediaFileID, source.ID)
+	}
+}
+
 func TestReplanAllowsAlternateFileV3PinsSeekOperations(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -3262,6 +3328,78 @@ func TestRemapSubtitleSelectionV3RejectsNegativeIndex(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err == nil {
 		t.Fatal("negative subtitle index was accepted")
+	}
+}
+
+func TestRemapSubtitleSelectionV3UsesTrackMetadataAndRejectsAmbiguity(t *testing.T) {
+	source := &models.MediaFile{ID: 1, SubtitleTracks: []models.SubtitleTrack{
+		{Index: 4, Codec: "hdmv_pgs_subtitle", Language: "eng", Title: "English SDH", HearingImpaired: true},
+		{Index: 5, Codec: "hdmv_pgs_subtitle", Language: "eng", Title: "English Commentary"},
+	}}
+	target := &models.MediaFile{ID: 2, SubtitleTracks: []models.SubtitleTrack{
+		{Index: 7, Codec: "hdmv_pgs_subtitle", Language: "eng", Title: "English SDH", HearingImpaired: true},
+		{Index: 8, Codec: "hdmv_pgs_subtitle", Language: "eng", Title: "English Commentary"},
+	}}
+	selected := 1
+	request := playback.StartRequestV3{SubtitleTrackIndex: &selected}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+
+	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err != nil {
+		t.Fatalf("remap commentary subtitle: %v", err)
+	}
+	if request.SubtitleTrackIndex == nil || *request.SubtitleTrackIndex != 1 {
+		t.Fatalf("remapped subtitle index = %v, want commentary index 1", request.SubtitleTrackIndex)
+	}
+
+	target.SubtitleTracks[0] = models.SubtitleTrack{Index: 7, Codec: "hdmv_pgs_subtitle", Language: "eng"}
+	target.SubtitleTracks[1] = models.SubtitleTrack{Index: 8, Codec: "hdmv_pgs_subtitle", Language: "eng"}
+	request.SubtitleTrackIndex = &selected
+	request.SubtitleTrackID = ""
+	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err == nil {
+		t.Fatal("ambiguous embedded subtitle remap was accepted")
+	}
+}
+
+func TestRemapSubtitleSelectionV3UsesDownloadedMetadataAndRejectsAmbiguity(t *testing.T) {
+	source := &models.MediaFile{ID: 1}
+	target := &models.MediaFile{ID: 2}
+	selected := 0
+	wanted := subtitles.DownloadedSubtitle{
+		ID: 10, MediaFileID: source.ID, Language: "eng", Format: subtitles.FormatSRT,
+		ReleaseName: "Feature Commentary", Provider: "provider-a",
+	}
+
+	repo := newMockSubtitleRepoForHandler()
+	repo.listResults = [][]subtitles.DownloadedSubtitle{
+		{wanted},
+		{
+			{ID: 20, MediaFileID: target.ID, Language: "eng", Format: subtitles.FormatSRT, ReleaseName: "Main dialog", Provider: "provider-a"},
+			{ID: 21, MediaFileID: target.ID, Language: "eng", Format: subtitles.FormatSRT, ReleaseName: "Feature Commentary", Provider: "provider-a"},
+		},
+	}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.SubtitleRepo = repo
+	request := playback.StartRequestV3{SubtitleTrackIndex: &selected}
+	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err != nil {
+		t.Fatalf("remap downloaded commentary subtitle: %v", err)
+	}
+	if request.SubtitleTrackIndex == nil || *request.SubtitleTrackIndex != 1 {
+		t.Fatalf("remapped downloaded subtitle index = %v, want commentary index 1", request.SubtitleTrackIndex)
+	}
+
+	repo = newMockSubtitleRepoForHandler()
+	repo.listResults = [][]subtitles.DownloadedSubtitle{
+		{wanted},
+		{
+			{ID: 22, MediaFileID: target.ID, Language: "eng", Format: subtitles.FormatSRT, ReleaseName: "Feature Commentary", Provider: "provider-a"},
+			{ID: 23, MediaFileID: target.ID, Language: "eng", Format: subtitles.FormatSRT, ReleaseName: "Feature Commentary", Provider: "provider-a"},
+		},
+	}
+	handler.SubtitleRepo = repo
+	request.SubtitleTrackIndex = &selected
+	request.SubtitleTrackID = ""
+	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err == nil {
+		t.Fatal("ambiguous downloaded subtitle remap was accepted")
 	}
 }
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -3405,6 +3405,43 @@ func TestRemapSubtitleSelectionV3UsesTrackMetadataAndRejectsAmbiguity(t *testing
 	}
 }
 
+func TestRemapSubtitleSelectionV3MatchesExternalSidecarSuffixAcrossVersions(t *testing.T) {
+	source := &models.MediaFile{
+		ID:       1,
+		FilePath: "/media/Movie.2160p.mkv",
+		ExternalSubtitles: []models.ExternalSubtitle{
+			{Path: "/media/Movie.2160p.commentary.en.srt", Title: "Movie.2160p.commentary.en.srt", Language: "eng", Format: "srt"},
+			{Path: "/media/Movie.2160p.sdh.en.srt", Title: "Movie.2160p.sdh.en.srt", Language: "eng", Format: "srt"},
+		},
+	}
+	target := &models.MediaFile{
+		ID:       2,
+		FilePath: "/media/Movie.1080p.mkv",
+		ExternalSubtitles: []models.ExternalSubtitle{
+			{Path: "/media/Movie.1080p.sdh.en.srt", Title: "Movie.1080p.sdh.en.srt", Language: "eng", Format: "srt"},
+			{Path: "/media/Movie.1080p.commentary.en.srt", Title: "Movie.1080p.commentary.en.srt", Language: "eng", Format: "srt"},
+		},
+	}
+	selected := 0
+	request := playback.StartRequestV3{SubtitleTrackIndex: &selected}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+
+	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err != nil {
+		t.Fatalf("remap commentary sidecar: %v", err)
+	}
+	if request.SubtitleTrackIndex == nil || *request.SubtitleTrackIndex != 1 {
+		t.Fatalf("remapped subtitle index = %v, want commentary index 1", request.SubtitleTrackIndex)
+	}
+
+	target.ExternalSubtitles[0].Title = "Movie.1080p.commentary.en.srt"
+	target.ExternalSubtitles[0].Path = "/media/Movie.1080p.commentary.en.srt"
+	request.SubtitleTrackIndex = &selected
+	request.SubtitleTrackID = ""
+	if err := handler.remapSubtitleSelectionV3(context.Background(), source, target, &request); err == nil {
+		t.Fatal("ambiguous external sidecar remap was accepted")
+	}
+}
+
 func TestRemapSubtitleSelectionV3UsesDownloadedMetadataAndRejectsAmbiguity(t *testing.T) {
 	source := &models.MediaFile{ID: 1}
 	target := &models.MediaFile{ID: 2}

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4924,7 +4925,7 @@ func TestLookupRemoteCapabilitiesStartsCacheTTLAfterRequestCompletes(t *testing.
 		ttl    time.Duration
 	}{
 		{name: "success", status: http.StatusOK, ttl: v3NodeCapabilityTTL},
-		{name: "error", status: http.StatusServiceUnavailable, ttl: v3NodeCapabilityErrorTTL},
+		{name: "error", status: http.StatusNotFound, ttl: v3NodeCapabilityErrorTTL},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			const requestDelay = 80 * time.Millisecond
@@ -4946,6 +4947,34 @@ func TestLookupRemoteCapabilitiesStartsCacheTTLAfterRequestCompletes(t *testing.
 				t.Fatalf("cache lifetime from request start = %s, want at least %s", lifetime, minimumLifetime)
 			}
 		})
+	}
+}
+
+func TestLookupRemoteCapabilitiesDoesNotCachePlanningDeadline(t *testing.T) {
+	var requests atomic.Int32
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if requests.Add(1) == 1 {
+			<-request.Context().Done()
+			return
+		}
+		_ = json.NewEncoder(w).Encode(playback.HWAccelInfo{})
+	}))
+	defer remote.Close()
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	firstCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer cancel()
+	if _, err := handler.lookupRemoteCapabilitiesV3(firstCtx, remote.URL, true); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("first lookup error = %v, want deadline exceeded", err)
+	}
+	if entry, ok := handler.v3NodeCapabilities[remote.URL]; ok && entry.err != nil && time.Now().Before(entry.expiresAt) {
+		t.Fatalf("planning deadline was negatively cached until %s", entry.expiresAt)
+	}
+	if _, err := handler.lookupRemoteCapabilitiesV3(context.Background(), remote.URL, true); err != nil {
+		t.Fatalf("retry lookup error = %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("remote requests = %d, want a fresh request after the deadline", requests.Load())
 	}
 }
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1418,6 +1418,10 @@ func TestHandleReplanPlaybackV3SeekReanchorKeepsCurrentRecipeEligible(t *testing
 	if newerRR.Code != http.StatusOK {
 		t.Fatalf("newer reanchor status = %d, body = %s", newerRR.Code, newerRR.Body.String())
 	}
+	var newerResponse playback.DecisionResponseV3
+	if err := json.Unmarshal(newerRR.Body.Bytes(), &newerResponse); err != nil {
+		t.Fatal(err)
+	}
 
 	staleRetryReq := httptest.NewRequest(http.MethodPost, "/api/v1/playback/"+started.SessionID+"/replan", strings.NewReader(string(body))).WithContext(newAuthorizedPlaybackContext())
 	staleRetryReq = withPlaybackRouteParam(staleRetryReq, "session_id", started.SessionID)
@@ -1425,6 +1429,13 @@ func TestHandleReplanPlaybackV3SeekReanchorKeepsCurrentRecipeEligible(t *testing
 	handler.HandleReplanPlaybackV3(staleRetryRR, staleRetryReq)
 	if staleRetryRR.Code != http.StatusConflict || !strings.Contains(staleRetryRR.Body.String(), "stale_playback_plan") {
 		t.Fatalf("stale reanchor replay status = %d, body = %s", staleRetryRR.Code, staleRetryRR.Body.String())
+	}
+	var staleResponse stalePlaybackPlanResponseV3
+	if err := json.Unmarshal(staleRetryRR.Body.Bytes(), &staleResponse); err != nil {
+		t.Fatal(err)
+	}
+	if staleResponse.CurrentDecision.PlaybackPlan == nil || newerResponse.PlaybackPlan == nil || staleResponse.CurrentDecision.PlaybackPlan.PlanID != newerResponse.PlaybackPlan.PlanID {
+		t.Fatalf("stale response current decision = %#v, want the latest plan", staleResponse.CurrentDecision)
 	}
 	latestRecord, err := handler.PlanStoreV3.GetAttempt(context.Background(), started.SessionID)
 	if err != nil {

--- a/internal/api/handlers/playback_v3_union_test.go
+++ b/internal/api/handlers/playback_v3_union_test.go
@@ -467,6 +467,7 @@ func TestIncompletePlaybackSettingsMakePolicyTerminalsRetryable(t *testing.T) {
 		{Reason: playback.TerminalHDRTranscodeUnsupportedV3, Message: "HDR unavailable"},
 		{Reason: terminalSubtitleConversionUnsupportedV3, Message: "The selected subtitle must be burned into the video, but this HDR source cannot be re-encoded."},
 		{Reason: terminalSubtitleConversionUnsupportedV3, Message: "The selected subtitle must be burned into the video, but 4K transcoding is disabled."},
+		{Reason: terminalSubtitleConversionUnsupportedV3, Message: "The selected subtitle format cannot be preserved on this version."},
 		{Reason: terminalNoAlternateVersionV3, Message: playback.TerminalMessage4KTranscodeDisabledV3},
 	}
 	for _, terminal := range tests {
@@ -630,6 +631,42 @@ func TestHLSToneMapCapabilityInventoryV3TreatsCompletedNodeFailureAsDefinitive(t
 	}
 	if len(inventory.union) != 0 {
 		t.Fatalf("failed node contributed capabilities: %#v", inventory.union)
+	}
+}
+
+func TestHLSToneMapCapabilityInventoryV3RetriesNodeWarmingResponse(t *testing.T) {
+	var requests atomic.Int32
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writeJSON(w, http.StatusOK, playback.HWAccelInfo{ToneMapCapabilities: tonemap.Capabilities{{
+			Mode: tonemap.ModeSoftware, Backend: tonemap.BackendSoftware, Filter: tonemap.SoftwareFilterBT2390,
+			SourceKinds: []tonemap.SourceKind{tonemap.SourcePQ},
+		}}})
+	}))
+	defer remote.Close()
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	handler.NodePlanner = enumeratingNodePlannerV3{urls: []string{remote.URL}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{config.PlaybackLocalTranscodeFallbackSettingKey: "false"}}
+
+	first, err := handler.hlsToneMapCapabilityInventoryV3(context.Background())
+	if !errors.Is(err, errRemoteCapabilityWarmingV3) {
+		t.Fatalf("first inventory error = %v, want remote capability warming", err)
+	}
+	if len(first.union) != 0 {
+		t.Fatalf("warming node contributed capabilities: %#v", first.union)
+	}
+
+	second, err := handler.hlsToneMapCapabilityInventoryV3(context.Background())
+	if err != nil {
+		t.Fatalf("retry inventory error = %v", err)
+	}
+	if requests.Load() != 2 || !second.union.Supports(tonemap.ModeSoftware, tonemap.SourcePQ) {
+		t.Fatalf("retry requests = %d capabilities = %#v, want a fresh successful probe", requests.Load(), second.union)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_union_test.go
+++ b/internal/api/handlers/playback_v3_union_test.go
@@ -223,6 +223,36 @@ func TestLocalToneMapCapabilitiesV3UsesLivePlaybackHardware(t *testing.T) {
 	}
 }
 
+func TestLocalToneMapCapabilitiesV3MemoizesHardwareResolutionByConfig(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	cfg := config.PlaybackConfig{FFmpegPath: "/opt/ffmpeg-a", HWAccel: "auto", HWDevice: "/dev/dri/renderD128"}
+	handler.PlaybackConfig = func() config.PlaybackConfig { return cfg }
+	var resolveCalls atomic.Int32
+	handler.v3HWAccelResolver = func(context.Context, string, string) string {
+		resolveCalls.Add(1)
+		return tonemap.BackendQSV
+	}
+	handler.v3ToneMapProbe = func(context.Context, string, string, string) (tonemap.Capabilities, error) {
+		return nil, nil
+	}
+
+	for range 2 {
+		if _, err := handler.localToneMapCapabilitiesV3(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := resolveCalls.Load(); got != 1 {
+		t.Fatalf("hardware resolution calls = %d, want one for unchanged config", got)
+	}
+	cfg.HWDevice = "/dev/dri/renderD129"
+	if _, err := handler.localToneMapCapabilitiesV3(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveCalls.Load(); got != 2 {
+		t.Fatalf("hardware resolution calls after config change = %d, want two", got)
+	}
+}
+
 // TestLocalToneMapCapabilitiesV3DoesNotSerializeCallers verifies that a
 // canceled request is not trapped behind another request's slow probe.
 func TestLocalToneMapCapabilitiesV3DoesNotSerializeCallers(t *testing.T) {
@@ -268,6 +298,38 @@ func TestLocalToneMapCapabilitiesV3DoesNotSerializeCallers(t *testing.T) {
 	}
 	close(release)
 	<-firstDone
+}
+
+func TestStartToneMapCapabilityWarmupUsesFullLocalProbePath(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{
+		config.PlaybackTranscodeHardwareToneMapSettingKey: "true",
+		config.PlaybackTranscodeSoftwareToneMapSettingKey: "true",
+	}}
+	handler.PlaybackConfig = playbackTestConfig("", "none")
+	started := make(chan time.Time, 1)
+	handler.v3ToneMapProbe = func(ctx context.Context, _, _, _ string) (tonemap.Capabilities, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			started <- time.Time{}
+			return nil, nil
+		}
+		started <- deadline
+		return nil, nil
+	}
+
+	handler.StartToneMapCapabilityWarmup(context.Background())
+	select {
+	case deadline := <-started:
+		if deadline.IsZero() {
+			t.Fatal("warmup probe has no deadline")
+		}
+		if remaining := time.Until(deadline); remaining <= v3NodeCapabilityPlanTimeout {
+			t.Fatalf("warmup budget = %s, want full probe budget", remaining)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("tone-map capability warmup did not start")
+	}
 }
 
 // TestHLSToneMapCapabilitiesV3FetchesNodesConcurrently verifies pooled node lookups overlap.
@@ -363,17 +425,40 @@ func TestHLSToneMapCapabilityInventoryV3StartsLocalAndRemoteConcurrently(t *test
 }
 
 func TestIncompleteToneMapPlanningBecomesRetryableStartFailure(t *testing.T) {
-	for _, reason := range []string{
-		playback.TerminalHDRTranscodeUnsupportedV3,
-		terminalSubtitleConversionUnsupportedV3,
+	for _, terminal := range []playback.TerminalV3{
+		{Reason: playback.TerminalHDRTranscodeUnsupportedV3},
+		{Reason: terminalSubtitleConversionUnsupportedV3, Message: "The selected subtitle must be burned into the video, but this HDR source cannot be re-encoded."},
 	} {
-		result := playback.PlannerResultV3{Terminal: &playback.TerminalV3{Reason: reason}}
+		result := playback.PlannerResultV3{Terminal: &terminal}
 
 		result = retryIncompleteToneMapPlanningV3(result, context.DeadlineExceeded)
 
-		if result.Terminal == nil || result.Terminal.Reason != transcodeStartFailedReasonV3 || !result.Terminal.Retryable {
-			t.Fatalf("terminal for %q = %#v, want retryable %q", reason, result.Terminal, transcodeStartFailedReasonV3)
+		if result.Terminal == nil || result.Terminal.Reason != capabilityWarmingReasonV3 || !result.Terminal.Retryable || result.Terminal.RetryAfterMillis <= 0 {
+			t.Fatalf("terminal for %q = %#v, want retryable %q with delay", terminal.Reason, result.Terminal, capabilityWarmingReasonV3)
 		}
+	}
+}
+
+func TestIncompleteToneMapPlanningDoesNotRewriteUnrelatedSubtitlePolicy(t *testing.T) {
+	terminal := &playback.TerminalV3{
+		Reason:  terminalSubtitleConversionUnsupportedV3,
+		Message: "The selected subtitle must be burned into the video, but 4K transcoding is disabled.",
+	}
+	result := retryIncompleteToneMapPlanningV3(playback.PlannerResultV3{Terminal: terminal}, context.DeadlineExceeded)
+	if result.Terminal != terminal {
+		t.Fatalf("unrelated subtitle policy terminal = %#v, want original terminal", result.Terminal)
+	}
+}
+
+func TestFallbackPlanningInputsCompleteV3RequiresDefinitiveSnapshots(t *testing.T) {
+	if !fallbackPlanningInputsCompleteV3(nil, nil) {
+		t.Fatal("complete capability and settings snapshots rejected fallback planning")
+	}
+	if fallbackPlanningInputsCompleteV3(context.DeadlineExceeded, nil) {
+		t.Fatal("incomplete capability snapshot allowed fallback planning")
+	}
+	if fallbackPlanningInputsCompleteV3(nil, context.DeadlineExceeded) {
+		t.Fatal("incomplete settings snapshot allowed fallback planning")
 	}
 }
 
@@ -515,12 +600,36 @@ func TestHLSToneMapCapabilitiesV3HonorsSharedDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
 	defer cancel()
 	started := time.Now()
-	got := handler.hlsToneMapCapabilitiesV3(ctx)
+	inventory, err := handler.hlsToneMapCapabilityInventoryV3(ctx)
 	if elapsed := time.Since(started); elapsed >= time.Second {
 		t.Fatalf("capability aggregation took %s, want shared caller deadline", elapsed)
 	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("capability inventory error = %v, want deadline exceeded", err)
+	}
+	got := inventory.union
 	if len(got) != 1 || !got.Supports(tonemap.ModeSoftware, tonemap.SourcePQ) {
 		t.Fatalf("aggregated capabilities = %#v, want the successful node retained", got)
+	}
+}
+
+func TestHLSToneMapCapabilityInventoryV3TreatsCompletedNodeFailureAsDefinitive(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer remote.Close()
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	handler.NodePlanner = enumeratingNodePlannerV3{urls: []string{remote.URL}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{config.PlaybackLocalTranscodeFallbackSettingKey: "false"}}
+
+	inventory, err := handler.hlsToneMapCapabilityInventoryV3(context.Background())
+	if err != nil {
+		t.Fatalf("completed node failure left capability inventory warming: %v", err)
+	}
+	if len(inventory.union) != 0 {
+		t.Fatalf("failed node contributed capabilities: %#v", inventory.union)
 	}
 }
 
@@ -547,10 +656,10 @@ func TestHLSToneMapCapabilityInventoryV3RedactsNodeURLSecrets(t *testing.T) {
 	t.Cleanup(func() { slog.SetDefault(previousLogger) })
 
 	_, err := handler.hlsToneMapCapabilityInventoryV3(context.Background())
-	if err == nil {
-		t.Fatal("capability inventory returned no error")
+	if err != nil {
+		t.Fatalf("completed node failure left capability inventory warming: %v", err)
 	}
-	diagnostics := logs.String() + "\n" + err.Error()
+	diagnostics := logs.String()
 	for _, secret := range []string{username, password, querySecret, fragmentSecret} {
 		if strings.Contains(diagnostics, secret) {
 			t.Fatalf("capability diagnostics contain %q: %q", secret, diagnostics)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1049,6 +1049,7 @@ func NewRouter(deps Dependencies) chi.Router {
 			playbackHandler.MarkerUpserter = deps.FileRepo
 		}
 		playbackHandler.MarkerUpdateNotifier = playback.NewMarkerUpdateNotifier(deps.SessionMgr, realtimeHub)
+		playbackHandler.StartToneMapCapabilityWarmup(deps.AppContext)
 		// Optimistic remux: a play is never blocked on the H.264 copy-safety
 		// scan, so the scan runs behind the issued plan and the notifier moves
 		// any session that is already stream-copying an unsafe source off that

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -22,6 +22,10 @@ const (
 	FeatureOutputChangeV3        = "output_change_v1"
 	FeatureDirectStreamResumeV3  = "direct_stream_resume_v1"
 	FeaturePlanSourceDurationV3  = "plan_source_duration_v1"
+	// FeatureCapabilityWarmingV3 advertises retryable capability_warming
+	// terminals and their server-guided retry delay. Clients can detect this
+	// contract through the capability endpoint before starting playback.
+	FeatureCapabilityWarmingV3 = "capability_warming_v1"
 	// FeatureSoftwareVideoDecodeV3 lets a strict evidence-tier client opt into
 	// bounded hardware:false video_decode entries. Without the feature, exact
 	// and platform_attested retain their historical hardware-only direct-play
@@ -95,6 +99,7 @@ func ServerFeaturesV3() []string {
 		FeatureAuthorizedMediaOriginsV3,
 		FeatureSoftwareVideoDecodeV3,
 		FeaturePlanInvalidatedV3,
+		FeatureCapabilityWarmingV3,
 		// Advertised so a client can tell "this server does not populate
 		// source.duration_seconds" apart from "this server knows the runtime
 		// is genuinely unknown". Without the distinction both look like an

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -806,9 +806,10 @@ type PlanV3 struct {
 }
 
 type TerminalV3 struct {
-	Reason    string `json:"reason"`
-	Message   string `json:"message"`
-	Retryable bool   `json:"retryable"`
+	Reason           string `json:"reason"`
+	Message          string `json:"message"`
+	Retryable        bool   `json:"retryable"`
+	RetryAfterMillis int64  `json:"retry_after_ms,omitempty"`
 }
 
 type DecisionResponseV3 struct {

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -37,6 +37,7 @@ func TestServerFeaturesV3ReturnsCompleteIndependentSlices(t *testing.T) {
 		FeatureAuthorizedMediaOriginsV3:   {},
 		FeatureSoftwareVideoDecodeV3:      {},
 		FeaturePlanInvalidatedV3:          {},
+		FeatureCapabilityWarmingV3:        {},
 		FeaturePlanSourceDurationV3:       {},
 	}
 	if len(first) != len(expected) {

--- a/internal/playback/testdata/protocol_v3/capability_response.json
+++ b/internal/playback/testdata/protocol_v3/capability_response.json
@@ -16,6 +16,7 @@
     "authorized_media_origins_v1",
     "software_video_decode_v1",
     "plan_invalidated_v1",
+    "capability_warming_v1",
     "plan_source_duration_v1"
   ],
   "deliveries": [

--- a/internal/playback/testdata/protocol_v3/conformance_matrix.json
+++ b/internal/playback/testdata/protocol_v3/conformance_matrix.json
@@ -6547,6 +6547,7 @@
             "authorized_media_origins_v1",
             "software_video_decode_v1",
             "plan_invalidated_v1",
+            "capability_warming_v1",
             "plan_source_duration_v1"
           ],
           "outcome": "adaptation_unavailable",

--- a/internal/playback/testdata/protocol_v3/decision_response.json
+++ b/internal/playback/testdata/protocol_v3/decision_response.json
@@ -13,6 +13,7 @@
     "authorized_media_origins_v1",
     "software_video_decode_v1",
     "plan_invalidated_v1",
+    "capability_warming_v1",
     "plan_source_duration_v1"
   ],
   "outcome": "playable",

--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -80,6 +80,16 @@ func probeCached(ctx context.Context, ffmpegPath, hardwareBackend, hardwareDevic
 		defer cancel()
 		result, err := probeWithRunner(probeCtx, ffmpegPath, hardwareBackend, hardwareDevice, run)
 		if err != nil {
+			// Keep a known-good inventory available, but do not let steady
+			// playback traffic turn one slow executor into a continuous probe
+			// loop. A failed refresh gets the same short retry backoff as a
+			// completed empty inventory.
+			probeCache.Lock()
+			if stale, ok := probeCache.entries[key]; ok && len(stale.capabilities) > 0 {
+				stale.expiresAt = now().Add(probeNegativeTTL)
+				probeCache.entries[key] = stale
+			}
+			probeCache.Unlock()
 			return nil, err
 		}
 		entry := probeCacheEntry{

--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -60,11 +60,13 @@ func Probe(ctx context.Context, ffmpegPath, hardwareBackend, hardwareDevice stri
 func probeCached(ctx context.Context, ffmpegPath, hardwareBackend, hardwareDevice string, run CommandRunner, now func() time.Time) (Capabilities, error) {
 	key := probeCacheKey(ffmpegPath, hardwareBackend, hardwareDevice)
 	probeCache.Lock()
-	if cached, ok := probeCache.entries[key]; ok && probeCacheEntryCurrent(cached, now()) {
+	cached, cachedOK := probeCache.entries[key]
+	if cachedOK && probeCacheEntryCurrent(cached, now()) {
 		result := append(Capabilities(nil), cached.capabilities...)
 		probeCache.Unlock()
 		return result, nil
 	}
+	stalePositive := cachedOK && len(cached.capabilities) > 0
 	probeCache.Unlock()
 
 	resultCh := probeCache.group.DoChan(key, func() (any, error) {
@@ -92,6 +94,13 @@ func probeCached(ctx context.Context, ffmpegPath, hardwareBackend, hardwareDevic
 		probeCache.Unlock()
 		return result, nil
 	})
+	if stalePositive {
+		// A previously validated executor remains safer than turning one periodic
+		// refresh into a new playback outage. The singleflight refresh above runs
+		// in the background and atomically replaces this inventory only after a
+		// complete probe succeeds.
+		return append(Capabilities(nil), cached.capabilities...), nil
+	}
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -17,6 +17,7 @@ import (
 const (
 	probeCommandTimeout = 5 * time.Second
 	probeNegativeTTL    = 15 * time.Second
+	probePositiveTTL    = 5 * time.Minute
 	probeTimeoutSlack   = time.Second
 	probeEndpointSlack  = 20 * time.Second
 	probeRequestSlack   = 5 * time.Second
@@ -34,8 +35,9 @@ const decodeProbeFixtureBase64 = "AAAAAUABDAH//wIgAAADAJAAAAMAAAMAHpWUCQAAAAFCAQ
 // output. Tests inject it to model individual FFmpeg capabilities and failures.
 type CommandRunner func(context.Context, string, ...string) ([]byte, error)
 
-// probeCacheEntry stores either a permanent positive capability result or a
-// short-lived negative result that is eligible for retry.
+// probeCacheEntry stores a bounded capability result. Positive inventories can
+// be partial (for example software succeeded while a hardware smoke test did
+// not), so they must be refreshed rather than pinned until process restart.
 type probeCacheEntry struct {
 	capabilities Capabilities
 	expiresAt    time.Time
@@ -78,7 +80,10 @@ func probeCached(ctx context.Context, ffmpegPath, hardwareBackend, hardwareDevic
 		if err != nil {
 			return nil, err
 		}
-		entry := probeCacheEntry{capabilities: append(Capabilities(nil), result...)}
+		entry := probeCacheEntry{
+			capabilities: append(Capabilities(nil), result...),
+			expiresAt:    now().Add(probePositiveTTL),
+		}
 		if len(result) == 0 {
 			entry.expiresAt = now().Add(probeNegativeTTL)
 		}
@@ -149,10 +154,9 @@ func probeCacheKey(ffmpegPath, hardwareBackend, hardwareDevice string) string {
 	return strings.Join([]string{binaryIdentity, backend, device, strings.Join(driverIdentities, ",")}, "\x00")
 }
 
-// probeCacheEntryCurrent reports whether a positive result or unexpired
-// negative result may be reused.
+// probeCacheEntryCurrent reports whether a bounded discovery result may be reused.
 func probeCacheEntryCurrent(entry probeCacheEntry, now time.Time) bool {
-	return len(entry.capabilities) > 0 || now.Before(entry.expiresAt)
+	return now.Before(entry.expiresAt)
 }
 
 // ProbeTotalTimeout budgets one bounded deadline for every listing and smoke

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -119,9 +121,9 @@ func TestProbeCommandDeadlineIsTransientAndNotCached(t *testing.T) {
 func TestProbeSuccessfulCapabilitiesExpire(t *testing.T) {
 	resetProbeCache(t)
 	now := time.Unix(100, 0)
-	calls := 0
+	var calls atomic.Int32
 	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
-		calls++
+		calls.Add(1)
 		if len(args) > 0 && args[len(args)-1] == "-filters" {
 			return []byte(" .S. zscale V->V\n .S. tonemapx V->V\n .S. sidedata V->V\n"), nil
 		}
@@ -137,7 +139,7 @@ func TestProbeSuccessfulCapabilitiesExpire(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("successful probe = %#v", got)
 	}
-	firstCalls := calls
+	firstCalls := calls.Load()
 	now = now.Add(probePositiveTTL - time.Second)
 	got, err = probeCached(context.Background(), "/ffmpeg-success", BackendSoftware, "", runner, func() time.Time { return now })
 	if err != nil {
@@ -146,16 +148,86 @@ func TestProbeSuccessfulCapabilitiesExpire(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("cached successful probe = %#v", got)
 	}
-	if calls != firstCalls {
-		t.Fatalf("unexpired successful probe reran: calls = %d, want %d", calls, firstCalls)
+	if calls.Load() != firstCalls {
+		t.Fatalf("unexpired successful probe reran: calls = %d, want %d", calls.Load(), firstCalls)
 	}
 	now = now.Add(2 * time.Second)
 	got, err = probeCached(context.Background(), "/ffmpeg-success", BackendSoftware, "", runner, func() time.Time { return now })
 	if err != nil || len(got) != 1 {
 		t.Fatalf("refreshed successful probe = %#v, error = %v", got, err)
 	}
-	if calls == firstCalls {
-		t.Fatal("expired successful probe was not refreshed")
+	refreshExpiry := now.Add(probePositiveTTL)
+	refreshDeadline := time.After(time.Second)
+	for {
+		probeCache.Lock()
+		refreshed := probeCache.entries[probeCacheKey("/ffmpeg-success", BackendSoftware, "")].expiresAt.Equal(refreshExpiry)
+		probeCache.Unlock()
+		if refreshed {
+			break
+		}
+		select {
+		case <-refreshDeadline:
+			t.Fatal("expired successful probe was not refreshed in the background")
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+func TestProbeExpiredPositiveReturnsWhileRefreshIsRunning(t *testing.T) {
+	resetProbeCache(t)
+	var nowUnix atomic.Int64
+	nowUnix.Store(100)
+	now := func() time.Time { return time.Unix(nowUnix.Load(), 0) }
+	var blockRefresh atomic.Bool
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	var startOnce sync.Once
+	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if blockRefresh.Load() {
+			startOnce.Do(func() { close(refreshStarted) })
+			<-releaseRefresh
+		}
+		if len(args) > 0 && args[len(args)-1] == "-filters" {
+			return []byte(" .S. zscale V->V\n .S. tonemapx V->V\n .S. sidedata V->V\n"), nil
+		}
+		if len(args) > 0 && args[len(args)-1] == "-encoders" {
+			return []byte("libx264"), nil
+		}
+		return nil, nil
+	}
+	seed, err := probeCached(context.Background(), "/ffmpeg-stale", BackendSoftware, "", runner, now)
+	if err != nil || len(seed) != 1 {
+		t.Fatalf("seed probe = %#v, error = %v", seed, err)
+	}
+
+	nowUnix.Add(int64((probePositiveTTL + time.Second) / time.Second))
+	blockRefresh.Store(true)
+	stale, err := probeCached(context.Background(), "/ffmpeg-stale", BackendSoftware, "", runner, now)
+	if err != nil || len(stale) != 1 {
+		t.Fatalf("stale probe = %#v, error = %v", stale, err)
+	}
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expired positive did not start a background refresh")
+	}
+	close(releaseRefresh)
+	wantExpiry := now().Add(probePositiveTTL)
+	refreshDeadline := time.After(time.Second)
+	for {
+		probeCache.Lock()
+		refreshed := probeCache.entries[probeCacheKey("/ffmpeg-stale", BackendSoftware, "")].expiresAt.Equal(wantExpiry)
+		probeCache.Unlock()
+		if refreshed {
+			break
+		}
+		select {
+		case <-refreshDeadline:
+			t.Fatal("background refresh did not replace the stale positive")
+		default:
+			runtime.Gosched()
+		}
 	}
 }
 

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -114,8 +114,9 @@ func TestProbeCommandDeadlineIsTransientAndNotCached(t *testing.T) {
 	}
 }
 
-// TestProbeSuccessfulCapabilitiesDoNotExpire verifies unchanged positive discovery remains cached.
-func TestProbeSuccessfulCapabilitiesDoNotExpire(t *testing.T) {
+// TestProbeSuccessfulCapabilitiesExpire verifies a positive-but-potentially-partial
+// discovery is periodically refreshed rather than pinned until process restart.
+func TestProbeSuccessfulCapabilitiesExpire(t *testing.T) {
 	resetProbeCache(t)
 	now := time.Unix(100, 0)
 	calls := 0
@@ -137,7 +138,7 @@ func TestProbeSuccessfulCapabilitiesDoNotExpire(t *testing.T) {
 		t.Fatalf("successful probe = %#v", got)
 	}
 	firstCalls := calls
-	now = now.Add(24 * time.Hour)
+	now = now.Add(probePositiveTTL - time.Second)
 	got, err = probeCached(context.Background(), "/ffmpeg-success", BackendSoftware, "", runner, func() time.Time { return now })
 	if err != nil {
 		t.Fatalf("cached successful probe error = %v", err)
@@ -146,7 +147,15 @@ func TestProbeSuccessfulCapabilitiesDoNotExpire(t *testing.T) {
 		t.Fatalf("cached successful probe = %#v", got)
 	}
 	if calls != firstCalls {
-		t.Fatalf("successful probe reran: calls = %d, want %d", calls, firstCalls)
+		t.Fatalf("unexpired successful probe reran: calls = %d, want %d", calls, firstCalls)
+	}
+	now = now.Add(2 * time.Second)
+	got, err = probeCached(context.Background(), "/ffmpeg-success", BackendSoftware, "", runner, func() time.Time { return now })
+	if err != nil || len(got) != 1 {
+		t.Fatalf("refreshed successful probe = %#v, error = %v", got, err)
+	}
+	if calls == firstCalls {
+		t.Fatal("expired successful probe was not refreshed")
 	}
 }
 

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -231,6 +231,75 @@ func TestProbeExpiredPositiveReturnsWhileRefreshIsRunning(t *testing.T) {
 	}
 }
 
+func TestProbeExpiredPositiveBacksOffAfterRefreshDeadline(t *testing.T) {
+	resetProbeCache(t)
+	var nowUnix atomic.Int64
+	nowUnix.Store(100)
+	now := func() time.Time { return time.Unix(nowUnix.Load(), 0) }
+	var failRefresh atomic.Bool
+	var refreshCalls atomic.Int32
+	runner := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		if failRefresh.Load() {
+			refreshCalls.Add(1)
+			return nil, context.DeadlineExceeded
+		}
+		if len(args) > 0 && args[len(args)-1] == "-filters" {
+			return []byte(" .S. zscale V->V\n .S. tonemapx V->V\n .S. sidedata V->V\n"), nil
+		}
+		if len(args) > 0 && args[len(args)-1] == "-encoders" {
+			return []byte("libx264"), nil
+		}
+		return nil, nil
+	}
+	seed, err := probeCached(context.Background(), "/ffmpeg-refresh-backoff", BackendSoftware, "", runner, now)
+	if err != nil || len(seed) != 1 {
+		t.Fatalf("seed probe = %#v, error = %v", seed, err)
+	}
+
+	nowUnix.Add(int64((probePositiveTTL + time.Second) / time.Second))
+	failRefresh.Store(true)
+	stale, err := probeCached(context.Background(), "/ffmpeg-refresh-backoff", BackendSoftware, "", runner, now)
+	if err != nil || len(stale) != 1 {
+		t.Fatalf("stale probe = %#v, error = %v", stale, err)
+	}
+	wantBackoff := now().Add(probeNegativeTTL)
+	deadline := time.After(time.Second)
+	for {
+		probeCache.Lock()
+		backedOff := probeCache.entries[probeCacheKey("/ffmpeg-refresh-backoff", BackendSoftware, "")].expiresAt.Equal(wantBackoff)
+		probeCache.Unlock()
+		if backedOff {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("failed background refresh did not advance its retry deadline")
+		default:
+			runtime.Gosched()
+		}
+	}
+	failedCalls := refreshCalls.Load()
+	stale, err = probeCached(context.Background(), "/ffmpeg-refresh-backoff", BackendSoftware, "", runner, now)
+	if err != nil || len(stale) != 1 {
+		t.Fatalf("backed-off stale probe = %#v, error = %v", stale, err)
+	}
+	if refreshCalls.Load() != failedCalls {
+		t.Fatal("stale positive retried before the refresh backoff expired")
+	}
+
+	nowUnix.Add(int64((probeNegativeTTL + time.Second) / time.Second))
+	_, _ = probeCached(context.Background(), "/ffmpeg-refresh-backoff", BackendSoftware, "", runner, now)
+	deadline = time.After(time.Second)
+	for refreshCalls.Load() == failedCalls {
+		select {
+		case <-deadline:
+			t.Fatal("stale positive did not retry after the refresh backoff expired")
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
 // TestProbeCacheInvalidatesWhenFFmpegBinaryChangesInPlace verifies that a
 // positive result is rechecked after the configured executable is replaced.
 func TestProbeCacheInvalidatesWhenFFmpegBinaryChangesInPlace(t *testing.T) {

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -836,18 +836,25 @@ func (s *Server) handleHWCapabilities(w http.ResponseWriter, r *http.Request) {
 	info.ProbeRequestTimeoutMillis = tonemap.ProbeRequestTimeout(configuredHWAccel, hwDevice).Milliseconds()
 	capabilities, err := tonemap.Probe(resolveCtx, playback.ResolveFFmpegPath(ffmpegPath), hwAccel, hwDevice)
 	if err != nil {
-		http.Error(w, "capability probe unavailable", http.StatusServiceUnavailable)
+		http.Error(w, "capability probe unavailable", capabilityProbeErrorStatus(resolveCtx, err))
 		return
 	}
 	info.ToneMapCapabilities = capabilities
 	registry, err := playback.ProbeTransformationRegistryWithToneMapV3Result(resolveCtx, ffmpegPath, info.ToneMapCapabilities)
 	if err != nil {
-		http.Error(w, "capability probe unavailable", http.StatusServiceUnavailable)
+		http.Error(w, "capability probe unavailable", capabilityProbeErrorStatus(resolveCtx, err))
 		return
 	}
 	info.Transformations = registry.Advertised()
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(info)
+}
+
+func capabilityProbeErrorStatus(ctx context.Context, err error) int {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusInternalServerError
 }
 
 func toneMapCapabilityResolveTimeout(hardwareBackend, hardwareDevice string) time.Duration {

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -379,6 +379,24 @@ func TestHandleHWCapabilitiesReturnsServiceUnavailableWhenDeadlineExpires(t *tes
 	}
 }
 
+func TestHandleHWCapabilitiesReturnsInternalServerErrorForCompletedProbeFailure(t *testing.T) {
+	server := newTestServer(t)
+	ffmpegPath := filepath.Join(t.TempDir(), "failed-inventory.sh")
+	script := "#!/bin/sh\ncase \"$2\" in\n-bsfs) echo dovi_rpu; exit 1 ;;\n-encoders) echo ' V....D libx264 H.264'; echo ' A....D aac AAC' ;;\nesac\n"
+	if err := os.WriteFile(ffmpegPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	server.watcher.Config().Playback.HWAccel = playback.HWAccelNone
+	recorder := httptest.NewRecorder()
+
+	server.handleHWCapabilities(recorder, httptest.NewRequest(http.MethodGet, "/hw-capabilities", nil))
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusInternalServerError, recorder.Body.String())
+	}
+}
+
 func TestToneMapCapabilityResolveTimeoutCoversConfiguredProbeBudget(t *testing.T) {
 	got := toneMapCapabilityResolveTimeout(tonemap.BackendQSV, "/dev/dri/renderD128")
 	if want := tonemap.ProbeEndpointTimeout(tonemap.BackendQSV, "/dev/dri/renderD128"); got != want {

--- a/web/src/player/components/WatchPage.test.ts
+++ b/web/src/player/components/WatchPage.test.ts
@@ -78,6 +78,7 @@ function playbackSession(
     qualityPreference: "original",
     shouldAutoPlay: true,
     loading: false,
+    loadingMessage: null,
     replacing: false,
     replanning: false,
     errorTitle: null,

--- a/web/src/player/components/WatchPage.tsx
+++ b/web/src/player/components/WatchPage.tsx
@@ -386,7 +386,9 @@ export function WatchPage({
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black">
           <div className="flex flex-col items-center gap-3">
             <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/20 border-t-white" />
-            <span className="text-sm text-white/60">Loading player...</span>
+            <span className="text-sm text-white/60">
+              {session.loadingMessage ?? "Loading player..."}
+            </span>
           </div>
         </div>
       );

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -1320,7 +1320,7 @@ describe("usePlaybackSession version switches", () => {
 
 describe("usePlaybackSession replans", () => {
   it("retries a warming replan with a fresh replan request id", async () => {
-    const replanBodies: Array<{ replan_request_id: string }> = [];
+    const replanBodies: Array<{ replan_request_id: string; position_seconds: number }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/playback/start")) {
@@ -1336,7 +1336,12 @@ describe("usePlaybackSession replans", () => {
         );
       }
       if (url.endsWith("/playback/session-warming-replan/replan")) {
-        replanBodies.push(JSON.parse(String(init?.body)) as { replan_request_id: string });
+        replanBodies.push(
+          JSON.parse(String(init?.body)) as {
+            replan_request_id: string;
+            position_seconds: number;
+          },
+        );
         if (replanBodies.length === 1) {
           return jsonResponse({
             protocol_version: 3,
@@ -1346,7 +1351,7 @@ describe("usePlaybackSession replans", () => {
               reason: "capability_warming",
               message: "Tone-map capability discovery is still warming.",
               retryable: true,
-              retry_after_ms: 1,
+              retry_after_ms: 50,
             },
           });
         }
@@ -1375,11 +1380,81 @@ describe("usePlaybackSession replans", () => {
     await waitFor(() => expect(result.current.plan).not.toBeNull());
 
     act(() => result.current.changeQuality("720p", 30));
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+    act(() => result.current.updatePlaybackState(37, true));
     await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:warmed-replan-0001"));
 
     expect(replanBodies).toHaveLength(2);
     expect(replanBodies[1]!.replan_request_id).not.toBe(replanBodies[0]!.replan_request_id);
+    expect(replanBodies[0]!.position_seconds).toBe(30);
+    expect(replanBodies[1]!.position_seconds).toBe(37);
     expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it("replays a user intent after adopting a stale plan reconciliation", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    const decision = (plan: ReturnType<typeof fixturePlanV3>) => ({
+      protocol_version: 3,
+      server_features: ["playback_plan_v3"],
+      outcome: "playable",
+      session_id: "session-1",
+      playback_plan: plan,
+    });
+    const reconciledPlan = fixturePlanV3({
+      plan_id: "plan:reconciled0001",
+      plan_attempt_key: "v3:reconciled0001",
+    });
+    const requestedPlan = fixturePlanV3({
+      plan_id: "plan:requested000001",
+      plan_attempt_key: "v3:requested000001",
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse(decision(fixturePlanV3()), { status: 201 });
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        if (replanBodies.length === 1) {
+          return jsonResponse(
+            {
+              error: "stale_playback_plan",
+              message: "The failed plan is no longer current",
+              current_decision: decision(reconciledPlan),
+            },
+            { status: 409 },
+          );
+        }
+        return jsonResponse(decision(requestedPlan));
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-reconcile-intent", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    act(() => result.current.changeQuality("720p", 30));
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:requested000001"));
+
+    expect(replanBodies).toHaveLength(2);
+    expect(replanBodies[0]).toMatchObject({
+      operation: "quality_change",
+      failed_plan_id: "plan:0123456789abcdef",
+      quality_preference: "720p",
+    });
+    expect(replanBodies[1]).toMatchObject({
+      operation: "quality_change",
+      failed_plan_id: "plan:reconciled0001",
+      quality_preference: "720p",
+    });
+    expect(result.current.qualityPreference).toBe("720p");
     unmount();
   });
 

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -374,6 +374,80 @@ describe("usePlaybackSession capability warming", () => {
 
     unmount();
   });
+
+  it("refreshes a replacement start position while capability warming", async () => {
+    const startBodies: Array<{
+      file_id: number;
+      playback_attempt_id: string;
+      start_position?: number;
+    }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        startBodies.push(
+          JSON.parse(String(init?.body)) as {
+            file_id: number;
+            playback_attempt_id: string;
+            start_position?: number;
+          },
+        );
+        if (startBodies.length === 2) {
+          return jsonResponse(
+            {
+              protocol_version: 3,
+              server_features: ["playback_plan_v3"],
+              outcome: "adaptation_unavailable",
+              terminal: {
+                reason: "capability_warming",
+                message: "Tone-map capability discovery is still warming.",
+                retryable: true,
+                retry_after_ms: 50,
+              },
+            },
+            { status: 201 },
+          );
+        }
+        const replacement = startBodies.length === 3;
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "playable",
+            session_id: replacement ? "session-replacement" : "session-initial",
+            playback_plan: fixturePlanV3({
+              session_id: replacement ? "session-replacement" : "session-initial",
+              requested_media_file_id: replacement ? 99 : 7,
+              effective_media_file_id: replacement ? 99 : 7,
+            }),
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-warming-replacement", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.sessionId).toBe("session-initial"));
+
+    act(() => {
+      result.current.updatePlaybackState(10, true);
+      result.current.switchVersion(99, 10);
+    });
+    await waitFor(() => expect(startBodies).toHaveLength(2));
+    act(() => result.current.updatePlaybackState(17, true));
+    await waitFor(() => expect(result.current.sessionId).toBe("session-replacement"));
+
+    expect(startBodies[1]).toMatchObject({ file_id: 99, start_position: 10 });
+    expect(startBodies[2]).toMatchObject({ file_id: 99, start_position: 17 });
+    expect(startBodies[2]!.playback_attempt_id).not.toBe(startBodies[1]!.playback_attempt_id);
+    unmount();
+  });
 });
 
 describe("usePlaybackSession quality changes", () => {

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -312,7 +312,7 @@ describe("routeEventPlanIdentityV3", () => {
 });
 
 describe("usePlaybackSession capability warming", () => {
-  it("retries a warming start with a fresh attempt id while keeping the requested file", async () => {
+  it("retries warming beyond the initial backoff sequence while keeping the requested file", async () => {
     const startBodies: Array<{ file_id: number; playback_attempt_id: string }> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -320,7 +320,7 @@ describe("usePlaybackSession capability warming", () => {
         startBodies.push(
           JSON.parse(String(init?.body)) as { file_id: number; playback_attempt_id: string },
         );
-        if (startBodies.length === 1) {
+        if (startBodies.length <= 7) {
           return jsonResponse(
             {
               protocol_version: 3,
@@ -367,9 +367,9 @@ describe("usePlaybackSession capability warming", () => {
     );
 
     await waitFor(() => expect(result.current.sessionId).toBe("session-warmed"));
-    expect(startBodies).toHaveLength(2);
-    expect(startBodies.map((body) => body.file_id)).toEqual([7, 7]);
-    expect(startBodies[1]!.playback_attempt_id).not.toBe(startBodies[0]!.playback_attempt_id);
+    expect(startBodies).toHaveLength(8);
+    expect(startBodies.map((body) => body.file_id)).toEqual(Array(8).fill(7));
+    expect(new Set(startBodies.map((body) => body.playback_attempt_id)).size).toBe(8);
     expect(result.current.error).toBeNull();
 
     unmount();

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -1926,6 +1926,77 @@ describe("usePlaybackSession server-invalidated plans", () => {
     unmount();
   });
 
+  it("interrupts a warming replacement start before handling an invalidation", async () => {
+    let startCount = 0;
+    const replanBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        startCount += 1;
+        if (startCount === 1) {
+          return jsonResponse(playableDecision(fixturePlanV3()), { status: 201 });
+        }
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "adaptation_unavailable",
+            terminal: {
+              reason: "capability_warming",
+              message: "Tone-map capability discovery is still warming.",
+              retryable: true,
+              retry_after_ms: 4_000,
+            },
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return jsonResponse(
+          playableDecision(
+            fixturePlanV3({
+              plan_id: "plan:replacement-invalidation",
+              plan_attempt_key: "v3:replacement-invalidation",
+              delivery: "server_transcode_hls",
+            }),
+          ),
+        );
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    act(() => result.current.switchVersion(99, 100));
+    await waitFor(() => expect(startCount).toBe(2));
+
+    let outcome: boolean | undefined;
+    act(() => {
+      void result.current
+        .invalidatePlan("plan:0123456789abcdef", "video_copy_unsafe", 100)
+        .then((value) => {
+          outcome = value;
+        });
+    });
+
+    await waitFor(() => expect(replanBodies).toHaveLength(1), { timeout: 500 });
+    await waitFor(() => expect(outcome).toBe(true));
+    expect(replanBodies[0]).toMatchObject({
+      operation: "failure_recovery",
+      failed_plan_id: "plan:0123456789abcdef",
+    });
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:replacement-invalidation"));
+    unmount();
+  });
+
   it("aborts an in-flight replan when the server invalidates the current plan", async () => {
     const replanBodies: Array<Record<string, unknown>> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1943,13 +2014,18 @@ describe("usePlaybackSession server-invalidated plans", () => {
           });
         }
         return jsonResponse(
-          playableDecision(
-            fixturePlanV3({
-              plan_id: "plan:4444444444444444",
-              plan_attempt_key: "v3:4444444444444444",
-              delivery: "server_transcode_hls",
-            }),
-          ),
+          {
+            error: "stale_playback_plan",
+            message: "The failed plan is no longer current",
+            current_decision: playableDecision(
+              fixturePlanV3({
+                plan_id: "plan:4444444444444444",
+                plan_attempt_key: "v3:4444444444444444",
+                delivery: "server_transcode_hls",
+              }),
+            ),
+          },
+          { status: 409 },
         );
       }
       if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -311,6 +311,71 @@ describe("routeEventPlanIdentityV3", () => {
   });
 });
 
+describe("usePlaybackSession capability warming", () => {
+  it("retries a warming start with a fresh attempt id while keeping the requested file", async () => {
+    const startBodies: Array<{ file_id: number; playback_attempt_id: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        startBodies.push(
+          JSON.parse(String(init?.body)) as { file_id: number; playback_attempt_id: string },
+        );
+        if (startBodies.length === 1) {
+          return jsonResponse(
+            {
+              protocol_version: 3,
+              server_features: ["playback_plan_v3"],
+              outcome: "adaptation_unavailable",
+              terminal: {
+                reason: "capability_warming",
+                message: "Tone-map capability discovery is still warming.",
+                retryable: true,
+                retry_after_ms: 1,
+              },
+            },
+            { status: 201 },
+          );
+        }
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "playable",
+            session_id: "session-warmed",
+            playback_plan: fixturePlanV3({
+              session_id: "session-warmed",
+              requested_media_file_id: 7,
+              effective_media_file_id: 7,
+            }),
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/route-events")) {
+        return new Response(null, { status: 202 });
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-warming", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.sessionId).toBe("session-warmed"));
+    expect(startBodies).toHaveLength(2);
+    expect(startBodies.map((body) => body.file_id)).toEqual([7, 7]);
+    expect(startBodies[1]!.playback_attempt_id).not.toBe(startBodies[0]!.playback_attempt_id);
+    expect(result.current.error).toBeNull();
+
+    unmount();
+  });
+});
+
 describe("usePlaybackSession quality changes", () => {
   it("rolls back a rejected quality and keeps it out of later replans", async () => {
     const plan = fixturePlanV3();
@@ -1254,6 +1319,70 @@ describe("usePlaybackSession version switches", () => {
 });
 
 describe("usePlaybackSession replans", () => {
+  it("retries a warming replan with a fresh replan request id", async () => {
+    const replanBodies: Array<{ replan_request_id: string }> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "playable",
+            session_id: "session-warming-replan",
+            playback_plan: fixturePlanV3({ session_id: "session-warming-replan" }),
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/session-warming-replan/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as { replan_request_id: string });
+        if (replanBodies.length === 1) {
+          return jsonResponse({
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "adaptation_unavailable",
+            terminal: {
+              reason: "capability_warming",
+              message: "Tone-map capability discovery is still warming.",
+              retryable: true,
+              retry_after_ms: 1,
+            },
+          });
+        }
+        return jsonResponse({
+          protocol_version: 3,
+          server_features: ["playback_plan_v3"],
+          outcome: "playable",
+          session_id: "session-warming-replan",
+          playback_plan: fixturePlanV3({
+            session_id: "session-warming-replan",
+            plan_id: "plan:warmed-replan-0001",
+            plan_attempt_key: "v3:warmed-replan",
+          }),
+        });
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-warming-replan", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan).not.toBeNull());
+
+    act(() => result.current.changeQuality("720p", 30));
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:warmed-replan-0001"));
+
+    expect(replanBodies).toHaveLength(2);
+    expect(replanBodies[1]!.replan_request_id).not.toBe(replanBodies[0]!.replan_request_id);
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
   it("drops a queued predecessor failure after the in-flight replan adopts a new plan", async () => {
     const initialPlan = fixturePlanV3();
     let resolveFirstReplan: ((response: Response) => void) | undefined;

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -324,7 +324,7 @@ describe("usePlaybackSession capability warming", () => {
           return jsonResponse(
             {
               protocol_version: 3,
-              server_features: ["playback_plan_v3"],
+              server_features: ["playback_plan_v3", "capability_warming_v1"],
               outcome: "adaptation_unavailable",
               terminal: {
                 reason: "capability_warming",
@@ -375,6 +375,43 @@ describe("usePlaybackSession capability warming", () => {
     unmount();
   });
 
+  it("does not retry a warming terminal without the advertised retry contract", async () => {
+    let startCount = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        startCount += 1;
+        return jsonResponse(
+          {
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "adaptation_unavailable",
+            terminal: {
+              reason: "capability_warming",
+              message: "Tone-map capability discovery is still warming.",
+              retryable: true,
+              retry_after_ms: 1,
+            },
+          },
+          { status: 201 },
+        );
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-warming-unadvertised", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.error).toContain("still checking"));
+    expect(startCount).toBe(1);
+    unmount();
+  });
+
   it("refreshes a replacement start position while capability warming", async () => {
     const startBodies: Array<{
       file_id: number;
@@ -395,7 +432,7 @@ describe("usePlaybackSession capability warming", () => {
           return jsonResponse(
             {
               protocol_version: 3,
-              server_features: ["playback_plan_v3"],
+              server_features: ["playback_plan_v3", "capability_warming_v1"],
               outcome: "adaptation_unavailable",
               terminal: {
                 reason: "capability_warming",
@@ -411,7 +448,7 @@ describe("usePlaybackSession capability warming", () => {
         return jsonResponse(
           {
             protocol_version: 3,
-            server_features: ["playback_plan_v3"],
+            server_features: ["playback_plan_v3", "capability_warming_v1"],
             outcome: "playable",
             session_id: replacement ? "session-replacement" : "session-initial",
             playback_plan: fixturePlanV3({
@@ -1419,7 +1456,7 @@ describe("usePlaybackSession replans", () => {
         if (replanBodies.length === 1) {
           return jsonResponse({
             protocol_version: 3,
-            server_features: ["playback_plan_v3"],
+            server_features: ["playback_plan_v3", "capability_warming_v1"],
             outcome: "adaptation_unavailable",
             terminal: {
               reason: "capability_warming",
@@ -1463,6 +1500,82 @@ describe("usePlaybackSession replans", () => {
     expect(replanBodies[0]!.position_seconds).toBe(30);
     expect(replanBodies[1]!.position_seconds).toBe(37);
     expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it("aborts a warming user-intent replan when failure recovery is queued", async () => {
+    const replanBodies: Array<{ operation: string }> = [];
+    let warmingRetryAborted = false;
+    const decision = (plan: ReturnType<typeof fixturePlanV3>) => ({
+      protocol_version: 3,
+      server_features: ["playback_plan_v3", "capability_warming_v1"],
+      outcome: "playable",
+      session_id: plan.session_id,
+      playback_plan: plan,
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse(decision(fixturePlanV3()), { status: 201 });
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as { operation: string });
+        if (replanBodies.length === 1) {
+          return jsonResponse({
+            protocol_version: 3,
+            server_features: ["playback_plan_v3", "capability_warming_v1"],
+            outcome: "adaptation_unavailable",
+            terminal: {
+              reason: "capability_warming",
+              message: "Tone-map capability discovery is still warming.",
+              retryable: true,
+              retry_after_ms: 0,
+            },
+          });
+        }
+        if (replanBodies.length === 2) {
+          return new Promise<Response>((_resolve, reject) => {
+            const abort = () => {
+              warmingRetryAborted = true;
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            };
+            if (init?.signal?.aborted) abort();
+            else init?.signal?.addEventListener("abort", abort, { once: true });
+          });
+        }
+        return jsonResponse(
+          decision(
+            fixturePlanV3({
+              plan_id: "plan:failure-recovery",
+              plan_attempt_key: "v3:failure-recovery",
+            }),
+          ),
+        );
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-warming-recovery", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan).not.toBeNull());
+
+    act(() => result.current.changeQuality("720p", 30));
+    await waitFor(() => expect(replanBodies).toHaveLength(2));
+    act(() => result.current.recoverFromFailure({ classification: "decoder_failure" }, 31));
+
+    await waitFor(() => expect(replanBodies).toHaveLength(3), { timeout: 500 });
+    expect(warmingRetryAborted).toBe(true);
+    expect(replanBodies.map((body) => body.operation)).toEqual([
+      "quality_change",
+      "quality_change",
+      "failure_recovery",
+    ]);
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:failure-recovery"));
     unmount();
   });
 
@@ -2015,7 +2128,7 @@ describe("usePlaybackSession server-invalidated plans", () => {
         if (replanBodies.length === 1) {
           return jsonResponse({
             protocol_version: 3,
-            server_features: ["playback_plan_v3"],
+            server_features: ["playback_plan_v3", "capability_warming_v1"],
             outcome: "adaptation_unavailable",
             terminal: {
               reason: "capability_warming",
@@ -2075,8 +2188,9 @@ describe("usePlaybackSession server-invalidated plans", () => {
     unmount();
   });
 
-  it("interrupts a warming replacement start before handling an invalidation", async () => {
+  it("aborts an in-flight warming replacement retry before handling an invalidation", async () => {
     let startCount = 0;
+    let replacementRetryAborted = false;
     const replanBodies: Array<Record<string, unknown>> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -2085,20 +2199,30 @@ describe("usePlaybackSession server-invalidated plans", () => {
         if (startCount === 1) {
           return jsonResponse(playableDecision(fixturePlanV3()), { status: 201 });
         }
-        return jsonResponse(
-          {
-            protocol_version: 3,
-            server_features: ["playback_plan_v3"],
-            outcome: "adaptation_unavailable",
-            terminal: {
-              reason: "capability_warming",
-              message: "Tone-map capability discovery is still warming.",
-              retryable: true,
-              retry_after_ms: 4_000,
+        if (startCount === 2) {
+          return jsonResponse(
+            {
+              protocol_version: 3,
+              server_features: ["playback_plan_v3", "capability_warming_v1"],
+              outcome: "adaptation_unavailable",
+              terminal: {
+                reason: "capability_warming",
+                message: "Tone-map capability discovery is still warming.",
+                retryable: true,
+                retry_after_ms: 0,
+              },
             },
-          },
-          { status: 201 },
-        );
+            { status: 201 },
+          );
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          const abort = () => {
+            replacementRetryAborted = true;
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          };
+          if (init?.signal?.aborted) abort();
+          else init?.signal?.addEventListener("abort", abort, { once: true });
+        });
       }
       if (url.endsWith("/playback/session-1/replan")) {
         replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
@@ -2125,7 +2249,7 @@ describe("usePlaybackSession server-invalidated plans", () => {
     await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
 
     act(() => result.current.switchVersion(99, 100));
-    await waitFor(() => expect(startCount).toBe(2));
+    await waitFor(() => expect(startCount).toBe(3));
 
     let outcome: boolean | undefined;
     act(() => {
@@ -2138,6 +2262,7 @@ describe("usePlaybackSession server-invalidated plans", () => {
 
     await waitFor(() => expect(replanBodies).toHaveLength(1), { timeout: 500 });
     await waitFor(() => expect(outcome).toBe(true));
+    expect(replacementRetryAborted).toBe(true);
     expect(replanBodies[0]).toMatchObject({
       operation: "failure_recovery",
       failed_plan_id: "plan:0123456789abcdef",

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -1854,6 +1854,139 @@ describe("usePlaybackSession server-invalidated plans", () => {
     unmount();
   });
 
+  it("interrupts a warming retry so an invalidation can meet its deadline", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse(playableDecision(fixturePlanV3()), { status: 201 });
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        if (replanBodies.length === 1) {
+          return jsonResponse({
+            protocol_version: 3,
+            server_features: ["playback_plan_v3"],
+            outcome: "adaptation_unavailable",
+            terminal: {
+              reason: "capability_warming",
+              message: "Tone-map capability discovery is still warming.",
+              retryable: true,
+              retry_after_ms: 4_000,
+            },
+          });
+        }
+        return jsonResponse(
+          playableDecision(
+            fixturePlanV3({
+              plan_id: "plan:3333333333333333",
+              plan_attempt_key: "v3:3333333333333333",
+              delivery: "server_transcode_hls",
+            }),
+          ),
+        );
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    act(() => result.current.changeQuality("720p", 100));
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+
+    let invalidation: Promise<boolean> | undefined;
+    act(() => {
+      invalidation = result.current.invalidatePlan(
+        "plan:0123456789abcdef",
+        "video_copy_unsafe",
+        100,
+      );
+    });
+
+    await waitFor(() => expect(replanBodies).toHaveLength(2), { timeout: 500 });
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await invalidation;
+    });
+
+    expect(outcome).toBe(true);
+    expect(replanBodies[1]).toMatchObject({
+      operation: "failure_recovery",
+      failed_plan_id: "plan:0123456789abcdef",
+      failure: { classification: "video_copy_unsafe" },
+    });
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:3333333333333333"));
+    unmount();
+  });
+
+  it("aborts an in-flight replan when the server invalidates the current plan", async () => {
+    const replanBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        return jsonResponse(playableDecision(fixturePlanV3()), { status: 201 });
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        if (replanBodies.length === 1) {
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("The operation was aborted.", "AbortError")),
+            );
+          });
+        }
+        return jsonResponse(
+          playableDecision(
+            fixturePlanV3({
+              plan_id: "plan:4444444444444444",
+              plan_attempt_key: "v3:4444444444444444",
+              delivery: "server_transcode_hls",
+            }),
+          ),
+        );
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    act(() => result.current.changeQuality("720p", 100));
+    await waitFor(() => expect(replanBodies).toHaveLength(1));
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.invalidatePlan(
+        "plan:0123456789abcdef",
+        "video_copy_unsafe",
+        100,
+      );
+    });
+
+    expect(outcome).toBe(true);
+    expect(replanBodies).toHaveLength(2);
+    expect(replanBodies[1]).toMatchObject({
+      operation: "failure_recovery",
+      failed_plan_id: "plan:0123456789abcdef",
+      failure: { classification: "video_copy_unsafe" },
+    });
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:4444444444444444"));
+    unmount();
+  });
+
   // The mirror image: the client really did move past the invalidated plan
   // while the command was in flight. Waiting must not turn that into a replan —
   // it would evict a route the server never complained about.

--- a/web/src/player/hooks/usePlaybackSession.test.ts
+++ b/web/src/player/hooks/usePlaybackSession.test.ts
@@ -2271,6 +2271,75 @@ describe("usePlaybackSession server-invalidated plans", () => {
     unmount();
   });
 
+  it("aborts the first in-flight replacement request before handling an invalidation", async () => {
+    let startCount = 0;
+    let replacementStartAborted = false;
+    const replanBodies: Array<Record<string, unknown>> = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/playback/start")) {
+        startCount += 1;
+        if (startCount === 1) {
+          return jsonResponse(playableDecision(fixturePlanV3()), { status: 201 });
+        }
+        return new Promise<Response>((_resolve, reject) => {
+          const abort = () => {
+            replacementStartAborted = true;
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          };
+          if (init?.signal?.aborted) abort();
+          else init?.signal?.addEventListener("abort", abort, { once: true });
+        });
+      }
+      if (url.endsWith("/playback/session-1/replan")) {
+        replanBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return jsonResponse(
+          playableDecision(
+            fixturePlanV3({
+              plan_id: "plan:first-replacement-invalidation",
+              plan_attempt_key: "v3:first-replacement-invalidation",
+              delivery: "server_transcode_hls",
+            }),
+          ),
+        );
+      }
+      if (url.endsWith("/playback/route-events")) return new Response(null, { status: 202 });
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, unmount } = renderHook(
+      () => usePlaybackSession("request-1", [], [], 7, 0, false, "auto"),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.plan?.plan_id).toBe("plan:0123456789abcdef"));
+
+    act(() => result.current.switchVersion(99, 100));
+    await waitFor(() => expect(startCount).toBe(2));
+
+    let outcome: boolean | undefined;
+    act(() => {
+      void result.current
+        .invalidatePlan("plan:0123456789abcdef", "video_copy_unsafe", 100)
+        .then((value) => {
+          outcome = value;
+        });
+    });
+
+    await waitFor(() => expect(replanBodies).toHaveLength(1), { timeout: 500 });
+    await waitFor(() => expect(outcome).toBe(true));
+    expect(replacementStartAborted).toBe(true);
+    expect(replanBodies[0]).toMatchObject({
+      operation: "failure_recovery",
+      failed_plan_id: "plan:0123456789abcdef",
+    });
+    await waitFor(() =>
+      expect(result.current.plan?.plan_id).toBe("plan:first-replacement-invalidation"),
+    );
+    unmount();
+  });
+
   it("aborts an in-flight replan when the server invalidates the current plan", async () => {
     const replanBodies: Array<Record<string, unknown>> = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -757,12 +757,13 @@ export function usePlaybackSession(
           throw new Error("No playable version found");
         }
 
+        let retryPosition = position;
         let decision: DecisionResponseV3;
         for (let retryIndex = 0; ; retryIndex += 1) {
           playbackAttemptIdRef.current = playbackAttemptId;
           decision = await requestStart(
             selectedFileId,
-            position,
+            retryPosition,
             forceStartPosition,
             playbackAttemptId,
           );
@@ -800,6 +801,7 @@ export function usePlaybackSession(
             return;
           }
           if (loadSequence !== loadSequenceRef.current) return;
+          retryPosition = playbackPositionRef.current;
 
           // Start decisions are idempotent by playback_attempt_id. A retry must
           // mint a new identity or the server will correctly replay the warming

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePlayerConfig } from "../context/PlayerConfigContext";
 import type { PlayerConfig } from "../context/PlayerConfigContext";
-import { playerFetch } from "../player-fetch";
+import { PlayerFetchError, playerFetch } from "../player-fetch";
 import { describePlanTerminal, describePlaybackTransportError } from "../playback-errors";
 import { useCodecDetection } from "./useCodecDetection";
 import {
@@ -60,6 +60,32 @@ function capabilityWarmingRetryDelayV3(
     );
   }
   return CAPABILITY_WARMING_RETRY_DELAYS_MS[retryIndex] ?? null;
+}
+
+function currentDecisionFromStalePlanErrorV3(error: unknown): DecisionResponseV3 | null {
+  if (
+    !(error instanceof PlayerFetchError) ||
+    error.status !== 409 ||
+    error.code !== "stale_playback_plan" ||
+    !error.rawBody
+  ) {
+    return null;
+  }
+  try {
+    const envelope = JSON.parse(error.rawBody) as { current_decision?: DecisionResponseV3 };
+    const decision = envelope.current_decision;
+    if (
+      decision?.protocol_version !== 3 ||
+      decision.outcome !== "playable" ||
+      !decision.session_id ||
+      !decision.playback_plan
+    ) {
+      return null;
+    }
+    return decision;
+  } catch {
+    return null;
+  }
 }
 
 interface PlaybackSessionState {
@@ -656,6 +682,7 @@ export function usePlaybackSession(
       const previousSessionId = sessionIdRef.current;
       const hasExistingSession = !!previousState.sessionId && !!previousState.streamUrl;
       const loadSequence = ++loadSequenceRef.current;
+      const warmingRetryEpoch = warmingRetryEpochRef.current;
       const previousAttempt = {
         playbackAttemptId: playbackAttemptIdRef.current,
         planAttemptId: planAttemptIdRef.current,
@@ -667,6 +694,16 @@ export function usePlaybackSession(
         planAttemptIdRef.current = previousAttempt.planAttemptId;
         attemptedPlanKeysRef.current = previousAttempt.attemptedPlanKeys;
         attemptCountRef.current = previousAttempt.attemptCount;
+      };
+      const restoreInterruptedReplacement = () => {
+        if (!hasExistingSession) return;
+        restorePreviousAttempt();
+        setState((current) => ({
+          ...current,
+          loading: false,
+          loadingMessage: null,
+          replacing: false,
+        }));
       };
 
       setState((current) => ({
@@ -750,7 +787,18 @@ export function usePlaybackSession(
             errorTitle: hasExistingSession ? current.errorTitle : null,
             error: hasExistingSession ? current.error : null,
           }));
-          await new Promise<void>((resolve) => window.setTimeout(resolve, retryDelay));
+          if (warmingRetryEpoch !== warmingRetryEpochRef.current) {
+            restoreInterruptedReplacement();
+            return;
+          }
+          const retryDelayElapsed = await waitForCapabilityWarmingRetry(
+            retryDelay,
+            warmingRetryEpoch,
+          );
+          if (!retryDelayElapsed) {
+            restoreInterruptedReplacement();
+            return;
+          }
           if (loadSequence !== loadSequenceRef.current) return;
 
           // Start decisions are idempotent by playback_attempt_id. A retry must
@@ -815,7 +863,15 @@ export function usePlaybackSession(
         endAdoption(loadSequence);
       }
     },
-    [adoptDecision, beginAdoption, endAdoption, requestStart, selectFileId, stopSession],
+    [
+      adoptDecision,
+      beginAdoption,
+      endAdoption,
+      requestStart,
+      selectFileId,
+      stopSession,
+      waitForCapabilityWarmingRetry,
+    ],
   );
 
   useEffect(() => {
@@ -1063,6 +1119,10 @@ export function usePlaybackSession(
         }
         return adopted;
       } catch (err) {
+        const currentDecision = currentDecisionFromStalePlanErrorV3(err);
+        if (currentDecision && loadSequence === loadSequenceRef.current) {
+          return adoptDecision(currentDecision);
+        }
         if (replanAbort.signal.aborted) return false;
         if (loadSequence !== loadSequenceRef.current) return false;
         if (retireSessionOnRefusal) {

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -1011,6 +1011,8 @@ export function usePlaybackSession(
 
       const isFailureRecovery =
         options.operation === "failure_recovery" || options.operation === "seek_failure_recovery";
+      const isUserIntent =
+        options.operation === "track_change" || options.operation === "quality_change";
       if (isFailureRecovery && attemptCountRef.current > MAX_ATTEMPT_COUNT_V3) {
         setState((current) => ({
           ...current,
@@ -1031,9 +1033,11 @@ export function usePlaybackSession(
         : [];
       const attemptCount = isFailureRecovery ? attemptCountRef.current : 1;
 
+      let retryPositionSeconds = options.positionSeconds;
       const buildBody = () =>
         buildReplanRequestV3({
           ...options,
+          positionSeconds: retryPositionSeconds,
           extraClientFeatures: VIDEO_CLIENT_FEATURES_V3,
           plan,
           playbackAttemptId,
@@ -1082,6 +1086,7 @@ export function usePlaybackSession(
           );
           if (!retryDelayElapsed) return false;
           if (loadSequence !== loadSequenceRef.current) return false;
+          retryPositionSeconds = playbackPositionRef.current;
         }
 
         // A version switch or a fresh start that landed while this was in
@@ -1121,7 +1126,22 @@ export function usePlaybackSession(
       } catch (err) {
         const currentDecision = currentDecisionFromStalePlanErrorV3(err);
         if (currentDecision && loadSequence === loadSequenceRef.current) {
-          return adoptDecision(currentDecision);
+          const adopted = adoptDecision(currentDecision);
+          if (!adopted || !isUserIntent) return adopted;
+          if (pendingReplanRef.current) return false;
+          // The stale response only reconciles what the server already
+          // committed; it does not fulfill this track/quality request. Queue
+          // the outstanding intent so finally dispatches it against the newly
+          // adopted durable plan after the in-flight guard is released.
+          return new Promise<boolean>((resolve) => {
+            pendingReplanRef.current = {
+              options: { ...options, positionSeconds: playbackPositionRef.current },
+              loadSequence,
+              retireSessionOnRefusal,
+              resolve,
+              planId: currentDecision.playback_plan!.plan_id,
+            };
+          });
         }
         if (replanAbort.signal.aborted) return false;
         if (loadSequence !== loadSequenceRef.current) return false;

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -400,7 +400,6 @@ export function usePlaybackSession(
   const warmingRetryEpochRef = useRef(0);
   const warmingRetryWaitersRef = useRef(new Set<() => void>());
   const activeStartAbortRef = useRef<AbortController | null>(null);
-  const activeStartWarmingRef = useRef(false);
   const activeReplanAbortRef = useRef<AbortController | null>(null);
   const activeReplanWarmingRef = useRef(false);
   const pendingReplanRef = useRef<{
@@ -803,10 +802,8 @@ export function usePlaybackSession(
             Date.now() - warmingRetryStartedAt,
           );
           if (retryDelay == null) {
-            activeStartWarmingRef.current = false;
             break;
           }
-          activeStartWarmingRef.current = true;
           setState((current) => ({
             ...current,
             loading: !hasExistingSession,
@@ -895,7 +892,6 @@ export function usePlaybackSession(
       } finally {
         if (activeStartAbortRef.current === startAbort) {
           activeStartAbortRef.current = null;
-          activeStartWarmingRef.current = false;
         }
         endAdoption(loadSequence);
       }
@@ -1387,15 +1383,15 @@ export function usePlaybackSession(
       if (settling) {
         // A server invalidation is subject to an eight-second acknowledgement
         // deadline. It supersedes queued replans and wakes any capability-
-        // warming delay immediately; the in-flight response may still adopt,
-        // so wait for that one request before deciding which plan was revoked.
+        // warming delay immediately. Abort a replacement start as soon as the
+        // plan still on screen is invalidated: even its first cold request can
+        // remain in capability discovery longer than the command deadline.
+        // Replans still reconcile a response that committed before its abort.
         const pendingReplan = pendingReplanRef.current;
         pendingReplanRef.current = null;
         pendingReplan?.resolve(false);
         if (planRef.current?.plan_id === planId) {
-          if (activeStartWarmingRef.current) {
-            activeStartAbortRef.current?.abort();
-          }
+          activeStartAbortRef.current?.abort();
           activeReplanAbortRef.current?.abort();
         }
         interruptCapabilityWarmingRetries();

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -38,6 +38,30 @@ import type {
   ResumeHints,
 } from "../types";
 
+const CAPABILITY_WARMING_REASON_V3 = "capability_warming";
+const CAPABILITY_WARMING_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+
+function capabilityWarmingRetryDelayV3(
+  decision: DecisionResponseV3,
+  retryIndex: number,
+): number | null {
+  const terminal = decision.terminal;
+  if (
+    !terminal?.retryable ||
+    terminal.reason !== CAPABILITY_WARMING_REASON_V3 ||
+    retryIndex >= CAPABILITY_WARMING_RETRY_DELAYS_MS.length
+  ) {
+    return null;
+  }
+  if (Number.isFinite(terminal.retry_after_ms) && Number(terminal.retry_after_ms) >= 0) {
+    return Math.max(
+      CAPABILITY_WARMING_RETRY_DELAYS_MS[retryIndex] ?? 250,
+      Math.min(Number(terminal.retry_after_ms), 4_000),
+    );
+  }
+  return CAPABILITY_WARMING_RETRY_DELAYS_MS[retryIndex] ?? null;
+}
+
 interface PlaybackSessionState {
   /**
    * The server's plan, verbatim. It is the single source of truth for the
@@ -61,6 +85,7 @@ interface PlaybackSessionState {
   qualityPreference: string;
   shouldAutoPlay: boolean;
   loading: boolean;
+  loadingMessage: string | null;
   replacing: boolean;
   replanning: boolean;
   errorTitle: string | null;
@@ -191,6 +216,7 @@ function planToSessionState(
     qualityPreference,
     shouldAutoPlay,
     loading: false,
+    loadingMessage: null,
     replacing: false,
     replanning: false,
     errorTitle: null,
@@ -284,6 +310,7 @@ export function usePlaybackSession(
     qualityPreference: qualityPreference?.trim() || "auto",
     shouldAutoPlay: true,
     loading: true,
+    loadingMessage: null,
     replacing: false,
     replanning: false,
     errorTitle: null,
@@ -440,6 +467,7 @@ export function usePlaybackSession(
         setState((current) => ({
           ...current,
           loading: false,
+          loadingMessage: null,
           replacing: false,
           replanning: false,
           errorTitle: failure.title,
@@ -616,13 +644,14 @@ export function usePlaybackSession(
       setState((current) => ({
         ...current,
         loading: !hasExistingSession,
+        loadingMessage: null,
         replacing: hasExistingSession,
         errorTitle: hasExistingSession ? current.errorTitle : null,
         error: hasExistingSession ? current.error : null,
       }));
 
       // A start begins a new attempt chain: fresh attempt id, empty loop guard.
-      const playbackAttemptId = randomUUID();
+      let playbackAttemptId = randomUUID();
       playbackAttemptIdRef.current = playbackAttemptId;
       attemptedPlanKeysRef.current = [];
       attemptCountRef.current = 1;
@@ -648,6 +677,7 @@ export function usePlaybackSession(
           durationSeconds: null,
           subtitleUrls: [],
           loading: false,
+          loadingMessage: null,
           replacing: false,
           replanning: false,
           errorTitle: nextError?.title ?? current.errorTitle,
@@ -662,12 +692,45 @@ export function usePlaybackSession(
           throw new Error("No playable version found");
         }
 
-        const decision = await requestStart(
-          selectedFileId,
-          position,
-          forceStartPosition,
-          playbackAttemptId,
-        );
+        let decision: DecisionResponseV3;
+        for (let retryIndex = 0; ; retryIndex += 1) {
+          playbackAttemptIdRef.current = playbackAttemptId;
+          decision = await requestStart(
+            selectedFileId,
+            position,
+            forceStartPosition,
+            playbackAttemptId,
+          );
+
+          if (loadSequence !== loadSequenceRef.current) {
+            const staleSessionId = decision.playback_plan?.session_id ?? decision.session_id;
+            if (staleSessionId) {
+              await stopSession(staleSessionId).catch(() => {
+                // Best effort cleanup for stale session starts.
+              });
+            }
+            return;
+          }
+
+          const retryDelay = capabilityWarmingRetryDelayV3(decision, retryIndex);
+          if (retryDelay == null) break;
+          setState((current) => ({
+            ...current,
+            loading: !hasExistingSession,
+            replacing: hasExistingSession,
+            loadingMessage: "Preparing transcoder…",
+            errorTitle: hasExistingSession ? current.errorTitle : null,
+            error: hasExistingSession ? current.error : null,
+          }));
+          await new Promise<void>((resolve) => window.setTimeout(resolve, retryDelay));
+          if (loadSequence !== loadSequenceRef.current) return;
+
+          // Start decisions are idempotent by playback_attempt_id. A retry must
+          // mint a new identity or the server will correctly replay the warming
+          // terminal forever even after the shared probe completes.
+          playbackAttemptId = randomUUID();
+          playbackAttemptIdRef.current = playbackAttemptId;
+        }
 
         if (loadSequence !== loadSequenceRef.current) {
           const staleSessionId = decision.playback_plan?.session_id ?? decision.session_id;
@@ -685,6 +748,7 @@ export function usePlaybackSession(
           setState((current) => ({
             ...current,
             loading: false,
+            loadingMessage: null,
             replacing: false,
             errorTitle: previousState.errorTitle,
             error: previousState.error,
@@ -711,6 +775,7 @@ export function usePlaybackSession(
           setState((current) => ({
             ...current,
             loading: false,
+            loadingMessage: null,
             replacing: false,
           }));
           return;
@@ -765,6 +830,9 @@ export function usePlaybackSession(
   // Clean up session on unmount.
   useEffect(() => {
     return () => {
+      // Supersede an in-flight start or bounded warming retry before cleaning
+      // up the session it may otherwise try to replace after unmount.
+      loadSequenceRef.current += 1;
       const sid = sessionIdRef.current;
       if (!sid) return;
 
@@ -879,22 +947,23 @@ export function usePlaybackSession(
         : [];
       const attemptCount = isFailureRecovery ? attemptCountRef.current : 1;
 
-      const body = buildReplanRequestV3({
-        ...options,
-        extraClientFeatures: VIDEO_CLIENT_FEATURES_V3,
-        plan,
-        playbackAttemptId,
-        replanRequestId: randomUUID(),
-        planAttemptId: planAttemptIdRef.current,
-        qualityPreference: qualityRef.current,
-        attemptedPlanKeys,
-        attemptCount,
-        metered: detectMeteredV3(),
-        bandwidthEstimateKbps: detectBandwidthEstimateKbpsV3(),
-        bandwidthCapKbps: maxBitrateKbps,
-        clientCapabilities,
-        clientPlaybackContext,
-      });
+      const buildBody = () =>
+        buildReplanRequestV3({
+          ...options,
+          extraClientFeatures: VIDEO_CLIENT_FEATURES_V3,
+          plan,
+          playbackAttemptId,
+          replanRequestId: randomUUID(),
+          planAttemptId: planAttemptIdRef.current,
+          qualityPreference: qualityRef.current,
+          attemptedPlanKeys,
+          attemptCount,
+          metered: detectMeteredV3(),
+          bandwidthEstimateKbps: detectBandwidthEstimateKbpsV3(),
+          bandwidthCapKbps: maxBitrateKbps,
+          clientCapabilities,
+          clientPlaybackContext,
+        });
 
       const loadSequence = loadSequenceRef.current;
       replanInFlightRef.current = true;
@@ -907,11 +976,21 @@ export function usePlaybackSession(
       }));
 
       try {
-        const decision = await playerFetch<DecisionResponseV3>(
-          config,
-          `/playback/${sessionId}/replan`,
-          { method: "POST", body: JSON.stringify(body) },
-        );
+        let decision: DecisionResponseV3;
+        for (let retryIndex = 0; ; retryIndex += 1) {
+          decision = await playerFetch<DecisionResponseV3>(
+            config,
+            `/playback/${sessionId}/replan`,
+            { method: "POST", body: JSON.stringify(buildBody()) },
+          );
+
+          if (loadSequence !== loadSequenceRef.current) return false;
+
+          const retryDelay = capabilityWarmingRetryDelayV3(decision, retryIndex);
+          if (retryDelay == null) break;
+          await new Promise<void>((resolve) => window.setTimeout(resolve, retryDelay));
+          if (loadSequence !== loadSequenceRef.current) return false;
+        }
 
         // A version switch or a fresh start that landed while this was in
         // flight owns the session now; this plan is already superseded.

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -362,6 +362,9 @@ export function usePlaybackSession(
   // decide against, so only it is waited on.
   const adoptionsInFlightRef = useRef(new Map<number, number>());
   const adoptionWaitersRef = useRef<Array<{ loadSequence: number; resolve: () => void }>>([]);
+  const warmingRetryEpochRef = useRef(0);
+  const warmingRetryWaitersRef = useRef(new Set<() => void>());
+  const activeReplanAbortRef = useRef<AbortController | null>(null);
   const pendingReplanRef = useRef<{
     options: ReplanOptions;
     loadSequence: number;
@@ -425,6 +428,31 @@ export function usePlaybackSession(
       adoptionWaitersRef.current.push({ loadSequence, resolve });
     });
   }, []);
+
+  const interruptCapabilityWarmingRetries = useCallback(() => {
+    warmingRetryEpochRef.current += 1;
+    for (const interrupt of Array.from(warmingRetryWaitersRef.current)) interrupt();
+  }, []);
+
+  const waitForCapabilityWarmingRetry = useCallback(
+    (delayMillis: number, epoch: number): Promise<boolean> =>
+      new Promise<boolean>((resolve) => {
+        let settled = false;
+        let timeoutId = 0;
+        const finish = (elapsed: boolean) => {
+          if (settled) return;
+          settled = true;
+          window.clearTimeout(timeoutId);
+          warmingRetryWaitersRef.current.delete(interrupt);
+          resolve(elapsed);
+        };
+        const interrupt = () => finish(false);
+        warmingRetryWaitersRef.current.add(interrupt);
+        timeoutId = window.setTimeout(() => finish(true), delayMillis);
+        if (epoch !== warmingRetryEpochRef.current) interrupt();
+      }),
+    [],
+  );
 
   const reportEvent = useCallback(
     (
@@ -966,6 +994,9 @@ export function usePlaybackSession(
         });
 
       const loadSequence = loadSequenceRef.current;
+      const warmingRetryEpoch = warmingRetryEpochRef.current;
+      const replanAbort = new AbortController();
+      activeReplanAbortRef.current = replanAbort;
       replanInFlightRef.current = true;
       beginAdoption(loadSequence);
       setState((current) => ({
@@ -981,14 +1012,19 @@ export function usePlaybackSession(
           decision = await playerFetch<DecisionResponseV3>(
             config,
             `/playback/${sessionId}/replan`,
-            { method: "POST", body: JSON.stringify(buildBody()) },
+            { method: "POST", body: JSON.stringify(buildBody()), signal: replanAbort.signal },
           );
 
           if (loadSequence !== loadSequenceRef.current) return false;
 
           const retryDelay = capabilityWarmingRetryDelayV3(decision, retryIndex);
           if (retryDelay == null) break;
-          await new Promise<void>((resolve) => window.setTimeout(resolve, retryDelay));
+          if (warmingRetryEpoch !== warmingRetryEpochRef.current) return false;
+          const retryDelayElapsed = await waitForCapabilityWarmingRetry(
+            retryDelay,
+            warmingRetryEpoch,
+          );
+          if (!retryDelayElapsed) return false;
           if (loadSequence !== loadSequenceRef.current) return false;
         }
 
@@ -1027,6 +1063,7 @@ export function usePlaybackSession(
         }
         return adopted;
       } catch (err) {
+        if (replanAbort.signal.aborted) return false;
         if (loadSequence !== loadSequenceRef.current) return false;
         if (retireSessionOnRefusal) {
           console.error("Failed to refresh playback output", err);
@@ -1041,6 +1078,9 @@ export function usePlaybackSession(
         }));
         return false;
       } finally {
+        if (activeReplanAbortRef.current === replanAbort) {
+          activeReplanAbortRef.current = null;
+        }
         replanInFlightRef.current = false;
         setState((current) => (current.replanning ? { ...current, replanning: false } : current));
 
@@ -1079,6 +1119,7 @@ export function usePlaybackSession(
       endAdoption,
       maxBitrateKbps,
       retireActiveSession,
+      waitForCapabilityWarmingRetry,
     ],
   );
   issueReplanRef.current = replan;
@@ -1211,7 +1252,20 @@ export function usePlaybackSession(
   const invalidatePlan = useCallback(
     async (planId: string, reason: string, currentPosition: number): Promise<boolean> => {
       const settling = awaitAdoptionSettled();
-      if (settling) await settling;
+      if (settling) {
+        // A server invalidation is subject to an eight-second acknowledgement
+        // deadline. It supersedes queued replans and wakes any capability-
+        // warming delay immediately; the in-flight response may still adopt,
+        // so wait for that one request before deciding which plan was revoked.
+        const pendingReplan = pendingReplanRef.current;
+        pendingReplanRef.current = null;
+        pendingReplan?.resolve(false);
+        if (planRef.current?.plan_id === planId) {
+          activeReplanAbortRef.current?.abort();
+        }
+        interruptCapabilityWarmingRetries();
+        await settling;
+      }
       const plan = planRef.current;
       if (!plan) return false;
       // The command names the plan the server invalidated. Once the client has
@@ -1228,7 +1282,7 @@ export function usePlaybackSession(
         failure: { classification, message: "The server invalidated this plan." },
       });
     },
-    [awaitAdoptionSettled, replan, reportEvent],
+    [awaitAdoptionSettled, interruptCapabilityWarmingRetries, replan, reportEvent],
   );
 
   const reanchorSeek = useCallback(

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -14,6 +14,7 @@ import { reportRouteEventV3 } from "../route-events-v3";
 import { buildPlayerStreamUrl } from "../stream-url";
 import { randomUUID } from "@/lib/uuid";
 import {
+  FEATURE_CAPABILITY_WARMING_V3,
   FEATURE_OUTPUT_CHANGE_V3,
   MAX_ATTEMPT_COUNT_V3,
   MAX_ATTEMPTED_PLAN_KEYS_V3,
@@ -54,6 +55,7 @@ function capabilityWarmingRetryDelayV3(
   if (
     !terminal?.retryable ||
     terminal.reason !== CAPABILITY_WARMING_REASON_V3 ||
+    !decision.server_features.includes(FEATURE_CAPABILITY_WARMING_V3) ||
     elapsedMs >= CAPABILITY_WARMING_RETRY_BUDGET_MS
   ) {
     return null;
@@ -397,7 +399,10 @@ export function usePlaybackSession(
   const adoptionWaitersRef = useRef<Array<{ loadSequence: number; resolve: () => void }>>([]);
   const warmingRetryEpochRef = useRef(0);
   const warmingRetryWaitersRef = useRef(new Set<() => void>());
+  const activeStartAbortRef = useRef<AbortController | null>(null);
+  const activeStartWarmingRef = useRef(false);
   const activeReplanAbortRef = useRef<AbortController | null>(null);
+  const activeReplanWarmingRef = useRef(false);
   const pendingReplanRef = useRef<{
     options: ReplanOptions;
     loadSequence: number;
@@ -577,6 +582,7 @@ export function usePlaybackSession(
       position: number,
       forceStartPosition: boolean,
       playbackAttemptId: string,
+      signal?: AbortSignal,
     ): Promise<DecisionResponseV3> => {
       const body = buildStartRequestV3({
         extraClientFeatures: VIDEO_CLIENT_FEATURES_V3,
@@ -598,6 +604,7 @@ export function usePlaybackSession(
       return playerFetch<DecisionResponseV3>(config, "/playback/start", {
         method: "POST",
         body: JSON.stringify(body),
+        signal,
       });
     },
     [
@@ -689,6 +696,9 @@ export function usePlaybackSession(
       const previousSessionId = sessionIdRef.current;
       const hasExistingSession = !!previousState.sessionId && !!previousState.streamUrl;
       const loadSequence = ++loadSequenceRef.current;
+      activeStartAbortRef.current?.abort();
+      const startAbort = new AbortController();
+      activeStartAbortRef.current = startAbort;
       const warmingRetryEpoch = warmingRetryEpochRef.current;
       const previousAttempt = {
         playbackAttemptId: playbackAttemptIdRef.current,
@@ -774,6 +784,7 @@ export function usePlaybackSession(
             retryPosition,
             forceStartPosition,
             playbackAttemptId,
+            startAbort.signal,
           );
 
           if (loadSequence !== loadSequenceRef.current) {
@@ -791,7 +802,11 @@ export function usePlaybackSession(
             retryIndex,
             Date.now() - warmingRetryStartedAt,
           );
-          if (retryDelay == null) break;
+          if (retryDelay == null) {
+            activeStartWarmingRef.current = false;
+            break;
+          }
+          activeStartWarmingRef.current = true;
           setState((current) => ({
             ...current,
             loading: !hasExistingSession,
@@ -858,6 +873,10 @@ export function usePlaybackSession(
         if (loadSequence !== loadSequenceRef.current) {
           return;
         }
+        if (startAbort.signal.aborted) {
+          restoreInterruptedReplacement();
+          return;
+        }
 
         if (hasExistingSession && allowPreserveExistingSessionOnError) {
           console.error(replacementErrorMessage, err);
@@ -874,6 +893,10 @@ export function usePlaybackSession(
         const nextError = describePlaybackSessionError(err, initialErrorMessage);
         retirePreviousSession(nextError);
       } finally {
+        if (activeStartAbortRef.current === startAbort) {
+          activeStartAbortRef.current = null;
+          activeStartWarmingRef.current = false;
+        }
         endAdoption(loadSequence);
       }
     },
@@ -1018,6 +1041,10 @@ export function usePlaybackSession(
               resolve,
               planId: plan.plan_id,
             };
+            if (isPendingFailureRecovery && activeReplanWarmingRef.current) {
+              activeReplanAbortRef.current?.abort();
+              interruptCapabilityWarmingRetries();
+            }
           });
         }
         return false;
@@ -1097,7 +1124,11 @@ export function usePlaybackSession(
             retryIndex,
             Date.now() - warmingRetryStartedAt,
           );
-          if (retryDelay == null) break;
+          if (retryDelay == null) {
+            activeReplanWarmingRef.current = false;
+            break;
+          }
+          activeReplanWarmingRef.current = true;
           if (warmingRetryEpoch !== warmingRetryEpochRef.current) return false;
           const retryDelayElapsed = await waitForCapabilityWarmingRetry(
             retryDelay,
@@ -1180,6 +1211,7 @@ export function usePlaybackSession(
         if (activeReplanAbortRef.current === replanAbort) {
           activeReplanAbortRef.current = null;
         }
+        activeReplanWarmingRef.current = false;
         replanInFlightRef.current = false;
         setState((current) => (current.replanning ? { ...current, replanning: false } : current));
 
@@ -1216,6 +1248,7 @@ export function usePlaybackSession(
       clientPlaybackContext,
       config,
       endAdoption,
+      interruptCapabilityWarmingRetries,
       maxBitrateKbps,
       retireActiveSession,
       waitForCapabilityWarmingRetry,
@@ -1360,6 +1393,9 @@ export function usePlaybackSession(
         pendingReplanRef.current = null;
         pendingReplan?.resolve(false);
         if (planRef.current?.plan_id === planId) {
+          if (activeStartWarmingRef.current) {
+            activeStartAbortRef.current?.abort();
+          }
           activeReplanAbortRef.current?.abort();
         }
         interruptCapabilityWarmingRetries();

--- a/web/src/player/hooks/usePlaybackSession.ts
+++ b/web/src/player/hooks/usePlaybackSession.ts
@@ -40,26 +40,33 @@ import type {
 
 const CAPABILITY_WARMING_REASON_V3 = "capability_warming";
 const CAPABILITY_WARMING_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
+// Remote nodes may advertise a probe request budget of up to five minutes.
+// Keep the client retry window aligned with that server-side bound so a cold,
+// healthy executor is not abandoned before its shared probe can finish.
+const CAPABILITY_WARMING_RETRY_BUDGET_MS = 5 * 60_000;
 
 function capabilityWarmingRetryDelayV3(
   decision: DecisionResponseV3,
   retryIndex: number,
+  elapsedMs: number,
 ): number | null {
   const terminal = decision.terminal;
   if (
     !terminal?.retryable ||
     terminal.reason !== CAPABILITY_WARMING_REASON_V3 ||
-    retryIndex >= CAPABILITY_WARMING_RETRY_DELAYS_MS.length
+    elapsedMs >= CAPABILITY_WARMING_RETRY_BUDGET_MS
   ) {
     return null;
   }
+  const fallbackDelay =
+    CAPABILITY_WARMING_RETRY_DELAYS_MS[
+      Math.min(retryIndex, CAPABILITY_WARMING_RETRY_DELAYS_MS.length - 1)
+    ] ?? 4_000;
+  let delay: number = fallbackDelay;
   if (Number.isFinite(terminal.retry_after_ms) && Number(terminal.retry_after_ms) >= 0) {
-    return Math.max(
-      CAPABILITY_WARMING_RETRY_DELAYS_MS[retryIndex] ?? 250,
-      Math.min(Number(terminal.retry_after_ms), 4_000),
-    );
+    delay = Math.max(50, Math.min(Number(terminal.retry_after_ms), 4_000));
   }
-  return CAPABILITY_WARMING_RETRY_DELAYS_MS[retryIndex] ?? null;
+  return Math.min(delay, CAPABILITY_WARMING_RETRY_BUDGET_MS - elapsedMs);
 }
 
 function currentDecisionFromStalePlanErrorV3(error: unknown): DecisionResponseV3 | null {
@@ -759,6 +766,7 @@ export function usePlaybackSession(
 
         let retryPosition = position;
         let decision: DecisionResponseV3;
+        const warmingRetryStartedAt = Date.now();
         for (let retryIndex = 0; ; retryIndex += 1) {
           playbackAttemptIdRef.current = playbackAttemptId;
           decision = await requestStart(
@@ -778,7 +786,11 @@ export function usePlaybackSession(
             return;
           }
 
-          const retryDelay = capabilityWarmingRetryDelayV3(decision, retryIndex);
+          const retryDelay = capabilityWarmingRetryDelayV3(
+            decision,
+            retryIndex,
+            Date.now() - warmingRetryStartedAt,
+          );
           if (retryDelay == null) break;
           setState((current) => ({
             ...current,
@@ -1070,6 +1082,7 @@ export function usePlaybackSession(
 
       try {
         let decision: DecisionResponseV3;
+        const warmingRetryStartedAt = Date.now();
         for (let retryIndex = 0; ; retryIndex += 1) {
           decision = await playerFetch<DecisionResponseV3>(
             config,
@@ -1079,7 +1092,11 @@ export function usePlaybackSession(
 
           if (loadSequence !== loadSequenceRef.current) return false;
 
-          const retryDelay = capabilityWarmingRetryDelayV3(decision, retryIndex);
+          const retryDelay = capabilityWarmingRetryDelayV3(
+            decision,
+            retryIndex,
+            Date.now() - warmingRetryStartedAt,
+          );
           if (retryDelay == null) break;
           if (warmingRetryEpoch !== warmingRetryEpochRef.current) return false;
           const retryDelayElapsed = await waitForCapabilityWarmingRetry(

--- a/web/src/player/playback-errors.test.ts
+++ b/web/src/player/playback-errors.test.ts
@@ -31,6 +31,19 @@ describe("describePlanTerminal", () => {
     });
   });
 
+  it("describes exhausted capability warming retries", () => {
+    expect(
+      describePlanTerminal({
+        reason: "capability_warming",
+        message: "Tone-map capability discovery is still warming.",
+        retryable: true,
+      }),
+    ).toEqual({
+      title: "The transcoder is still starting",
+      message: "The server is still checking its video conversion capabilities. Please try again.",
+    });
+  });
+
   it("keeps the server's explanation of why a subtitle cannot be used", () => {
     expect(
       describePlanTerminal({

--- a/web/src/player/playback-errors.ts
+++ b/web/src/player/playback-errors.ts
@@ -75,6 +75,12 @@ export function describePlanTerminal(terminal: TerminalV3): PlaybackPolicyErrorD
         title: "Playback unavailable",
         message: "The server couldn't start converting this file. Please try again.",
       };
+    case "capability_warming":
+      return {
+        title: "The transcoder is still starting",
+        message:
+          "The server is still checking its video conversion capabilities. Please try again.",
+      };
     case "capacity_unavailable":
       return {
         title: "The server is busy",

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -556,6 +556,7 @@ export interface TerminalV3 {
   reason: string;
   message: string;
   retryable: boolean;
+  retry_after_ms?: number;
 }
 
 export interface DecisionResponseV3 {

--- a/web/src/player/protocol-v3.ts
+++ b/web/src/player/protocol-v3.ts
@@ -136,6 +136,7 @@ export const FEATURE_OUTPUT_CHANGE_V3 = "output_change_v1";
  * this must actually implement the command.
  */
 export const FEATURE_PLAN_INVALIDATED_V3 = "plan_invalidated_v1";
+export const FEATURE_CAPABILITY_WARMING_V3 = "capability_warming_v1";
 
 /** The `original` rung label, which always preserves the source. */
 export const QUALITY_ORIGINAL_V3 = "original";


### PR DESCRIPTION
## Problem

The first HDR playback after a server restart could hit the planning deadline while tone-map capability discovery was still running. The planner treated that incomplete executor inventory as definitive and could select a lower-resolution SDR version. Refreshing worked because the shared probe had finished by then.

Subtitle selection made this more visible: when the server considered an alternate file, duplicate same-language subtitle tracks could be remapped to the first match rather than the intended track.

## Changes

- warm local and remote tone-map capabilities asynchronously at startup without gating server readiness
- keep the requested file pinned while capability or settings discovery is incomplete
- return retryable `capability_warming` decisions with `retry_after_ms`
- retry warming starts and replans with fresh idempotency IDs through the maximum advertised five-minute probe budget
- advertise `capability_warming_v1` and gate automatic web retries on that server capability
- expire positive capability and hardware-resolution caches so partial results are checked again
- serve an expired known-good tone-map capability while its singleflight refresh runs in the background
- back off failed background refreshes and short-cache failed automatic hardware detection
- do not negative-cache incomplete capability deadlines or remote-node warming responses
- reserve retryable node warming for canceled or deadline-limited probes and treat completed probe failures as definitive exclusions
- let realtime plan invalidation supersede start and replan warming waits and abort a stale in-flight replan
- abort in-flight replacement starts, including their initial cold request, when plan invalidation must meet its acknowledgement deadline
- let decoder/transport failure recovery preempt lower-priority warming user-intent replans
- reconcile an interrupted replan with the server's durably committed current decision
- replay outstanding track/quality intent after reconciliation and refresh live positions for warming starts and replans
- disambiguate embedded, external, and downloaded subtitle remapping by track metadata, match sidecars by their version-stable filename suffix, and reject ties
- document the additive playback v3 contract change

## Testing

- `go test ./internal/api/handlers -count=1` — passed
- `make test-web` — 285 files and 2,078 tests passed
- focused tone-map, playback contract, and web regression tests — passed
- `go build ./...` and `go vet ./...` — passed
- `golangci-lint run --new-from-merge-base="origin/main" ./...` — 0 issues
- `pnpm run lint` — 0 errors and 155 existing warnings
- `pnpm run format:check` and `pnpm run build` — passed; Vite reported the existing font-resolution and large-chunk warnings
- settings binding, playback fixture, local-path, formatting, and diff checks — passed
- `make test-go` — two existing `internal/jellycompat` process-lock tests fail; both failures reproduce from the exact `origin/main` revision

### Shared dev

- deployed commit `15f37e07b494b5cbb68673a76040a24a1d9cb747` with `make dev-deploy`
- verified the API container and all four transcode/proxy nodes healthy; the deployed source hashes match the PR working tree
- temporarily enabled 4K transcoding for validation, then restored the prior shared-dev value
- started the requested 4K file with subtitles off, the English SDH track, and the English commentary track
- all three decisions advertised `capability_warming_v1`; their plans kept `requested_media_file_id` and `effective_media_file_id` on `6786489`, selected the intended subtitle track, and used 3840-wide H.264/AAC HLS with HDR-to-SDR tone mapping
- fetched all three generated manifests successfully; each began with `#EXTM3U`

Shared dev currently stores `allow_4k_transcode=false`. With that value, selecting the 1080p SDR alternate is expected even though hardware and software tone mapping are enabled; tone mapping does not override the separate 4K-transcode policy.

Related issue: N/A — narrow fix

## AI Disclosure

- Tool(s): T3 Code through the Codex harness; Claude Code through the `claude-advisor` CLIProxy wrapper
- Model(s): `gpt-5.6-sol`; `claude-opus-5`
- Involvement: Fully AI-generated and human-directed; maintainer review required
- Adversarial review: Claude Opus performed a read-only source review focused on concurrency, retry and idempotency behavior, fallback safety, cache semantics, subtitle remapping, and API compatibility. It found that completed node failures could poison the warming state, some subtitle-policy terminals were too broadly reclassified, downloaded-subtitle ties were not rejected, the retry delay needed a floor, and the idempotency wording was ambiguous. Those findings were fixed and covered by targeted tests. Remaining risks are the one-shot nature of startup warmup and native clients relying on their existing manual retry UI rather than the web client's bounded automatic retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved startup resilience for HDR and 4K playback while requested files remain prioritized.
  - Added automatic retries while playback capabilities are still initializing, with server-guided retry timing.
  - Added clearer loading messages, including when the transcoder is starting.
  - Improved subtitle matching using descriptive metadata and rejected ambiguous selections.
- **Bug Fixes**
  - Prevented premature lower-resolution fallback before compatibility checks are complete.
  - Improved playback retry and replacement handling without displaying unnecessary errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
