### PR TITLE
fix(playback): surface 4K-transcode policy in errors and version fallback

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -1098,9 +1098,10 @@ The source rung is always present, labelled `original`, with
 `preserves_source: true`. Transcode rungs are added below the source resolution
 class, plus at the same class when they reduce bitrate, and only when HLS is
 available to the client, transcoding is enabled, and 4K transcoding is permitted
-for a 4K source. A source counts as 4K when its catalog resolution label reads
-`2160p`, `4k`, or `uhd` (case- and whitespace-insensitive) or its probed
-dimensions reach 3840x2160. HDR plans additionally require
+for a 4K-or-higher source. A source falls under that policy when its catalog
+resolution label reads `2160p`, `4k`, `uhd`, `4320p`, or `8k` (case- and
+whitespace-insensitive), its probed width is at least 3840, or its probed height
+is at least 2160. HDR plans additionally require
 at least one enabled tone-map policy. A source-preserving HDR plan advertises
 those lower rungs without probing an executor; selecting one performs the lazy
 capability validation during the quality-change replan. The published ladder

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -1108,6 +1108,12 @@ capability validation during the quality-change replan. The published ladder
 uses compound labels so each menu selection pins both a resolution class and a
 bitrate:
 
+When a planner terminal permits media-version fallback, start and replan order
+same-edition candidates with non-4K versions first, then continue through the
+remaining candidates until one produces a plan. A refused lower-resolution
+candidate therefore does not hide a later 4K version that can direct-play or
+remux without video encoding.
+
 | label | display_name | height | kbps |
 | --- | --- | --- | --- |
 | `2160p-high` | 4K High | 2160 | 40000 |

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -1098,7 +1098,9 @@ The source rung is always present, labelled `original`, with
 `preserves_source: true`. Transcode rungs are added below the source resolution
 class, plus at the same class when they reduce bitrate, and only when HLS is
 available to the client, transcoding is enabled, and 4K transcoding is permitted
-for a 4K source. HDR plans additionally require
+for a 4K source. A source counts as 4K when its catalog resolution label reads
+`2160p`, `4k`, or `uhd` (case- and whitespace-insensitive) or its probed
+dimensions reach 3840x2160. HDR plans additionally require
 at least one enabled tone-map policy. A source-preserving HDR plan advertises
 those lower rungs without probing an executor; selecting one performs the lazy
 capability validation during the quality-change replan. The published ladder

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -1903,8 +1903,12 @@ func (h *PlaybackHandler) maybeStartThrottler(ctx context.Context, session *play
 	session.StartThrottler(threshold)
 }
 
-// findAlternateFile finds a non-4K file version for the same content.
-// Prefers SDR over HDR, then highest resolution, then highest bitrate.
+// findAlternateFile finds another file version for the same content. It
+// prefers non-4K versions because they can escape a disabled-4K-transcode
+// terminal, but when none exist it returns a 4K candidate so the planner can
+// still accept one that direct-plays or remuxes without forbidden video
+// encoding.
+// Within each class it prefers SDR, then resolution, then bitrate.
 func (h *PlaybackHandler) findAlternateFile(ctx context.Context, source *models.MediaFile) (*models.MediaFile, error) {
 	if h.FileVersionFetcher == nil {
 		return nil, fmt.Errorf("file version fetcher not configured")
@@ -1921,14 +1925,9 @@ func (h *PlaybackHandler) findAlternateFile(ctx context.Context, source *models.
 		return nil, err
 	}
 
-	// Filter to non-4K candidates.
 	candidates := make([]*models.MediaFile, 0, len(files))
 	for _, f := range files {
-		// Share the planner's 4K test: a sibling labeled "4K" or "UHD" is just
-		// as refused by the 4K policy as one labeled "2160p", and offering it
-		// as the fallback only reproduces the terminal this picker exists to
-		// escape.
-		if f.ID == source.ID || playback.Is4KMediaFileV3(f) {
+		if f.ID == source.ID {
 			continue
 		}
 		if source.EditionKey != "" && f.EditionKey != source.EditionKey {
@@ -1949,9 +1948,17 @@ func (h *PlaybackHandler) findAlternateFile(ctx context.Context, source *models.
 		return nil, nil
 	}
 
-	// Sort: SDR before HDR, then highest resolution, then highest bitrate.
+	// Prefer non-4K before 4K so a lower-resolution sibling is tried first.
+	// Keep 4K siblings at the end: when no non-4K sibling exists, the planner
+	// may still direct-play or remux one because the policy only forbids video
+	// encoding.
 	sort.Slice(candidates, func(i, j int) bool {
 		a, b := candidates[i], candidates[j]
+		a4K := playback.Is4KMediaFileV3(a)
+		b4K := playback.Is4KMediaFileV3(b)
+		if a4K != b4K {
+			return !a4K
+		}
 		// Prefer SDR over HDR (SDR = !HDR, so !HDR < HDR means SDR first).
 		if a.HDR != b.HDR {
 			return !a.HDR

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -1924,7 +1924,11 @@ func (h *PlaybackHandler) findAlternateFile(ctx context.Context, source *models.
 	// Filter to non-4K candidates.
 	candidates := make([]*models.MediaFile, 0, len(files))
 	for _, f := range files {
-		if f.ID == source.ID || f.Resolution == "2160p" {
+		// Share the planner's 4K test: a sibling labeled "4K" or "UHD" is just
+		// as refused by the 4K policy as one labeled "2160p", and offering it
+		// as the fallback only reproduces the terminal this picker exists to
+		// escape.
+		if f.ID == source.ID || playback.Is4KMediaFileV3(f) {
 			continue
 		}
 		if source.EditionKey != "" && f.EditionKey != source.EditionKey {

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -1910,6 +1910,18 @@ func (h *PlaybackHandler) maybeStartThrottler(ctx context.Context, session *play
 // encoding.
 // Within each class it prefers SDR, then resolution, then bitrate.
 func (h *PlaybackHandler) findAlternateFile(ctx context.Context, source *models.MediaFile) (*models.MediaFile, error) {
+	candidates, err := h.findAlternateFiles(ctx, source)
+	if err != nil || len(candidates) == 0 {
+		return nil, err
+	}
+	return candidates[0], nil
+}
+
+// findAlternateFiles returns every compatible edition/version candidate in
+// fallback order. Callers that plan candidates must keep trying after a
+// terminal: a lower-resolution candidate can still fail while a later 4K
+// candidate direct-plays or remuxes without forbidden video encoding.
+func (h *PlaybackHandler) findAlternateFiles(ctx context.Context, source *models.MediaFile) ([]*models.MediaFile, error) {
 	if h.FileVersionFetcher == nil {
 		return nil, fmt.Errorf("file version fetcher not configured")
 	}
@@ -1971,7 +1983,7 @@ func (h *PlaybackHandler) findAlternateFile(ctx context.Context, source *models.
 		return a.Bitrate > b.Bitrate
 	})
 
-	return candidates[0], nil
+	return candidates, nil
 }
 
 const (

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -1155,9 +1155,7 @@ func TestFindAlternateFile_DoesNotCrossEdition(t *testing.T) {
 	}
 }
 
-// The fallback exists to escape the 4K-transcode refusal, so it has to exclude
-// every spelling the planner treats as 4K — not only the "2160p" literal.
-func TestFindAlternateFile_ExcludesAll4KLabels(t *testing.T) {
+func TestFindAlternateFile_PrefersNon4KAcrossLabelsAndDimensions(t *testing.T) {
 	source := &models.MediaFile{
 		ID:         1,
 		ContentID:  "movie-1",
@@ -1173,7 +1171,8 @@ func TestFindAlternateFile_ExcludesAll4KLabels(t *testing.T) {
 					source,
 					{ID: 2, ContentID: "movie-1", Resolution: "4K", Bitrate: 28_000_000},
 					{ID: 3, ContentID: "movie-1", Resolution: " uhd ", Bitrate: 26_000_000},
-					{ID: 4, ContentID: "movie-1", Resolution: "1080p", Bitrate: 12_000_000},
+					{ID: 4, ContentID: "movie-1", Resolution: "1080p", Bitrate: 24_000_000, VideoTracks: []models.VideoTrack{{Width: 3840, Height: 1626}}},
+					{ID: 5, ContentID: "movie-1", Resolution: "1080p", Bitrate: 12_000_000, VideoTracks: []models.VideoTrack{{Width: 1920, Height: 1080}}},
 				},
 			},
 		},
@@ -1186,12 +1185,12 @@ func TestFindAlternateFile_ExcludesAll4KLabels(t *testing.T) {
 	if alternate == nil {
 		t.Fatal("expected alternate file")
 	}
-	if alternate.ID != 4 {
-		t.Fatalf("alternate.ID = %d (resolution %q), want 4", alternate.ID, alternate.Resolution)
+	if alternate.ID != 5 {
+		t.Fatalf("alternate.ID = %d (resolution %q), want 5", alternate.ID, alternate.Resolution)
 	}
 }
 
-func TestFindAlternateFile_NoNon4KVersion(t *testing.T) {
+func TestFindAlternateFile_Returns4KVersionWhenItIsTheOnlyAlternate(t *testing.T) {
 	source := &models.MediaFile{ID: 1, ContentID: "movie-1", Resolution: "2160p", Bitrate: 30_000_000}
 
 	handler := &PlaybackHandler{
@@ -1209,8 +1208,11 @@ func TestFindAlternateFile_NoNon4KVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("findAlternateFile: %v", err)
 	}
-	if alternate != nil {
-		t.Fatalf("alternate = %+v, want none", alternate)
+	if alternate == nil {
+		t.Fatal("expected 4K alternate to reach the planner")
+	}
+	if alternate.ID != 2 {
+		t.Fatalf("alternate.ID = %d, want 2", alternate.ID)
 	}
 }
 

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -1169,6 +1169,7 @@ func TestFindAlternateFile_PrefersNon4KAcrossLabelsAndDimensions(t *testing.T) {
 			byContent: map[string][]*models.MediaFile{
 				"movie-1": {
 					source,
+					{ID: 6, ContentID: "movie-1", Resolution: "8K", Bitrate: 40_000_000},
 					{ID: 2, ContentID: "movie-1", Resolution: "4K", Bitrate: 28_000_000},
 					{ID: 3, ContentID: "movie-1", Resolution: " uhd ", Bitrate: 26_000_000},
 					{ID: 4, ContentID: "movie-1", Resolution: "1080p", Bitrate: 24_000_000, VideoTracks: []models.VideoTrack{{Width: 3840, Height: 1626}}},

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -1155,6 +1155,65 @@ func TestFindAlternateFile_DoesNotCrossEdition(t *testing.T) {
 	}
 }
 
+// The fallback exists to escape the 4K-transcode refusal, so it has to exclude
+// every spelling the planner treats as 4K — not only the "2160p" literal.
+func TestFindAlternateFile_ExcludesAll4KLabels(t *testing.T) {
+	source := &models.MediaFile{
+		ID:         1,
+		ContentID:  "movie-1",
+		Resolution: "2160p",
+		HDR:        true,
+		Bitrate:    30_000_000,
+	}
+
+	handler := &PlaybackHandler{
+		FileVersionFetcher: testPlaybackFileVersionFetcher{
+			byContent: map[string][]*models.MediaFile{
+				"movie-1": {
+					source,
+					{ID: 2, ContentID: "movie-1", Resolution: "4K", Bitrate: 28_000_000},
+					{ID: 3, ContentID: "movie-1", Resolution: " uhd ", Bitrate: 26_000_000},
+					{ID: 4, ContentID: "movie-1", Resolution: "1080p", Bitrate: 12_000_000},
+				},
+			},
+		},
+	}
+
+	alternate, err := handler.findAlternateFile(context.Background(), source)
+	if err != nil {
+		t.Fatalf("findAlternateFile: %v", err)
+	}
+	if alternate == nil {
+		t.Fatal("expected alternate file")
+	}
+	if alternate.ID != 4 {
+		t.Fatalf("alternate.ID = %d (resolution %q), want 4", alternate.ID, alternate.Resolution)
+	}
+}
+
+func TestFindAlternateFile_NoNon4KVersion(t *testing.T) {
+	source := &models.MediaFile{ID: 1, ContentID: "movie-1", Resolution: "2160p", Bitrate: 30_000_000}
+
+	handler := &PlaybackHandler{
+		FileVersionFetcher: testPlaybackFileVersionFetcher{
+			byContent: map[string][]*models.MediaFile{
+				"movie-1": {
+					source,
+					{ID: 2, ContentID: "movie-1", Resolution: "uhd", Bitrate: 26_000_000},
+				},
+			},
+		},
+	}
+
+	alternate, err := handler.findAlternateFile(context.Background(), source)
+	if err != nil {
+		t.Fatalf("findAlternateFile: %v", err)
+	}
+	if alternate != nil {
+		t.Fatalf("alternate = %+v, want none", alternate)
+	}
+}
+
 func TestTranscodeResolutionHeight(t *testing.T) {
 	tests := []struct {
 		resolution string

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -1123,23 +1123,51 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 	})
 	timings.mark("planning")
 	if terminalAllowsAlternateFileV3(result.Terminal) && shouldTryAlternateFileV3(req.QualityPreference) {
-		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
-			effectiveFile = h.ensurePlaybackProbe(r.Context(), alternate)
-			audioIndex = remapAudioIndexV3(requestedFile, effectiveFile, audioIndex)
-			if err := h.remapSubtitleSelectionV3(r.Context(), requestedFile, effectiveFile, &req); err != nil {
-				response, persistErr := h.persistTerminalStartDecisionV3(r.Context(), userID, profileID, req, requestDigests, requestedFile.ID, effectiveFile.ID, playback.NewTerminalResponseV3("subtitle_unavailable_in_version", err.Error(), false))
-				if persistErr != nil {
-					writeStartAttemptPersistenceErrorV3(w, persistErr)
-					return
+		if alternates, alternateErr := h.findAlternateFiles(r.Context(), requestedFile); alternateErr == nil {
+			baseReq := req
+			baseAudioIndex := audioIndex
+			var firstFailureResult playback.PlannerResultV3
+			var firstFailureToneMapErr error
+			var firstFailureFile *models.MediaFile
+			var firstFailureReq playback.StartRequestV3
+			firstFailureAudioIndex := 0
+			for _, alternate := range alternates {
+				candidateFile := h.ensurePlaybackProbe(r.Context(), alternate)
+				candidateReq := baseReq
+				candidateAudioIndex := remapAudioIndexV3(requestedFile, candidateFile, baseAudioIndex)
+				var candidateResult playback.PlannerResultV3
+				var candidateToneMapErr error
+				if err := h.remapSubtitleSelectionV3(r.Context(), requestedFile, candidateFile, &candidateReq); err != nil {
+					candidateResult = playback.PlannerResultV3{Terminal: &playback.TerminalV3{Reason: terminalSubtitleUnavailableInVersionV3, Message: err.Error(), Retryable: false}}
+				} else {
+					if err := preflightPlaybackFile(r.Context(), candidateFile, h.MissingMarker, h.EventsHub); err != nil {
+						continue
+					}
+					candidateResult, candidateToneMapErr = h.planPlaybackWithCapabilitiesV3(r.Context(), playback.PlannerInputV3{Request: candidateReq, RequestedFile: requestedFile, EffectiveFile: candidateFile, AudioTrackIndex: candidateAudioIndex, Settings: settings, Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), candidateFile), Now: time.Now(), AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), candidateFile)})
 				}
-				writeJSON(w, http.StatusCreated, response)
-				return
+				if candidateResult.Terminal == nil {
+					req = candidateReq
+					effectiveFile = candidateFile
+					audioIndex = candidateAudioIndex
+					result = candidateResult
+					toneMapCapabilityErr = candidateToneMapErr
+					break
+				}
+				if firstFailureFile == nil {
+					firstFailureResult = candidateResult
+					firstFailureToneMapErr = candidateToneMapErr
+					firstFailureFile = candidateFile
+					firstFailureReq = candidateReq
+					firstFailureAudioIndex = candidateAudioIndex
+				}
 			}
-			if err := preflightPlaybackFile(r.Context(), effectiveFile, h.MissingMarker, h.EventsHub); err != nil {
-				writePlaybackFilePreflightError(w, err)
-				return
+			if result.Terminal != nil && firstFailureFile != nil {
+				req = firstFailureReq
+				effectiveFile = firstFailureFile
+				audioIndex = firstFailureAudioIndex
+				result = firstFailureResult
+				toneMapCapabilityErr = firstFailureToneMapErr
 			}
-			result, toneMapCapabilityErr = h.planPlaybackWithCapabilitiesV3(r.Context(), playback.PlannerInputV3{Request: req, RequestedFile: requestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: settings, Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
 		}
 	}
 	result = retryIncompleteToneMapPlanningV3(result, toneMapCapabilityErr)
@@ -3678,22 +3706,59 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		result, toneMapCapabilityErr = h.planPlaybackWithCapabilitiesV3(r.Context(), playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: plannerSettings, Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
 	}
 	if terminalAllowsAlternateFileV3(result.Terminal) && replanAllowsAlternateFileV3(operation, start.QualityPreference) {
-		if alternate, alternateErr := h.findAlternateFile(r.Context(), requestedFile); alternateErr == nil && alternate != nil {
-			alternate = h.ensurePlaybackProbe(r.Context(), alternate)
-			remappedAudio := remapAudioIndexV3(effectiveFile, alternate, audioIndex)
-			if err := h.remapSubtitleSelectionV3(r.Context(), effectiveFile, alternate, &start); err == nil {
-				start.FileID = alternate.ID
-				if err := preflightPlaybackFile(r.Context(), alternate, h.MissingMarker, h.EventsHub); err == nil {
-					effectiveFile = alternate
-					audioIndex = remappedAudio
-					result, toneMapCapabilityErr = h.planPlaybackWithCapabilitiesV3(r.Context(), playback.PlannerInputV3{Request: start, RequestedFile: plannerRequestedFile, EffectiveFile: effectiveFile, AudioTrackIndex: audioIndex, Settings: plannerSettings, Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), effectiveFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), effectiveFile)})
+		if alternates, alternateErr := h.findAlternateFiles(r.Context(), requestedFile); alternateErr == nil {
+			baseStart := start
+			baseEffectiveFile := effectiveFile
+			baseAudioIndex := audioIndex
+			var firstFailureResult playback.PlannerResultV3
+			var firstFailureToneMapErr error
+			var firstFailureFile *models.MediaFile
+			var firstFailureStart playback.StartRequestV3
+			firstFailureAudioIndex := 0
+			for _, alternate := range alternates {
+				if alternate.ID == baseEffectiveFile.ID {
+					continue
 				}
-			} else if start.SubtitleTrackIndex != nil || start.SubtitleTrackID != "" {
-				result = playback.PlannerResultV3{Terminal: &playback.TerminalV3{
-					Reason:    "subtitle_unavailable_in_version",
-					Message:   "The selected subtitle track is unavailable in the fallback media version.",
-					Retryable: false,
-				}}
+				candidateFile := h.ensurePlaybackProbe(r.Context(), alternate)
+				candidateStart := baseStart
+				candidateAudioIndex := remapAudioIndexV3(baseEffectiveFile, candidateFile, baseAudioIndex)
+				var candidateResult playback.PlannerResultV3
+				var candidateToneMapErr error
+				if err := h.remapSubtitleSelectionV3(r.Context(), baseEffectiveFile, candidateFile, &candidateStart); err != nil {
+					candidateResult = playback.PlannerResultV3{Terminal: &playback.TerminalV3{
+						Reason:    terminalSubtitleUnavailableInVersionV3,
+						Message:   "The selected subtitle track is unavailable in the fallback media version.",
+						Retryable: false,
+					}}
+				} else {
+					candidateStart.FileID = candidateFile.ID
+					if err := preflightPlaybackFile(r.Context(), candidateFile, h.MissingMarker, h.EventsHub); err != nil {
+						continue
+					}
+					candidateResult, candidateToneMapErr = h.planPlaybackWithCapabilitiesV3(r.Context(), playback.PlannerInputV3{Request: candidateStart, RequestedFile: plannerRequestedFile, EffectiveFile: candidateFile, AudioTrackIndex: candidateAudioIndex, Settings: plannerSettings, Registry: h.transformationRegistryV3(r.Context()), DVRPUStrippable: h.lazyDVRPUStrippableV3(r.Context(), candidateFile), Now: time.Now(), AttemptedKeys: attemptedKeys, AdditionalSubtitles: h.downloadedSubtitleInventoryV3(r.Context(), candidateFile)})
+				}
+				if candidateResult.Terminal == nil {
+					start = candidateStart
+					effectiveFile = candidateFile
+					audioIndex = candidateAudioIndex
+					result = candidateResult
+					toneMapCapabilityErr = candidateToneMapErr
+					break
+				}
+				if firstFailureFile == nil {
+					firstFailureResult = candidateResult
+					firstFailureToneMapErr = candidateToneMapErr
+					firstFailureFile = candidateFile
+					firstFailureStart = candidateStart
+					firstFailureAudioIndex = candidateAudioIndex
+				}
+			}
+			if result.Terminal != nil && firstFailureFile != nil {
+				start = firstFailureStart
+				effectiveFile = firstFailureFile
+				audioIndex = firstFailureAudioIndex
+				result = firstFailureResult
+				toneMapCapabilityErr = firstFailureToneMapErr
 			}
 		}
 	}
@@ -4355,6 +4420,7 @@ const (
 	terminalNoAlternateVersionV3            = "no_alternate_version"
 	terminalHDRTranscodeUnsupportedV3       = playback.TerminalHDRTranscodeUnsupportedV3
 	terminalSubtitleConversionUnsupportedV3 = "subtitle_conversion_unsupported"
+	terminalSubtitleUnavailableInVersionV3  = "subtitle_unavailable_in_version"
 )
 
 // terminalAllowsAlternateFileV3 reports whether a refusal is the kind another

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -4405,7 +4405,7 @@ func (h *PlaybackHandler) clarifyOriginalQuality4KTerminalV3(ctx context.Context
 	if !alternateFilePinned || terminal == nil || terminal.Reason != terminalNoAlternateVersionV3 || terminal.Message != playback.TerminalMessage4KTranscodeDisabledV3 {
 		return
 	}
-	if alternate, err := h.findAlternateFile(ctx, requestedFile); err == nil && alternate != nil {
+	if alternate, err := h.findAlternateFile(ctx, requestedFile); err == nil && alternate != nil && !playback.Is4KMediaFileV3(alternate) {
 		terminal.Message = "4K transcoding is disabled and quality 'original' pins the 4K version; a compatible lower-resolution version of this title is available."
 	}
 }

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -269,6 +269,7 @@ func TestHandleStartPlaybackV3ExplainsOriginalQuality4KPinWhenAlternateExists(t 
 	}{
 		{name: "lower-resolution alternate exists", alternateResolution: "1080p", wantMessage: "compatible lower-resolution version of this title is available"},
 		{name: "only 4K alternate exists", alternateResolution: "UHD", wantMessage: playback.TerminalMessage4KTranscodeDisabledV3},
+		{name: "only label-only 8K alternate exists", alternateResolution: "8K", wantMessage: playback.TerminalMessage4KTranscodeDisabledV3},
 		{name: "no alternate", wantMessage: playback.TerminalMessage4KTranscodeDisabledV3},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -288,10 +289,14 @@ func TestHandleStartPlaybackV3ExplainsOriginalQuality4KPinWhenAlternateExists(t 
 				alternate.Resolution = test.alternateResolution
 				alternate.Bitrate = 8_000
 				alternate.VideoTracks = append([]models.VideoTrack(nil), source.VideoTracks...)
-				if test.alternateResolution == "1080p" {
+				switch test.alternateResolution {
+				case "1080p":
 					alternate.VideoTracks[0].Width = 1920
 					alternate.VideoTracks[0].Height = 1080
 					alternate.VideoTracks[0].Level = 41
+				case "8K":
+					alternate.VideoTracks[0].Width = 0
+					alternate.VideoTracks[0].Height = 0
 				}
 				alternate.VideoTracks[0].Bitrate = 8_000
 				versions = append(versions, alternate)

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -263,11 +263,12 @@ func TestValidateAdvertisedTransformationsV3RejectsOldVideoRecipe(t *testing.T) 
 
 func TestHandleStartPlaybackV3ExplainsOriginalQuality4KPinWhenAlternateExists(t *testing.T) {
 	for _, test := range []struct {
-		name             string
-		includeAlternate bool
-		wantMessage      string
+		name                string
+		alternateResolution string
+		wantMessage         string
 	}{
-		{name: "alternate exists", includeAlternate: true, wantMessage: "compatible lower-resolution version of this title is available"},
+		{name: "lower-resolution alternate exists", alternateResolution: "1080p", wantMessage: "compatible lower-resolution version of this title is available"},
+		{name: "only 4K alternate exists", alternateResolution: "UHD", wantMessage: playback.TerminalMessage4KTranscodeDisabledV3},
 		{name: "no alternate", wantMessage: playback.TerminalMessage4KTranscodeDisabledV3},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -280,16 +281,18 @@ func TestHandleStartPlaybackV3ExplainsOriginalQuality4KPinWhenAlternateExists(t 
 			source.VideoTracks[0].Bitrate = 32_000
 
 			versions := []*models.MediaFile{source}
-			if test.includeAlternate {
+			if test.alternateResolution != "" {
 				alternateValue := *source
 				alternate := &alternateValue
 				alternate.ID = 84
-				alternate.Resolution = "1080p"
+				alternate.Resolution = test.alternateResolution
 				alternate.Bitrate = 8_000
 				alternate.VideoTracks = append([]models.VideoTrack(nil), source.VideoTracks...)
-				alternate.VideoTracks[0].Width = 1920
-				alternate.VideoTracks[0].Height = 1080
-				alternate.VideoTracks[0].Level = 41
+				if test.alternateResolution == "1080p" {
+					alternate.VideoTracks[0].Width = 1920
+					alternate.VideoTracks[0].Height = 1080
+					alternate.VideoTracks[0].Level = 41
+				}
 				alternate.VideoTracks[0].Bitrate = 8_000
 				versions = append(versions, alternate)
 			}

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -371,6 +371,159 @@ func TestHandleStartPlaybackV3TriesAlternateAfterHDRTerminal(t *testing.T) {
 	}
 }
 
+func TestHandleStartPlaybackV3TriesLater4KAlternateAfterNon4KTerminal(t *testing.T) {
+	source := v3HandlerFixtureFile(t)
+	source.CodecVideo = "hevc"
+	source.Resolution = "2160p"
+	source.Bitrate = 32_000
+	source.VideoTracks[0] = models.VideoTrack{
+		Codec: "hevc", Profile: "main 10", Level: 150, Width: 3840, Height: 2160,
+		FrameRate: "24000/1001", Bitrate: 32_000, BitDepth: 10,
+		VideoRange: "DolbyVision", VideoRangeType: "DOVIWithHDR10", DVProfile: 8, DVBLCompatID: 1,
+	}
+
+	lowerValue := *source
+	lower := &lowerValue
+	lower.ID = 84
+	lower.Resolution = "1080p"
+	lower.Bitrate = 8_000
+	lower.VideoTracks = append([]models.VideoTrack(nil), source.VideoTracks...)
+	lower.VideoTracks[0].Width = 1920
+	lower.VideoTracks[0].Height = 1080
+	lower.VideoTracks[0].Bitrate = 8_000
+
+	playableValue := *source
+	playable := &playableValue
+	playable.ID = 85
+	playable.CodecVideo = "h264"
+	playable.Resolution = "UHD"
+	playable.Bitrate = 12_000
+	playable.VideoTracks = []models.VideoTrack{{
+		Codec: "h264", Profile: "high", Level: 52, Width: 3840, Height: 2160,
+		FrameRate: "24000/1001", Bitrate: 12_000, BitDepth: 8,
+		VideoRange: "SDR", VideoRangeType: "SDR",
+	}}
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), testPlaybackFileResolver{file: source})
+	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{
+		source.ContentID: {source, lower, playable},
+	}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"allow_4k_transcode": "false"}}
+	handler.PlaybackConfig = playbackTestConfig("", "")
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+
+	start := v3HandlerStartRequest()
+	start.QualityPreference = "auto"
+	start.Capabilities.MaxResolution = "2160p"
+	start.Capabilities.VideoDecode[0].Levels = []int{52}
+	start.Capabilities.VideoDecode[0].MaxWidth = 3840
+	start.Capabilities.VideoDecode[0].MaxHeight = 2160
+	start.Capabilities.VideoDecode[0].MaxBitrateKbps = 50_000
+	start.ClientPlaybackContext.Deliveries[playback.DeliveryClassHLSV3] = playback.DeliveryCapabilityV3{
+		Enabled: true, SupportedOnDevice: true, Containers: []string{"hls"},
+		VideoCodecs: []string{"h264"}, AudioDecodeCodecs: []string{"aac"},
+	}
+	rr := httptest.NewRecorder()
+	handler.HandleStartPlayback(rr, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, start))).WithContext(newAuthorizedPlaybackContext()))
+
+	var response playback.DecisionResponseV3
+	if rr.Code != http.StatusCreated || json.Unmarshal(rr.Body.Bytes(), &response) != nil || response.PlaybackPlan == nil {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if response.PlaybackPlan.EffectiveMediaFileID != playable.ID {
+		t.Fatalf("effective file = %d, want later directly playable 4K alternate %d", response.PlaybackPlan.EffectiveMediaFileID, playable.ID)
+	}
+}
+
+func TestHandleReplanPlaybackV3TriesLater4KAlternateAfterNon4KTerminal(t *testing.T) {
+	source := v3HandlerFixtureFile(t)
+	source.Resolution = "2160p"
+	source.Bitrate = 32_000
+	source.VideoTracks[0].Level = 52
+	source.VideoTracks[0].Width = 3840
+	source.VideoTracks[0].Height = 2160
+	source.VideoTracks[0].Bitrate = 32_000
+
+	lowerValue := *source
+	lower := &lowerValue
+	lower.ID = 84
+	lower.Resolution = "1080p"
+	lower.Bitrate = 8_000
+	lower.HDR = true
+	lower.VideoTracks = append([]models.VideoTrack(nil), source.VideoTracks...)
+	lower.VideoTracks[0].Width = 1920
+	lower.VideoTracks[0].Height = 1080
+	lower.VideoTracks[0].Bitrate = 8_000
+	lower.VideoTracks[0].VideoRange = "HDR10"
+	lower.VideoTracks[0].VideoRangeType = "HDR10"
+
+	playableValue := *source
+	playable := &playableValue
+	playable.ID = 85
+	playable.CodecVideo = "hevc"
+	playable.Resolution = "UHD"
+	playable.Bitrate = 12_000
+	playable.VideoTracks = []models.VideoTrack{{
+		Codec: "hevc", Profile: "main", Level: 52, Width: 3840, Height: 2160,
+		FrameRate: "24000/1001", Bitrate: 12_000, BitDepth: 8,
+		VideoRange: "SDR", VideoRangeType: "SDR",
+	}}
+
+	manager := playback.NewSessionManager(0, 0)
+	files := map[int]*models.MediaFile{source.ID: source, lower.ID: lower, playable.ID: playable}
+	handler := NewPlaybackHandler(manager, mapPlaybackFileResolver{files: files})
+	handler.FileVersionFetcher = testPlaybackFileVersionFetcher{byContent: map[string][]*models.MediaFile{
+		source.ContentID: {source, lower, playable},
+	}}
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{"allow_4k_transcode": "false"}}
+	handler.PlaybackConfig = playbackTestConfig("", "")
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+
+	startRequest := v3HandlerStartRequest()
+	startRequest.Capabilities.MaxResolution = "2160p"
+	startRequest.Capabilities.VideoDecode[0].Levels = []int{52}
+	startRequest.Capabilities.VideoDecode[0].MaxWidth = 3840
+	startRequest.Capabilities.VideoDecode[0].MaxHeight = 2160
+	startRequest.Capabilities.VideoDecode[0].MaxBitrateKbps = 50_000
+	startRequest.ClientPlaybackContext.Deliveries[playback.DeliveryClassHLSV3] = playback.DeliveryCapabilityV3{
+		Enabled: true, SupportedOnDevice: true, Containers: []string{"hls"},
+		VideoCodecs: []string{"hevc"}, AudioDecodeCodecs: []string{"aac"},
+	}
+	startRR := httptest.NewRecorder()
+	handler.HandleStartPlayback(startRR, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, startRequest))).WithContext(newAuthorizedPlaybackContext()))
+	var started playback.DecisionResponseV3
+	if startRR.Code != http.StatusCreated || json.Unmarshal(startRR.Body.Bytes(), &started) != nil || started.PlaybackPlan == nil {
+		t.Fatalf("start status=%d body=%s", startRR.Code, startRR.Body.String())
+	}
+
+	replanCapabilities := startRequest.Capabilities
+	replanCapabilities.CodecsVideo = []string{"hevc"}
+	replanCapabilities.CodecsVideoHardware = []string{"hevc"}
+	replanCapabilities.VideoDecode = []playback.VideoDecodeCapabilityV3{{
+		Codec: "hevc", Profiles: []string{"main"}, Levels: []int{52}, BitDepths: []int{8},
+		MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 50_000, Hardware: true,
+	}}
+	currentKey := playback.PlanAttemptKeyV3(*started.PlaybackPlan, startRequest.ClientPlaybackContext.Output.OutputContextID, nil)
+	replanned := postPlaybackReplanV3(t, handler, started.SessionID, playback.ReplanRequestV3{
+		ProtocolVersion: playback.ProtocolV3, Operation: playback.ReplanOperationFailureRecoveryV3,
+		PlaybackAttemptID: startRequest.PlaybackAttemptID, ReplanRequestID: "later-4k-replan-0001",
+		FailedPlanID: started.PlaybackPlan.PlanID, PlanAttemptID: "later-4k-plan-0001",
+		PlanAttemptKey: currentKey, AttemptedPlanKeys: []string{currentKey}, AttemptCount: 1,
+		QualityPreference: "auto", SelectedTracks: started.PlaybackPlan.SelectedTracks,
+		Failure:      playback.FailureV3{Classification: "playback_error"},
+		Capabilities: replanCapabilities, ClientPlaybackContext: startRequest.ClientPlaybackContext,
+	})
+	if replanned.Terminal != nil {
+		t.Fatalf("replan terminal = %+v", *replanned.Terminal)
+	}
+	if replanned.PlaybackPlan == nil {
+		t.Fatalf("replan = %#v", replanned)
+	}
+	if replanned.PlaybackPlan.EffectiveMediaFileID != playable.ID {
+		t.Fatalf("effective file = %d, want later directly playable 4K alternate %d", replanned.PlaybackPlan.EffectiveMediaFileID, playable.ID)
+	}
+}
+
 func TestReplanAllowsAlternateFileV3PinsSeekOperations(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -971,12 +971,35 @@ func clientTransformationAvailableV3(request StartRequestV3, name, version strin
 	return false
 }
 
-func is4KSourceV3(file *models.MediaFile, source SourceDescriptorV3) bool {
-	resolution := ""
-	if file != nil {
-		resolution = strings.ToLower(strings.TrimSpace(file.Resolution))
+const (
+	resolutionLabel2160p = "2160p"
+	resolutionLabel4K    = "4k"
+	resolutionLabelUHD   = "uhd"
+)
+
+// Is4KMediaFileV3 reports whether a catalog file's own recorded resolution
+// label marks it as 4K. Scanners and imports write the label in several
+// spellings, so anything that has to agree with the planner's 4K policy — the
+// fallback-version picker included — must normalize the same way rather than
+// compare against a single literal.
+//
+// models.MediaFile carries no probed width/height of its own (those live on its
+// video tracks), so this is a label-only answer. Callers holding a
+// SourceDescriptorV3 should also consult its dimensions, as is4KSourceV3 does.
+func Is4KMediaFileV3(file *models.MediaFile) bool {
+	if file == nil {
+		return false
 	}
-	return resolution == "2160p" || resolution == "4k" || resolution == "uhd" || source.Width >= 3840 || source.Height >= 2160
+	switch strings.ToLower(strings.TrimSpace(file.Resolution)) {
+	case resolutionLabel2160p, resolutionLabel4K, resolutionLabelUHD:
+		return true
+	default:
+		return false
+	}
+}
+
+func is4KSourceV3(file *models.MediaFile, source SourceDescriptorV3) bool {
+	return Is4KMediaFileV3(file) || source.Width >= 3840 || source.Height >= 2160
 }
 
 type QualityResultV3 struct {

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -971,22 +971,16 @@ func clientTransformationAvailableV3(request StartRequestV3, name, version strin
 	return false
 }
 
-const (
-	resolutionLabel2160p = "2160p"
-	resolutionLabel4K    = "4k"
-	resolutionLabelUHD   = "uhd"
-)
-
-// Is4KMediaFileV3 reports whether a catalog file is recorded as 4K. Scanners
-// and imports write the resolution label in several spellings, and the stored
-// primary video track can carry dimensions that disagree with that label, so
-// callers use both facts to stay aligned with the planner's 4K policy.
+// Is4KMediaFileV3 reports whether a catalog file is recorded as 4K or higher.
+// Scanners and imports write the resolution label in several spellings, and the
+// stored primary video track can carry dimensions that disagree with that label,
+// so callers use both facts to stay aligned with the planner's 4K policy.
 func Is4KMediaFileV3(file *models.MediaFile) bool {
 	if file == nil {
 		return false
 	}
-	switch strings.ToLower(strings.TrimSpace(file.Resolution)) {
-	case resolutionLabel2160p, resolutionLabel4K, resolutionLabelUHD:
+	labelWidth, labelHeight := dimensionsFromResolutionV3(file.Resolution)
+	if labelWidth >= 3840 || labelHeight >= 2160 {
 		return true
 	}
 	return len(file.VideoTracks) > 0 && (file.VideoTracks[0].Width >= 3840 || file.VideoTracks[0].Height >= 2160)

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -977,15 +977,10 @@ const (
 	resolutionLabelUHD   = "uhd"
 )
 
-// Is4KMediaFileV3 reports whether a catalog file's own recorded resolution
-// label marks it as 4K. Scanners and imports write the label in several
-// spellings, so anything that has to agree with the planner's 4K policy — the
-// fallback-version picker included — must normalize the same way rather than
-// compare against a single literal.
-//
-// models.MediaFile carries no probed width/height of its own (those live on its
-// video tracks), so this is a label-only answer. Callers holding a
-// SourceDescriptorV3 should also consult its dimensions, as is4KSourceV3 does.
+// Is4KMediaFileV3 reports whether a catalog file is recorded as 4K. Scanners
+// and imports write the resolution label in several spellings, and the stored
+// primary video track can carry dimensions that disagree with that label, so
+// callers use both facts to stay aligned with the planner's 4K policy.
 func Is4KMediaFileV3(file *models.MediaFile) bool {
 	if file == nil {
 		return false
@@ -993,9 +988,8 @@ func Is4KMediaFileV3(file *models.MediaFile) bool {
 	switch strings.ToLower(strings.TrimSpace(file.Resolution)) {
 	case resolutionLabel2160p, resolutionLabel4K, resolutionLabelUHD:
 		return true
-	default:
-		return false
 	}
+	return len(file.VideoTracks) > 0 && (file.VideoTracks[0].Width >= 3840 || file.VideoTracks[0].Height >= 2160)
 }
 
 func is4KSourceV3(file *models.MediaFile, source SourceDescriptorV3) bool {

--- a/internal/playback/plan_v3_4k_policy_test.go
+++ b/internal/playback/plan_v3_4k_policy_test.go
@@ -16,7 +16,10 @@ func TestIs4KMediaFileV3(t *testing.T) {
 		{name: "uppercase 4K", file: &models.MediaFile{Resolution: "4K"}, want: true},
 		{name: "padded uhd", file: &models.MediaFile{Resolution: " uhd "}, want: true},
 		{name: "mixed case UHD", file: &models.MediaFile{Resolution: "Uhd"}, want: true},
+		{name: "width from primary track", file: &models.MediaFile{Resolution: "1080p", VideoTracks: []models.VideoTrack{{Width: 3840, Height: 1626}}}, want: true},
+		{name: "height from primary track", file: &models.MediaFile{VideoTracks: []models.VideoTrack{{Width: 2880, Height: 2160}}}, want: true},
 		{name: "1080p", file: &models.MediaFile{Resolution: "1080p"}, want: false},
+		{name: "sub-4K primary track", file: &models.MediaFile{Resolution: "1080p", VideoTracks: []models.VideoTrack{{Width: 1920, Height: 1080}}}, want: false},
 		{name: "720p", file: &models.MediaFile{Resolution: "720p"}, want: false},
 		{name: "empty label", file: &models.MediaFile{}, want: false},
 		{name: "nil file", file: nil, want: false},
@@ -54,8 +57,33 @@ func TestIs4KSourceV3UsesLabelAndProbedDimensions(t *testing.T) {
 	}
 }
 
+func TestPlanPlaybackV3DirectPlays4KWhen4KTranscodeDisabled(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.Resolution = "UHD"
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.VideoTracks[0].ColorTransfer = "bt709"
+	req := validStartRequestV3()
+	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{
+		Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10},
+		MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true,
+	}}
+	direct := req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]
+	direct.Containers = []string{"mkv"}
+	direct.VideoCodecs = []string{"hevc"}
+	direct.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3] = direct
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: false}, Registry: testTransformationRegistryV3(),
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 {
+		t.Fatalf("a directly playable 4K source was blocked by the transcode policy: %s", ExplainPlannerResultV3(result))
+	}
+}
+
 // A measured 1080p source must still plan a transcode with the 4K policy off.
-// still plans a transcode with the 4K policy off.
 func TestPlanPlaybackV3PlansKnownNon4KSourceWhen4KDisabled(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.Resolution = "1080p"

--- a/internal/playback/plan_v3_4k_policy_test.go
+++ b/internal/playback/plan_v3_4k_policy_test.go
@@ -16,6 +16,8 @@ func TestIs4KMediaFileV3(t *testing.T) {
 		{name: "uppercase 4K", file: &models.MediaFile{Resolution: "4K"}, want: true},
 		{name: "padded uhd", file: &models.MediaFile{Resolution: " uhd "}, want: true},
 		{name: "mixed case UHD", file: &models.MediaFile{Resolution: "Uhd"}, want: true},
+		{name: "4320p", file: &models.MediaFile{Resolution: "4320p"}, want: true},
+		{name: "uppercase 8K", file: &models.MediaFile{Resolution: "8K"}, want: true},
 		{name: "width from primary track", file: &models.MediaFile{Resolution: "1080p", VideoTracks: []models.VideoTrack{{Width: 3840, Height: 1626}}}, want: true},
 		{name: "height from primary track", file: &models.MediaFile{VideoTracks: []models.VideoTrack{{Width: 2880, Height: 2160}}}, want: true},
 		{name: "1080p", file: &models.MediaFile{Resolution: "1080p"}, want: false},

--- a/internal/playback/plan_v3_4k_policy_test.go
+++ b/internal/playback/plan_v3_4k_policy_test.go
@@ -1,0 +1,82 @@
+package playback
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestIs4KMediaFileV3(t *testing.T) {
+	tests := []struct {
+		name string
+		file *models.MediaFile
+		want bool
+	}{
+		{name: "2160p", file: &models.MediaFile{Resolution: "2160p"}, want: true},
+		{name: "uppercase 4K", file: &models.MediaFile{Resolution: "4K"}, want: true},
+		{name: "padded uhd", file: &models.MediaFile{Resolution: " uhd "}, want: true},
+		{name: "mixed case UHD", file: &models.MediaFile{Resolution: "Uhd"}, want: true},
+		{name: "1080p", file: &models.MediaFile{Resolution: "1080p"}, want: false},
+		{name: "720p", file: &models.MediaFile{Resolution: "720p"}, want: false},
+		{name: "empty label", file: &models.MediaFile{}, want: false},
+		{name: "nil file", file: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Is4KMediaFileV3(tt.file); got != tt.want {
+				t.Fatalf("Is4KMediaFileV3(%+v) = %t, want %t", tt.file, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIs4KSourceV3UsesLabelAndProbedDimensions(t *testing.T) {
+	tests := []struct {
+		name   string
+		file   *models.MediaFile
+		source SourceDescriptorV3
+		want   bool
+	}{
+		{name: "label only", file: &models.MediaFile{Resolution: "4k"}, source: SourceDescriptorV3{Width: 1920, Height: 1080}, want: true},
+		{name: "width only", file: &models.MediaFile{Resolution: "1080p"}, source: SourceDescriptorV3{Width: 3840, Height: 1626}, want: true},
+		{name: "height only", file: &models.MediaFile{Resolution: ""}, source: SourceDescriptorV3{Width: 2880, Height: 2160}, want: true},
+		{name: "neither", file: &models.MediaFile{Resolution: "1080p"}, source: SourceDescriptorV3{Width: 1920, Height: 1080}, want: false},
+		{name: "nothing known", file: nil, source: SourceDescriptorV3{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := is4KSourceV3(tt.file, tt.source); got != tt.want {
+				t.Fatalf("is4KSourceV3 = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+// A measured 1080p source must still plan a transcode with the 4K policy off.
+// still plans a transcode with the 4K policy off.
+func TestPlanPlaybackV3PlansKnownNon4KSourceWhen4KDisabled(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.Resolution = "1080p"
+	file.Bitrate = 8_000
+	file.VideoTracks[0] = models.VideoTrack{Codec: "hevc", Profile: "Main 10", Level: 120, Width: 1920, Height: 1080, FrameRate: "24000/1001", Bitrate: 8_000, BitDepth: 10, VideoRange: "SDR", VideoRangeType: "SDR", ColorRange: "tv", ColorTransfer: "bt709"}
+
+	req := validStartRequestV3()
+	req.Capabilities.CodecsVideo = []string{"h264"}
+	req.Capabilities.MaxResolution = "1080p"
+	for _, delivery := range []string{DeliveryClassProgressiveV3, DeliveryClassHLSV3} {
+		packaged := req.ClientPlaybackContext.Deliveries[delivery]
+		packaged.VideoCodecs = []string{"h264"}
+		packaged.AudioDecodeCodecs = []string{"aac"}
+		req.ClientPlaybackContext.Deliveries[delivery] = packaged
+	}
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: false}, Registry: testTransformationRegistryV3(),
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryTranscodeHLSV3 {
+		t.Fatalf("a measured 1080p source lost its transcode route: %s", ExplainPlannerResultV3(result))
+	}
+}

--- a/web/src/player/playback-errors.test.ts
+++ b/web/src/player/playback-errors.test.ts
@@ -60,6 +60,69 @@ describe("describePlanTerminal", () => {
     });
   });
 
+  it("keeps the server's reason for refusing every version of an item", () => {
+    expect(
+      describePlanTerminal({
+        reason: "no_alternate_version",
+        message: "A lower-resolution source is required because 4K transcoding is disabled.",
+        retryable: false,
+      }),
+    ).toEqual({
+      title: "No playable version found",
+      message: "A lower-resolution source is required because 4K transcoding is disabled.",
+    });
+  });
+
+  it("falls back to a generic sentence when no alternate version carries no message", () => {
+    expect(
+      describePlanTerminal({ reason: "no_alternate_version", message: "   ", retryable: false }),
+    ).toEqual({
+      title: "No playable version found",
+      message:
+        "Silo couldn't find a way to play this file on this device. Try another version if one is available.",
+    });
+  });
+
+  it("keeps the generic sentence for an exhausted adaptation search", () => {
+    expect(
+      describePlanTerminal({
+        reason: "adaptation_exhausted",
+        message: "All compatible playback recipes have already failed for this output route.",
+        retryable: false,
+      }),
+    ).toEqual({
+      title: "No playable version found",
+      message:
+        "Silo couldn't find a way to play this file on this device. Try another version if one is available.",
+    });
+  });
+
+  it("keeps the server's explanation of a failed conversion start", () => {
+    expect(
+      describePlanTerminal({
+        reason: "transcode_start_failed",
+        message: "Failed to start the playback transport.",
+        retryable: true,
+      }),
+    ).toEqual({
+      title: "Playback unavailable",
+      message: "Failed to start the playback transport.",
+    });
+  });
+
+  it("falls back to a generic sentence when a conversion failure carries no message", () => {
+    expect(
+      describePlanTerminal({
+        reason: "transcode_node_unavailable",
+        message: " ",
+        retryable: true,
+      }),
+    ).toEqual({
+      title: "Playback unavailable",
+      message: "The server couldn't start converting this file. Please try again.",
+    });
+  });
+
   it("falls back to the server's own message for reasons it does not name", () => {
     expect(
       describePlanTerminal({

--- a/web/src/player/playback-errors.ts
+++ b/web/src/player/playback-errors.ts
@@ -48,10 +48,19 @@ export function describePlanTerminal(terminal: TerminalV3): PlaybackPolicyErrorD
       };
     case "adaptation_exhausted":
     case "adaptation_unavailable":
-    case "no_alternate_version":
       return {
         title: "No playable version found",
         message:
+          "Silo couldn't find a way to play this file on this device. Try another version if one is available.",
+      };
+    case "no_alternate_version":
+      return {
+        title: "No playable version found",
+        // The server names the policy that ruled the source out (4K
+        // transcoding disabled, for one); the generic sentence only covers a
+        // missing message.
+        message:
+          terminal.message?.trim() ||
           "Silo couldn't find a way to play this file on this device. Try another version if one is available.",
       };
     case "hdr_transcode_unsupported":
@@ -73,7 +82,12 @@ export function describePlanTerminal(terminal: TerminalV3): PlaybackPolicyErrorD
     case "transcode_start_failed":
       return {
         title: "Playback unavailable",
-        message: "The server couldn't start converting this file. Please try again.",
+        // The server names which part of the conversion path failed (no
+        // transcode node, settings unavailable, transport refused to start);
+        // the generic sentence only covers a missing message.
+        message:
+          terminal.message?.trim() ||
+          "The server couldn't start converting this file. Please try again.",
       };
     case "capacity_unavailable":
       return {


### PR DESCRIPTION
## Problem

With `allow_4k_transcode` off, a viewer who plays a 4K file that needs conversion can end up on a generic "The server couldn't start converting this file. Please try again." instead of being told the policy that blocked it. Two defects sat behind that:

- Alternate-version selection and the planner did not share one definition of 4K. Label-only checks could miss a dimensionally 4K source, while discarding every labelled 4K sibling could also hide a version that the planner could direct-play or remux without violating the no-4K-transcode policy.
- The web player's `describePlanTerminal` discarded the server's `terminal.message` for `no_alternate_version` and transcode-failure reasons, so the policy-specific explanation the server already sends never reached the viewer.

## Approach

- Added shared `playback.Is4KMediaFileV3` classification using the planner's normalized resolution mapping (`2160p`/`4k`/`uhd` and `4320p`/`8k`) plus primary-video dimensions (`width >= 3840` or `height >= 2160`), matching the planner's policy boundary.
- Alternate selection now ranks non-4K versions ahead of 4K versions instead of filtering 4K versions out. Start and replan walk the ordered candidates until one produces a plan, so a refused lower-resolution candidate cannot hide a later 4K sibling that can direct-play or remux.
- Guarded original-quality terminal clarification so it only claims a lower-resolution version exists when the selected alternate is actually non-4K.
- Web: `no_alternate_version` and the transcode-failure bucket now show `terminal.message` when present, keeping the old generic copy as fallback. Apple and Android already render `terminal.message` verbatim, so no client follow-up is needed for this change (two adjacent Android findings were filed separately as Silo-Server/silo-android#246 and Silo-Server/silo-android#247).
- Updated `playback-protocol-v3.md` to document the 4K classification.

Text-only UI change (error copy), covered by unit tests; no layout change, so no screenshot.

## Review follow-up

Addressed both inline review findings:

- Dimensionally 4K files can no longer bypass fallback ordering because the shared classifier inspects probed dimensions as well as labels.
- 4K siblings are retained as planner candidates, preserving direct-play/remux behavior when video encoding is disabled.
- An independent Fable review found that the original-quality clarification could incorrectly claim a lower-resolution sibling existed when the only alternate was also 4K; that path is now guarded and regression-tested.
- Follow-up automated review found the same classification mismatch for label-only 8K/4320p files. The helper now reuses the planner's resolution mapping, and fallback ordering plus clarification have 8K regression coverage.
- A final review found that selection still planned only the first ordered candidate. Start and replan now continue after candidate terminals, with end-to-end coverage for a refused 1080p sibling followed by a directly playable 4K sibling.

## Validation

- `go test ./internal/playback ./internal/api/handlers`
- `pnpm exec vitest run src/player/playback-errors.test.ts` (15 tests)
- `go build ./...`
- `go vet ./...`
- `gofmt -l .`
- `golangci-lint run --new-from-merge-base=origin/main ./...` (0 issues)
- `pnpm run lint` (0 errors; 155 inherited warnings)
- `pnpm run format:check`
- `pnpm run build`
- `make test-web` (2,103 tests)
- `make verify-settings-bindings-all`
- `make verify-playback-fixtures`
- `make verify-local-paths`
- `git diff --check`

`make test-go` passes outside two pre-existing, environment-dependent `internal/jellycompat` failures that reproduce on clean `origin/main`: `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`. No PR code touches `internal/jellycompat`.

The branch was rebased onto current `origin/main`. Main removed the feature changelog and its requirement, so the obsolete changelog edit was dropped during the rebase.

Related issue: N/A — narrow fix

## AI Disclosure

- Tool(s): Claude Code, Codex
- Model(s): Claude Fable/Opus/Sonnet during the original implementation; GPT-5.6 Codex for review fixes; Fable for an independent adversarial review
- Involvement: Fully AI-generated, human verified
- Adversarial review: Review agents examined planner ordering, 4K classification, direct-play/remux preservation, terminal clarification, client message handling, and regression coverage. The material findings were fixed and tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved playback planning for progressive and HLS streams with better audio compatibility, including surround-aware stereo conversion.
  - Added consistent 4K detection using quality labels and video dimensions.
  - Playback now evaluates multiple alternatives, preferring compatible non-4K media while retaining 4K when appropriate.
  - Enhanced playback errors to display useful server-provided details, including subtitle availability issues.

- **Bug Fixes**
  - Improved cancellation of pending playback actions when stopping or aborting.
  - Corrected 4K alternate-version recommendations and quality handling.
  - Improved retry and playback preparation behavior when earlier alternatives cannot be used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->