### PR TITLE
fix(web): stop carousel hover clipping and inset card progress bars

### DIFF
--- a/web/src/components/CastCarousel.tsx
+++ b/web/src/components/CastCarousel.tsx
@@ -46,7 +46,7 @@ export default function CastCarousel({ cast, limit = 20, fullBleed = false }: Ca
       <div
         ref={emblaRef}
         className={cn(
-          "embla__viewport overflow-hidden",
+          "embla__viewport -mt-1 overflow-hidden pt-1",
           fullBleed && "pr-4 sm:pr-6 lg:pr-10 xl:pr-12",
         )}
       >

--- a/web/src/components/ContinueWatchingCard.tsx
+++ b/web/src/components/ContinueWatchingCard.tsx
@@ -250,11 +250,12 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
             {/* Hover dim behind the play button */}
             <div className="media-card-hover-dim absolute inset-0 bg-black/0 transition-colors duration-150" />
 
-            {/* Progress bar */}
+            {/* Progress bar — inset pill so a full bar doesn't read as a
+                stray edge along the artwork */}
             {!isNextUp && progressPercent > 0 && (
-              <div className="bg-background/40 absolute inset-x-0 bottom-0 h-[3px]">
+              <div className="absolute inset-x-2.5 bottom-2 h-[3px] overflow-hidden rounded-full bg-black/40">
                 <div
-                  className="h-full transition-all duration-300"
+                  className="h-full rounded-full transition-all duration-300"
                   style={{
                     width: `${Math.min(progressPercent, 100)}%`,
                     background: "var(--primary)",

--- a/web/src/components/EpisodeRow.tsx
+++ b/web/src/components/EpisodeRow.tsx
@@ -64,9 +64,9 @@ export default function EpisodeRow({ episode, rating, watched, progress }: Episo
           />
         )}
         {hasProgress && (
-          <div className="bg-background/40 absolute inset-x-0 bottom-0 h-[3px]">
+          <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
             <div
-              className="h-full rounded-r-sm"
+              className="h-full rounded-full"
               style={{
                 width: `${derivedProgress}%`,
                 background: "var(--primary)",

--- a/web/src/components/MediaCarousel.tsx
+++ b/web/src/components/MediaCarousel.tsx
@@ -100,7 +100,7 @@ export default function MediaCarousel({
 
         <div
           ref={emblaRef}
-          className={`embla__viewport overflow-hidden${viewportPadX}`}
+          className={`embla__viewport -mt-1 overflow-hidden pt-1${viewportPadX}`}
           tabIndex={0}
           aria-label="Media carousel"
           onKeyDown={(e) => {

--- a/web/src/components/WatchTonightCard.tsx
+++ b/web/src/components/WatchTonightCard.tsx
@@ -126,9 +126,9 @@ export default function WatchTonightCard({ item, onPlay }: WatchTonightCardProps
 
           {/* Progress bar */}
           {isInProgress && progressPercent > 0 && (
-            <div className="bg-background/40 absolute inset-x-0 bottom-0 h-[3px]">
+            <div className="absolute inset-x-2.5 bottom-2 h-[3px] overflow-hidden rounded-full bg-black/40">
               <div
-                className="h-full transition-all duration-300"
+                className="h-full rounded-full transition-all duration-300"
                 style={{
                   width: `${Math.min(progressPercent, 100)}%`,
                   background: "var(--primary)",

--- a/web/src/pages/ItemDetail/SeasonCarousel.tsx
+++ b/web/src/pages/ItemDetail/SeasonCarousel.tsx
@@ -37,7 +37,7 @@ export default function SeasonCarousel({ seasons }: SeasonCarouselProps) {
           </button>
         )}
 
-        <div ref={emblaRef} className="embla__viewport overflow-hidden pb-5">
+        <div ref={emblaRef} className="embla__viewport -mt-1 overflow-hidden pt-1 pb-5">
           <ul role="list" className="embla__container flex cursor-grab list-none gap-4">
             {sorted.map((season) => {
               const userData = season.user_data;
@@ -82,11 +82,12 @@ export default function SeasonCarousel({ seasons }: SeasonCarouselProps) {
                         </div>
                       )}
 
-                      {/* Progress bar — thin line at the bottom of the poster */}
+                      {/* Progress bar — inset pill so a full bar doesn't read
+                          as a stray edge along the artwork */}
                       {(isCompleted || hasProgress) && (
-                        <div className="absolute inset-x-0 bottom-0 h-[3px] bg-black/40">
+                        <div className="absolute inset-x-2.5 bottom-2 h-[3px] overflow-hidden rounded-full bg-black/40">
                           <div
-                            className="h-full transition-all duration-300"
+                            className="h-full rounded-full transition-all duration-300"
                             style={{
                               width: isCompleted ? "100%" : `${progressPercent}%`,
                               background: isCompleted ? "#4caf50" : "var(--primary)",

--- a/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
+++ b/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
@@ -127,9 +127,9 @@ export default function EpisodeCarousel({
                             </div>
                           )}
                           {progress != null && (
-                            <div className="absolute inset-x-0 bottom-0 h-[3px] bg-black/40">
+                            <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
                               <div
-                                className="h-full rounded-r-sm"
+                                className="h-full rounded-full"
                                 style={{ width: `${progress}%`, background: "var(--primary)" }}
                               />
                             </div>

--- a/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
+++ b/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
@@ -82,9 +82,9 @@ export default function SeasonEpisodeGrid({
                   {!episode.user_data?.played &&
                     (episode.user_data?.position_seconds ?? 0) > 0 &&
                     (episode.user_data?.duration_seconds ?? 0) > 0 && (
-                      <div className="absolute inset-x-0 bottom-0 h-[3px] bg-black/40">
+                      <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
                         <div
-                          className="progress-fill h-full rounded-r-sm"
+                          className="progress-fill h-full rounded-full"
                           style={{
                             width: `${Math.max(
                               0,

--- a/web/src/pages/ItemDetail/components/TrailersSection.tsx
+++ b/web/src/pages/ItemDetail/components/TrailersSection.tsx
@@ -38,7 +38,7 @@ export default function TrailersSection({ videos }: TrailersSectionProps) {
           </button>
         )}
 
-        <div ref={emblaRef} className="embla__viewport overflow-hidden">
+        <div ref={emblaRef} className="embla__viewport -mt-1 overflow-hidden pt-1">
           <ul role="list" className="embla__container flex cursor-grab list-none gap-3">
             {playable.map((video) => (
               <li key={`${video.site}-${video.site_key}`} className="embla__slide shrink-0">


### PR DESCRIPTION
## Problem

Two visual defects on home-screen carousel cards:

1. **Hover clipping** — hovering a card lifts it 4px (`.media-card:hover` applies `translateY(-4px)`), but every embla carousel viewport uses `overflow-hidden` flush against the cards, so the top of the hovered card was cut off.
2. **White edge along card bottoms** — the watch-progress bar sits flush against the artwork's bottom edge. The default dark theme's `--primary` accent is near-white (`#e8e8ec`), so a full (or near-full) bar reads as a stray white edge / rendering artifact rather than a progress indicator.

## Fix

- Give each embla viewport 4px of top headroom (`pt-1 -mt-1`) so the hover lift renders without clipping: `MediaCarousel`, `CastCarousel`, `SeasonCarousel`, `TrailersSection`.
- Restyle the progress bar as an inset rounded pill (inset from the edges, `rounded-full`, dark track) across all card/thumbnail surfaces so it reads as deliberate UI in every theme: `ContinueWatchingCard`, `SeasonCarousel`, `EpisodeRow`, `WatchTonightCard`, `EpisodeCarousel`, `SeasonEpisodeGrid`. The player's `PlayingNextScreen` countdown bar is separate player chrome and was left as is.

## Validation

- Verified in a real browser (Vite dev server against the shared dev deployment, Playwright): hovered card tops now render fully including rounded corners, and the progress bar shows as an inset pill with visible track and fill.
- `prettier --check` clean on all touched files; focused vitest run for the touched components: 7 files, 22 tests, all passing.

Related issue: N/A — narrow fix.

## AI disclosure

Implemented with Claude Code (Claude Fable 5) operated by the repository maintainer; changes reviewed and behaviorally verified in-browser before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)