### PR TITLE
fix(web): disable native MKV playback in Firefox

### DIFF
--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -5,6 +5,12 @@
 ### Clear stale library troubleshooting entries after path changes
 Full library scans now reconcile troubleshooting entries across the whole library, so diagnostics for removed or replaced root paths disappear after the path-change scan completes. Subtree and single-file scans remain scoped and cannot clear diagnostics elsewhere in the library.
 
+### Start Firefox MKV playback without downloading the whole file first
+Firefox reports native Matroska support even though common MKV files with audio can still require
+the entire source to download before the first frame. The web player no longer advertises native
+MKV delivery on Firefox, so Silo selects a streaming-safe codec-copy remux instead. Other browsers
+that can stream MKV keep direct play, and Firefox keeps its video and audio codec capabilities.
+
 ## 2026-08-24
 
 ### Restore loudness when Silo downmixes surround audio to stereo

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -202,7 +202,8 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	audioOK, passthrough, audioClaims := audioEligibilityV3(source, input.Request)
 	originalAudioSelectionOK := audioSelectionUsesContainerDefaultV3(file, input.AudioTrackIndex) ||
 		clientSelectsOriginalAudioTrackV3(input.Request)
-	if !audioOK && source.AudioCodec == "" && (file == nil || len(file.AudioTracks) == 0) {
+	noAudioTrack := source.AudioCodec == "" && (file == nil || len(file.AudioTracks) == 0)
+	if !audioOK && noAudioTrack {
 		// Video-only media has no audio stream to adapt: treating the absence
 		// as an unsupported codec would force a pointless AAC conversion — or
 		// a terminal when conversion is unavailable — on a playable file. An
@@ -425,8 +426,8 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		plan.Delivery = DeliveryRemuxProgressiveV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: mimeVideoMP4V3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
 		plan.DecisionReason = "container_normalization"
-		progressiveAudioOK := deliverySupportsAudioClaimV3(input.Request, DeliveryClassProgressiveV3, source.AudioCodec, audioClaims, audioOK)
-		hlsAudioOK := hlsNativeAudioCodecV3(source.AudioCodec) &&
+		progressiveAudioOK := noAudioTrack || deliverySupportsAudioClaimV3(input.Request, DeliveryClassProgressiveV3, source.AudioCodec, audioClaims, audioOK)
+		hlsAudioOK := noAudioTrack || hlsNativeAudioCodecV3(source.AudioCodec) &&
 			deliverySupportsAudioClaimV3(input.Request, DeliveryClassHLSV3, source.AudioCodec, audioClaims, audioOK)
 		// Defer conversion when either packaging route can preserve the source
 		// audio. A progressive-incompatible codec can still take an HLS copy
@@ -493,7 +494,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 					}
 					plan.EffectiveRecipe.AudioCodec = "aac"
 					plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: hlsAudioAdaptationReasonV3}
-					plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: []string{ClaimAudioDecodeV3}})
+					plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
 					plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
 				}
 				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, false)

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -19,14 +19,15 @@ type PlannerSettingsV3 struct {
 }
 
 const (
-	TerminalMessage4KTranscodeDisabledV3 = "A lower-resolution source is required because 4K transcoding is disabled."
-	containerMP4V3                       = "mp4"
-	mimeVideoMP4V3                       = "video/mp4"
-	degradationAudioConvertedV3          = "audio_converted"
-	hlsAudioAdaptationReasonV3           = "hls_audio_adaptation"
-	audioLayoutMonoV3                    = "mono"
-	audioLayoutStereoV3                  = "stereo"
-	audioLayoutSurround51V3              = "5.1"
+	TerminalMessage4KTranscodeDisabledV3   = "A lower-resolution source is required because 4K transcoding is disabled."
+	containerMP4V3                         = "mp4"
+	mimeVideoMP4V3                         = "video/mp4"
+	degradationAudioConvertedV3            = "audio_converted"
+	hlsAudioAdaptationReasonV3             = "hls_audio_adaptation"
+	decisionReasonContainerNormalizationV3 = "container_normalization"
+	audioLayoutMonoV3                      = "mono"
+	audioLayoutStereoV3                    = "stereo"
+	audioLayoutSurround51V3                = "5.1"
 )
 
 type PlannerInputV3 struct {
@@ -422,20 +423,13 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	// video stream-copy route: the avc1/fMP4 segment would desync strict
 	// decoders. Skipping the remux branch drops through to the HLS transcode.
 	if videoOK && !source.VideoCopyUnsafe && (remuxRangeOK || dvStripEligible) && (remuxSubtitleOK || hlsRemuxSubtitleOK) {
-		plan := base
-		plan.Delivery = DeliveryRemuxProgressiveV3
-		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: mimeVideoMP4V3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
-		plan.DecisionReason = "container_normalization"
 		progressiveAudioOK := noAudioTrack || deliverySupportsAudioClaimV3(input.Request, DeliveryClassProgressiveV3, source.AudioCodec, audioClaims, audioOK)
 		hlsAudioOK := noAudioTrack || hlsNativeAudioCodecV3(source.AudioCodec) &&
 			deliverySupportsAudioClaimV3(input.Request, DeliveryClassHLSV3, source.AudioCodec, audioClaims, audioOK)
-		// Defer conversion when either packaging route can preserve the source
-		// audio. A progressive-incompatible codec can still take an HLS copy
-		// route without requiring an AAC encoder.
-		transcodeAudio := !progressiveAudioOK && !hlsAudioOK
-		progressiveAudioChannels := 0
-		localAudioConvertOK := input.Registry != nil && input.Registry.Available(TransformationAudioToAACV3)
-		if transcodeAudio {
+		progressiveTranscodeAudio := !progressiveAudioOK
+		hlsTranscodeAudio := !hlsAudioOK
+		localAudioConvertOK := input.Registry.Available(TransformationAudioToAACV3)
+		if progressiveTranscodeAudio && hlsTranscodeAudio {
 			// The HLS remux branch below can offload the conversion to a
 			// pooled node, but only for clients that can run an HLS
 			// delivery: a progressive-only client must keep this terminal
@@ -448,6 +442,22 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			if !audioConvertOK {
 				return terminalPlannerResultV3(TerminalAudioConversionUnsupportedV3, "The required validated AAC conversion toolchain is unavailable.", true)
 			}
+		}
+		dvStrip := dvStripEligible && (source.DVProfile == 7 || !rangeOK)
+		remuxBase := base
+		if dvStrip {
+			remuxBase.Transformations = append(remuxBase.Transformations, TransformationV3{Name: TransformationServerDV7HDR10V3, Executor: ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: DV7ToHDR10ClaimsV3()})
+			remuxBase.EffectiveRecipe.DynamicRange = DynamicRangeHDR10V3
+			remuxBase.Claims.Video = VideoClaimsV3{HDR10: true}
+			remuxBase.DegradationWarnings = append(remuxBase.DegradationWarnings, DegradationWarningV3{Code: "dolby_vision_removed", Message: "Dolby Vision metadata is removed and the validated HDR10 base layer is preserved."})
+		}
+
+		plan := cloneRemuxPlanCandidateV3(remuxBase)
+		plan.Delivery = DeliveryRemuxProgressiveV3
+		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: mimeVideoMP4V3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
+		plan.DecisionReason = decisionReasonContainerNormalizationV3
+		progressiveAudioChannels := 0
+		if progressiveTranscodeAudio && localAudioConvertOK {
 			progressiveAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassProgressiveV3, source.AudioChannels, false)
 			plan.EffectiveRecipe.AudioCodec = "aac"
 			plan.EffectiveRecipe.AudioChannels = intPointerV3(progressiveAudioChannels)
@@ -457,13 +467,6 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: fmt.Sprintf("The selected audio track is converted to AAC %s.", audioLayoutForChannelsV3(progressiveAudioChannels))})
 			plan.DecisionReason = "audio_adaptation"
 		}
-		dvStrip := dvStripEligible && (source.DVProfile == 7 || !rangeOK)
-		if dvStrip {
-			plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationServerDV7HDR10V3, Executor: ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: DV7ToHDR10ClaimsV3()})
-			plan.EffectiveRecipe.DynamicRange = DynamicRangeHDR10V3
-			plan.Claims.Video = VideoClaimsV3{HDR10: true}
-			plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: "dolby_vision_removed", Message: "Dolby Vision metadata is removed and the validated HDR10 base layer is preserved."})
-		}
 		if !dvStrip {
 			applyCopiedVideoQuirksV3(&plan, source, input.Request, high10Quirk)
 		}
@@ -471,35 +474,35 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		// server transformations must be locally available; when only pooled
 		// nodes carry them, the HLS remux below ships the same recipe on a
 		// node-offloadable delivery instead.
-		progressiveExecutable := (!transcodeAudio || localAudioConvertOK) && (!dvStrip || dvStripEligibleLocal)
+		progressiveExecutable := (!progressiveTranscodeAudio || localAudioConvertOK) && (!dvStrip || dvStripEligibleLocal)
 		if remuxSubtitleOK && progressiveExecutable {
 			applySubtitleDecisionV3(&plan, remuxSubtitle.Decision)
 			plan.Claims.Subtitles = remuxSubtitle.Claims
 			finalizePlanIdentityV3(&plan, input.Request.PlaybackAttemptID, input.Request.ClientPlaybackContext.Output.OutputContextID)
 			if deliverySupportsPlanV3(input.Request, DeliveryClassProgressiveV3, plan) && !planAttemptedV3(plan, input.Request.ClientPlaybackContext.Output.OutputContextID, input.AttemptedKeys) {
-				return PlannerResultV3{Plan: &plan, PlayMethod: PlayRemux, TranscodeAudio: transcodeAudio, TargetAudioCodec: plan.EffectiveRecipe.AudioCodec, SourceAudioChannels: stereoDownmixSourceChannelsV3(source.AudioChannels, progressiveAudioChannels, transcodeAudio), TargetAudioChannels: progressiveAudioChannels, SubtitleTrackIndex: remuxSubtitle.SelectedIndex, SubtitleTransportTrackIndex: remuxSubtitle.TransportIndex, SubtitleCodec: remuxSubtitle.Codec, DownloadedSubtitleID: remuxSubtitle.DownloadedSubtitleID}
+				return PlannerResultV3{Plan: &plan, PlayMethod: PlayRemux, TranscodeAudio: progressiveTranscodeAudio, TargetAudioCodec: plan.EffectiveRecipe.AudioCodec, SourceAudioChannels: stereoDownmixSourceChannelsV3(source.AudioChannels, progressiveAudioChannels, progressiveTranscodeAudio), TargetAudioChannels: progressiveAudioChannels, SubtitleTrackIndex: remuxSubtitle.SelectedIndex, SubtitleTransportTrackIndex: remuxSubtitle.TransportIndex, SubtitleCodec: remuxSubtitle.Codec, DownloadedSubtitleID: remuxSubtitle.DownloadedSubtitleID}
 			}
 		}
 		if deliveryAvailableV3(input.Request, DeliveryClassHLSV3) && hlsRemuxSubtitleOK {
-			plan.AppliedQuirks = []AppliedQuirkV3{}
-			plan.RuntimeCorrections = []string{}
+			plan = cloneRemuxPlanCandidateV3(remuxBase)
 			plan.Delivery = DeliveryRemuxHLSV3
 			plan.Stream = StreamV3{Protocol: StreamHLSV3, Container: "hls", MIMEType: "application/vnd.apple.mpegurl", Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
-			hlsTranscodeAudio := !hlsAudioOK
 			hlsAudioChannels := 0
 			if hlsTranscodeAudio {
-				if !transcodeAudio {
-					if !input.hlsRegistry().Available(TransformationAudioToAACV3) {
-						return terminalPlannerResultV3(TerminalAudioConversionUnsupportedV3, "The HLS route requires the validated AAC conversion toolchain.", true)
-					}
-					plan.EffectiveRecipe.AudioCodec = "aac"
-					plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: hlsAudioAdaptationReasonV3}
-					plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
-					plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
+				if !input.hlsRegistry().Available(TransformationAudioToAACV3) {
+					return terminalPlannerResultV3(TerminalAudioConversionUnsupportedV3, "The HLS route requires the validated AAC conversion toolchain.", true)
 				}
-				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, false)
+				// HLS packaging cannot safely copy non-native codecs such as
+				// DTS, TrueHD, or Opus. Preserve surround when adapting those
+				// codecs; a native codec rejected by the scoped client claim
+				// keeps the normal compatibility downmix policy.
+				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, !hlsNativeAudioCodecV3(source.AudioCodec))
+				plan.EffectiveRecipe.AudioCodec = "aac"
 				plan.EffectiveRecipe.AudioChannels = intPointerV3(hlsAudioChannels)
 				plan.EffectiveRecipe.AudioLayout = audioLayoutForChannelsV3(hlsAudioChannels)
+				plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: hlsAudioAdaptationReasonV3}
+				plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
+				plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
 			}
 			if audioQuirk, ok := hlsEAC3AudioCorrectionV3(source, input.Request); ok && !hlsTranscodeAudio {
 				if !input.hlsRegistry().Available(TransformationAudioToAACV3) {
@@ -514,25 +517,6 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 				plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
 				plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: fmt.Sprintf("The selected audio track is converted to AAC %s for this device's HLS route.", audioLayoutForChannelsV3(hlsAudioChannels))})
 				appendAppliedQuirkV3(&plan, *audioQuirk, "")
-			}
-			// DTS and TrueHD are not HLS-native audio codecs. A client's
-			// progressive DTS decode claim does not transfer to segmented
-			// fMP4/TS: copied DTS in an HLS route drags Media3's audio clock
-			// (device stall corrections, ~0.3x pacing, frozen position
-			// reports), so the copy is converted to AAC — surround-preserving
-			// when the source is multichannel.
-			if !hlsTranscodeAudio && !hlsNativeAudioCodecV3(source.AudioCodec) {
-				if !input.hlsRegistry().Available(TransformationAudioToAACV3) {
-					return terminalPlannerResultV3(TerminalAudioConversionUnsupportedV3, "The HLS route requires the validated AAC conversion toolchain.", true)
-				}
-				hlsTranscodeAudio = true
-				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, true)
-				plan.EffectiveRecipe.AudioCodec = "aac"
-				plan.EffectiveRecipe.AudioChannels = intPointerV3(hlsAudioChannels)
-				plan.EffectiveRecipe.AudioLayout = audioLayoutForChannelsV3(hlsAudioChannels)
-				plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: hlsAudioAdaptationReasonV3}
-				plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
-				plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
 			}
 			if !dvStrip {
 				applyCopiedVideoQuirksV3(&plan, source, input.Request, high10Quirk)
@@ -691,7 +675,7 @@ func planAudioOnlyV3(input PlannerInputV3, file *models.MediaFile, source Source
 	// before it will attach a source buffer, and "video/mp4" with no video
 	// track is exactly the mismatch that makes that probe lie.
 	plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: AudioOnlyRemuxMIMEV3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
-	plan.DecisionReason = "container_normalization"
+	plan.DecisionReason = decisionReasonContainerNormalizationV3
 	targetAudioChannels := audioOnlyAACOutputChannelsV3(request, source)
 	targetAudioBitrateKbps := 0
 	if transcodeAudio {
@@ -1511,6 +1495,16 @@ func deliveryAvailableV3(request StartRequestV3, deliveryClass string) bool {
 		return false
 	}
 	return capability.Enabled && capability.SupportedOnDevice
+}
+
+// cloneRemuxPlanCandidateV3 keeps progressive and HLS candidate mutations
+// independent while preserving the common source and dynamic-range recipe.
+func cloneRemuxPlanCandidateV3(plan PlanV3) PlanV3 {
+	plan.Transformations = append([]TransformationV3{}, plan.Transformations...)
+	plan.AppliedQuirks = append([]AppliedQuirkV3{}, plan.AppliedQuirks...)
+	plan.RuntimeCorrections = append([]string{}, plan.RuntimeCorrections...)
+	plan.DegradationWarnings = append([]DegradationWarningV3{}, plan.DegradationWarnings...)
+	return plan
 }
 
 // deliverySupportsAudioClaimV3 narrows a device-wide audio claim to the active

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -424,7 +424,13 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		plan.Delivery = DeliveryRemuxProgressiveV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: mimeVideoMP4V3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
 		plan.DecisionReason = "container_normalization"
-		transcodeAudio := !deliveryDecodesAudioCodecV3(input.Request, DeliveryClassProgressiveV3, source.AudioCodec, audioOK)
+		progressiveAudioOK := deliverySupportsAudioClaimV3(input.Request, DeliveryClassProgressiveV3, source.AudioCodec, audioClaims, audioOK)
+		hlsAudioOK := hlsNativeAudioCodecV3(source.AudioCodec) &&
+			deliverySupportsAudioClaimV3(input.Request, DeliveryClassHLSV3, source.AudioCodec, audioClaims, audioOK)
+		// Defer conversion when either packaging route can preserve the source
+		// audio. A progressive-incompatible codec can still take an HLS copy
+		// route without requiring an AAC encoder.
+		transcodeAudio := !progressiveAudioOK && !hlsAudioOK
 		progressiveAudioChannels := 0
 		localAudioConvertOK := input.Registry != nil && input.Registry.Available(TransformationAudioToAACV3)
 		if transcodeAudio {
@@ -477,9 +483,18 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			plan.RuntimeCorrections = []string{}
 			plan.Delivery = DeliveryRemuxHLSV3
 			plan.Stream = StreamV3{Protocol: StreamHLSV3, Container: "hls", MIMEType: "application/vnd.apple.mpegurl", Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
-			hlsTranscodeAudio := transcodeAudio
+			hlsTranscodeAudio := !hlsAudioOK
 			hlsAudioChannels := 0
 			if hlsTranscodeAudio {
+				if !transcodeAudio {
+					if !input.hlsRegistry().Available(TransformationAudioToAACV3) {
+						return terminalPlannerResultV3(TerminalAudioConversionUnsupportedV3, "The HLS route requires the validated AAC conversion toolchain.", true)
+					}
+					plan.EffectiveRecipe.AudioCodec = "aac"
+					plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: "hls_audio_adaptation"}
+					plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: []string{ClaimAudioDecodeV3}})
+					plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
+				}
 				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, false)
 				plan.EffectiveRecipe.AudioChannels = intPointerV3(hlsAudioChannels)
 				plan.EffectiveRecipe.AudioLayout = audioLayoutForChannelsV3(hlsAudioChannels)
@@ -1496,15 +1511,24 @@ func deliveryAvailableV3(request StartRequestV3, deliveryClass string) bool {
 	return capability.Enabled && capability.SupportedOnDevice
 }
 
-// deliveryDecodesAudioCodecV3 narrows a device-wide audio claim to the active
-// delivery when the client supplies a scoped list. Empty scoped lists retain
-// the legacy fallback because older clients use them to mean "unspecified."
-func deliveryDecodesAudioCodecV3(request StartRequestV3, deliveryClass, codec string, fallback bool) bool {
+// deliverySupportsAudioClaimV3 narrows a device-wide audio claim to the active
+// delivery when the client supplies scoped decode or passthrough lists. Empty
+// scoped lists retain the legacy fallback because older clients use them to
+// mean "unspecified."
+func deliverySupportsAudioClaimV3(request StartRequestV3, deliveryClass, codec string, claim AudioClaimsV3, fallback bool) bool {
 	capability, ok := request.ClientPlaybackContext.Deliveries[deliveryClass]
-	if !ok || len(capability.AudioDecodeCodecs) == 0 {
+	if !ok || !capability.Enabled || !capability.SupportedOnDevice {
+		return false
+	}
+	hasAudioConstraints := len(capability.AudioDecodeCodecs) > 0 || len(capability.AudioPassthroughCodecs) > 0
+	if !hasAudioConstraints {
 		return fallback
 	}
-	return containsFoldV3(capability.AudioDecodeCodecs, codec)
+	supportedCodecs := capability.AudioDecodeCodecs
+	if claim.Passthrough {
+		supportedCodecs = capability.AudioPassthroughCodecs
+	}
+	return containsFoldV3(supportedCodecs, codec)
 }
 
 // deliverySupportsPlanV3 applies the capability limits scoped to the delivery

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -424,7 +424,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		plan.Delivery = DeliveryRemuxProgressiveV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: mimeVideoMP4V3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
 		plan.DecisionReason = "container_normalization"
-		transcodeAudio := !audioOK
+		transcodeAudio := !deliveryDecodesAudioCodecV3(input.Request, DeliveryClassProgressiveV3, source.AudioCodec, audioOK)
 		progressiveAudioChannels := 0
 		localAudioConvertOK := input.Registry != nil && input.Registry.Available(TransformationAudioToAACV3)
 		if transcodeAudio {
@@ -1494,6 +1494,17 @@ func deliveryAvailableV3(request StartRequestV3, deliveryClass string) bool {
 		return false
 	}
 	return capability.Enabled && capability.SupportedOnDevice
+}
+
+// deliveryDecodesAudioCodecV3 narrows a device-wide audio claim to the active
+// delivery when the client supplies a scoped list. Empty scoped lists retain
+// the legacy fallback because older clients use them to mean "unspecified."
+func deliveryDecodesAudioCodecV3(request StartRequestV3, deliveryClass, codec string, fallback bool) bool {
+	capability, ok := request.ClientPlaybackContext.Deliveries[deliveryClass]
+	if !ok || len(capability.AudioDecodeCodecs) == 0 {
+		return fallback
+	}
+	return containsFoldV3(capability.AudioDecodeCodecs, codec)
 }
 
 // deliverySupportsPlanV3 applies the capability limits scoped to the delivery

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -23,6 +23,9 @@ const (
 	containerMP4V3                         = "mp4"
 	mimeVideoMP4V3                         = "video/mp4"
 	degradationAudioConvertedV3            = "audio_converted"
+	audioCodecAACV3                        = "aac"
+	serverAudioAdaptationReasonV3          = "server_audio_adaptation"
+	decisionReasonAudioAdaptationV3        = "audio_adaptation"
 	hlsAudioAdaptationReasonV3             = "hls_audio_adaptation"
 	decisionReasonContainerNormalizationV3 = "container_normalization"
 	audioLayoutMonoV3                      = "mono"
@@ -428,6 +431,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			deliverySupportsAudioClaimV3(input.Request, DeliveryClassHLSV3, source.AudioCodec, audioClaims, audioOK)
 		progressiveTranscodeAudio := !progressiveAudioOK
 		hlsTranscodeAudio := !hlsAudioOK
+		hlsAudioQuirk, hlsAudioQuirkOK := hlsEAC3AudioCorrectionV3(source, input.Request)
 		localAudioConvertOK := input.Registry.Available(TransformationAudioToAACV3)
 		if progressiveTranscodeAudio && hlsTranscodeAudio {
 			// The HLS remux branch below can offload the conversion to a
@@ -452,39 +456,50 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			remuxBase.DegradationWarnings = append(remuxBase.DegradationWarnings, DegradationWarningV3{Code: "dolby_vision_removed", Message: "Dolby Vision metadata is removed and the validated HDR10 base layer is preserved."})
 		}
 
-		plan := cloneRemuxPlanCandidateV3(remuxBase)
-		plan.Delivery = DeliveryRemuxProgressiveV3
-		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: mimeVideoMP4V3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
-		plan.DecisionReason = decisionReasonContainerNormalizationV3
+		progressivePlan := cloneRemuxPlanCandidateV3(remuxBase)
+		progressivePlan.Delivery = DeliveryRemuxProgressiveV3
+		progressivePlan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: containerMP4V3, MIMEType: mimeVideoMP4V3, Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
+		progressivePlan.DecisionReason = decisionReasonContainerNormalizationV3
 		progressiveAudioChannels := 0
 		if progressiveTranscodeAudio && localAudioConvertOK {
 			progressiveAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassProgressiveV3, source.AudioChannels, false)
-			plan.EffectiveRecipe.AudioCodec = "aac"
-			plan.EffectiveRecipe.AudioChannels = intPointerV3(progressiveAudioChannels)
-			plan.EffectiveRecipe.AudioLayout = audioLayoutForChannelsV3(progressiveAudioChannels)
-			plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: "server_audio_adaptation"}
-			plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
-			plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: fmt.Sprintf("The selected audio track is converted to AAC %s.", audioLayoutForChannelsV3(progressiveAudioChannels))})
-			plan.DecisionReason = "audio_adaptation"
+			progressivePlan.EffectiveRecipe.AudioCodec = audioCodecAACV3
+			progressivePlan.EffectiveRecipe.AudioChannels = intPointerV3(progressiveAudioChannels)
+			progressivePlan.EffectiveRecipe.AudioLayout = audioLayoutForChannelsV3(progressiveAudioChannels)
+			progressivePlan.Claims.Audio = AudioClaimsV3{Codec: audioCodecAACV3, Reason: serverAudioAdaptationReasonV3}
+			progressivePlan.Transformations = append(progressivePlan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
+			progressivePlan.DegradationWarnings = append(progressivePlan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: fmt.Sprintf("The selected audio track is converted to AAC %s.", audioLayoutForChannelsV3(progressiveAudioChannels))})
+			progressivePlan.DecisionReason = decisionReasonAudioAdaptationV3
 		}
 		if !dvStrip {
-			applyCopiedVideoQuirksV3(&plan, source, input.Request, high10Quirk)
+			applyCopiedVideoQuirksV3(&progressivePlan, source, input.Request, high10Quirk)
 		}
 		// The progressive remux executes on this process's ffmpeg, so its
 		// server transformations must be locally available; when only pooled
 		// nodes carry them, the HLS remux below ships the same recipe on a
 		// node-offloadable delivery instead.
 		progressiveExecutable := (!progressiveTranscodeAudio || localAudioConvertOK) && (!dvStrip || dvStripEligibleLocal)
-		if remuxSubtitleOK && progressiveExecutable {
-			applySubtitleDecisionV3(&plan, remuxSubtitle.Decision)
-			plan.Claims.Subtitles = remuxSubtitle.Claims
-			finalizePlanIdentityV3(&plan, input.Request.PlaybackAttemptID, input.Request.ClientPlaybackContext.Output.OutputContextID)
-			if deliverySupportsPlanV3(input.Request, DeliveryClassProgressiveV3, plan) && !planAttemptedV3(plan, input.Request.ClientPlaybackContext.Output.OutputContextID, input.AttemptedKeys) {
-				return PlannerResultV3{Plan: &plan, PlayMethod: PlayRemux, TranscodeAudio: progressiveTranscodeAudio, TargetAudioCodec: plan.EffectiveRecipe.AudioCodec, SourceAudioChannels: stereoDownmixSourceChannelsV3(source.AudioChannels, progressiveAudioChannels, progressiveTranscodeAudio), TargetAudioChannels: progressiveAudioChannels, SubtitleTrackIndex: remuxSubtitle.SelectedIndex, SubtitleTransportTrackIndex: remuxSubtitle.TransportIndex, SubtitleCodec: remuxSubtitle.Codec, DownloadedSubtitleID: remuxSubtitle.DownloadedSubtitleID}
+		tryProgressive := func() (PlannerResultV3, bool) {
+			if !remuxSubtitleOK || !progressiveExecutable {
+				return PlannerResultV3{}, false
+			}
+			candidate := cloneRemuxPlanCandidateV3(progressivePlan)
+			applySubtitleDecisionV3(&candidate, remuxSubtitle.Decision)
+			candidate.Claims.Subtitles = remuxSubtitle.Claims
+			finalizePlanIdentityV3(&candidate, input.Request.PlaybackAttemptID, input.Request.ClientPlaybackContext.Output.OutputContextID)
+			if deliverySupportsPlanV3(input.Request, DeliveryClassProgressiveV3, candidate) && !planAttemptedV3(candidate, input.Request.ClientPlaybackContext.Output.OutputContextID, input.AttemptedKeys) {
+				return PlannerResultV3{Plan: &candidate, PlayMethod: PlayRemux, TranscodeAudio: progressiveTranscodeAudio, TargetAudioCodec: candidate.EffectiveRecipe.AudioCodec, SourceAudioChannels: stereoDownmixSourceChannelsV3(source.AudioChannels, progressiveAudioChannels, progressiveTranscodeAudio), TargetAudioChannels: progressiveAudioChannels, SubtitleTrackIndex: remuxSubtitle.SelectedIndex, SubtitleTransportTrackIndex: remuxSubtitle.TransportIndex, SubtitleCodec: remuxSubtitle.Codec, DownloadedSubtitleID: remuxSubtitle.DownloadedSubtitleID}, true
+			}
+			return PlannerResultV3{}, false
+		}
+		progressiveFirst := !progressiveTranscodeAudio || hlsTranscodeAudio || hlsAudioQuirkOK
+		if progressiveFirst {
+			if result, ok := tryProgressive(); ok {
+				return result
 			}
 		}
 		if deliveryAvailableV3(input.Request, DeliveryClassHLSV3) && hlsRemuxSubtitleOK {
-			plan = cloneRemuxPlanCandidateV3(remuxBase)
+			plan := cloneRemuxPlanCandidateV3(remuxBase)
 			plan.Delivery = DeliveryRemuxHLSV3
 			plan.Stream = StreamV3{Protocol: StreamHLSV3, Container: "hls", MIMEType: "application/vnd.apple.mpegurl", Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
 			hlsAudioChannels := 0
@@ -504,7 +519,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 				plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
 				plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
 			}
-			if audioQuirk, ok := hlsEAC3AudioCorrectionV3(source, input.Request); ok && !hlsTranscodeAudio {
+			if hlsAudioQuirkOK && !hlsTranscodeAudio {
 				if !input.hlsRegistry().Available(TransformationAudioToAACV3) {
 					return terminalPlannerResultV3(TerminalAudioConversionUnsupportedV3, "The device-specific HLS route requires the validated AAC conversion toolchain.", true)
 				}
@@ -516,7 +531,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 				plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: "device_hls_audio_adaptation"}
 				plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
 				plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: fmt.Sprintf("The selected audio track is converted to AAC %s for this device's HLS route.", audioLayoutForChannelsV3(hlsAudioChannels))})
-				appendAppliedQuirkV3(&plan, *audioQuirk, "")
+				appendAppliedQuirkV3(&plan, *hlsAudioQuirk, "")
 			}
 			if !dvStrip {
 				applyCopiedVideoQuirksV3(&plan, source, input.Request, high10Quirk)
@@ -535,6 +550,11 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 					targetAudio = "aac"
 				}
 				return PlannerResultV3{Plan: &plan, PlayMethod: PlayRemux, TranscodeAudio: hlsTranscodeAudio, TargetVideoCodec: "copy", TargetAudioCodec: targetAudio, SourceAudioChannels: stereoDownmixSourceChannelsV3(source.AudioChannels, hlsAudioChannels, hlsTranscodeAudio), TargetAudioChannels: hlsAudioChannels, TargetResolution: resolutionLabelV3(source.Height), TargetBitrateKbps: source.BitrateKbps, SubtitleTrackIndex: hlsSubtitle.SelectedIndex, SubtitleTransportTrackIndex: hlsSubtitle.TransportIndex, SubtitleCodec: hlsSubtitle.Codec, DownloadedSubtitleID: hlsSubtitle.DownloadedSubtitleID}
+			}
+		}
+		if !progressiveFirst {
+			if result, ok := tryProgressive(); ok {
+				return result
 			}
 		}
 	}

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -23,6 +23,7 @@ const (
 	containerMP4V3                       = "mp4"
 	mimeVideoMP4V3                       = "video/mp4"
 	degradationAudioConvertedV3          = "audio_converted"
+	hlsAudioAdaptationReasonV3           = "hls_audio_adaptation"
 	audioLayoutMonoV3                    = "mono"
 	audioLayoutStereoV3                  = "stereo"
 	audioLayoutSurround51V3              = "5.1"
@@ -491,7 +492,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 						return terminalPlannerResultV3(TerminalAudioConversionUnsupportedV3, "The HLS route requires the validated AAC conversion toolchain.", true)
 					}
 					plan.EffectiveRecipe.AudioCodec = "aac"
-					plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: "hls_audio_adaptation"}
+					plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: hlsAudioAdaptationReasonV3}
 					plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: "1", ValidatedClaims: []string{ClaimAudioDecodeV3}})
 					plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
 				}
@@ -528,7 +529,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 				plan.EffectiveRecipe.AudioCodec = "aac"
 				plan.EffectiveRecipe.AudioChannels = intPointerV3(hlsAudioChannels)
 				plan.EffectiveRecipe.AudioLayout = audioLayoutForChannelsV3(hlsAudioChannels)
-				plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: "hls_audio_adaptation"}
+				plan.Claims.Audio = AudioClaimsV3{Codec: "aac", Reason: hlsAudioAdaptationReasonV3}
 				plan.Transformations = append(plan.Transformations, TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}})
 				plan.DegradationWarnings = append(plan.DegradationWarnings, DegradationWarningV3{Code: degradationAudioConvertedV3, Message: "The selected audio track is converted to AAC for HLS delivery."})
 			}
@@ -536,7 +537,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 				applyCopiedVideoQuirksV3(&plan, source, input.Request, high10Quirk)
 			}
 			if hlsTranscodeAudio {
-				plan.DecisionReason = "hls_audio_adaptation"
+				plan.DecisionReason = hlsAudioAdaptationReasonV3
 			} else {
 				plan.DecisionReason = "hls_packaging_required"
 			}

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -3157,6 +3157,36 @@ func TestPlanPlaybackV3AudioOnlyConvertsForProgressiveCodecSubset(t *testing.T) 
 	}
 }
 
+func TestPlanPlaybackV3VideoRemuxConvertsForProgressiveAudioCodecSubset(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.CodecAudio = "vorbis"
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.AudioTracks[0] = models.AudioTrack{Codec: "vorbis", Channels: 2, Layout: "stereo"}
+
+	req := validStartRequestV3()
+	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	req.Capabilities.AudioEvidence = EvidenceDeclaredV3
+	req.Capabilities.CodecsAudio = []string{"aac", "vorbis"}
+	req.Capabilities.Containers = []string{"mp4"}
+	progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+	progressive.Containers = []string{"mp4"}
+	progressive.VideoCodecs = []string{"hevc"}
+	progressive.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: testTransformationRegistryV3(),
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	if result.Plan.DecisionReason != "audio_adaptation" || len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != TransformationAudioToAACV3 {
+		t.Fatalf("converted plan = %#v", result.Plan)
+	}
+}
+
 // A container mismatch on decodable audio is a remux, not a conversion, and a
 // client with neither route left gets an honest terminal. An audio-only file
 // with no probed audio codec keeps its own metadata terminal.

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -3187,6 +3187,72 @@ func TestPlanPlaybackV3VideoRemuxConvertsForProgressiveAudioCodecSubset(t *testi
 	}
 }
 
+func TestPlanPlaybackV3VideoRemuxPreservesHLSOnlyAudioCodec(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.CodecAudio = "eac3"
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.AudioTracks[0] = models.AudioTrack{Codec: "eac3", Channels: 6, Layout: "5.1"}
+
+	req := validStartRequestV3()
+	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	req.Capabilities.AudioEvidence = EvidenceDeclaredV3
+	req.Capabilities.CodecsAudio = []string{"aac", "eac3"}
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassOriginalHTTPV3)
+	progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+	progressive.Containers = []string{"mp4"}
+	progressive.VideoCodecs = []string{"hevc"}
+	progressive.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+	hls := req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+	hls.Containers = []string{"hls"}
+	hls.VideoCodecs = []string{"hevc"}
+	hls.AudioDecodeCodecs = []string{"eac3"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: NewTransformationRegistryV3(nil),
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxHLSV3 || result.TranscodeAudio || result.TargetAudioCodec != "copy" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
+func TestPlanPlaybackV3VideoRemuxHonorsProgressiveAudioPassthrough(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.CodecAudio = "ac3"
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.AudioTracks[0] = models.AudioTrack{Codec: "ac3", Channels: 6, Layout: "5.1"}
+
+	req := validStartRequestV3()
+	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	req.ClientFeatures = append(req.ClientFeatures, FeatureLayoutPassthrough)
+	req.Capabilities.CodecsAudio = []string{"aac"}
+	req.Capabilities.AudioPassthrough = &AudioPassthroughV3{
+		PassthroughCodecs: []string{"ac3"}, MaxChannels: 6,
+		Entries: []AudioPassthroughEntryV3{{Codec: "ac3", ChannelCounts: []int{6}, Layouts: []string{"5.1"}}},
+	}
+	req.Capabilities.Containers = []string{"mp4"}
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassOriginalHTTPV3)
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassHLSV3)
+	progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+	progressive.Containers = []string{"mp4"}
+	progressive.VideoCodecs = []string{"hevc"}
+	progressive.AudioDecodeCodecs = []string{"aac"}
+	progressive.AudioPassthroughCodecs = []string{"ac3"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: NewTransformationRegistryV3(nil),
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || result.TranscodeAudio || !result.Plan.Claims.Audio.Passthrough {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
 // A container mismatch on decodable audio is a remux, not a conversion, and a
 // client with neither route left gets an honest terminal. An audio-only file
 // with no probed audio codec keeps its own metadata terminal.

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -3253,6 +3253,111 @@ func TestPlanPlaybackV3VideoRemuxHonorsProgressiveAudioPassthrough(t *testing.T)
 	}
 }
 
+func TestPlanPlaybackV3VideoOnlyRemuxIgnoresScopedAudioConstraints(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.CodecAudio = ""
+	file.AudioChannels = 0
+	file.AudioTracks = nil
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+
+	req := validStartRequestV3()
+	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	req.Capabilities.Containers = []string{"mp4"}
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassOriginalHTTPV3)
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassHLSV3)
+	progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+	progressive.Containers = []string{"mp4"}
+	progressive.VideoCodecs = []string{"hevc"}
+	progressive.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: nil,
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || result.TranscodeAudio || len(result.Plan.Transformations) != 0 {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+	if result.Plan.Claims.Audio.Reason != "no_audio_track" || result.Plan.EffectiveRecipe.AudioCodec != "" {
+		t.Fatalf("audio recipe = %#v, claims = %#v", result.Plan.EffectiveRecipe, result.Plan.Claims.Audio)
+	}
+}
+
+func TestPlanPlaybackV3VideoRemuxWithNilRegistryReturnsAudioConversionTerminal(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.CodecAudio = "vorbis"
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.AudioTracks[0] = models.AudioTrack{Codec: "vorbis", Channels: 2, Layout: "stereo"}
+
+	req := validStartRequestV3()
+	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	req.Capabilities.AudioEvidence = EvidenceDeclaredV3
+	req.Capabilities.CodecsAudio = []string{"aac", "vorbis"}
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassOriginalHTTPV3)
+	progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+	progressive.Containers = []string{"mp4"}
+	progressive.VideoCodecs = []string{"hevc"}
+	progressive.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+	hls := req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+	hls.Containers = []string{"hls"}
+	hls.VideoCodecs = []string{"hevc"}
+	hls.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: nil,
+	})
+	if result.Terminal == nil || result.Terminal.Reason != TerminalAudioConversionUnsupportedV3 || !result.Terminal.Retryable {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
+func TestPlanPlaybackV3VideoRemuxUsesCurrentAACRecipeForHLSFallback(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.CodecAudio = "opus"
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.AudioTracks[0] = models.AudioTrack{Codec: "opus", Channels: 2, Layout: "stereo"}
+
+	req := validStartRequestV3()
+	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	req.Capabilities.AudioEvidence = EvidenceDeclaredV3
+	req.Capabilities.CodecsAudio = []string{"aac", "opus"}
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassOriginalHTTPV3)
+	progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+	progressive.Containers = []string{"mp4"}
+	progressive.VideoCodecs = []string{"hevc"}
+	progressive.AudioDecodeCodecs = []string{"opus"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+	hls := req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+	hls.Containers = []string{"hls"}
+	hls.VideoCodecs = []string{"hevc"}
+	hls.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+
+	input := PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: testTransformationRegistryV3(),
+	}
+	progressiveResult := PlanPlaybackV3(input)
+	if progressiveResult.Plan == nil || progressiveResult.Plan.Delivery != DeliveryRemuxProgressiveV3 {
+		t.Fatalf("progressive result = %s", ExplainPlannerResultV3(progressiveResult))
+	}
+	input.AttemptedKeys = []string{progressiveResult.Plan.PlanAttemptKey}
+
+	hlsResult := PlanPlaybackV3(input)
+	if hlsResult.Plan == nil || hlsResult.Plan.Delivery != DeliveryRemuxHLSV3 || !hlsResult.TranscodeAudio || len(hlsResult.Plan.Transformations) != 1 {
+		t.Fatalf("HLS result = %s", ExplainPlannerResultV3(hlsResult))
+	}
+	if hlsResult.Plan.Transformations[0].RecipeVersion != TransformationAudioToAACRecipeVersionV3 {
+		t.Fatalf("AAC recipe version = %q, want %q", hlsResult.Plan.Transformations[0].RecipeVersion, TransformationAudioToAACRecipeVersionV3)
+	}
+}
+
 // A container mismatch on decodable audio is a remux, not a conversion, and a
 // client with neither route left gets an honest terminal. An audio-only file
 // with no probed audio codec keeps its own metadata terminal.

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -3212,7 +3212,7 @@ func TestPlanPlaybackV3VideoRemuxPreservesHLSOnlyAudioCodec(t *testing.T) {
 
 	result := PlanPlaybackV3(PlannerInputV3{
 		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
-		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: NewTransformationRegistryV3(nil),
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: testTransformationRegistryV3(),
 	})
 	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxHLSV3 || result.TranscodeAudio || result.TargetAudioCodec != "copy" {
 		t.Fatalf("result = %s", ExplainPlannerResultV3(result))

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -3219,6 +3219,38 @@ func TestPlanPlaybackV3VideoRemuxPreservesHLSOnlyAudioCodec(t *testing.T) {
 	}
 }
 
+func TestPlanPlaybackV3VideoRemuxAdaptsProgressiveWhenHLSVideoUnsupported(t *testing.T) {
+	file := detailedFixtureFileV3()
+	file.CodecAudio = "eac3"
+	file.VideoTracks[0].VideoRange = "SDR"
+	file.VideoTracks[0].VideoRangeType = "SDR"
+	file.AudioTracks[0] = models.AudioTrack{Codec: "eac3", Channels: 6, Layout: "5.1"}
+
+	req := validStartRequestV3()
+	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+	req.Capabilities.AudioEvidence = EvidenceDeclaredV3
+	req.Capabilities.CodecsAudio = []string{"aac", "eac3"}
+	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassOriginalHTTPV3)
+	progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+	progressive.Containers = []string{"mp4"}
+	progressive.VideoCodecs = []string{"hevc"}
+	progressive.AudioDecodeCodecs = []string{"aac"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+	hls := req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+	hls.Containers = []string{"hls"}
+	hls.VideoCodecs = []string{"h264"}
+	hls.AudioDecodeCodecs = []string{"eac3"}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+
+	result := PlanPlaybackV3(PlannerInputV3{
+		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+		Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: testTransformationRegistryV3(),
+	})
+	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" {
+		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
 func TestPlanPlaybackV3VideoRemuxHonorsProgressiveAudioPassthrough(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.CodecAudio = "ac3"
@@ -3319,9 +3351,10 @@ func TestPlanPlaybackV3VideoRemuxWithNilRegistryReturnsAudioConversionTerminal(t
 func TestPlanPlaybackV3VideoRemuxUsesCurrentAACRecipeForHLSFallback(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.CodecAudio = "opus"
+	file.AudioChannels = 6
 	file.VideoTracks[0].VideoRange = "SDR"
 	file.VideoTracks[0].VideoRangeType = "SDR"
-	file.AudioTracks[0] = models.AudioTrack{Codec: "opus", Channels: 2, Layout: "stereo"}
+	file.AudioTracks[0] = models.AudioTrack{Codec: "opus", Channels: 6, Layout: "5.1"}
 
 	req := validStartRequestV3()
 	req.Capabilities.VideoEvidence = EvidenceDeclaredV3
@@ -3355,6 +3388,9 @@ func TestPlanPlaybackV3VideoRemuxUsesCurrentAACRecipeForHLSFallback(t *testing.T
 	}
 	if hlsResult.Plan.Transformations[0].RecipeVersion != TransformationAudioToAACRecipeVersionV3 {
 		t.Fatalf("AAC recipe version = %q, want %q", hlsResult.Plan.Transformations[0].RecipeVersion, TransformationAudioToAACRecipeVersionV3)
+	}
+	if hlsResult.TargetAudioChannels != 6 || hlsResult.Plan.EffectiveRecipe.AudioChannels == nil || *hlsResult.Plan.EffectiveRecipe.AudioChannels != 6 {
+		t.Fatalf("HLS AAC channels = %d, recipe = %#v", hlsResult.TargetAudioChannels, hlsResult.Plan.EffectiveRecipe)
 	}
 }
 

--- a/web/src/player/client-context-v3.test.ts
+++ b/web/src/player/client-context-v3.test.ts
@@ -39,6 +39,7 @@ describe("buildDeliveriesV3", () => {
       codecsVideo: ["h264"],
       progressiveCodecsVideo: ["h264"],
       codecsAudio: ["aac"],
+      progressiveCodecsAudio: ["aac"],
       maxResolution: "1080p",
       hdr: false,
       hdrDetails: {
@@ -65,6 +66,7 @@ describe("structured HDR capabilities", () => {
     codecsVideo: ["hevc"],
     progressiveCodecsVideo: ["hevc"],
     codecsAudio: ["eac3"],
+    progressiveCodecsAudio: ["eac3"],
     maxResolution: "2160p",
     hdr: true,
     hdrDetails: {
@@ -118,5 +120,19 @@ describe("structured HDR capabilities", () => {
     expect(deliveries.original_http?.video_codecs).toEqual(["h264"]);
     expect(deliveries.progressive?.video_codecs).toEqual(["h264", "hevc"]);
     expect(deliveries.hls?.video_codecs).toEqual(["h264"]);
+  });
+
+  it("scopes container-specific audio evidence to progressive MP4", () => {
+    const containerScopedProbe = {
+      ...probe,
+      codecsAudio: ["aac", "vorbis"],
+      progressiveCodecsAudio: ["aac"],
+    };
+
+    const deliveries = buildDeliveriesV3(containerScopedProbe);
+
+    expect(deliveries.original_http?.audio_decode_codecs).toEqual(["aac", "vorbis"]);
+    expect(deliveries.progressive?.audio_decode_codecs).toEqual(["aac"]);
+    expect(deliveries.hls?.audio_decode_codecs).toEqual(["aac", "vorbis"]);
   });
 });

--- a/web/src/player/client-context-v3.ts
+++ b/web/src/player/client-context-v3.ts
@@ -80,6 +80,8 @@ export interface WebCapabilityProbe {
   progressiveCodecsVideo: string[];
   /** Audio codec names the browser reported support for. */
   codecsAudio: string[];
+  /** Audio codecs supported specifically inside progressive MP4 delivery. */
+  progressiveCodecsAudio: string[];
   /** Best-effort screen-derived resolution ceiling. */
   maxResolution: string;
   /** Best-effort HDR display detection. */
@@ -168,6 +170,7 @@ export function buildDeliveriesV3(
     }),
     progressive: buildDeliveryCapability(probe, {
       video_codecs: probe.progressiveCodecsVideo,
+      audio_decode_codecs: probe.progressiveCodecsAudio,
       hdr_details: progressiveHDRDetails,
     }),
     hls: buildDeliveryCapability(probe, {

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -36,6 +36,7 @@ import { resolvePendingSeekTime } from "../utils/pendingSeek";
 import { resolveVersionAudioLanguage } from "../utils/effectiveAudioLanguage";
 import { HlsStartupGuard } from "../utils/hlsStartupGuard";
 import { resolveHLSEngineV3 } from "../utils/hlsEngine";
+import { isFirefoxUserAgent } from "../utils/browser";
 import { normalizeSubtitleMode } from "../utils/subtitleMode";
 import type {
   PlaybackExitState,
@@ -514,9 +515,7 @@ export function VideoPlayer({
   }, [isPlayerReady, planRevision]);
 
   const isFirefoxBrowser =
-    typeof navigator !== "undefined" &&
-    /firefox/i.test(navigator.userAgent) &&
-    !/seamonkey/i.test(navigator.userAgent);
+    typeof navigator !== "undefined" && isFirefoxUserAgent(navigator.userAgent);
   const watchTogether =
     watchTogetherConnection ??
     ({

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -268,4 +268,37 @@ describe("probeWebCapabilities", () => {
     expect(canPlayType).toHaveBeenCalledWith('video/webm; codecs="vp09.00.10.08"');
     expect(canPlayType).not.toHaveBeenCalledWith('video/webm; codecs="avc1.640028"');
   });
+
+  it("does not advertise native MKV playback on Firefox", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0",
+    });
+    const supportedTypes = new Set([
+      'video/x-matroska; codecs="avc1.640028"',
+      'video/mp4; codecs="avc1.640028"',
+      'audio/mp4; codecs="mp4a.40.2"',
+    ]);
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      supportedTypes.has(mime) ? "probably" : "",
+    );
+
+    const capabilities = probeWebCapabilities();
+
+    expect(capabilities.containers).not.toContain("mkv");
+    expect(capabilities.codecsVideo).toContain("h264");
+    expect(capabilities.codecsAudio).toContain("aac");
+  });
+
+  it("keeps advertising native MKV playback on other capable browsers", () => {
+    vi.stubGlobal("navigator", {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140.0 Safari/537.36",
+    });
+    vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
+      mime === 'video/x-matroska; codecs="avc1.640028"' ? "probably" : "",
+    );
+
+    expect(probeWebCapabilities().containers).toContain("mkv");
+  });
 });

--- a/web/src/player/hooks/useCodecDetection.test.ts
+++ b/web/src/player/hooks/useCodecDetection.test.ts
@@ -252,6 +252,8 @@ describe("probeWebCapabilities", () => {
     expect(capabilities.codecsAudio).toEqual(
       expect.arrayContaining(["mp3", "flac", "opus", "vorbis"]),
     );
+    expect(capabilities.progressiveCodecsAudio).toEqual(expect.arrayContaining(["flac", "opus"]));
+    expect(capabilities.progressiveCodecsAudio).not.toContain("vorbis");
     expect(capabilities.containers).toEqual(expect.arrayContaining(["mp4", "mp3", "flac", "ogg"]));
   });
 
@@ -278,6 +280,7 @@ describe("probeWebCapabilities", () => {
       'video/x-matroska; codecs="avc1.640028"',
       'video/mp4; codecs="avc1.640028"',
       'audio/mp4; codecs="mp4a.40.2"',
+      'audio/webm; codecs="vorbis"',
     ]);
     vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((mime) =>
       supportedTypes.has(mime) ? "probably" : "",
@@ -288,6 +291,9 @@ describe("probeWebCapabilities", () => {
     expect(capabilities.containers).not.toContain("mkv");
     expect(capabilities.codecsVideo).toContain("h264");
     expect(capabilities.codecsAudio).toContain("aac");
+    expect(capabilities.codecsAudio).toContain("vorbis");
+    expect(capabilities.progressiveCodecsAudio).toContain("aac");
+    expect(capabilities.progressiveCodecsAudio).not.toContain("vorbis");
   });
 
   it("keeps advertising native MKV playback on other capable browsers", () => {

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -161,6 +161,7 @@ function testMediaElementType(mime: string): boolean {
 export function probeWebCapabilities(): WebCapabilityProbe {
   const codecsVideo: string[] = [];
   const codecsAudio: string[] = [];
+  const progressiveCodecsAudio: string[] = [];
   const containers: string[] = [];
   const isFirefox =
     typeof navigator !== "undefined" && isFirefoxUserAgent(navigator.userAgent ?? "");
@@ -189,6 +190,13 @@ export function probeWebCapabilities(): WebCapabilityProbe {
   for (const [name, mimeTypes] of Object.entries(AUDIO_CODEC_MAP)) {
     if (mimeTypes.some(testMediaType)) {
       codecsAudio.push(name);
+    }
+    if (
+      mimeTypes
+        .filter((mime) => mime.startsWith("audio/mp4") || mime.startsWith("video/mp4"))
+        .some(testMediaType)
+    ) {
+      progressiveCodecsAudio.push(name);
     }
   }
 
@@ -252,6 +260,7 @@ export function probeWebCapabilities(): WebCapabilityProbe {
     codecsVideo,
     progressiveCodecsVideo,
     codecsAudio,
+    progressiveCodecsAudio,
     maxResolution,
     hdr,
     hdrDetails,

--- a/web/src/player/hooks/useCodecDetection.ts
+++ b/web/src/player/hooks/useCodecDetection.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { detectHLSSupport, type WebCapabilityProbe } from "../client-context-v3";
+import { isFirefoxUserAgent } from "../utils/browser";
 
 /** Maps our codec names to the MIME declarations browsers expose for them. */
 const VIDEO_CODEC_MAP: Record<string, string> = {
@@ -161,9 +162,17 @@ export function probeWebCapabilities(): WebCapabilityProbe {
   const codecsVideo: string[] = [];
   const codecsAudio: string[] = [];
   const containers: string[] = [];
+  const isFirefox =
+    typeof navigator !== "undefined" && isFirefoxUserAgent(navigator.userAgent ?? "");
 
   // Test containers.
   for (const [name, mimeTypes] of Object.entries(CONTAINER_MAP)) {
+    // Firefox 145+ reports native Matroska support, but its demuxer still
+    // requires the complete resource before starting common audio+video MKVs
+    // (Mozilla bug 2000420). Advertising that container turns direct play into
+    // a full-file download. Keep the codec claims so the planner can select a
+    // codec-copy remux instead.
+    if (name === "mkv" && isFirefox) continue;
     if (mimeTypes.some(testMediaType)) {
       containers.push(name);
     }

--- a/web/src/player/utils/browser.ts
+++ b/web/src/player/utils/browser.ts
@@ -1,3 +1,4 @@
+/** Detects Firefox while excluding SeaMonkey's compatibility user-agent token. */
 export function isFirefoxUserAgent(userAgent: string): boolean {
   return /firefox/i.test(userAgent) && !/seamonkey/i.test(userAgent);
 }

--- a/web/src/player/utils/browser.ts
+++ b/web/src/player/utils/browser.ts
@@ -1,0 +1,3 @@
+export function isFirefoxUserAgent(userAgent: string): boolean {
+  return /firefox/i.test(userAgent) && !/seamonkey/i.test(userAgent);
+}


### PR DESCRIPTION
## Problem

Related issue: [Mozilla Bug 2000420](https://bugzilla.mozilla.org/show_bug.cgi?id=2000420)

Firefox 145 and later report native Matroska support, but common audio/video MKVs can buffer the entire file before playback starts, even from a range-capable HTTP server. Silo trusts the browser capability result and chooses original MKV delivery, leaving users to disable `media.mkv.enabled` themselves to get streaming playback.

## Approach

Do not advertise the MKV container from the web capability probe when the browser is Firefox. Keep Firefox's video and audio codec capabilities so the playback planner can choose a progressive codec-copy MP4 remux without re-encoding. Other browsers retain native MKV direct play.

The web client scopes audio codec probes to progressive MP4 delivery as well. The planner evaluates progressive and HLS audio support independently and honors validated passthrough claims, so it preserves codecs on a compatible route instead of converting them unnecessarily. If an MKV track is decodable by Firefox but cannot be copied into MP4 or HLS, such as Vorbis, the planner converts that audio track to AAC while still copying the video. The change also reuses one Firefox user-agent helper in the existing Firefox playback fallback and records the behavior in the feature changelog.

## Validation

- `pnpm exec vitest run src/player/hooks/useCodecDetection.test.ts src/player/client-context-v3.test.ts`: 29 tests passed after addressing review feedback.
- `go test ./internal/playback/...`: passed after addressing review feedback.
- `make test-web`: 287 files and 2,076 tests passed.
- `pnpm run lint`: passed with 155 existing warnings and no errors.
- `pnpm run format:check`: passed.
- `pnpm run build`: passed.
- `make embed-stub`, `go build ./...`, `gofmt -l .`, and `go vet ./...`: passed; `gofmt` printed no files.
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --new-from-merge-base=origin/main ./...`: 0 issues.
- `make verify-settings-bindings-all`, `make verify-playback-fixtures`, and `make verify-local-paths`: passed.
- On an isolated test deployment, release fixture FX-001 (MKV, H.264 High 1080p, AAC stereo) selected `original_http` with the old capability set and `server_remux_progressive` MP4 with the Firefox-filtered capability set. The remux kept both codecs unchanged and began returning the stream in about 55 ms.

`make test-go` does not pass on this prerelease macOS 27 host. Both runs failed the unrelated `internal/jellycompat` process-identity tests `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`; the first concurrent run also hit timing-sensitive failures in `internal/httpstream` and `internal/policy`, which passed on the serial rerun. The complete modified playback package passes with `go test ./internal/playback/...`.

A final Firefox UI playback run was not possible on this host: official Firefox Stable, Developer Edition, and Nightly builds all failed macOS signature validation. I did not bypass Gatekeeper.

## Risks

Firefox will use a codec-copy remux for MKVs that it claims it can play directly, adding remux work on the server. Audio codecs that Firefox cannot accept inside progressive MP4 are converted to AAC, while the video remains a stream copy. Firefox versions without native MKV support already omit the container, and non-Firefox browsers are unchanged. When Mozilla fixes Bug 2000420, the Firefox exclusion should be reevaluated.

## AI Disclosure

- Tool(s): Codex
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: Reviewed the complete diff against Mozilla's range-server reproduction, checked Firefox-only and non-Firefox capability paths, verified that codec claims remain intact, and exercised both planner outcomes on the same fixture. No unresolved findings remain.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Firefox MKV playback with streaming-safe remuxing while preserving direct playback in supported browsers.
  * Added progressive audio codec detection for more accurate playback compatibility.
  * Improved progressive and HLS audio handling, including AAC conversion when required.
  * Preserved source channel information during stereo downmixing to support consistent loudness.

* **Bug Fixes**
  * Improved browser-specific playback capability detection and audio compatibility across delivery formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->