### PR TITLE
feat(web): optimize video player UI for mobile touch devices

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,14 +2,17 @@
 <html lang="en" data-theme="arctic-frost">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Silo</title>
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300..900&family=Sora:wght@300..800&family=Urbanist:wght@300..900&family=Manrope:wght@300..800&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300..900&family=Sora:wght@300..800&family=Urbanist:wght@300..900&family=Manrope:wght@300..800&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1165,6 +1165,7 @@
     justify-content: center;
     width: 2.5rem;
     height: 2.5rem;
+    flex-shrink: 0;
     border-radius: 9999px;
     color: rgb(255 255 255 / 0.78);
     background: transparent;

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -139,7 +139,10 @@ export default function DetailHero({
       <div
         className={`page-shell-wide relative flex flex-col justify-end pb-8 ${
           isCompact
-            ? "h-[35vh] min-h-[300px] pt-20 lg:h-[42vh]"
+            ? // min-height (not fixed height) below lg: bottom-justified content
+              // taller than the hero would otherwise overflow out the top, under
+              // the floating back button.
+              "min-h-[max(35vh,300px)] pt-20 lg:h-[42vh]"
             : "min-h-[60dvh] pt-28 lg:min-h-[72dvh]"
         }`}
       >

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -524,8 +524,11 @@ export default function ActionBar({
       </div>
 
       {/* ── Stream info controls (second row) ──────────────── */}
+      {/* flex-wrap matters: without it this row's min-content width (two or
+          three nowrap trigger buttons) inflates the auto-sized hero column
+          past narrow viewports, clipping the whole info column. */}
       {hasStreamControls && (
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
           {versions && hasMultipleVersions && selectedVersion && onSelectVersion && (
             <VersionDropdown
               versions={versions}

--- a/web/src/player/components/AudioTrackMenu.tsx
+++ b/web/src/player/components/AudioTrackMenu.tsx
@@ -7,12 +7,16 @@ import {
   compactAudioMeta,
   formatLanguageName,
 } from "@/pages/ItemDetail/components/versionFormatUtils";
+import { PlayerMenuSurface } from "./PlayerMenuSurface";
 
 interface AudioTrackMenuProps {
   tracks: PlayerAudioTrack[];
   activeIndex: number;
   onSelect: (index: number, currentPosition: number) => void;
   currentPosition: number;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  hideTrigger?: boolean;
 }
 
 /**
@@ -54,8 +58,20 @@ export function AudioTrackMenu({
   activeIndex,
   onSelect,
   currentPosition,
+  open: controlledOpen,
+  onOpenChange,
+  hideTrigger = false,
 }: AudioTrackMenuProps) {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = useCallback(
+    (value: boolean | ((previous: boolean) => boolean)) => {
+      const next = typeof value === "function" ? value(open) : value;
+      if (controlledOpen === undefined) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [controlledOpen, onOpenChange, open],
+  );
   const menuRef = useRef<HTMLDivElement>(null);
 
   const handleSelect = useCallback(
@@ -121,22 +137,24 @@ export function AudioTrackMenu({
 
   return (
     <div ref={menuRef} className="relative" onBlur={handleBlur}>
-      <button
-        type="button"
-        className={`player-utility-btn ${disabled ? "cursor-default opacity-40" : ""}`}
-        onClick={disabled ? undefined : () => setOpen((v) => !v)}
-        aria-label="Audio tracks"
-        aria-expanded={open}
-        aria-disabled={disabled}
-        aria-haspopup="menu"
-      >
-        <AudioLines className="h-[18px] w-[18px]" />
-      </button>
+      {!hideTrigger && (
+        <button
+          type="button"
+          className={`player-utility-btn ${disabled ? "cursor-default opacity-40" : ""}`}
+          onClick={disabled ? undefined : () => setOpen((v) => !v)}
+          aria-label="Audio tracks"
+          aria-expanded={open}
+          aria-disabled={disabled}
+          aria-haspopup="menu"
+        >
+          <AudioLines className="h-[18px] w-[18px]" />
+        </button>
+      )}
 
       {open && (
-        <div
-          role="menu"
+        <PlayerMenuSurface
           className="absolute right-0 bottom-full z-30 mb-2 max-w-[min(360px,calc(100vw-1rem))] min-w-[280px] rounded-lg bg-black/90 py-1.5 shadow-xl backdrop-blur-sm"
+          onClose={() => setOpen(false)}
           onKeyDown={handleMenuKeyDown}
         >
           <div className="px-3 py-1.5 text-xs font-medium tracking-wide text-white/50 uppercase">
@@ -179,7 +197,7 @@ export function AudioTrackMenu({
               </button>
             );
           })}
-        </div>
+        </PlayerMenuSurface>
       )}
     </div>
   );

--- a/web/src/player/components/ChaptersMenu.tsx
+++ b/web/src/player/components/ChaptersMenu.tsx
@@ -2,11 +2,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ListVideo } from "lucide-react";
 import type { PlayerChapter } from "../types";
 import { formatTime } from "./SeekBar";
+import { PlayerMenuSurface } from "./PlayerMenuSurface";
 
 interface ChaptersMenuProps {
   chapters: PlayerChapter[];
   currentTime: number;
   onSeek: (seconds: number) => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  hideTrigger?: boolean;
 }
 
 function findActiveChapterIndex(chapters: PlayerChapter[], currentTime: number): number {
@@ -15,8 +19,24 @@ function findActiveChapterIndex(chapters: PlayerChapter[], currentTime: number):
   );
 }
 
-export function ChaptersMenu({ chapters, currentTime, onSeek }: ChaptersMenuProps) {
-  const [open, setOpen] = useState(false);
+export function ChaptersMenu({
+  chapters,
+  currentTime,
+  onSeek,
+  open: controlledOpen,
+  onOpenChange,
+  hideTrigger = false,
+}: ChaptersMenuProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const open = controlledOpen ?? uncontrolledOpen;
+  const setOpen = useCallback(
+    (value: boolean | ((previous: boolean) => boolean)) => {
+      const next = typeof value === "function" ? value(open) : value;
+      if (controlledOpen === undefined) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [controlledOpen, onOpenChange, open],
+  );
   const menuRef = useRef<HTMLDivElement>(null);
   const menuItemsRef = useRef<(HTMLButtonElement | null)[]>([]);
   const activeIndex = useMemo(
@@ -75,21 +95,23 @@ export function ChaptersMenu({ chapters, currentTime, onSeek }: ChaptersMenuProp
 
   return (
     <div ref={menuRef} className="relative" onBlur={handleBlur}>
-      <button
-        type="button"
-        className="player-utility-btn"
-        onClick={() => setOpen((value) => !value)}
-        aria-label="Chapters"
-        aria-expanded={open}
-        aria-haspopup="menu"
-      >
-        <ListVideo className="h-[18px] w-[18px]" />
-      </button>
+      {!hideTrigger && (
+        <button
+          type="button"
+          className="player-utility-btn"
+          onClick={() => setOpen((value) => !value)}
+          aria-label="Chapters"
+          aria-expanded={open}
+          aria-haspopup="menu"
+        >
+          <ListVideo className="h-[18px] w-[18px]" />
+        </button>
+      )}
 
       {open && (
-        <div
-          role="menu"
+        <PlayerMenuSurface
           className="absolute right-0 bottom-full z-30 mb-2 flex max-h-[60vh] min-w-[280px] flex-col overflow-y-auto rounded-lg bg-black/90 py-1.5 shadow-xl backdrop-blur-sm"
+          onClose={() => setOpen(false)}
           onKeyDown={handleMenuKeyDown}
         >
           <div className="px-3 py-1.5 text-xs font-medium tracking-wide text-white/50 uppercase">
@@ -139,7 +161,7 @@ export function ChaptersMenu({ chapters, currentTime, onSeek }: ChaptersMenuProp
               </span>
             </button>
           ))}
-        </div>
+        </PlayerMenuSurface>
       )}
     </div>
   );

--- a/web/src/player/components/PlayerControls.test.tsx
+++ b/web/src/player/components/PlayerControls.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PlayerControls } from "./PlayerControls";
 
 function renderControls(markerEditAvailable: boolean) {
@@ -50,6 +50,8 @@ function renderControls(markerEditAvailable: boolean) {
 }
 
 describe("PlayerControls", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it("hides marker editing when unavailable", () => {
     renderControls(false);
 
@@ -60,5 +62,27 @@ describe("PlayerControls", () => {
     renderControls(true);
 
     expect(screen.getByRole("button", { name: "Edit markers" })).toBeInTheDocument();
+  });
+
+  it("uses the mobile transport and hides hardware-volume controls on coarse pointers", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        media: "(pointer: coarse)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+
+    renderControls(false);
+
+    expect(screen.getByRole("button", { name: "More player options" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Play" })).toHaveClass("h-16", "w-16");
+    expect(screen.queryByRole("button", { name: /mute/i })).toBeNull();
   });
 });

--- a/web/src/player/components/PlayerControls.tsx
+++ b/web/src/player/components/PlayerControls.tsx
@@ -1,7 +1,10 @@
+import { useState, type ReactNode } from "react";
 import {
   Info,
+  ListVideo,
   Maximize,
   Minimize,
+  MoreHorizontal,
   Pause,
   PictureInPicture2,
   Play,
@@ -10,6 +13,7 @@ import {
   SkipBack,
   SkipForward,
   Tags,
+  AudioLines,
 } from "lucide-react";
 import { CircleButton } from "./CircleButton";
 import { SeekBar, formatTime } from "./SeekBar";
@@ -28,6 +32,8 @@ import type {
 } from "../types";
 import type { VersionInfo } from "./QualityMenu";
 import type { PlayerConfig } from "../context/PlayerConfigContext";
+import { useCoarsePointer } from "../hooks/useCoarsePointer";
+import { PlayerMenuSurface } from "./PlayerMenuSurface";
 
 interface PlayerControlsProps {
   // Visibility
@@ -93,11 +99,12 @@ interface PlayerControlsProps {
   onVolumeChange: (volume: number) => void;
   onMutedChange: (muted: boolean) => void;
   onFullscreenToggle: () => void;
+  onSurfaceTap?: () => void;
 }
 
 /** Skip amount for the ±seconds buttons, matching keyboard shortcuts. */
-const SKIP_BACK_SECONDS = 10;
-const SKIP_FORWARD_SECONDS = 30;
+export const SKIP_BACK_SECONDS = 10;
+export const SKIP_FORWARD_SECONDS = 30;
 
 export function PlayerControls({
   visible,
@@ -150,7 +157,12 @@ export function PlayerControls({
   onVolumeChange,
   onMutedChange,
   onFullscreenToggle,
+  onSurfaceTap,
 }: PlayerControlsProps) {
+  const isCoarsePointer = useCoarsePointer();
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const [audioOpen, setAudioOpen] = useState(false);
+  const [chaptersOpen, setChaptersOpen] = useState(false);
   const safeDuration = duration > 0 ? duration : 0;
   const handleSkipBack = () => onSeek(Math.max(0, currentTime - SKIP_BACK_SECONDS));
   const handleSkipForward = () =>
@@ -165,18 +177,87 @@ export function PlayerControls({
       className={`player-controls absolute inset-0 z-10 transition-opacity duration-300 ${
         visible ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
-      onClick={onPlayPause}
+      onClick={onSurfaceTap ?? onPlayPause}
     >
       {/* Gradient scrim — darkens the bottom of the frame just enough that
           white controls stay legible without washing out the picture. */}
       <div className="player-scrim pointer-events-none absolute inset-0" />
+
+      {/* Touch transport cluster. pointer-events pass through the empty area
+          so surface taps still toggle controls / double-tap-seek; only the
+          cluster itself is interactive. */}
+      {isCoarsePointer && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-[max(0.75rem,env(safe-area-inset-left))]">
+          <div
+            className="pointer-events-auto flex items-center gap-2"
+            onClick={(event) => event.stopPropagation()}
+          >
+            {showEpisodeSlots ? (
+              hasPrevEpisode ? (
+                <CircleButton
+                  size="md"
+                  variant="secondary"
+                  ariaLabel="Previous episode"
+                  onClick={onPrevEpisode}
+                >
+                  <SkipBack className="h-5 w-5" fill="currentColor" />
+                </CircleButton>
+              ) : (
+                <ClusterSlotSpacer size="md" />
+              )
+            ) : null}
+            <CircleButton
+              size="md"
+              variant="secondary"
+              ariaLabel={`Back ${SKIP_BACK_SECONDS} seconds`}
+              onClick={handleSkipBack}
+            >
+              <SkipIcon direction="back" seconds={SKIP_BACK_SECONDS} />
+            </CircleButton>
+            <button
+              type="button"
+              className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-white text-black shadow-xl focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+              aria-label={playing ? "Pause" : "Play"}
+              onClick={onPlayPause}
+            >
+              {playing ? (
+                <Pause className="h-7 w-7" fill="currentColor" strokeWidth={0} />
+              ) : (
+                <Play className="ml-1 h-7 w-7" fill="currentColor" strokeWidth={0} />
+              )}
+            </button>
+            <CircleButton
+              size="md"
+              variant="secondary"
+              ariaLabel={`Forward ${SKIP_FORWARD_SECONDS} seconds`}
+              onClick={handleSkipForward}
+            >
+              <SkipIcon direction="forward" seconds={SKIP_FORWARD_SECONDS} />
+            </CircleButton>
+            {showEpisodeSlots ? (
+              hasNextEpisode ? (
+                <CircleButton
+                  size="md"
+                  variant="secondary"
+                  ariaLabel="Next episode"
+                  onClick={onNextEpisode}
+                >
+                  <SkipForward className="h-5 w-5" fill="currentColor" />
+                </CircleButton>
+              ) : (
+                <ClusterSlotSpacer size="md" />
+              )
+            ) : null}
+          </div>
+        </div>
+      )}
 
       {/* ───── BOTTOM HUD ─────
           Three-column grid: metadata left, main playback cluster center,
           utility rail right. Seek bar spans the full width above the row
           so the playhead is always anchored to the frame edge.           */}
       <div
-        className="player-hud player-rise absolute inset-x-0 bottom-0 z-10 px-3 pt-4 pb-3 sm:px-6 sm:pb-5"
+        className="player-hud player-rise absolute inset-x-0 bottom-0 z-10 px-[max(0.75rem,env(safe-area-inset-left))] pt-4 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:px-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] sm:pb-[max(1.25rem,env(safe-area-inset-bottom))]"
         onClick={(e) => e.stopPropagation()}
       >
         <SeekBar
@@ -195,132 +276,23 @@ export function PlayerControls({
             of the frame regardless of how long the title or utility rail is.
             `minmax(0,1fr)` forces the side columns to honor 1fr behaviour
             rather than growing with their content — the cluster stays put. */}
-        <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 sm:gap-5">
-          {/* ─── Left: Title / episode / time ─── */}
-          <div className="flex min-w-0 flex-col gap-0.5">
-            {title ? (
-              <div
-                className="truncate text-[15px] leading-tight font-semibold tracking-tight text-white sm:text-base"
-                title={title}
-              >
-                {title}
-              </div>
-            ) : null}
-            <div className="flex items-center gap-2 text-[10px] leading-tight text-white/55 uppercase">
-              {subtitleLabel ? (
-                <>
-                  <span
-                    className="truncate tracking-[0.22em]"
-                    style={{ maxWidth: "38ch" }}
-                    title={subtitleLabel}
-                  >
-                    {subtitleLabel}
-                  </span>
-                  <span className="text-white/25">·</span>
-                </>
+        {isCoarsePointer ? (
+          <div className="mt-2 flex min-w-0 items-center gap-2">
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              {title ? (
+                <div
+                  className="truncate text-[15px] leading-tight font-semibold tracking-tight text-white"
+                  title={title}
+                >
+                  {title}
+                </div>
               ) : null}
-              <span className="font-mono text-[11px] tracking-[0.12em] text-white/75 normal-case tabular-nums">
+              <div className="font-mono text-[11px] tracking-[0.12em] text-white/75 tabular-nums">
                 {formatTime(currentTime)}
                 <span className="mx-1 text-white/30">/</span>
                 {formatTime(duration)}
-              </span>
+              </div>
             </div>
-          </div>
-
-          {/* ─── Center: Main playback cluster ─── */}
-          {/* When ANY episode navigation exists (series context), both the
-              prev and next slots are reserved so the play button stays
-              exactly on the cluster's centerline even at the first or last
-              episode. For movies the slots are omitted entirely, leaving a
-              symmetric 3-button cluster that's also perfectly centered. */}
-          <div className="flex items-center justify-center gap-2 sm:gap-3">
-            {showEpisodeSlots ? (
-              hasPrevEpisode ? (
-                <CircleButton
-                  size="sm"
-                  variant="secondary"
-                  ariaLabel="Previous episode"
-                  onClick={onPrevEpisode}
-                >
-                  <SkipBack className="h-[18px] w-[18px]" fill="currentColor" />
-                </CircleButton>
-              ) : (
-                <ClusterSlotSpacer size="sm" />
-              )
-            ) : null}
-
-            <CircleButton
-              size="sm"
-              variant="secondary"
-              ariaLabel={`Back ${SKIP_BACK_SECONDS} seconds`}
-              onClick={handleSkipBack}
-            >
-              <SkipIcon direction="back" seconds={SKIP_BACK_SECONDS} />
-            </CircleButton>
-
-            <CircleButton
-              size="md"
-              variant="primary"
-              ariaLabel={playing ? "Pause" : "Play"}
-              onClick={onPlayPause}
-              data-paused={!playing}
-            >
-              {playing ? (
-                <Pause className="h-6 w-6" strokeWidth={0} fill="currentColor" />
-              ) : (
-                <Play className="ml-[2px] h-6 w-6" strokeWidth={0} fill="currentColor" />
-              )}
-            </CircleButton>
-
-            <CircleButton
-              size="sm"
-              variant="secondary"
-              ariaLabel={`Forward ${SKIP_FORWARD_SECONDS} seconds`}
-              onClick={handleSkipForward}
-            >
-              <SkipIcon direction="forward" seconds={SKIP_FORWARD_SECONDS} />
-            </CircleButton>
-
-            {showEpisodeSlots ? (
-              hasNextEpisode ? (
-                <CircleButton
-                  size="sm"
-                  variant="secondary"
-                  ariaLabel="Next episode"
-                  onClick={onNextEpisode}
-                >
-                  <SkipForward className="h-[18px] w-[18px]" fill="currentColor" />
-                </CircleButton>
-              ) : (
-                <ClusterSlotSpacer size="sm" />
-              )
-            ) : null}
-          </div>
-
-          {/* ─── Right: Utility rail ─── */}
-          <div className="flex items-center justify-end gap-0.5">
-            <div className="hidden sm:block">
-              <VolumeControl
-                volume={volume}
-                muted={muted}
-                onVolumeChange={onVolumeChange}
-                onMutedChange={onMutedChange}
-              />
-            </div>
-
-            <div className="player-hud-divider mx-1 hidden sm:block" />
-
-            {onAudioSelect && (
-              <AudioTrackMenu
-                tracks={audioTracks}
-                activeIndex={activeAudioIndex}
-                onSelect={onAudioSelect}
-                currentPosition={currentTime}
-              />
-            )}
-
-            <ChaptersMenu chapters={chapters ?? []} currentTime={currentTime} onSeek={onSeek} />
-
             <SubtitleMenu
               tracks={subtitleTracks}
               activeIndex={activeSubtitleIndex}
@@ -334,7 +306,6 @@ export function PlayerControls({
               getSubtitleStartPosition={getSubtitleStartPosition}
               audioTracks={audioTracks}
             />
-
             <QualityMenu
               options={qualityOptions}
               activeId={activeQualityId}
@@ -344,43 +315,16 @@ export function PlayerControls({
               versions={versions}
               onSwitchVersion={onSwitchVersion}
             />
-
-            {markerEditAvailable && onToggleMarkerEdit && (
-              <button
-                type="button"
-                className="player-utility-btn"
-                onClick={onToggleMarkerEdit}
-                aria-label="Edit markers"
-                aria-pressed={markerEditActive}
-                title="Edit markers"
-                data-active={markerEditActive ? "true" : "false"}
-              >
-                <Tags className="h-[18px] w-[18px]" />
-              </button>
-            )}
-
             <button
               type="button"
               className="player-utility-btn"
-              onClick={onTogglePlaybackInfo}
-              aria-label="Playback info"
-              data-active={showPlaybackInfo ? "true" : "false"}
+              aria-label="More player options"
+              aria-expanded={overflowOpen}
+              aria-haspopup="menu"
+              onClick={() => setOverflowOpen(true)}
             >
-              <Info className="h-[18px] w-[18px]" />
+              <MoreHorizontal className="h-5 w-5" />
             </button>
-
-            {onTogglePiP && document.pictureInPictureEnabled && (
-              <button
-                type="button"
-                className="player-utility-btn"
-                onClick={onTogglePiP}
-                aria-label="Picture in Picture (P)"
-                title="Picture in Picture (P)"
-              >
-                <PictureInPicture2 className="h-[18px] w-[18px]" />
-              </button>
-            )}
-
             <button
               type="button"
               className="player-utility-btn"
@@ -394,9 +338,312 @@ export function PlayerControls({
               )}
             </button>
           </div>
-        </div>
+        ) : (
+          <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 sm:gap-5">
+            {/* ─── Left: Title / episode / time ─── */}
+            <div className="flex min-w-0 flex-col gap-0.5">
+              {title ? (
+                <div
+                  className="truncate text-[15px] leading-tight font-semibold tracking-tight text-white sm:text-base"
+                  title={title}
+                >
+                  {title}
+                </div>
+              ) : null}
+              <div className="flex items-center gap-2 text-[10px] leading-tight text-white/55 uppercase">
+                {subtitleLabel ? (
+                  <>
+                    <span
+                      className="truncate tracking-[0.22em]"
+                      style={{ maxWidth: "38ch" }}
+                      title={subtitleLabel}
+                    >
+                      {subtitleLabel}
+                    </span>
+                    <span className="text-white/25">·</span>
+                  </>
+                ) : null}
+                <span className="font-mono text-[11px] tracking-[0.12em] text-white/75 normal-case tabular-nums">
+                  {formatTime(currentTime)}
+                  <span className="mx-1 text-white/30">/</span>
+                  {formatTime(duration)}
+                </span>
+              </div>
+            </div>
+
+            {/* ─── Center: Main playback cluster ─── */}
+            {/* When ANY episode navigation exists (series context), both the
+              prev and next slots are reserved so the play button stays
+              exactly on the cluster's centerline even at the first or last
+              episode. For movies the slots are omitted entirely, leaving a
+              symmetric 3-button cluster that's also perfectly centered. */}
+            <div className="flex items-center justify-center gap-2 sm:gap-3">
+              {showEpisodeSlots ? (
+                hasPrevEpisode ? (
+                  <CircleButton
+                    size="sm"
+                    variant="secondary"
+                    ariaLabel="Previous episode"
+                    onClick={onPrevEpisode}
+                  >
+                    <SkipBack className="h-[18px] w-[18px]" fill="currentColor" />
+                  </CircleButton>
+                ) : (
+                  <ClusterSlotSpacer size="sm" />
+                )
+              ) : null}
+
+              <CircleButton
+                size="sm"
+                variant="secondary"
+                ariaLabel={`Back ${SKIP_BACK_SECONDS} seconds`}
+                onClick={handleSkipBack}
+              >
+                <SkipIcon direction="back" seconds={SKIP_BACK_SECONDS} />
+              </CircleButton>
+
+              <CircleButton
+                size="md"
+                variant="primary"
+                ariaLabel={playing ? "Pause" : "Play"}
+                onClick={onPlayPause}
+                data-paused={!playing}
+              >
+                {playing ? (
+                  <Pause className="h-6 w-6" strokeWidth={0} fill="currentColor" />
+                ) : (
+                  <Play className="ml-[2px] h-6 w-6" strokeWidth={0} fill="currentColor" />
+                )}
+              </CircleButton>
+
+              <CircleButton
+                size="sm"
+                variant="secondary"
+                ariaLabel={`Forward ${SKIP_FORWARD_SECONDS} seconds`}
+                onClick={handleSkipForward}
+              >
+                <SkipIcon direction="forward" seconds={SKIP_FORWARD_SECONDS} />
+              </CircleButton>
+
+              {showEpisodeSlots ? (
+                hasNextEpisode ? (
+                  <CircleButton
+                    size="sm"
+                    variant="secondary"
+                    ariaLabel="Next episode"
+                    onClick={onNextEpisode}
+                  >
+                    <SkipForward className="h-[18px] w-[18px]" fill="currentColor" />
+                  </CircleButton>
+                ) : (
+                  <ClusterSlotSpacer size="sm" />
+                )
+              ) : null}
+            </div>
+
+            {/* ─── Right: Utility rail ─── */}
+            <div className="flex items-center justify-end gap-0.5">
+              <div className="hidden sm:pointer-fine:block">
+                <VolumeControl
+                  volume={volume}
+                  muted={muted}
+                  onVolumeChange={onVolumeChange}
+                  onMutedChange={onMutedChange}
+                />
+              </div>
+
+              <div className="player-hud-divider mx-1 hidden sm:block" />
+
+              {onAudioSelect && (
+                <AudioTrackMenu
+                  tracks={audioTracks}
+                  activeIndex={activeAudioIndex}
+                  onSelect={onAudioSelect}
+                  currentPosition={currentTime}
+                />
+              )}
+
+              <ChaptersMenu chapters={chapters ?? []} currentTime={currentTime} onSeek={onSeek} />
+
+              <SubtitleMenu
+                tracks={subtitleTracks}
+                activeIndex={activeSubtitleIndex}
+                onSelect={onSubtitleSelect}
+                delayMs={subtitleDelayMs}
+                onDelayChange={onSubtitleDelayChange}
+                mediaFileId={mediaFileId}
+                playerConfig={playerConfig}
+                onRefreshSubtitles={onRefreshSubtitles}
+                sessionId={sessionId}
+                getSubtitleStartPosition={getSubtitleStartPosition}
+                audioTracks={audioTracks}
+              />
+
+              <QualityMenu
+                options={qualityOptions}
+                activeId={activeQualityId}
+                isTranscoding={isTranscoding}
+                error={qualityError}
+                onSelect={onQualitySelect}
+                versions={versions}
+                onSwitchVersion={onSwitchVersion}
+              />
+
+              {markerEditAvailable && onToggleMarkerEdit && (
+                <button
+                  type="button"
+                  className="player-utility-btn"
+                  onClick={onToggleMarkerEdit}
+                  aria-label="Edit markers"
+                  aria-pressed={markerEditActive}
+                  title="Edit markers"
+                  data-active={markerEditActive ? "true" : "false"}
+                >
+                  <Tags className="h-[18px] w-[18px]" />
+                </button>
+              )}
+
+              <button
+                type="button"
+                className="player-utility-btn"
+                onClick={onTogglePlaybackInfo}
+                aria-label="Playback info"
+                data-active={showPlaybackInfo ? "true" : "false"}
+              >
+                <Info className="h-[18px] w-[18px]" />
+              </button>
+
+              {onTogglePiP && document.pictureInPictureEnabled && (
+                <button
+                  type="button"
+                  className="player-utility-btn"
+                  onClick={onTogglePiP}
+                  aria-label="Picture in Picture (P)"
+                  title="Picture in Picture (P)"
+                >
+                  <PictureInPicture2 className="h-[18px] w-[18px]" />
+                </button>
+              )}
+
+              <button
+                type="button"
+                className="player-utility-btn"
+                onClick={onFullscreenToggle}
+                aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+              >
+                {isFullscreen ? (
+                  <Minimize className="h-[18px] w-[18px]" />
+                ) : (
+                  <Maximize className="h-[18px] w-[18px]" />
+                )}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
+
+      {isCoarsePointer && overflowOpen && (
+        <PlayerMenuSurface className="" onClose={() => setOverflowOpen(false)}>
+          <div className="py-1">
+            {onAudioSelect && audioTracks.length > 0 && (
+              <OverflowAction
+                icon={<AudioLines className="h-5 w-5" />}
+                label="Audio tracks"
+                onClick={() => {
+                  setOverflowOpen(false);
+                  setAudioOpen(true);
+                }}
+              />
+            )}
+            {(chapters?.length ?? 0) > 0 && (
+              <OverflowAction
+                icon={<ListVideo className="h-5 w-5" />}
+                label="Chapters"
+                onClick={() => {
+                  setOverflowOpen(false);
+                  setChaptersOpen(true);
+                }}
+              />
+            )}
+            <OverflowAction
+              icon={<Info className="h-5 w-5" />}
+              label="Playback info"
+              active={showPlaybackInfo}
+              onClick={() => {
+                onTogglePlaybackInfo();
+                setOverflowOpen(false);
+              }}
+            />
+            {onTogglePiP && document.pictureInPictureEnabled && (
+              <OverflowAction
+                icon={<PictureInPicture2 className="h-5 w-5" />}
+                label="Picture in Picture"
+                onClick={() => {
+                  onTogglePiP();
+                  setOverflowOpen(false);
+                }}
+              />
+            )}
+            {markerEditAvailable && onToggleMarkerEdit && (
+              <OverflowAction
+                icon={<Tags className="h-5 w-5" />}
+                label="Edit markers"
+                active={markerEditActive}
+                onClick={() => {
+                  onToggleMarkerEdit();
+                  setOverflowOpen(false);
+                }}
+              />
+            )}
+          </div>
+        </PlayerMenuSurface>
+      )}
+      {isCoarsePointer && onAudioSelect && (
+        <AudioTrackMenu
+          tracks={audioTracks}
+          activeIndex={activeAudioIndex}
+          onSelect={onAudioSelect}
+          currentPosition={currentTime}
+          open={audioOpen}
+          onOpenChange={setAudioOpen}
+          hideTrigger
+        />
+      )}
+      {isCoarsePointer && (
+        <ChaptersMenu
+          chapters={chapters ?? []}
+          currentTime={currentTime}
+          onSeek={onSeek}
+          open={chaptersOpen}
+          onOpenChange={setChaptersOpen}
+          hideTrigger
+        />
+      )}
     </div>
+  );
+}
+
+function OverflowAction({
+  icon,
+  label,
+  active = false,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      role="menuitem"
+      type="button"
+      className={`flex min-h-12 w-full items-center gap-3 px-5 py-3 text-left text-sm ${active ? "bg-white/10 text-white" : "text-white/80"}`}
+      onClick={onClick}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
   );
 }
 

--- a/web/src/player/components/PlayerMenuSurface.test.tsx
+++ b/web/src/player/components/PlayerMenuSurface.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PlayerMenuSurface } from "./PlayerMenuSurface";
+
+function mockPointer(coarse: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => ({
+      matches: coarse,
+      media: "(pointer: coarse)",
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
+describe("PlayerMenuSurface", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("keeps the supplied anchored popover wrapper for fine pointers", () => {
+    mockPointer(false);
+    render(
+      <PlayerMenuSurface className="desktop-popover" onClose={vi.fn()}>
+        Item
+      </PlayerMenuSurface>,
+    );
+    expect(screen.getByRole("menu")).toHaveClass("desktop-popover");
+    expect(screen.queryByRole("button", { name: "Close menu" })).toBeNull();
+  });
+
+  it("renders a dismissible bottom sheet for coarse pointers", () => {
+    mockPointer(true);
+    const onClose = vi.fn();
+    render(
+      <PlayerMenuSurface className="desktop-popover" onClose={onClose}>
+        Item
+      </PlayerMenuSurface>,
+    );
+    expect(screen.getByRole("menu")).toHaveClass("fixed", "bottom-0", "rounded-t-2xl");
+    fireEvent.click(screen.getByRole("button", { name: "Close menu" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/player/components/PlayerMenuSurface.tsx
+++ b/web/src/player/components/PlayerMenuSurface.tsx
@@ -1,0 +1,57 @@
+import { useEffect, type KeyboardEvent, type ReactNode } from "react";
+import { useCoarsePointer } from "../hooks/useCoarsePointer";
+
+interface PlayerMenuSurfaceProps {
+  children: ReactNode;
+  className: string;
+  onClose: () => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
+}
+
+export function PlayerMenuSurface({
+  children,
+  className,
+  onClose,
+  onKeyDown,
+}: PlayerMenuSurfaceProps) {
+  const isCoarsePointer = useCoarsePointer();
+
+  useEffect(() => {
+    if (!isCoarsePointer) return;
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isCoarsePointer, onClose]);
+
+  if (!isCoarsePointer) {
+    return (
+      <div role="menu" className={className} onKeyDown={onKeyDown}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="fixed inset-0 z-40 bg-black/50"
+        aria-label="Close menu"
+        onClick={(event) => {
+          event.stopPropagation();
+          onClose();
+        }}
+      />
+      <div
+        role="menu"
+        className="fixed inset-x-0 bottom-0 z-50 max-h-[70dvh] overflow-y-auto rounded-t-2xl bg-black/90 pt-2 pb-[max(0.75rem,env(safe-area-inset-bottom))] shadow-2xl backdrop-blur"
+        onKeyDown={onKeyDown}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/web/src/player/components/QualityMenu.tsx
+++ b/web/src/player/components/QualityMenu.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, Settings } from "lucide-react";
 import { resolveActiveQualityOptionId } from "../playback-info";
 import type { QualityOption } from "../types";
+import { PlayerMenuSurface } from "./PlayerMenuSurface";
 
 export interface VersionInfo {
   fileId: number;
@@ -113,9 +114,9 @@ export function QualityMenu({
       </button>
 
       {open && (
-        <div
-          role="menu"
+        <PlayerMenuSurface
           className="absolute right-0 bottom-full z-30 mb-2 min-w-[200px] rounded-lg bg-black/90 py-1 shadow-lg backdrop-blur"
+          onClose={() => setOpen(false)}
           onKeyDown={handleMenuKeyDown}
         >
           {error && <div className="px-3 py-1 text-xs text-red-400">{error}</div>}
@@ -197,7 +198,7 @@ export function QualityMenu({
               </button>
             );
           })}
-        </div>
+        </PlayerMenuSurface>
       )}
     </div>
   );

--- a/web/src/player/components/SeekBar.tsx
+++ b/web/src/player/components/SeekBar.tsx
@@ -386,7 +386,7 @@ export function SeekBar({
       >
         <div
           className={[
-            "relative h-[3px] w-full rounded-full bg-white/15 transition-[height] duration-200 ease-out group-hover/seek:h-[5px]",
+            "relative h-[3px] w-full rounded-full bg-white/15 transition-[height] duration-200 ease-out group-hover/seek:h-[5px] pointer-coarse:h-[5px]",
             editing ? "h-[5px]" : "",
           ].join(" ")}
         >
@@ -439,7 +439,7 @@ export function SeekBar({
           />
           {/* Thumb */}
           <div
-            className="absolute top-1/2 z-[3] h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-[0_4px_14px_rgb(0_0_0/0.45)] ring-1 ring-black/10 transition-all duration-200 group-hover/seek:opacity-100"
+            className="absolute top-1/2 z-[3] h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white opacity-0 shadow-[0_4px_14px_rgb(0_0_0/0.45)] ring-1 ring-black/10 transition-all duration-200 group-hover/seek:opacity-100 pointer-coarse:opacity-100"
             style={{ left: `${playedPercent}%` }}
           />
           {/* Editable marker handles for the active region */}

--- a/web/src/player/components/SubtitleMenu.tsx
+++ b/web/src/player/components/SubtitleMenu.tsx
@@ -11,6 +11,7 @@ import { getLanguageName } from "../utils/languageNames";
 import { sortSubtitlesBySource } from "../utils/subtitleSort";
 import { getSubtitleFormatLabel, isSubtitleFormatLabel } from "../utils/subtitleCodecs";
 import { isTranslatableSource } from "./subtitleTranslateRequest";
+import { PlayerMenuSurface } from "./PlayerMenuSurface";
 
 interface SubtitleMenuProps {
   tracks: PlayerSubtitleInfo[];
@@ -182,9 +183,9 @@ export function SubtitleMenu({
       </button>
 
       {open && (
-        <div
-          role="menu"
+        <PlayerMenuSurface
           className="absolute right-0 bottom-full z-30 mb-2 flex w-max max-w-[min(420px,calc(100vw-1rem))] min-w-[220px] flex-col rounded-lg bg-black/90 shadow-lg backdrop-blur"
+          onClose={() => setOpen(false)}
           onKeyDown={handleMenuKeyDown}
         >
           <div className="shrink-0 py-1">
@@ -351,7 +352,7 @@ export function SubtitleMenu({
               Appearance…
             </button>
           </div>
-        </div>
+        </PlayerMenuSurface>
       )}
 
       <SubtitleAppearancePanel open={appearanceOpen} onClose={() => setAppearanceOpen(false)} />

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -22,8 +22,11 @@ const controls = vi.hoisted(() => ({
   current: null as null | {
     activeSubtitleIndex: number | null;
     subtitleTracks: PlayerSubtitleInfo[];
+    visible: boolean;
+    onSurfaceTap?: (event: React.MouseEvent<HTMLElement>) => void;
   },
 }));
+const playerSeek = vi.hoisted(() => vi.fn());
 const subtitleTimeline = vi.hoisted(() => ({
   textOffsetSeconds: null as number | null,
   assOffsetSeconds: null as number | null,
@@ -44,7 +47,7 @@ vi.mock("../hooks/useWatchProgress", () => ({
 }));
 vi.mock("../hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: vi.fn() }));
 vi.mock("../hooks/useRemuxSeeking", () => ({
-  useRemuxSeeking: () => ({ handleSeek: vi.fn() }),
+  useRemuxSeeking: () => ({ handleSeek: playerSeek }),
 }));
 vi.mock("../hooks/useSubtitleTracks", () => ({
   useSubtitleTracks: (...args: unknown[]) => {
@@ -89,8 +92,15 @@ vi.mock("hls.js", () => ({
   },
 }));
 vi.mock("./PlayerControls", () => ({
+  SKIP_BACK_SECONDS: 10,
+  SKIP_FORWARD_SECONDS: 30,
   PlayerControls: vi.fn(
-    (props: { activeSubtitleIndex: number | null; subtitleTracks: PlayerSubtitleInfo[] }) => {
+    (props: {
+      activeSubtitleIndex: number | null;
+      subtitleTracks: PlayerSubtitleInfo[];
+      visible: boolean;
+      onSurfaceTap?: (event: React.MouseEvent<HTMLElement>) => void;
+    }) => {
       controls.current = props;
       return null;
     },
@@ -179,6 +189,7 @@ describe("VideoPlayer plan failure recovery", () => {
     hlsJS.supported = false;
     hlsJS.constructed.mockClear();
     toastError.mockClear();
+    playerSeek.mockClear();
     vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
     vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
     vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
@@ -187,6 +198,54 @@ describe("VideoPlayer plan failure recovery", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+  });
+
+  it("toggles controls on a coarse-pointer single tap and seeks on a left double tap", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({
+        matches: true,
+        media: "(pointer: coarse)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+    try {
+      const { container } = renderPlayer({ shouldAutoPlay: false });
+      const video = container.querySelector("video");
+      if (!video) throw new Error("expected video element");
+      Object.defineProperty(video, "readyState", { configurable: true, value: 3 });
+      Object.defineProperty(video, "currentTime", { configurable: true, value: 50 });
+      fireEvent.canPlay(video);
+      await vi.waitFor(() => expect(controls.current?.onSurfaceTap).toBeTypeOf("function"));
+
+      act(() =>
+        controls.current?.onSurfaceTap?.({
+          clientX: 200,
+          currentTarget: { getBoundingClientRect: () => ({ left: 0, width: 390 }) },
+        } as unknown as React.MouseEvent<HTMLElement>),
+      );
+      act(() => vi.advanceTimersByTime(250));
+      expect(controls.current?.visible).toBe(false);
+
+      const leftTap = {
+        clientX: 20,
+        currentTarget: { getBoundingClientRect: () => ({ left: 0, width: 390 }) },
+      } as unknown as React.MouseEvent<HTMLElement>;
+      act(() => {
+        controls.current?.onSurfaceTap?.(leftTap);
+        controls.current?.onSurfaceTap?.(leftTap);
+      });
+      expect(playerSeek).toHaveBeenCalledWith(40);
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    }
   });
 
   it("loads a replacement transport without resuming paused playback", async () => {

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ParsedCue } from "../utils/parseVTT";
 import { resolveSubtitleAutoSelect } from "../utils/subtitleSort";
 import type HlsType from "hls.js";
-import { PlayerControls } from "./PlayerControls";
+import { PlayerControls, SKIP_BACK_SECONDS, SKIP_FORWARD_SECONDS } from "./PlayerControls";
 import { PlaybackInfoOverlay } from "./PlaybackInfoOverlay";
 import { PlaybackNoticeOverlay } from "./PlaybackNoticeOverlay";
 import { IntroSkipButton } from "./IntroSkipButton";
@@ -17,6 +17,7 @@ import { useSubtitleTracks } from "../hooks/useSubtitleTracks";
 import { useASSSubtitles } from "../hooks/useASSSubtitles";
 import { useSubtitleAppearance } from "../hooks/useSubtitleAppearance";
 import { useSubtitleLayout } from "../hooks/useSubtitleLayout";
+import { useCoarsePointer } from "../hooks/useCoarsePointer";
 import { computeSubtitleFontSize } from "@/lib/subtitleAppearance";
 import { useNextEpisode } from "../hooks/useNextEpisode";
 import { MARKER_KINDS, useMarkerEditor } from "../hooks/useMarkerEditor";
@@ -1859,7 +1860,9 @@ export function VideoPlayer({
 
   // -- Control visibility (hover anywhere to show) --
   const [controlsVisible, setControlsVisible] = useState(true);
+  const isCoarsePointer = useCoarsePointer();
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const surfaceTapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clearControlsTimer = useCallback(() => {
     if (hideTimerRef.current) {
@@ -2284,6 +2287,60 @@ export function VideoPlayer({
     video.pause();
   }, [sessionId, showWatchTogetherNotice, watchTogether, watchTogetherRoomId, watchTogetherSync]);
 
+  const handleSurfaceTap = useCallback(
+    (event?: React.MouseEvent<HTMLElement>) => {
+      if (!isCoarsePointer) {
+        handlePlayPause();
+        return;
+      }
+      if (surfaceTapTimerRef.current) {
+        clearTimeout(surfaceTapTimerRef.current);
+        surfaceTapTimerRef.current = null;
+        const rect = event?.currentTarget.getBoundingClientRect();
+        const relativeX = rect && event ? (event.clientX - rect.left) / rect.width : 0.5;
+        const now = videoRef.current?.currentTime ?? currentTime;
+        if (relativeX < 1 / 3) {
+          handlePlayerSeek(Math.max(0, now - SKIP_BACK_SECONDS));
+          resetControlsTimer();
+        } else if (relativeX > 2 / 3) {
+          handlePlayerSeek(
+            Math.min(duration || now + SKIP_FORWARD_SECONDS, now + SKIP_FORWARD_SECONDS),
+          );
+          resetControlsTimer();
+        } else {
+          handlePlayPause();
+        }
+        return;
+      }
+      surfaceTapTimerRef.current = setTimeout(() => {
+        surfaceTapTimerRef.current = null;
+        if (controlsVisible) {
+          clearControlsTimer();
+          setControlsVisible(false);
+        } else {
+          resetControlsTimer();
+        }
+      }, 250);
+    },
+    [
+      clearControlsTimer,
+      controlsVisible,
+      currentTime,
+      duration,
+      handlePlayPause,
+      handlePlayerSeek,
+      isCoarsePointer,
+      resetControlsTimer,
+    ],
+  );
+
+  useEffect(
+    () => () => {
+      if (surfaceTapTimerRef.current) clearTimeout(surfaceTapTimerRef.current);
+    },
+    [],
+  );
+
   useEffect(() => {
     reportRoomReadyRef.current = watchTogetherSync.reportReady;
   }, [watchTogetherSync.reportReady]);
@@ -2683,7 +2740,7 @@ export function VideoPlayer({
       {/* Back button + media info */}
       {!isDetached && (
         <div
-          className={`absolute top-4 left-4 z-50 flex items-center gap-3 transition-opacity duration-300 ${
+          className={`absolute top-[max(1rem,env(safe-area-inset-top))] left-[max(1rem,env(safe-area-inset-left))] z-50 flex items-center gap-3 transition-opacity duration-300 ${
             controlsVisible ? "opacity-100" : "pointer-events-none opacity-0"
           }`}
         >
@@ -2847,7 +2904,7 @@ export function VideoPlayer({
       <video
         ref={videoRef}
         className={isDetached ? "h-full w-full" : "absolute inset-0 h-full w-full"}
-        onClick={displayMode === "postroll" ? undefined : handlePlayPause}
+        onClick={displayMode === "postroll" ? undefined : handleSurfaceTap}
         playsInline
         style={!isPlayerReady ? { visibility: "hidden" } : undefined}
       />
@@ -2979,6 +3036,7 @@ export function VideoPlayer({
           onVolumeChange={handleVolumeChange}
           onMutedChange={handleMutedChange}
           onFullscreenToggle={handleFullscreenToggle}
+          onSurfaceTap={isCoarsePointer ? handleSurfaceTap : undefined}
           showPlaybackInfo={showPlaybackInfo}
           onTogglePlaybackInfo={() => setShowPlaybackInfo((v) => !v)}
           hasPrevEpisode={!!prevEpisodeRef}

--- a/web/src/player/hooks/useCoarsePointer.ts
+++ b/web/src/player/hooks/useCoarsePointer.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+const QUERY = "(pointer: coarse)";
+
+export function useCoarsePointer(): boolean {
+  const [isCoarse, setIsCoarse] = useState(() =>
+    typeof window === "undefined" || !window.matchMedia ? false : window.matchMedia(QUERY).matches,
+  );
+
+  useEffect(() => {
+    if (!window.matchMedia) return;
+    const media = window.matchMedia(QUERY);
+    const update = () => setIsCoarse(media.matches);
+    update();
+    media.addEventListener("change", update);
+    return () => media.removeEventListener("change", update);
+  }, []);
+
+  return isCoarse;
+}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

On touch devices, the video player's desktop-oriented controls are crowded and difficult to use. Item detail layouts and seek controls can also overflow or clip on narrow viewports.

## Approach

Add coarse-pointer-specific transport controls with larger touch targets, move secondary actions into a bottom-sheet overflow menu, and provide shared responsive menu surfaces. Preserve the existing desktop control layout while adding safe-area support, responsive wrapping, and mobile layout fixes for item details and the seek bar.

## Validation

- Not run; validation results were not provided.
- Added and updated Vitest coverage for coarse-pointer controls, menu surfaces, and player behavior.
- No screenshots or recordings provided.

## Risks

None identified. The changes are frontend-only and retain the existing desktop interaction model.

## AI Disclosure

- Tool(s): Codex
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: Not performed.

## Checklist

- [ ] I read and can explain the complete diff.
- [ ] This pull request addresses one concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video playback controls for touch devices, including larger controls, safer spacing, and easier access to secondary actions.
  * Added touch-friendly menus that open as dismissible bottom sheets.
  * Added touch gestures for showing controls and double-tap seeking.
  * Seek bars are easier to use on touchscreens.
* **Bug Fixes**
  * Improved responsive hero sizing, button layout, and narrow-screen wrapping.
  * Updated mobile viewport handling for edge-to-edge displays.
* **Tests**
  * Added coverage for touch interactions, menus, and responsive player behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->