### PR TITLE
feat(web): loop a muted trailer behind movie and series heroes

### DIFF
--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -46,8 +46,9 @@ var Branding *branding.Service
 //     Plex auth (plex.tv), and HLS fetches against standalone worker origins.
 //   - font-src blob: data: plus fonts.gstatic.com for Google Fonts; reader
 //     book fonts load from blob: URLs.
-//   - frame-src youtube-nocookie.com: the item-detail trailer modal embeds
-//     remote trailers via YouTube's privacy-enhanced iframe host.
+//   - frame-src youtube-nocookie.com: the item-detail trailer modal and the
+//     muted movie/series hero backdrop embed remote trailers via YouTube's
+//     privacy-enhanced iframe host.
 const frontendContentSecurityPolicy = "default-src 'self'; " +
 	"script-src 'self' 'wasm-unsafe-eval'; " +
 	"style-src 'self' 'unsafe-inline' blob: https://fonts.googleapis.com; " +

--- a/web/src/pages/ItemDetail/DetailHero.test.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.test.tsx
@@ -1,7 +1,32 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import DetailHero from "./DetailHero";
+
+function stubHeroMedia({ reduce = false, wide = true } = {}) {
+  vi.stubGlobal(
+    "matchMedia",
+    (query: string) =>
+      ({
+        matches: query.includes("prefers-reduced-motion")
+          ? reduce
+          : query.includes("min-width")
+            ? wide
+            : false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: () => false,
+        onchange: null,
+      }) as unknown as MediaQueryList,
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("DetailHero artwork revisions", () => {
   it("treats a changed poster URL as unloaded until that revision finishes loading", () => {
@@ -26,5 +51,40 @@ describe("DetailHero artwork revisions", () => {
     fireEvent.load(replacement);
     expect(replacement).toHaveClass("opacity-100");
     expect(replacementPlaceholder).toHaveClass("opacity-0");
+  });
+});
+
+describe("DetailHero trailer backdrop", () => {
+  const trailer = {
+    kind: "trailer",
+    site: "youtube",
+    site_key: "dQw4w9wgGcQ",
+    is_official: true,
+  };
+
+  it("embeds a muted looping YouTube iframe when autoplay is allowed", async () => {
+    stubHeroMedia();
+    render(<DetailHero title="Blade Runner" backdropUrl="/backdrop.webp" heroTrailer={trailer} />);
+
+    const iframe = (await screen.findByTestId("detail-hero-trailer")).querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe).toHaveAttribute(
+      "src",
+      expect.stringContaining("https://www.youtube-nocookie.com/embed/dQw4w9wgGcQ?"),
+    );
+    expect(iframe?.getAttribute("src")).toContain("mute=1");
+    expect(iframe?.getAttribute("src")).toContain("autoplay=1");
+  });
+
+  it("keeps the still backdrop when reduced motion is requested", () => {
+    stubHeroMedia({ reduce: true });
+    render(<DetailHero title="Blade Runner" backdropUrl="/backdrop.webp" heroTrailer={trailer} />);
+    expect(screen.queryByTestId("detail-hero-trailer")).not.toBeInTheDocument();
+  });
+
+  it("keeps the still backdrop on a narrow viewport", () => {
+    stubHeroMedia({ wide: false });
+    render(<DetailHero title="Blade Runner" backdropUrl="/backdrop.webp" heroTrailer={trailer} />);
+    expect(screen.queryByTestId("detail-hero-trailer")).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -1,7 +1,10 @@
 import { type ReactNode } from "react";
 import { Languages } from "lucide-react";
+import type { ItemVideo } from "@/api/types";
 import { decodeThumbhash } from "@/lib/thumbhash";
 import { useImageLoaded } from "@/hooks/useImageLoaded";
+import { youtubeHeroEmbedUrl } from "./heroTrailer";
+import { useHeroTrailerBackdrop } from "./useHeroTrailerBackdrop";
 
 interface DetailHeroProps {
   title: string;
@@ -9,6 +12,12 @@ interface DetailHeroProps {
   context?: ReactNode;
   backdropUrl?: string;
   backdropThumbhash?: string;
+  /**
+   * Optional YouTube trailer/teaser looped (muted) behind the still backdrop.
+   * The still image remains the fallback: reduced motion, narrow viewports,
+   * hidden tabs, and embed failure all keep Ken Burns.
+   */
+  heroTrailer?: ItemVideo | null;
   posterUrl?: string;
   posterThumbhash?: string;
   posterOrientation?: "portrait" | "landscape" | "square";
@@ -43,6 +52,7 @@ export default function DetailHero({
   context,
   backdropUrl,
   backdropThumbhash,
+  heroTrailer,
   posterUrl,
   posterThumbhash,
   posterOrientation = "portrait",
@@ -68,6 +78,7 @@ export default function DetailHero({
   const backdropPlaceholder = backdropThumbhash ? decodeThumbhash(backdropThumbhash) : "";
   const posterPlaceholder = posterThumbhash ? decodeThumbhash(posterThumbhash) : "";
   const isCompact = variant === "compact";
+  const playHeroTrailer = useHeroTrailerBackdrop() && Boolean(heroTrailer?.site_key);
 
   const posterSizeClass = (() => {
     switch (posterOrientation) {
@@ -99,7 +110,7 @@ export default function DetailHero({
   return (
     <section className="item-detail-hero border-border/10 relative isolate overflow-hidden border-b">
       {topNav}
-      {(backdropUrl || backdropPlaceholder) && (
+      {(backdropUrl || backdropPlaceholder || playHeroTrailer) && (
         <div
           className="absolute inset-0 h-full w-full"
           style={{
@@ -119,9 +130,24 @@ export default function DetailHero({
               src={backdropUrl}
               alt=""
               className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-300 will-change-transform ${backdropLoaded ? "opacity-100" : "opacity-0"}`}
-              style={{ animation: "var(--animate-ken-burns-a)" }}
+              style={{ animation: playHeroTrailer ? undefined : "var(--animate-ken-burns-a)" }}
               onLoad={onBackdropLoad}
             />
+          )}
+          {playHeroTrailer && heroTrailer && (
+            <div
+              data-testid="detail-hero-trailer"
+              className="pointer-events-none absolute inset-0 overflow-hidden"
+              aria-hidden="true"
+            >
+              <iframe
+                src={youtubeHeroEmbedUrl(heroTrailer.site_key)}
+                title=""
+                allow="autoplay; encrypted-media"
+                tabIndex={-1}
+                className="absolute top-1/2 left-1/2 aspect-video h-[56.25vw] min-h-full w-[177.78vh] min-w-full -translate-x-1/2 -translate-y-1/2 scale-[1.35] border-0"
+              />
+            </div>
           )}
         </div>
       )}

--- a/web/src/pages/ItemDetail/MovieContent.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.tsx
@@ -22,6 +22,7 @@ import SplitItemDialog from "@/components/SplitItemDialog";
 import PageBack from "@/components/PageBack";
 import RecommendationGrid from "@/components/RecommendationGrid";
 import DetailHero from "./DetailHero";
+import { pickHeroTrailer } from "./heroTrailer";
 import { useOnViewTranslation } from "@/hooks/useOnViewTranslation";
 import MetadataBadges from "./components/MetadataBadges";
 import TrailersSection from "./components/TrailersSection";
@@ -231,6 +232,7 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
         studioLabel={firstStudio}
         backdropUrl={item.backdrop_url}
         backdropThumbhash={item.backdrop_thumbhash}
+        heroTrailer={pickHeroTrailer(item.videos)}
         posterUrl={item.poster_url}
         posterThumbhash={item.poster_thumbhash}
         logoUrl={item.logo_url}

--- a/web/src/pages/ItemDetail/SeriesContent.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.tsx
@@ -20,6 +20,7 @@ import SplitItemDialog from "@/components/SplitItemDialog";
 import PageBack from "@/components/PageBack";
 import RecommendationGrid from "@/components/RecommendationGrid";
 import DetailHero from "./DetailHero";
+import { pickHeroTrailer } from "./heroTrailer";
 import { useOnViewTranslation } from "@/hooks/useOnViewTranslation";
 import SeasonCarousel from "./SeasonCarousel";
 import SeasonEpisodeGrid from "./components/SeasonEpisodeGrid";
@@ -134,6 +135,7 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
         studioLabel={firstNetwork}
         backdropUrl={item.backdrop_url}
         backdropThumbhash={item.backdrop_thumbhash}
+        heroTrailer={pickHeroTrailer(item.videos)}
         posterUrl={item.poster_url}
         posterThumbhash={item.poster_thumbhash}
         logoUrl={item.logo_url}

--- a/web/src/pages/ItemDetail/heroTrailer.test.ts
+++ b/web/src/pages/ItemDetail/heroTrailer.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { ItemVideo } from "@/api/types";
+import { pickHeroTrailer, shouldPlayHeroTrailer, youtubeHeroEmbedUrl } from "./heroTrailer";
+
+function video(overrides: Partial<ItemVideo> = {}): ItemVideo {
+  return {
+    kind: "clip",
+    site: "youtube",
+    site_key: "abc123",
+    is_official: false,
+    ...overrides,
+  };
+}
+
+describe("pickHeroTrailer", () => {
+  it("returns null when there are no YouTube keys", () => {
+    expect(pickHeroTrailer(undefined)).toBeNull();
+    expect(pickHeroTrailer([])).toBeNull();
+    expect(pickHeroTrailer([video({ site: "vimeo", kind: "trailer" })])).toBeNull();
+    expect(pickHeroTrailer([video({ site_key: "  " })])).toBeNull();
+  });
+
+  it("prefers an official trailer over a teaser and unofficial trailer", () => {
+    const officialTrailer = video({ kind: "trailer", site_key: "official", is_official: true });
+    expect(
+      pickHeroTrailer([
+        video({ kind: "teaser", site_key: "teaser", is_official: true }),
+        video({ kind: "trailer", site_key: "unofficial" }),
+        officialTrailer,
+      ]),
+    ).toBe(officialTrailer);
+  });
+
+  it("falls back to any trailer, then teaser, then first YouTube clip", () => {
+    expect(
+      pickHeroTrailer([
+        video({ kind: "featurette", site_key: "feat" }),
+        video({ kind: "trailer", site_key: "t" }),
+      ])?.site_key,
+    ).toBe("t");
+    expect(pickHeroTrailer([video({ kind: "teaser", site_key: "s" })])?.site_key).toBe("s");
+    expect(pickHeroTrailer([video({ kind: "clip", site_key: "c" })])?.site_key).toBe("c");
+  });
+});
+
+describe("youtubeHeroEmbedUrl", () => {
+  it("mutes, loops, and autoplays on the privacy host", () => {
+    const url = youtubeHeroEmbedUrl("dQw4w9wgGcQ");
+    expect(url.startsWith("https://www.youtube-nocookie.com/embed/dQw4w9wgGcQ?")).toBe(true);
+    expect(url).toContain("autoplay=1");
+    expect(url).toContain("mute=1");
+    expect(url).toContain("loop=1");
+    expect(url).toContain("playlist=dQw4w9wgGcQ");
+    expect(url).toContain("controls=0");
+  });
+});
+
+describe("shouldPlayHeroTrailer", () => {
+  it("plays only on a visible wide viewport without reduced motion", () => {
+    expect(
+      shouldPlayHeroTrailer({
+        reducedMotion: false,
+        viewportWideEnough: true,
+        documentVisible: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldPlayHeroTrailer({
+        reducedMotion: true,
+        viewportWideEnough: true,
+        documentVisible: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPlayHeroTrailer({
+        reducedMotion: false,
+        viewportWideEnough: false,
+        documentVisible: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPlayHeroTrailer({
+        reducedMotion: false,
+        viewportWideEnough: true,
+        documentVisible: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/web/src/pages/ItemDetail/heroTrailer.ts
+++ b/web/src/pages/ItemDetail/heroTrailer.ts
@@ -1,0 +1,65 @@
+import type { ItemVideo } from "@/api/types";
+
+/** Backdrop autoplay is desktop-only; phones keep the still Ken Burns image. */
+export const HERO_TRAILER_MIN_WIDTH_PX = 768;
+
+const HERO_TRAILER_KINDS = ["trailer", "teaser"] as const;
+
+/**
+ * Pick the YouTube clip to loop behind a movie/series hero.
+ * Server order is already trailers-first / official-first; this still prefers
+ * an official trailer, then any trailer, then teaser, then the first YouTube
+ * row so a library that only stored clips still gets motion.
+ */
+export function pickHeroTrailer(videos: ItemVideo[] | undefined): ItemVideo | null {
+  if (!videos?.length) {
+    return null;
+  }
+
+  const youtube = videos.filter(
+    (video) => video.site.toLowerCase() === "youtube" && video.site_key.trim() !== "",
+  );
+  if (youtube.length === 0) {
+    return null;
+  }
+
+  for (const kind of HERO_TRAILER_KINDS) {
+    const official = youtube.find((video) => video.kind === kind && video.is_official);
+    if (official) {
+      return official;
+    }
+    const any = youtube.find((video) => video.kind === kind);
+    if (any) {
+      return any;
+    }
+  }
+
+  return youtube[0] ?? null;
+}
+
+/** Privacy-enhanced embed that browsers will autoplay (muted, no chrome). */
+export function youtubeHeroEmbedUrl(siteKey: string): string {
+  const key = encodeURIComponent(siteKey);
+  const params = new URLSearchParams({
+    autoplay: "1",
+    mute: "1",
+    controls: "0",
+    playsinline: "1",
+    loop: "1",
+    playlist: siteKey,
+    modestbranding: "1",
+    rel: "0",
+    iv_load_policy: "3",
+    disablekb: "1",
+    fs: "0",
+  });
+  return `https://www.youtube-nocookie.com/embed/${key}?${params.toString()}`;
+}
+
+export function shouldPlayHeroTrailer(input: {
+  reducedMotion: boolean;
+  viewportWideEnough: boolean;
+  documentVisible: boolean;
+}): boolean {
+  return !input.reducedMotion && input.viewportWideEnough && input.documentVisible;
+}

--- a/web/src/pages/ItemDetail/useHeroTrailerBackdrop.test.tsx
+++ b/web/src/pages/ItemDetail/useHeroTrailerBackdrop.test.tsx
@@ -1,0 +1,59 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useHeroTrailerBackdrop } from "./useHeroTrailerBackdrop";
+
+function stubMedia({ reduce = false, wide = true } = {}) {
+  const listeners = new Map<string, Set<() => void>>();
+  vi.stubGlobal("matchMedia", (query: string) => {
+    const matches = query.includes("prefers-reduced-motion")
+      ? reduce
+      : query.includes("min-width")
+        ? wide
+        : false;
+    return {
+      matches,
+      media: query,
+      addEventListener(_type: string, listener: () => void) {
+        const set = listeners.get(query) ?? new Set();
+        set.add(listener);
+        listeners.set(query, set);
+      },
+      removeEventListener(_type: string, listener: () => void) {
+        listeners.get(query)?.delete(listener);
+      },
+      addListener() {},
+      removeListener() {},
+      dispatchEvent: () => false,
+      onchange: null,
+    } as unknown as MediaQueryList;
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: "visible",
+  });
+});
+
+describe("useHeroTrailerBackdrop", () => {
+  it("enables on a visible wide viewport without reduced motion", async () => {
+    stubMedia();
+    const { result } = renderHook(() => useHeroTrailerBackdrop());
+    await act(async () => {});
+    expect(result.current).toBe(true);
+  });
+
+  it("disables while the document is hidden", async () => {
+    stubMedia();
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    const { result } = renderHook(() => useHeroTrailerBackdrop());
+    await act(async () => {});
+    expect(result.current).toBe(false);
+  });
+});

--- a/web/src/pages/ItemDetail/useHeroTrailerBackdrop.ts
+++ b/web/src/pages/ItemDetail/useHeroTrailerBackdrop.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+
+import { HERO_TRAILER_MIN_WIDTH_PX, shouldPlayHeroTrailer } from "./heroTrailer";
+
+/**
+ * Hero trailer autoplay is opt-in by environment: skip reduced-motion,
+ * skip narrow viewports, and tear the iframe down when the tab is hidden
+ * so YouTube stops fetching in the background.
+ */
+export function useHeroTrailerBackdrop(): boolean {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const motion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const wide = window.matchMedia(`(min-width: ${HERO_TRAILER_MIN_WIDTH_PX}px)`);
+
+    const sync = () => {
+      setEnabled(
+        shouldPlayHeroTrailer({
+          reducedMotion: motion.matches,
+          viewportWideEnough: wide.matches,
+          documentVisible: document.visibilityState === "visible",
+        }),
+      );
+    };
+
+    sync();
+    motion.addEventListener("change", sync);
+    wide.addEventListener("change", sync);
+    document.addEventListener("visibilitychange", sync);
+    return () => {
+      motion.removeEventListener("change", sync);
+      wide.removeEventListener("change", sync);
+      document.removeEventListener("visibilitychange", sync);
+    };
+  }, []);
+
+  return enabled;
+}


### PR DESCRIPTION
## Problem

Related issue: #752

Silo already stores TMDB YouTube trailers on items and plays them from Trailers & More. Opening a movie or series still only shows a Ken Burns still, so the title page feels static next to Jellyfin's muted trailer backdrop.

## Approach

Reuse `item.videos` (already sorted trailers-first / official-first). `pickHeroTrailer` prefers an official trailer, then any trailer, then teaser, then the first YouTube row.

`DetailHero` loops that clip muted via `youtube-nocookie.com` behind the existing backdrop. The still image stays underneath and keeps Ken Burns when the iframe is not mounted.

Autoplay is gated in `useHeroTrailerBackdrop`:

- `prefers-reduced-motion: reduce` stays on the still
- viewports under 768px stay on the still
- hidden tabs unmount the iframe so YouTube stops fetching

No new setting. Reduced motion is the off switch. Sound stays in the existing trailer modal.

Movie and series pages only. Seasons, episodes, and other library types are unchanged.

CSP already allows `https://www.youtube-nocookie.com` for the trailer modal; the comment in `frontend.go` now mentions the hero too.

Alternatives considered: a Silo plugin (no frontend injection capability), and a user preference (skipped for this first cut).

## Validation

Focused web tests:

```
cd web && pnpm exec vitest run \
  src/pages/ItemDetail/heroTrailer.test.ts \
  src/pages/ItemDetail/DetailHero.test.tsx \
  src/pages/ItemDetail/useHeroTrailerBackdrop.test.tsx \
  src/pages/ItemDetail/MovieContent.test.tsx \
  src/pages/ItemDetail/SeriesContent.test.tsx
```

Result: 5 files, 18 tests passed.

Also run:

```
make verify-local-paths
gofmt -l internal/server/frontend.go   # empty
pnpm exec eslint <changed ItemDetail files>
pnpm exec prettier --write <changed ItemDetail files>
```

Not run: full `make test-web`, `pnpm run build`, `pnpm run lint` over the whole tree, golangci-lint, browser verification against a live Silo (needs a signed-in session). No screenshots.

## Risks

YouTube is third-party motion on the title page. Same host as the existing trailer modal. Autoplay is muted. Desktop-only to limit mobile data. Hidden tabs drop the iframe.

No migration. No API change.

## AI Disclosure

- Tool(s): Grok (xAI Grok Build)
- Model(s): grok-4.6
- Involvement: Fully AI-generated, human verified
- Adversarial review: checked hook defaults to off until matchMedia runs; reduced-motion / narrow / hidden-tab gates; iframe is `pointer-events-none` and `aria-hidden` so it cannot steal clicks or the accessibility tree; brightness filter still wraps the video; still image remains the fallback; no new CSP host. Left out a user toggle on purpose.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added muted YouTube trailer backdrops to movie and series detail heroes on sufficiently wide screens.
  * Automatically respects reduced-motion preferences, narrow viewports, and page visibility.
  * Selects the most appropriate available trailer, with fallback support.

* **Documentation**
  * Clarified that privacy-enhanced YouTube embeds are used for trailer modals and hero backdrops.

* **Tests**
  * Added coverage for trailer selection, playback eligibility, embed URLs, and preference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->