### PR TITLE
Add textless poster art for mobile featured heroes

### DIFF
--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -89,12 +89,46 @@ GET /api/v1/images/capability
     "logo": { "small": 500, "medium": 500, "large": 1280 },
     "profile": { "small": 300, "medium": 500, "large": 500 }
   },
-  "original_max_width_px": 1920
+  "original_max_width_px": 1920,
+  "textless_poster": {
+    "endpoint": "/api/v1/catalog/items/{id}/images/textless-poster",
+    "supported_types": ["movie", "series"]
+  }
 }
 ```
 
 A `404` here means the server predates `image_size`. Keep using the server's
 defaults rather than sending a parameter it will ignore.
+
+`textless_poster` is optional and appears only when the deployment has wired
+the provider-backed viewer route. Mobile clients should use it for portrait
+featured cards and fall back to the item's normal poster/backdrop when the
+field is absent or the response has no `poster_url`.
+
+## Textless featured poster
+
+```http
+GET /api/v1/catalog/items/{id}/images/textless-poster
+```
+
+```json
+{
+  "poster_url": "https://example.invalid/resolved-provider-image"
+}
+```
+
+The route is authenticated and applies the same library/content-rating scope
+as catalog item detail before contacting metadata providers. It supports movie
+and series items. Selection prefers an explicit provider
+`includes_text=false` signal, then a provider's language-neutral portrait
+poster when the provider does not expose that flag. A successful response may
+omit `poster_url` when no textless portrait exists; that is a normal client
+fallback state, not a missing item.
+
+Selected provider paths are cached in a bounded in-process cache and concurrent
+misses for the same item are collapsed. Returned provider paths are resolved
+with the `featured` variant at response time so expiring URLs are not retained
+in that cache.
 
 ## Fallback while artwork is being regenerated
 

--- a/internal/api/handlers/images_capability.go
+++ b/internal/api/handlers/images_capability.go
@@ -49,10 +49,31 @@ type imagesCapabilityResponse struct {
 	// OriginalMaxWidthPx bounds the "original" size: cached originals are
 	// downscaled to this on ingest, so asking for original never yields more.
 	OriginalMaxWidthPx int `json:"original_max_width_px"`
+	// TextlessPoster is present only when the viewer-facing endpoint is wired
+	// in this deployment. Clients feature-detect it instead of guessing from a
+	// server version.
+	TextlessPoster *textlessPosterCapability `json:"textless_poster,omitempty"`
+}
+
+type textlessPosterCapability struct {
+	Endpoint       string   `json:"endpoint"`
+	SupportedTypes []string `json:"supported_types"`
 }
 
 // HandleImagesCapability reports the image_size contract.
 func HandleImagesCapability(w http.ResponseWriter, r *http.Request) {
+	handleImagesCapability(w, false)
+}
+
+// NewImagesCapabilityHandler returns a capability handler whose optional
+// fields reflect the routes actually wired by this deployment.
+func NewImagesCapabilityHandler(textlessPosterEnabled bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		handleImagesCapability(w, textlessPosterEnabled)
+	}
+}
+
+func handleImagesCapability(w http.ResponseWriter, textlessPosterEnabled bool) {
 	widths := make(map[string]imageSizeWidths, len(imageTypesWithWidths))
 	for _, imageType := range imageTypesWithWidths {
 		widths[imageType] = imageSizeWidths{
@@ -62,14 +83,22 @@ func HandleImagesCapability(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(imagesCapabilityResponse{
+	response := imagesCapabilityResponse{
 		SchemaVersion:      1,
 		Param:              imagesize.QueryParam,
 		Sizes:              imagesize.All,
 		Widths:             widths,
 		OriginalMaxWidthPx: imageutil.MaxCachedOriginalDimension,
-	})
+	}
+	if textlessPosterEnabled {
+		response.TextlessPoster = &textlessPosterCapability{
+			Endpoint:       "/api/v1/catalog/items/{id}/images/textless-poster",
+			SupportedTypes: []string{"movie", "series"},
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 // variantWidthPx reports the pixel width a size resolves to for an image type.

--- a/internal/api/handlers/images_capability.go
+++ b/internal/api/handlers/images_capability.go
@@ -93,7 +93,7 @@ func handleImagesCapability(w http.ResponseWriter, textlessPosterEnabled bool) {
 	if textlessPosterEnabled {
 		response.TextlessPoster = &textlessPosterCapability{
 			Endpoint:       "/api/v1/catalog/items/{id}/images/textless-poster",
-			SupportedTypes: []string{"movie", "series"},
+			SupportedTypes: []string{textlessPosterMovieType, textlessPosterSeriesType},
 		}
 	}
 

--- a/internal/api/handlers/images_capability_test.go
+++ b/internal/api/handlers/images_capability_test.go
@@ -27,6 +27,9 @@ func TestHandleImagesCapability(t *testing.T) {
 	if got.SchemaVersion != 1 {
 		t.Errorf("schema_version = %d, want 1", got.SchemaVersion)
 	}
+	if got.TextlessPoster != nil {
+		t.Errorf("textless_poster = %+v, want omitted when route is unavailable", got.TextlessPoster)
+	}
 	if got.Param != "image_size" {
 		t.Errorf("param = %q, want image_size", got.Param)
 	}
@@ -69,5 +72,27 @@ func TestHandleImagesCapability(t *testing.T) {
 	}
 	if got.Widths["logo"].Large != 1280 {
 		t.Errorf("logo large width = %d, want 1280", got.Widths["logo"].Large)
+	}
+}
+
+func TestImagesCapabilityAdvertisesWiredTextlessPosterRoute(t *testing.T) {
+	rec := httptest.NewRecorder()
+	NewImagesCapabilityHandler(true)(rec, httptest.NewRequest(http.MethodGet, "/api/v1/images/capability", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got imagesCapabilityResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got.TextlessPoster == nil {
+		t.Fatal("textless_poster is missing")
+	}
+	if got.TextlessPoster.Endpoint != "/api/v1/catalog/items/{id}/images/textless-poster" {
+		t.Errorf("endpoint = %q", got.TextlessPoster.Endpoint)
+	}
+	if len(got.TextlessPoster.SupportedTypes) != 2 || got.TextlessPoster.SupportedTypes[0] != "movie" || got.TextlessPoster.SupportedTypes[1] != "series" {
+		t.Errorf("supported_types = %v, want [movie series]", got.TextlessPoster.SupportedTypes)
 	}
 }

--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -463,6 +463,7 @@ type sectionItemResponse struct {
 	RatingRTCritic    *int                   `json:"rating_rt_critic,omitempty"`
 	RatingRTAudience  *int                   `json:"rating_rt_audience,omitempty"`
 	OriginalLanguage  string                 `json:"original_language,omitempty"`
+	Tagline           string                 `json:"tagline,omitempty"`
 	Overview          string                 `json:"overview,omitempty"`
 	PositionSeconds   *float64               `json:"position_seconds,omitempty"`
 	DurationSeconds   *float64               `json:"duration_seconds,omitempty"`
@@ -1457,6 +1458,7 @@ func (h *SectionHandler) toSectionItemResponse(sectionType sections.SectionType,
 		RatingRTCritic:    item.RatingRTCritic,
 		RatingRTAudience:  item.RatingRTAudience,
 		OriginalLanguage:  item.OriginalLanguage,
+		Tagline:           item.Tagline,
 		Overview:          item.Overview,
 		PosterThumbhash:   item.PosterThumbhash,
 		BackdropThumbhash: item.BackdropThumbhash,

--- a/internal/api/handlers/sections_test.go
+++ b/internal/api/handlers/sections_test.go
@@ -109,6 +109,7 @@ func TestBuildSectionsResponseEnrichesEpisodeMetadata(t *testing.T) {
 				ContentID: "episode-1",
 				Type:      "episode",
 				Title:     "Dumbston Checks In",
+				Tagline:   "A short featured quote.",
 				Status:    "matched",
 			}},
 		},
@@ -129,6 +130,9 @@ func TestBuildSectionsResponseEnrichesEpisodeMetadata(t *testing.T) {
 	}
 	if item.EpisodeNumber == nil || *item.EpisodeNumber != 1 {
 		t.Fatalf("episode number = %v, want 1", item.EpisodeNumber)
+	}
+	if item.Tagline != "A short featured quote." {
+		t.Fatalf("tagline = %q, want %q", item.Tagline, "A short featured quote.")
 	}
 }
 

--- a/internal/api/handlers/textless_poster.go
+++ b/internal/api/handlers/textless_poster.go
@@ -19,6 +19,8 @@ import (
 )
 
 const (
+	textlessPosterMovieType        = "movie"
+	textlessPosterSeriesType       = "series"
 	textlessPosterCacheSize        = 512
 	textlessPosterCacheTTL         = 6 * time.Hour
 	textlessPosterNegativeCacheTTL = 15 * time.Minute
@@ -176,7 +178,7 @@ func (h *TextlessPosterHandler) HandleGet(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load item")
 		return
 	}
-	if item.Type != "movie" && item.Type != "series" {
+	if item.Type != textlessPosterMovieType && item.Type != textlessPosterSeriesType {
 		writeError(w, http.StatusBadRequest, "unsupported_type", "Textless posters are available for movies and series")
 		return
 	}

--- a/internal/api/handlers/textless_poster.go
+++ b/internal/api/handlers/textless_poster.go
@@ -1,0 +1,316 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+const (
+	textlessPosterCacheSize        = 512
+	textlessPosterCacheTTL         = 6 * time.Hour
+	textlessPosterNegativeCacheTTL = 15 * time.Minute
+	textlessPosterFetchTimeout     = 20 * time.Second
+)
+
+// TextlessPosterItemLookup loads an item and applies the canonical viewer
+// access filter before any remote provider work is allowed to start.
+type TextlessPosterItemLookup interface {
+	GetByID(ctx context.Context, contentID string) (*models.MediaItem, error)
+	EnsureAccessible(ctx context.Context, contentID string, filter catalog.AccessFilter) error
+}
+
+// TextlessPosterImageService is the read-only provider operation needed by the
+// mobile hero artwork endpoint.
+type TextlessPosterImageService interface {
+	FetchItemImages(ctx context.Context, providerIDs map[string]string, contentType string, language string, folderID int) ([]metadata.RemoteImage, map[string]string, error)
+}
+
+type textlessPosterAccessFilter func(http.ResponseWriter, *http.Request) (catalog.AccessFilter, bool)
+
+type textlessPosterResponse struct {
+	PosterURL string `json:"poster_url,omitempty"`
+}
+
+type textlessPosterCacheEntry struct {
+	path      string
+	expiresAt time.Time
+	lastUsed  time.Time
+}
+
+// textlessPosterCache is bounded and expiry-on-access, so the handler needs no
+// background sweeper or lifecycle goroutine.
+type textlessPosterCache struct {
+	mu      sync.Mutex
+	entries map[string]textlessPosterCacheEntry
+	maxSize int
+}
+
+func newTextlessPosterCache(maxSize int) *textlessPosterCache {
+	return &textlessPosterCache{
+		entries: make(map[string]textlessPosterCacheEntry),
+		maxSize: maxSize,
+	}
+}
+
+func (c *textlessPosterCache) get(key string) (string, bool) {
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if !now.Before(entry.expiresAt) {
+		delete(c.entries, key)
+		return "", false
+	}
+	entry.lastUsed = now
+	c.entries[key] = entry
+	return entry.path, true
+}
+
+func (c *textlessPosterCache) set(key, path string, ttl time.Duration) {
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for existingKey, entry := range c.entries {
+		if !now.Before(entry.expiresAt) {
+			delete(c.entries, existingKey)
+		}
+	}
+	if c.maxSize > 0 && len(c.entries) >= c.maxSize {
+		var oldestKey string
+		var oldestTime time.Time
+		for existingKey, entry := range c.entries {
+			if oldestKey == "" || entry.lastUsed.Before(oldestTime) {
+				oldestKey = existingKey
+				oldestTime = entry.lastUsed
+			}
+		}
+		delete(c.entries, oldestKey)
+	}
+	c.entries[key] = textlessPosterCacheEntry{
+		path:      path,
+		expiresAt: now.Add(ttl),
+		lastUsed:  now,
+	}
+}
+
+// TextlessPosterHandler returns a provider-backed portrait poster without
+// title text for the mobile featured-card presentation.
+type TextlessPosterHandler struct {
+	accessFilter  textlessPosterAccessFilter
+	items         TextlessPosterItemLookup
+	folders       MatchFolderLookup
+	images        TextlessPosterImageService
+	imageResolver ImageURLResolver
+	cache         *textlessPosterCache
+	flight        singleflight.Group
+}
+
+// NewTextlessPosterHandler wires the viewer-scoped textless poster endpoint.
+func NewTextlessPosterHandler(
+	itemsHandler *ItemsHandler,
+	items TextlessPosterItemLookup,
+	folders MatchFolderLookup,
+	images TextlessPosterImageService,
+	imageResolver ImageURLResolver,
+) *TextlessPosterHandler {
+	return &TextlessPosterHandler{
+		accessFilter:  itemsHandler.accessFilterOrError,
+		items:         items,
+		folders:       folders,
+		images:        images,
+		imageResolver: imageResolver,
+		cache:         newTextlessPosterCache(textlessPosterCacheSize),
+	}
+}
+
+// HandleGet returns GET /api/v1/catalog/items/{id}/images/textless-poster.
+func (h *TextlessPosterHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
+	contentID := strings.TrimSpace(chi.URLParam(r, "id"))
+	if contentID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Item ID is required")
+		return
+	}
+	if h == nil || h.accessFilter == nil || h.items == nil || h.images == nil {
+		writeError(w, http.StatusServiceUnavailable, "unavailable", "Textless posters are not configured")
+		return
+	}
+
+	filter, ok := h.accessFilter(w, r)
+	if !ok {
+		return
+	}
+	if err := h.items.EnsureAccessible(r.Context(), contentID, filter); err != nil {
+		if errors.Is(err, catalog.ErrItemNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "Item not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "textless poster: access check failed", "component", "api", "content_id", contentID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve item access")
+		return
+	}
+
+	item, err := h.items.GetByID(r.Context(), contentID)
+	if err != nil {
+		if errors.Is(err, catalog.ErrItemNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "Item not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "textless poster: item lookup failed", "component", "api", "content_id", contentID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load item")
+		return
+	}
+	if item.Type != "movie" && item.Type != "series" {
+		writeError(w, http.StatusBadRequest, "unsupported_type", "Textless posters are available for movies and series")
+		return
+	}
+
+	folderID := 0
+	if h.folders != nil {
+		folderID, err = h.folders.GetFolderIDForItem(r.Context(), contentID)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "textless poster: folder lookup failed", "component", "api", "content_id", contentID, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Could not determine library for item")
+			return
+		}
+	}
+
+	providerIDs := buildProviderIDs(item)
+	if len(providerIDs) == 0 {
+		h.writeResponse(w, r, "")
+		return
+	}
+	language := strings.TrimSpace(item.DefaultMetadataLanguage)
+	if language == "" {
+		language = "en"
+	}
+	cacheKey := textlessPosterCacheKey(item, folderID, language)
+	path, err := h.textlessPosterPath(r.Context(), cacheKey, providerIDs, item.Type, language, folderID)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		slog.ErrorContext(r.Context(), "textless poster: provider fetch failed", "component", "api", "content_id", contentID, "error", err)
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to fetch textless poster")
+		return
+	}
+	h.writeResponse(w, r, path)
+}
+
+func (h *TextlessPosterHandler) textlessPosterPath(
+	ctx context.Context,
+	cacheKey string,
+	providerIDs map[string]string,
+	contentType string,
+	language string,
+	folderID int,
+) (string, error) {
+	if path, ok := h.cache.get(cacheKey); ok {
+		return path, nil
+	}
+
+	result := h.flight.DoChan(cacheKey, func() (any, error) {
+		if path, ok := h.cache.get(cacheKey); ok {
+			return path, nil
+		}
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), textlessPosterFetchTimeout)
+		defer cancel()
+		images, _, err := h.images.FetchItemImages(fetchCtx, providerIDs, contentType, language, folderID)
+		if err != nil {
+			return "", err
+		}
+		path := selectTextlessPoster(images)
+		ttl := textlessPosterCacheTTL
+		if path == "" {
+			ttl = textlessPosterNegativeCacheTTL
+		}
+		h.cache.set(cacheKey, path, ttl)
+		return path, nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case fetched := <-result:
+		if fetched.Err != nil {
+			return "", fetched.Err
+		}
+		path, _ := fetched.Val.(string)
+		return path, nil
+	}
+}
+
+func (h *TextlessPosterHandler) writeResponse(w http.ResponseWriter, r *http.Request, path string) {
+	posterURL := strings.TrimSpace(path)
+	if posterURL != "" && h.imageResolver != nil {
+		if resolved := strings.TrimSpace(h.imageResolver.ResolveImageURL(r.Context(), posterURL, "featured")); resolved != "" {
+			posterURL = resolved
+		}
+	}
+	w.Header().Set("Cache-Control", "private, max-age=900")
+	writeJSON(w, http.StatusOK, textlessPosterResponse{PosterURL: posterURL})
+}
+
+func textlessPosterCacheKey(item *models.MediaItem, folderID int, language string) string {
+	return fmt.Sprintf(
+		"%s|%s|%s|%s|%s|%d|%s",
+		item.ContentID,
+		item.Type,
+		item.TmdbID,
+		item.TvdbID,
+		item.ImdbID,
+		folderID,
+		language,
+	)
+}
+
+// selectTextlessPoster first trusts an explicit provider IncludesText=false
+// signal. Providers that do not expose the flag may fall back to their
+// language-neutral poster, which is the established textless convention.
+func selectTextlessPoster(images []metadata.RemoteImage) string {
+	if path := highestRatedTextlessPoster(images, true); path != "" {
+		return path
+	}
+	return highestRatedTextlessPoster(images, false)
+}
+
+func highestRatedTextlessPoster(images []metadata.RemoteImage, explicit bool) string {
+	bestPath := ""
+	bestRating := -1.0
+	for _, image := range images {
+		if image.Type != metadata.ImagePoster || strings.TrimSpace(image.URL) == "" {
+			continue
+		}
+		if image.Width > 0 && image.Height > 0 && image.Height <= image.Width {
+			continue
+		}
+		if explicit {
+			if image.IncludesText == nil || *image.IncludesText {
+				continue
+			}
+		} else if image.IncludesText != nil || strings.TrimSpace(image.Language) != "" {
+			continue
+		}
+		if bestPath == "" || image.Rating > bestRating {
+			bestPath = image.URL
+			bestRating = image.Rating
+		}
+	}
+	return bestPath
+}

--- a/internal/api/handlers/textless_poster_test.go
+++ b/internal/api/handlers/textless_poster_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func boolPointer(value bool) *bool { return &value }
+
+func TestSelectTextlessPosterPrefersExplicitSignal(t *testing.T) {
+	images := []metadata.RemoteImage{
+		{URL: "neutral-high", Type: metadata.ImagePoster, Language: "", Width: 1000, Height: 1500, Rating: 9.9},
+		{URL: "explicit", Type: metadata.ImagePoster, Language: "en", Width: 1000, Height: 1500, Rating: 5, IncludesText: boolPointer(false)},
+		{URL: "with-text", Type: metadata.ImagePoster, Language: "", Width: 1000, Height: 1500, Rating: 10, IncludesText: boolPointer(true)},
+	}
+
+	if got := selectTextlessPoster(images); got != "explicit" {
+		t.Fatalf("selectTextlessPoster() = %q, want explicit", got)
+	}
+}
+
+func TestSelectTextlessPosterFallsBackToBestNeutralPortrait(t *testing.T) {
+	images := []metadata.RemoteImage{
+		{URL: "localized", Type: metadata.ImagePoster, Language: "en", Width: 1000, Height: 1500, Rating: 10},
+		{URL: "landscape", Type: metadata.ImagePoster, Language: "", Width: 1600, Height: 900, Rating: 10},
+		{URL: "neutral-low", Type: metadata.ImagePoster, Language: "", Width: 1000, Height: 1500, Rating: 5},
+		{URL: "neutral-high", Type: metadata.ImagePoster, Language: "  ", Width: 1000, Height: 1500, Rating: 8},
+	}
+
+	if got := selectTextlessPoster(images); got != "neutral-high" {
+		t.Fatalf("selectTextlessPoster() = %q, want neutral-high", got)
+	}
+}
+
+type deniedTextlessPosterItems struct{}
+
+func (deniedTextlessPosterItems) GetByID(context.Context, string) (*models.MediaItem, error) {
+	return &models.MediaItem{ContentID: "hidden", Type: "movie", TmdbID: "1"}, nil
+}
+
+func (deniedTextlessPosterItems) EnsureAccessible(context.Context, string, catalog.AccessFilter) error {
+	return catalog.ErrItemNotFound
+}
+
+type countingTextlessPosterImages struct{ calls int }
+
+func (f *countingTextlessPosterImages) FetchItemImages(context.Context, map[string]string, string, string, int) ([]metadata.RemoteImage, map[string]string, error) {
+	f.calls++
+	return nil, nil, nil
+}
+
+func TestTextlessPosterHandlerChecksAccessBeforeProviderFetch(t *testing.T) {
+	images := &countingTextlessPosterImages{}
+	handler := &TextlessPosterHandler{
+		accessFilter: func(http.ResponseWriter, *http.Request) (catalog.AccessFilter, bool) {
+			return catalog.AccessFilter{}, true
+		},
+		items:  deniedTextlessPosterItems{},
+		images: images,
+		cache:  newTextlessPosterCache(4),
+	}
+
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", "hidden")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog/items/hidden/images/textless-poster", nil)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rec := httptest.NewRecorder()
+	handler.HandleGet(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if images.calls != 0 {
+		t.Fatalf("provider calls = %d, want 0", images.calls)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -549,6 +549,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	// Build browse/search/items handlers if DB is available.
 	var itemsHandler *handlers.ItemsHandler
 	var catalogResourceHandler *handlers.CatalogResourceHandler
+	var textlessPosterHandler *handlers.TextlessPosterHandler
 	var catalogHandler *handlers.CatalogHandler
 	var literaryWorkHandler *handlers.LiteraryWorkHandler
 	var peopleHandler *handlers.PeopleHandler
@@ -1238,6 +1239,15 @@ func NewRouter(deps Dependencies) chi.Router {
 			detailSvc,
 		)
 		adminImageHandler.EventsHub = deps.EventsHub
+	}
+	if imageSvc, ok := deps.MetadataService.(handlers.TextlessPosterImageService); ok && itemsHandler != nil && itemRepo != nil && deps.DB != nil && deps.PluginImageResolver != nil {
+		textlessPosterHandler = handlers.NewTextlessPosterHandler(
+			itemsHandler,
+			itemRepo,
+			&handlers.PoolFolderLookup{Pool: deps.DB},
+			imageSvc,
+			deps.PluginImageResolver,
+		)
 	}
 
 	var adminIntroHandler *handlers.AdminIntroHandler
@@ -2099,7 +2109,7 @@ func NewRouter(deps Dependencies) chi.Router {
 
 				// Artwork size selection. Static: the answer depends only on
 				// the server's variant ladder, not on the caller.
-				r.Get("/images/capability", handlers.HandleImagesCapability)
+				r.Get("/images/capability", handlers.NewImagesCapabilityHandler(textlessPosterHandler != nil))
 
 				// User notifications: profile-scoped inbox, preferences, and
 				// the websocket handshake ticket.
@@ -2225,6 +2235,9 @@ func NewRouter(deps Dependencies) chi.Router {
 					}
 					if catalogResourceHandler != nil {
 						r.Get("/catalog/items/{id}", catalogResourceHandler.HandleGetItemDetail)
+						if textlessPosterHandler != nil {
+							r.Get("/catalog/items/{id}/images/textless-poster", textlessPosterHandler.HandleGet)
+						}
 						r.Get("/catalog/items/{id}/episodes", catalogResourceHandler.HandleGetItemEpisodes)
 						r.Get("/catalog/items/{id}/versions", catalogResourceHandler.HandleGetItemVersions)
 						r.Get("/catalog/items/{id}/manga-files", catalogResourceHandler.HandleGetMangaFiles)


### PR DESCRIPTION
## What I changed

I added a safe, authenticated way for the mobile apps to request clean textless poster art for featured hero cards. This keeps the phone design consistent without using an admin image route or trying to scrape artwork client-side.

The endpoint:

- uses the same catalogue access checks as the rest of the viewer API
- supports movies and series only
- selects the best portrait artwork explicitly marked as textless, with a conservative language fallback when the provider does not include that flag
- returns an empty successful response when no suitable artwork exists, so clients can fall back cleanly
- uses bounded positive and negative caching plus singleflight request sharing to avoid repeated provider work
- is advertised through the images capability response

I also exposed the existing media tagline in Home section items so the phone hero can show a short quote instead of truncating a long overview.

## Linked mobile PRs

- Apple hero: https://github.com/Silo-Server/silo-apple/pull/197
- Android hero: https://github.com/Silo-Server/silo-android/pull/248

These three PRs are designed to land together. The clients retain their normal poster/title fallbacks if the new endpoint is unavailable.

## Testing

- `go test ./internal/api/handlers`
- `go test ./internal/api`
- Added coverage for authentication, catalogue access, supported content types, textless selection, fallbacks, caching, cancellation, capability advertisement, and Home taglines.

## AI disclosure

I designed the mobile hero experience and its clean-art behaviour, directed the implementation, and tested the result in the iPhone and Android emulators. I used OpenAI Codex (GPT-5) to help implement and refine the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional textless portrait posters for movies and series, with secure access checks and provider-based image selection.
  * Added capability metadata describing textless poster availability and supported media types.
  * Added optional tagline information to section item responses.
* **Documentation**
  * Updated image API documentation with textless poster configuration, response details, and supported options.
* **Bug Fixes**
  * Improved poster selection with fallback handling when explicit text metadata is unavailable.
  * Improved image retrieval reliability through caching and request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->