### PR TITLE
docs: use custom Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="#quick-start">Quick start</a>
   · <a href="docs/wiki/index.md">Documentation</a>
   · <a href="docs/release-versioning.md">Builds &amp; releases</a>
-  · <a href="https://discord.com/invite/4RxuUQAEnW">Discord</a>
+  · <a href="http://discord.gg/siloserver">Discord</a>
   · <a href="#supporting-silo">Support Silo</a>
   · <a href="CONTRIBUTING.md">Contributing</a>
 </p>
@@ -116,7 +116,7 @@ defines each tag and the SemVer contract.
 
 ## Community and contributions
 
-Questions and discussion: [Discord](https://discord.com/invite/4RxuUQAEnW).
+Questions and discussion: [Discord](http://discord.gg/siloserver).
 Bugs, install problems, and performance issues: the
 [GitHub issue forms](https://github.com/Silo-Server/silo-server/issues/new/choose),
 which ask for reproduction steps and raw logs.


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

The README still points to the old Discord invite token in both community links.

## Approach

Replace both links with the requested custom invite URL: `http://discord.gg/siloserver`.

## Validation

- `git diff --check` — passed.
- Legacy invite search in `README.md` — no matches.
- Custom invite search in `README.md` — both expected links found.
- `go build ./...` — passed.
- `gofmt -l .` — passed with no output.
- `go vet ./...` — passed.
- `golangci-lint run --new-from-merge-base="origin/main" ./...` using v2.12.2 — passed with 0 issues.
- `pnpm --dir web run lint` — passed with 0 errors and 166 existing warnings.
- `pnpm --dir web run format:check` — passed.
- `pnpm --dir web run build` — passed.
- `make test-web` — passed: 293 files, 2,158 tests.
- `make verify-settings-bindings-all` — passed.
- `make verify-playback-fixtures` — passed.
- `make verify-local-paths` — passed.
- `make test-go` — failed in two reproducible `internal/jellycompat` process-identity tests: `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`. This branch changes only `README.md` and has no diff in `internal/jellycompat`.

## Risks

None identified. This changes documentation links only.

## AI Disclosure

- Tool(s): Codex desktop
- Model(s): GPT-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: Reviewed the complete diff, searched tracked files for the legacy invite token and alternate Discord invite forms, confirmed the exact requested URL appears twice, and verified there are no code changes.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
