### PR TITLE
fix(web): keep card menus visible without hover

### DIFF
--- a/docs/feature-changelog.md
+++ b/docs/feature-changelog.md
@@ -2,6 +2,11 @@
 
 ## 2026-08-25
 
+### Keep card menus accessible on touchscreen computers
+Media-card action buttons now remain visible on desktop-width touchscreen and hybrid computers
+whose primary input cannot hover. Mouse and trackpad systems retain the existing reveal-on-hover
+behavior.
+
 ### Clear stale library troubleshooting entries after path changes
 Full library scans now reconcile troubleshooting entries across the whole library, so diagnostics for removed or replaced root paths disappear after the path-change scan completes. Subtree and single-file scans remain scoped and cannot clear diagnostics elsewhere in the library.
 

--- a/web/src/components/MediaItemMenu.tsx
+++ b/web/src/components/MediaItemMenu.tsx
@@ -213,7 +213,9 @@ export default function MediaItemMenu({
   const triggerClassName = cn(
     "inline-flex items-center justify-center rounded-md border border-border/20 bg-background/60 text-foreground shadow-sm backdrop-blur-sm transition-[opacity,background-color] duration-150 hover:bg-background/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
     variant === "wide" ? "size-9" : "size-8",
-    "opacity-100 md:opacity-0 md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100",
+    // A desktop-width touchscreen can report `hover: none`; hiding by width alone
+    // leaves those users with no pointer interaction that can reveal the trigger.
+    "opacity-100 md:[@media(hover:hover)]:opacity-0 md:group-hover/card:opacity-100 md:group-focus-within/card:opacity-100",
   );
 
   async function handleAction(actionKey: Extract<MediaItemMenuEntry, { kind: "action" }>["key"]) {


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Media-card action buttons were hidden at the `md` breakpoint even when the browser reported that its primary input could not hover. On desktop-width touchscreen and hybrid systems, the matching `group-hover` rule could never reveal the button. Focusing a card could reveal it, which explains why a right-click appeared to make the menu available.

## Approach

Keep the action button visible by default. Hide it at desktop widths only inside `@media (hover: hover)`, where the existing hover rule can reveal it again. Keyboard focus behavior is unchanged.

The feature changelog records the user-visible fix.

## Validation

- `cd web && pnpm exec vitest run src/components/MediaItemMenu.test.tsx` — 11 tests passed.
- `cd web && pnpm run lint` — passed with 0 errors and 155 existing warnings.
- `cd web && pnpm run format:check` — passed.
- `cd web && pnpm run build` — passed. The generated CSS contains the nested `min-width: 48rem` and `hover: hover` guard.
- `make test-web` — 287 test files passed, 2,074 tests passed.
- Headless Chrome against the production CSS at a 1024px viewport:
  - Desktop input (`hover: hover`): opacity was `0` initially, `1` on card hover, and `1` on focus.
  - Touch-primary input (`hover: none`): opacity was `1` initially and `1` on focus.
- `make embed-stub`, `go build ./...`, `gofmt -l .`, and `go vet ./...` — passed.
- `make verify-settings-bindings-all`, `make verify-playback-fixtures`, and `make verify-local-paths` — passed.
- `golangci-lint run --new-from-merge-base=origin/main ./...` — did not pass because the branch contains no changed Go files; golangci-lint reported `no go files to analyze`.
- `make test-go` — all packages passed except two existing macOS-incompatible tests in `internal/jellycompat`: `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`. They expect Linux `/proc` process tokens, and this branch does not change that package.

No screenshot is included because the regression is an input-capability state rather than a visual layout change; the computed-style browser results above exercise both states directly.

## Risks

Low. Browsers without primary hover capability now keep the action button visible. Mouse and trackpad systems retain the existing reveal-on-hover presentation.

## AI Disclosure

- Tool(s): Codex desktop
- Model(s): GPT-5
- Involvement: Fully AI-generated, awaiting human review
- Adversarial review: Reviewed the complete diff and generated CSS for breakpoint ordering, selector specificity, focus accessibility, and behavior across normal desktop and touch-primary Chromium contexts. The default-visible rule was retained as the fail-safe; no additional findings remained.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
