### PR TITLE
fix(scanner): clear stale skipped roots

### DIFF
--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -1,5 +1,10 @@
 # Feature Changelog
 
+## 2026-08-25
+
+### Clear stale library troubleshooting entries after path changes
+Full library scans now reconcile troubleshooting entries across the whole library, so diagnostics for removed or replaced root paths disappear after the path-change scan completes. Subtree and single-file scans remain scoped and cannot clear diagnostics elsewhere in the library.
+
 ## 2026-08-24
 
 ### Start audiobook playback once after browser capability detection

--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -42,6 +42,7 @@ type FolderRepository interface {
 type SkippedRootRepository interface {
 	Upsert(ctx context.Context, root models.SkippedMediaRoot) error
 	Delete(ctx context.Context, folderID int, rootPath string) error
+	DeleteMissingByFolder(ctx context.Context, folderID int, seenRoots []string) error
 	DeleteMissingInScope(ctx context.Context, folderID int, scopePath string, seenRoots []string) error
 }
 
@@ -535,6 +536,7 @@ func (e *Executor) reconcileSkippedRoots(
 	for _, scope := range matchScopes {
 		seenRootsByScope[scope] = []string{}
 	}
+	seenSkippedRoots := make([]string, 0, len(observations))
 
 	for _, observation := range observations {
 		if observation.HasFolderIDs {
@@ -551,6 +553,7 @@ func (e *Executor) reconcileSkippedRoots(
 			}); err != nil {
 				return fmt.Errorf("upsert skipped root %q: %w", observation.RootPath, err)
 			}
+			seenSkippedRoots = append(seenSkippedRoots, observation.RootPath)
 		}
 
 		for _, scope := range matchScopes {
@@ -558,6 +561,13 @@ func (e *Executor) reconcileSkippedRoots(
 				seenRootsByScope[scope] = append(seenRootsByScope[scope], observation.RootPath)
 			}
 		}
+	}
+
+	if mode == scopeModeLibrary {
+		if err := e.skippedRootRepo.DeleteMissingByFolder(ctx, folderID, seenSkippedRoots); err != nil {
+			return fmt.Errorf("delete stale skipped roots for folder %d: %w", folderID, err)
+		}
+		return nil
 	}
 
 	for _, scope := range matchScopes {

--- a/internal/libraryingest/executor_test.go
+++ b/internal/libraryingest/executor_test.go
@@ -2,6 +2,8 @@ package libraryingest
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -10,6 +12,71 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/scanner"
 )
+
+type skippedRootMemoryRepo struct {
+	roots map[string]models.SkippedMediaRoot
+}
+
+func newSkippedRootMemoryRepo(roots ...models.SkippedMediaRoot) *skippedRootMemoryRepo {
+	repo := &skippedRootMemoryRepo{roots: make(map[string]models.SkippedMediaRoot, len(roots))}
+	for _, root := range roots {
+		repo.roots[skippedRootKey(root.MediaFolderID, root.RootPath)] = root
+	}
+	return repo
+}
+
+func skippedRootKey(folderID int, rootPath string) string {
+	return fmt.Sprintf("%d:%s", folderID, filepath.Clean(rootPath))
+}
+
+func (r *skippedRootMemoryRepo) Upsert(_ context.Context, root models.SkippedMediaRoot) error {
+	root.RootPath = filepath.Clean(root.RootPath)
+	r.roots[skippedRootKey(root.MediaFolderID, root.RootPath)] = root
+	return nil
+}
+
+func (r *skippedRootMemoryRepo) Delete(_ context.Context, folderID int, rootPath string) error {
+	delete(r.roots, skippedRootKey(folderID, rootPath))
+	return nil
+}
+
+func (r *skippedRootMemoryRepo) DeleteMissingByFolder(_ context.Context, folderID int, seenRoots []string) error {
+	seen := make(map[string]struct{}, len(seenRoots))
+	for _, rootPath := range seenRoots {
+		seen[filepath.Clean(rootPath)] = struct{}{}
+	}
+	for key, root := range r.roots {
+		if root.MediaFolderID != folderID {
+			continue
+		}
+		if _, ok := seen[filepath.Clean(root.RootPath)]; !ok {
+			delete(r.roots, key)
+		}
+	}
+	return nil
+}
+
+func (r *skippedRootMemoryRepo) DeleteMissingInScope(_ context.Context, folderID int, scopePath string, seenRoots []string) error {
+	scopePath = filepath.Clean(scopePath)
+	seen := make(map[string]struct{}, len(seenRoots))
+	for _, rootPath := range seenRoots {
+		seen[filepath.Clean(rootPath)] = struct{}{}
+	}
+	for key, root := range r.roots {
+		if root.MediaFolderID != folderID || !isSameOrDescendant(scopePath, root.RootPath) {
+			continue
+		}
+		if _, ok := seen[filepath.Clean(root.RootPath)]; !ok {
+			delete(r.roots, key)
+		}
+	}
+	return nil
+}
+
+func (r *skippedRootMemoryRepo) has(folderID int, rootPath string) bool {
+	_, ok := r.roots[skippedRootKey(folderID, rootPath)]
+	return ok
+}
 
 // settleControlledMatcher simulates a TV match drainer whose provider lookup is
 // still in flight when the settle window expires. The batch only returns once
@@ -215,5 +282,76 @@ func TestIngestFolderLetsActiveDrainerBatchFinishAfterSettleWindow(t *testing.T)
 	}
 	if matcher.processAllBeforeBatch.Load() {
 		t.Fatal("final scoped matcher ran before the active drainer batch completed")
+	}
+}
+
+func TestReconcileSkippedRootsFullLibraryPrunesRemovedRoot(t *testing.T) {
+	const folderID = 42
+	const removedRoot = "/old-library/Movie"
+	const currentRoot = "/new-library/Movie"
+
+	repo := newSkippedRootMemoryRepo(models.SkippedMediaRoot{
+		MediaFolderID: folderID,
+		RootPath:      removedRoot,
+		Reason:        scanner.RootObservationReasonMissingFolderIDs,
+	})
+	exec := &Executor{skippedRootRepo: repo}
+	scanResult := &scanner.ScanResult{RootObservations: []scanner.RootObservation{
+		{
+			RootPath:       currentRoot,
+			SampleFilePath: filepath.Join(currentRoot, "movie.mkv"),
+			FileCount:      1,
+			Reason:         scanner.RootObservationReasonMissingFolderIDs,
+		},
+	}}
+
+	err := exec.reconcileSkippedRoots(
+		context.Background(),
+		folderID,
+		"movies",
+		scopeModeLibrary,
+		"",
+		[]string{"/new-library"},
+		scanResult,
+	)
+	if err != nil {
+		t.Fatalf("reconcile skipped roots: %v", err)
+	}
+	if repo.has(folderID, removedRoot) {
+		t.Fatalf("removed library root %q remains after authoritative full-library reconcile", removedRoot)
+	}
+	if !repo.has(folderID, currentRoot) {
+		t.Fatalf("current skipped root %q was not retained", currentRoot)
+	}
+}
+
+func TestReconcileSkippedRootsSubtreeKeepsRootsOutsideScope(t *testing.T) {
+	const folderID = 42
+	const outsideRoot = "/other-library/Movie"
+	const staleScopedRoot = "/current-library/Old Movie"
+
+	repo := newSkippedRootMemoryRepo(
+		models.SkippedMediaRoot{MediaFolderID: folderID, RootPath: outsideRoot},
+		models.SkippedMediaRoot{MediaFolderID: folderID, RootPath: staleScopedRoot},
+	)
+	exec := &Executor{skippedRootRepo: repo}
+
+	err := exec.reconcileSkippedRoots(
+		context.Background(),
+		folderID,
+		"movies",
+		scopeModeSubtree,
+		"/current-library",
+		[]string{"/current-library"},
+		&scanner.ScanResult{},
+	)
+	if err != nil {
+		t.Fatalf("reconcile skipped roots: %v", err)
+	}
+	if repo.has(folderID, staleScopedRoot) {
+		t.Fatalf("stale scoped root %q remains after subtree reconcile", staleScopedRoot)
+	}
+	if !repo.has(folderID, outsideRoot) {
+		t.Fatalf("subtree reconcile removed out-of-scope root %q", outsideRoot)
 	}
 }

--- a/internal/metadata/skipped_root_repo.go
+++ b/internal/metadata/skipped_root_repo.go
@@ -146,6 +146,24 @@ func (r *SkippedRootRepository) Delete(ctx context.Context, folderID int, rootPa
 	return nil
 }
 
+// DeleteMissingByFolder removes skipped roots for a folder that were not seen
+// during an authoritative full-library scan.
+func (r *SkippedRootRepository) DeleteMissingByFolder(ctx context.Context, folderID int, seenRoots []string) error {
+	if seenRoots == nil {
+		seenRoots = []string{}
+	}
+
+	_, err := r.pool.Exec(ctx, `
+		DELETE FROM skipped_media_roots
+		WHERE media_folder_id = $1
+		  AND NOT (root_path = ANY($2))
+	`, folderID, seenRoots)
+	if err != nil {
+		return fmt.Errorf("deleting missing skipped media roots by folder: %w", err)
+	}
+	return nil
+}
+
 // DeleteMissingInScope removes skipped roots under scopePath that were not seen.
 func (r *SkippedRootRepository) DeleteMissingInScope(ctx context.Context, folderID int, scopePath string, seenRoots []string) error {
 	if seenRoots == nil {


### PR DESCRIPTION
## Problem

Related issue: #754

A full library scan only removed skipped-root diagnostics beneath the library's current path scopes. If an administrator removed or replaced a path, diagnostics beneath the old path were outside every cleanup scope and remained in Libraries > Troubleshooting indefinitely.

## Approach

Treat a successful full-library scan as authoritative for the library's complete skipped-root set. The ingest executor now keeps the skipped roots observed by that scan and asks the repository to remove every other row for the library. Subtree and single-file scans retain the existing scope-limited cleanup behavior.

The change includes regressions for both sides of that boundary: full scans remove entries beneath removed paths, while subtree scans leave entries outside their scope alone. No API, schema, Apple, Android, or Jellyfin-compatible contract changes are required.

## Validation

Passing:

- `go test ./internal/libraryingest ./internal/metadata ./internal/api/... -count=1`
- `go build ./...`
- `go vet ./...`
- `golangci-lint run --new-from-merge-base=origin/main ./...` — 0 issues
- `gofmt -l` on the changed Go files — no output
- `make verify-local-paths`
- Isolated full-server sandbox: health checks passed before and after the probe; `POST /api/v1/scan` accepted a full scan; a synthetic stale skipped-root row changed from present to absent after the scan.
- Pinned-head PR preview at `c9923b23a312b11cd625cd5b5fb48dd7e629f046`: a fresh isolated sandbox returned the synthetic removed-path diagnostic through the admin API before a full scan and omitted it afterward (`1 → 0`). An accepted subtree scan preserved an out-of-scope diagnostic at `1`. Pre- and post-probe health checks passed, with `0` recent server errors and `0` warnings.
- GitHub checks: Go, Web, Docs hygiene, and CodeRabbit passed. The optional Claude job was skipped.

`make test-go` was also run, but the repository-wide suite did not pass. Failures were confined to untouched timing and process-identity tests in `internal/httpstream`, `internal/jellycompat`, and `internal/policy`. The touched packages passed during that run; `internal/httpstream` also passed when rerun alone.

## Risks

A completed full scan can now remove stale diagnostic rows anywhere in its library, rather than only under currently configured paths. That broader cleanup is the intended behavior. Scoped scans cannot use the folder-wide delete. No migration or API compatibility risk was identified.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): GPT-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: Reviewed the complete base-to-head diff for cleanup scope, failed and partial scans, concurrent scan ownership, data loss, API compatibility, and client/Jellyfin impact. Added positive and negative regression tests and exercised the normal scan API against an isolated server. No change-specific defect remained after review.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
