### PR TITLE
feat(web): replace touch card overlays with long-press action sheet

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1260,40 +1260,47 @@
     transform: translateY(-4px);
   }
 
-  /* Keep card actions visible by default for touch, keyboard-only, and older
-     browsers. When any connected precise pointer can hover, hide them until
-     the card itself is hovered. This deliberately uses a direct :hover
+  /* Card actions stay hidden at rest so touch devices get clean artwork; a
+     long press opens the action sheet instead. Keyboard focus and an open
+     menu reveal them on every device so keyboard and assistive-tech users
+     always have a visible, hittable target. */
+  .media-card-action-trigger,
+  .media-card-play-trigger {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .media-card-action-trigger[data-state="open"],
+  .media-card-action-trigger:focus-visible,
+  .media-card-play-trigger:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  /* Hover reveal is for precise pointers only, so a tap-emulated :hover on a
+     phone cannot uncover the controls. This deliberately uses a direct :hover
      selector: Tailwind's group-hover variant is limited to the primary
      pointer's (hover: hover) result, which can exclude Windows hybrid devices
      even while an attached mouse is actively hovering the card. */
-  .media-card-action-trigger,
-  .media-card-play-trigger {
-    opacity: 1;
-  }
-  .media-card-play-trigger {
-    pointer-events: auto;
-  }
   @media (any-hover: hover) and (any-pointer: fine) {
     .group\/media:hover .media-card-hover-dim {
       background-color: rgb(0 0 0 / 0.3);
     }
-    .media-card-action-trigger,
-    .media-card-play-trigger {
-      opacity: 0;
-    }
-    .media-card-play-trigger {
-      pointer-events: none;
-    }
     .group\/card:hover .media-card-action-trigger,
-    .media-card-action-trigger[data-state="open"],
-    .media-card-action-trigger:focus-visible,
-    .group\/media:hover .media-card-play-trigger,
-    .media-card-play-trigger:focus-visible {
+    .group\/media:hover .media-card-play-trigger {
       opacity: 1;
-    }
-    .group\/media:hover .media-card-play-trigger,
-    .media-card-play-trigger:focus-visible {
       pointer-events: auto;
+    }
+  }
+
+  /* A long press on a card opens the action sheet, so the browser's own image
+     and link callout has to stay out of the way. Text selection is only
+     disabled for coarse primary pointers: a mouse user can still select a
+     card's caption. */
+  .media-card-longpress {
+    -webkit-touch-callout: none;
+  }
+  @media (pointer: coarse) {
+    .media-card-longpress {
+      user-select: none;
     }
   }
 

--- a/web/src/components/ContinueWatchingCard.test.tsx
+++ b/web/src/components/ContinueWatchingCard.test.tsx
@@ -1,7 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
+import type { SectionItem } from "@/api/types";
 import ContinueWatchingCard from "./ContinueWatchingCard";
 
 const startPlayback = () => {};
@@ -9,6 +11,26 @@ const startPlayback = () => {};
 vi.mock("@/playback/watchPlaybackContext", () => ({
   useWatchPlaybackController: () => ({ startPlayback }),
 }));
+
+const continueMovie: SectionItem = {
+  content_id: "movie-001",
+  type: "movie",
+  title: "Apex",
+  year: 2024,
+  genres: [],
+  status: "matched",
+  rating_imdb: 6.5,
+  overview: "Movie overview",
+  item_source: "continue_watching",
+  position_seconds: 600,
+  duration_seconds: 7200,
+  progress_updated_at: "2026-03-07T00:00:00Z",
+  poster_url: "/movie-poster.jpg",
+  poster_thumbhash: "",
+  backdrop_url: "/movie-backdrop.jpg",
+  backdrop_thumbhash: "",
+  logo_url: "",
+};
 
 describe("ContinueWatchingCard", () => {
   it("prefers the backdrop image for section episodes (backdrop_url is the horizontal still)", () => {
@@ -47,8 +69,10 @@ describe("ContinueWatchingCard", () => {
 
     expect(markup).toContain('src="/episode-backdrop.jpg"');
     expect(markup).not.toContain('src="/season-poster.jpg"');
+    // Visibility of the play trigger is owned by app.css, not utility classes.
     expect(markup).toContain("media-card-play-trigger");
     expect(markup).not.toContain("pointer-fine:opacity-0");
+    expect(markup).not.toContain("opacity-0");
   });
 
   it("prefers the backdrop image for movies (poster_url is a vertical poster)", () => {
@@ -354,5 +378,23 @@ describe("ContinueWatchingCard", () => {
 
     expect(markup).toContain('href="/item/book-001?libraryId=7&amp;play=1"');
     expect(markup).not.toContain('href="/watch/book-001');
+  });
+
+  function renderCard() {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ContinueWatchingCard sectionItem={continueMovie} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    return screen.getByAltText("Apex").closest("a");
+  }
+
+  it("always points the artwork at the item detail page", () => {
+    expect(renderCard()).toHaveAttribute("href", "/item/movie-001");
+    // The caption also reaches the detail page.
+    expect(screen.getByText("Apex").closest("a")).toHaveAttribute("href", "/item/movie-001");
   });
 });

--- a/web/src/components/ContinueWatchingCard.tsx
+++ b/web/src/components/ContinueWatchingCard.tsx
@@ -1,6 +1,6 @@
 import ViewTransitionLink from "@/components/ViewTransitionLink";
 import { BookOpen, Play } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useLocation } from "react-router";
 import type { ItemDetail, SectionItem } from "@/api/types";
 import type { ProgressEntry } from "@/api/types";
@@ -36,6 +36,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
   const location = useLocation();
   const playbackController = useWatchPlaybackController();
   const { cardPresentation } = useUICustomization();
+  const cardRef = useRef<HTMLDivElement>(null);
   const card =
     "sectionItem" in props && props.sectionItem
       ? {
@@ -222,7 +223,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
   const imageSrc = imagePrimary || imageFallback;
 
   return (
-    <div className={`group/card ${containerWidth}`}>
+    <div ref={cardRef} className={`media-card-longpress group/card ${containerWidth}`}>
       <div className="group/media relative">
         <ViewTransitionLink to={detailHref} className="block">
           <div className={`media-card-image relative ${imageAspect} overflow-hidden rounded-xl`}>
@@ -297,6 +298,8 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
           showFavoriteShortcut={false}
           dismissAction={dismissAction}
           hasPartialProgress={hasPartialProgress}
+          longPressRef={cardRef}
+          itemTitle={heading}
         />
       </div>
 

--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useImageLoaded } from "@/hooks/useImageLoaded";
 import { Check, Layers } from "lucide-react";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
@@ -196,9 +197,10 @@ export default function ItemCard({
   const { cardPresentation } = useUICustomization();
   const showCaption = cardPresentation.caption !== "artwork";
   const showMetadata = cardPresentation.caption === "title_metadata";
+  const cardRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className="media-card group/card">
+    <div ref={cardRef} className="media-card media-card-longpress group/card">
       <div className="relative">
         <ViewTransitionLink
           to={itemHref}
@@ -307,6 +309,8 @@ export default function ItemCard({
           userState={item.user_state}
           variant="poster"
           narrowPosterActions={narrowPosterActions}
+          longPressRef={cardRef}
+          itemTitle={displayTitle}
         />
       </div>
       {showCaption ? (

--- a/web/src/components/MediaItemMenu.test.tsx
+++ b/web/src/components/MediaItemMenu.test.tsx
@@ -1,9 +1,10 @@
+import { act, useRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import type { ItemDetail } from "@/api/types";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MediaItemMenu, { buildMediaItemMenuModel, MetadataActionDialogHost } from "./MediaItemMenu";
 import { mediaItemMenuTriggerClassName } from "./mediaItemMenuTrigger";
 
@@ -380,14 +381,15 @@ describe("MediaItemMenu metadata dialogs", () => {
 });
 
 describe("MediaItemMenu trigger visibility", () => {
-  it("uses open state and keyboard focus without keeping a mouse-closed card focused", () => {
+  it("leaves reveal rules to the media-card CSS instead of utility classes", () => {
     const className = mediaItemMenuTriggerClassName();
 
     expect(className).toContain("media-card-action-trigger");
     expect(className).not.toContain("pointer-fine:");
-    expect(className).not.toContain("opacity-100");
-    expect(className).not.toContain("md:opacity-0");
+    expect(className).not.toContain("opacity-");
+    expect(className).not.toContain("group-hover");
     expect(className).not.toContain("group-focus-within");
+    expect(className).toContain("focus-visible:ring-2");
     expect(className).toContain("size-6");
     expect(className).toContain("sm:size-8");
   });
@@ -1019,5 +1021,128 @@ describe("MediaItemMenu trigger visibility", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "More actions" }));
     expect(screen.getByRole("menuitem", { name: "Add to Favorites" })).toBeTruthy();
+  });
+});
+
+describe("MediaItemMenu long-press action sheet", () => {
+  function LongPressCard({ onCardClick }: { onCardClick?: () => void }) {
+    const cardRef = useRef<HTMLDivElement>(null);
+
+    return (
+      <MemoryRouter>
+        <div ref={cardRef} data-testid="card">
+          <a href="/item/movie-1" onClick={onCardClick}>
+            Card link
+          </a>
+          <MediaItemMenu
+            contentId="movie-1"
+            mediaType="movie"
+            userState={{ played: false, is_favorite: false, in_watchlist: false }}
+            variant="poster"
+            longPressRef={cardRef}
+            itemTitle="Apex"
+          />
+        </div>
+      </MemoryRouter>
+    );
+  }
+
+  function pressCard(clientX = 40, clientY = 60) {
+    fireEvent.pointerDown(screen.getByTestId("card"), {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX,
+      clientY,
+    });
+  }
+
+  function holdPastLongPress() {
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens the sheet with the full action set after a touch hold", () => {
+    render(<LongPressCard />);
+
+    pressCard();
+    holdPastLongPress();
+
+    const sheet = screen.getByRole("dialog");
+    expect(within(sheet).getByText("Apex")).toBeTruthy();
+    expect(within(sheet).getByRole("button", { name: "Mark Watched" })).toBeTruthy();
+    expect(within(sheet).getByRole("button", { name: "Add to Favorites" })).toBeTruthy();
+    expect(within(sheet).getByRole("button", { name: "Add to Watchlist" })).toBeTruthy();
+  });
+
+  it("ignores mouse presses so precise pointers keep the hover controls", () => {
+    render(<LongPressCard />);
+
+    fireEvent.pointerDown(screen.getByTestId("card"), {
+      pointerId: 2,
+      pointerType: "mouse",
+      clientX: 40,
+      clientY: 60,
+    });
+    holdPastLongPress();
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("cancels the hold once the pointer moves like a carousel swipe", () => {
+    render(<LongPressCard />);
+
+    pressCard();
+    fireEvent.pointerMove(window, { pointerId: 1, pointerType: "touch", clientX: 96, clientY: 60 });
+    holdPastLongPress();
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("cancels the hold when the finger lifts before the delay", () => {
+    render(<LongPressCard />);
+
+    pressCard();
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    fireEvent.pointerUp(window, { pointerId: 1, pointerType: "touch", clientX: 40, clientY: 60 });
+    holdPastLongPress();
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("swallows the click the platform sends after the hold", () => {
+    const onCardClick = vi.fn();
+    render(<LongPressCard onCardClick={onCardClick} />);
+
+    pressCard();
+    holdPastLongPress();
+    fireEvent.pointerUp(window, { pointerId: 1, pointerType: "touch", clientX: 40, clientY: 60 });
+
+    const link = screen.getByText("Card link");
+    expect(fireEvent.click(link)).toBe(false);
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it("runs the selected action and closes the sheet", () => {
+    render(<LongPressCard />);
+
+    pressCard();
+    holdPastLongPress();
+    fireEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "Mark Watched" }),
+    );
+
+    expect(mocks.toggleWatched).toHaveBeenCalledWith(true);
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });

--- a/web/src/components/MediaItemMenu.tsx
+++ b/web/src/components/MediaItemMenu.tsx
@@ -1,4 +1,12 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Check,
   Eye,
@@ -42,6 +50,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useLongPress } from "@/hooks/useLongPress";
 import { cn } from "@/lib/utils";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { buildMediaPlayHref } from "@/lib/mediaNavigation";
@@ -102,6 +118,10 @@ interface MediaItemMenuProps {
   showWatchedShortcut?: boolean;
   /** Uses smaller poster controls on narrow catalog cards. */
   narrowPosterActions?: boolean;
+  /** Card root whose long press opens the touch action sheet. */
+  longPressRef?: RefObject<HTMLElement | null>;
+  /** Heading for the touch action sheet. */
+  itemTitle?: string;
 }
 
 export function buildMediaItemMenuModel({
@@ -255,6 +275,90 @@ function MediaItemMenuActionIcon({
     case "matchItem":
       return <MediaActionIcon action="matchItem" />;
   }
+}
+
+function MediaItemActionSheetRow({
+  disabled,
+  onSelect,
+  children,
+}: {
+  disabled?: boolean;
+  onSelect: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onSelect}
+      className="hover:bg-accent/60 active:bg-accent flex min-h-11 w-full items-center gap-3 px-5 py-3 text-left text-sm font-medium transition-colors disabled:opacity-50"
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Touch equivalent of the three-dot dropdown: the same action model presented
+ * as a bottom sheet, opened by long-pressing the card.
+ */
+function MediaItemActionSheet({
+  open,
+  onOpenChange,
+  title,
+  entries,
+  userState,
+  isPending,
+  isRefreshing,
+  onSelectAction,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  entries: MediaItemMenuEntry[];
+  userState?: MediaItemUserState;
+  isPending: boolean;
+  isRefreshing: boolean;
+  onSelectAction: (actionKey: MediaItemMenuActionKey) => void;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        showCloseButton={false}
+        className="max-h-[80svh] gap-0 overflow-y-auto rounded-t-2xl p-0 pb-[env(safe-area-inset-bottom)]"
+      >
+        <SheetHeader className="px-5 pt-4 pb-2">
+          <SheetTitle className="truncate text-left text-base">{title ?? "Actions"}</SheetTitle>
+          <SheetDescription className="sr-only">Choose an action for this item.</SheetDescription>
+        </SheetHeader>
+        <div className="flex flex-col pb-3">
+          {entries.map((entry, index) =>
+            entry.kind === "separator" ? (
+              <div
+                key={`separator-${index}`}
+                aria-hidden="true"
+                className="bg-border/60 my-1.5 h-px"
+              />
+            ) : (
+              <MediaItemActionSheetRow
+                key={entry.key}
+                disabled={isPending}
+                onSelect={() => onSelectAction(entry.key)}
+              >
+                <MediaItemMenuActionIcon
+                  actionKey={entry.key}
+                  userState={userState}
+                  isRefreshing={isRefreshing}
+                />
+                {entry.label}
+              </MediaItemActionSheetRow>
+            ),
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
 }
 
 function CardQuickActionButton({
@@ -562,6 +666,8 @@ export default function MediaItemMenu({
   hasPartialProgress = false,
   showWatchedShortcut = false,
   narrowPosterActions = false,
+  longPressRef,
+  itemTitle,
 }: MediaItemMenuProps) {
   const navigate = useViewTransitionNavigate();
   const location = useLocation();
@@ -577,6 +683,7 @@ export default function MediaItemMenu({
   const [refreshDialogOpen, setRefreshDialogOpen] = useState(false);
   const [filesDialogOpen, setFilesDialogOpen] = useState(false);
   const [metadataAction, setMetadataAction] = useState<MetadataAction | null>(null);
+  const [actionSheetOpen, setActionSheetOpen] = useState(false);
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
   const lastMenuInteractionRef = useRef<"keyboard" | "pointer" | null>(null);
   const pointerClosedMenuRef = useRef(false);
@@ -626,6 +733,10 @@ export default function MediaItemMenu({
     canCurateMetadata,
     showCollectionActions,
     dismissLabel,
+  });
+  useLongPress(longPressRef, {
+    onLongPress: () => setActionSheetOpen(true),
+    enabled: model.length > 0,
   });
   const showPosterFavorite =
     variant === "poster" &&
@@ -884,6 +995,19 @@ export default function MediaItemMenu({
           </DropdownMenu>
         )}
       </div>
+      <MediaItemActionSheet
+        open={actionSheetOpen}
+        onOpenChange={setActionSheetOpen}
+        title={itemTitle}
+        entries={model}
+        userState={currentUserState}
+        isPending={isPending}
+        isRefreshing={refreshMetadataMutation.isPending}
+        onSelectAction={(actionKey) => {
+          setActionSheetOpen(false);
+          void handleAction(actionKey);
+        }}
+      />
       <RefreshMetadataDialog
         open={refreshDialogOpen}
         onOpenChange={setRefreshDialogOpen}

--- a/web/src/components/SectionItemCard.tsx
+++ b/web/src/components/SectionItemCard.tsx
@@ -38,6 +38,7 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
   const showCaption = cardPresentation.caption !== "artwork";
   const showMetadata = cardPresentation.caption === "title_metadata";
   const cardRef = useRef<HTMLDivElement>(null);
+  const displayTitle = episodeLabels ? episodeLabels.seriesTitle : item.title;
 
   return (
     <div ref={cardRef} className="media-card media-card-longpress group/card">
@@ -102,14 +103,12 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
           userState={item.user_state}
           variant="poster"
           longPressRef={cardRef}
-          itemTitle={item.title}
+          itemTitle={displayTitle}
         />
       </div>
       {showCaption ? (
         <ViewTransitionLink to={itemHref} className="block px-1 pt-3">
-          <div className="truncate text-[14px] font-semibold tracking-tight">
-            {episodeLabels ? episodeLabels.seriesTitle : item.title}
-          </div>
+          <div className="truncate text-[14px] font-semibold tracking-tight">{displayTitle}</div>
           {showMetadata && upcomingEvent ? (
             <>
               {subtitle && (

--- a/web/src/components/SectionItemCard.tsx
+++ b/web/src/components/SectionItemCard.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useImageLoaded } from "@/hooks/useImageLoaded";
 import ViewTransitionLink from "@/components/ViewTransitionLink";
 import MediaItemMenu from "@/components/MediaItemMenu";
@@ -36,9 +37,10 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
   const { cardPresentation } = useUICustomization();
   const showCaption = cardPresentation.caption !== "artwork";
   const showMetadata = cardPresentation.caption === "title_metadata";
+  const cardRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className="media-card group/card">
+    <div ref={cardRef} className="media-card media-card-longpress group/card">
       <div className="relative">
         <ViewTransitionLink to={itemHref} className="block overflow-hidden rounded-xl">
           <div
@@ -99,6 +101,8 @@ export default function SectionItemCard({ item, libraryId }: SectionItemCardProp
           libraryId={libraryId}
           userState={item.user_state}
           variant="poster"
+          longPressRef={cardRef}
+          itemTitle={item.title}
         />
       </div>
       {showCaption ? (

--- a/web/src/hooks/useLongPress.ts
+++ b/web/src/hooks/useLongPress.ts
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+
+const LONG_PRESS_DELAY_MS = 500;
+/** A hold that drifts further than this is a carousel swipe or a page scroll. */
+const LONG_PRESS_MOVE_TOLERANCE_PX = 10;
+/**
+ * How long after a long press the follow-up click and callout are swallowed.
+ * The browser delivers them a few frames later — or, when the platform opens
+ * its own callout instead, not at all — so the window has to expire on its own.
+ */
+const LONG_PRESS_SUPPRESS_MS = 800;
+
+interface UseLongPressOptions {
+  onLongPress: () => void;
+  /** Skips all listeners when false (e.g. a card with no actions to offer). */
+  enabled?: boolean;
+}
+
+/**
+ * Fires `onLongPress` when a touch (or pen) press on `targetRef` is held still
+ * for {@link LONG_PRESS_DELAY_MS}, then suppresses the click and context menu
+ * the platform sends afterwards so the card's own link does not also navigate.
+ * Mouse presses are ignored: precise pointers use the hover controls instead.
+ */
+export function useLongPress(
+  targetRef: RefObject<HTMLElement | null> | undefined,
+  { onLongPress, enabled = true }: UseLongPressOptions,
+) {
+  // Held in a ref so a caller's inline callback cannot re-attach the listeners
+  // mid-press, which would cancel the hold on every parent render.
+  const onLongPressRef = useRef(onLongPress);
+  useEffect(() => {
+    onLongPressRef.current = onLongPress;
+  });
+
+  useEffect(() => {
+    const target = targetRef?.current;
+    if (!target || !enabled) return;
+
+    let timer: number | null = null;
+    let press: { pointerId: number; clientX: number; clientY: number } | null = null;
+    let suppressUntil = 0;
+
+    function stopTracking() {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+        timer = null;
+      }
+      press = null;
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerup", handlePointerUp);
+      window.removeEventListener("pointercancel", handlePointerUp);
+    }
+
+    function handlePointerMove(event: PointerEvent) {
+      if (!press || event.pointerId !== press.pointerId) return;
+      if (
+        Math.abs(event.clientX - press.clientX) > LONG_PRESS_MOVE_TOLERANCE_PX ||
+        Math.abs(event.clientY - press.clientY) > LONG_PRESS_MOVE_TOLERANCE_PX
+      ) {
+        stopTracking();
+      }
+    }
+
+    function handlePointerUp(event: PointerEvent) {
+      if (press && event.pointerId !== press.pointerId) return;
+      stopTracking();
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+      suppressUntil = 0;
+      stopTracking();
+      if (event.pointerType !== "touch" && event.pointerType !== "pen") return;
+
+      press = { pointerId: event.pointerId, clientX: event.clientX, clientY: event.clientY };
+      // Movement can leave the card (a swipe), so the follow-up listeners live
+      // on the window rather than the element.
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+      window.addEventListener("pointercancel", handlePointerUp);
+
+      timer = window.setTimeout(() => {
+        timer = null;
+        press = null;
+        suppressUntil = Date.now() + LONG_PRESS_SUPPRESS_MS;
+        onLongPressRef.current();
+      }, LONG_PRESS_DELAY_MS);
+    }
+
+    function handleClickCapture(event: MouseEvent) {
+      if (Date.now() > suppressUntil) return;
+      suppressUntil = 0;
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    function handleContextMenu(event: Event) {
+      if (!press && Date.now() > suppressUntil) return;
+      event.preventDefault();
+    }
+
+    target.addEventListener("pointerdown", handlePointerDown);
+    target.addEventListener("click", handleClickCapture, true);
+    target.addEventListener("contextmenu", handleContextMenu);
+    return () => {
+      stopTracking();
+      target.removeEventListener("pointerdown", handlePointerDown);
+      target.removeEventListener("click", handleClickCapture, true);
+      target.removeEventListener("contextmenu", handleContextMenu);
+    };
+  }, [enabled, targetRef]);
+}

--- a/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
+++ b/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Link } from "react-router";
 import { Play, ChevronLeft, ChevronRight } from "lucide-react";
 import type { EpisodeListItem } from "@/api/types";
@@ -55,121 +55,15 @@ export default function EpisodeCarousel({
 
         <div ref={emblaRef} className="embla__viewport overflow-hidden py-4 pl-4">
           <ul role="list" className="embla__container flex cursor-grab list-none gap-3">
-            {episodes.map((ep) => {
-              const isCurrent = ep.episode_number === currentEpisodeNumber;
-              const thumbhashUrl = ep.still_thumbhash ? decodeThumbhash(ep.still_thumbhash) : "";
-              const progress =
-                !ep.user_data?.played &&
-                (ep.user_data?.position_seconds ?? 0) > 0 &&
-                (ep.user_data?.duration_seconds ?? 0) > 0
-                  ? Math.max(
-                      0,
-                      Math.min(
-                        100,
-                        ((ep.user_data?.position_seconds ?? 0) /
-                          (ep.user_data?.duration_seconds ?? 1)) *
-                          100,
-                      ),
-                    )
-                  : null;
-
-              return (
-                <li
-                  key={ep.content_id}
-                  data-episode={ep.episode_number}
-                  className="embla__slide shrink-0"
-                >
-                  <div
-                    className="group/card w-[240px]"
-                    onMouseEnter={() => prefetchEpisodeDetail(ep.content_id)}
-                    onFocus={() => prefetchEpisodeDetail(ep.content_id)}
-                    onTouchStart={() => prefetchEpisodeDetail(ep.content_id)}
-                  >
-                    <div className="relative">
-                      <Link
-                        to={`/item/${ep.content_id}`}
-                        state={episodeLinkState}
-                        aria-current={isCurrent ? "page" : undefined}
-                        className="block"
-                      >
-                        <div
-                          className={cn(
-                            "surface-panel-subtle relative aspect-video overflow-hidden rounded-[1.1rem] border transition-[border-color,box-shadow] duration-200",
-                            isCurrent
-                              ? "border-transparent shadow-[0_0_0_2px_var(--primary)]"
-                              : "border-border/30",
-                          )}
-                          style={
-                            thumbhashUrl
-                              ? { backgroundImage: `url(${thumbhashUrl})`, backgroundSize: "cover" }
-                              : undefined
-                          }
-                        >
-                          {ep.still_url ? (
-                            <img
-                              src={ep.still_url}
-                              alt={ep.title || `Episode ${ep.episode_number}`}
-                              className="h-full w-full object-cover"
-                              loading="lazy"
-                            />
-                          ) : (
-                            <div className="bg-accent/30 flex h-full w-full items-center justify-center">
-                              <Play size={28} className="text-muted-foreground/30" />
-                            </div>
-                          )}
-                          {isCurrent && (
-                            <div className="bg-primary text-primary-foreground pointer-events-none absolute top-2.5 left-2.5 z-10 flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] leading-none font-semibold tracking-[0.08em] uppercase shadow-[0_2px_8px_rgb(0_0_0/0.28)]">
-                              <span className="relative flex size-1.5">
-                                <span className="bg-primary-foreground absolute inline-flex h-full w-full animate-ping rounded-full opacity-60" />
-                                <span className="bg-primary-foreground relative inline-flex size-1.5 rounded-full" />
-                              </span>
-                              Now Viewing
-                            </div>
-                          )}
-                          {progress != null && (
-                            <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
-                              <div
-                                className="h-full rounded-full"
-                                style={{ width: `${progress}%`, background: "var(--primary)" }}
-                              />
-                            </div>
-                          )}
-                        </div>
-                      </Link>
-                      <MediaItemMenu
-                        contentId={ep.content_id}
-                        mediaType="episode"
-                        userState={toEpisodeUserState(ep.user_data)}
-                        variant="wide"
-                        showCollectionActions={false}
-                        showWatchedShortcut
-                        hasPartialProgress={progress != null}
-                      />
-                    </div>
-                    <Link
-                      to={`/item/${ep.content_id}`}
-                      state={episodeLinkState}
-                      aria-current={isCurrent ? "page" : undefined}
-                      className="block"
-                    >
-                      <div className="text-muted-foreground/70 mt-2 flex items-center gap-2 text-xs">
-                        <span>Episode {ep.episode_number}</span>
-                        {ep.user_data?.played && <WatchedCheckIndicator className="ml-auto" />}
-                      </div>
-                      <p
-                        className="truncate text-sm font-semibold"
-                        style={isCurrent ? { color: "var(--primary)" } : undefined}
-                      >
-                        {ep.title || `Episode ${ep.episode_number}`}
-                      </p>
-                      {ep.runtime > 0 && (
-                        <p className="text-muted-foreground/70 text-xs">{ep.runtime}m</p>
-                      )}
-                    </Link>
-                  </div>
-                </li>
-              );
-            })}
+            {episodes.map((ep) => (
+              <EpisodeCarouselCard
+                key={ep.content_id}
+                ep={ep}
+                isCurrent={ep.episode_number === currentEpisodeNumber}
+                episodeLinkState={episodeLinkState}
+                onPrefetch={() => prefetchEpisodeDetail(ep.content_id)}
+              />
+            ))}
           </ul>
         </div>
 
@@ -185,5 +79,127 @@ export default function EpisodeCarousel({
         )}
       </div>
     </div>
+  );
+}
+
+function EpisodeCarouselCard({
+  ep,
+  isCurrent,
+  episodeLinkState,
+  onPrefetch,
+}: {
+  ep: EpisodeListItem;
+  isCurrent: boolean;
+  episodeLinkState?: EpisodeNavigationState;
+  onPrefetch: () => void;
+}) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const thumbhashUrl = ep.still_thumbhash ? decodeThumbhash(ep.still_thumbhash) : "";
+  const episodeTitle = ep.title || `Episode ${ep.episode_number}`;
+  const progress =
+    !ep.user_data?.played &&
+    (ep.user_data?.position_seconds ?? 0) > 0 &&
+    (ep.user_data?.duration_seconds ?? 0) > 0
+      ? Math.max(
+          0,
+          Math.min(
+            100,
+            ((ep.user_data?.position_seconds ?? 0) / (ep.user_data?.duration_seconds ?? 1)) * 100,
+          ),
+        )
+      : null;
+
+  return (
+    <li data-episode={ep.episode_number} className="embla__slide shrink-0">
+      <div
+        ref={cardRef}
+        className="media-card-longpress group/card w-[240px]"
+        onMouseEnter={onPrefetch}
+        onFocus={onPrefetch}
+        onTouchStart={onPrefetch}
+      >
+        <div className="relative">
+          <Link
+            to={`/item/${ep.content_id}`}
+            state={episodeLinkState}
+            aria-current={isCurrent ? "page" : undefined}
+            className="block"
+          >
+            <div
+              className={cn(
+                "surface-panel-subtle relative aspect-video overflow-hidden rounded-[1.1rem] border transition-[border-color,box-shadow] duration-200",
+                isCurrent
+                  ? "border-transparent shadow-[0_0_0_2px_var(--primary)]"
+                  : "border-border/30",
+              )}
+              style={
+                thumbhashUrl
+                  ? { backgroundImage: `url(${thumbhashUrl})`, backgroundSize: "cover" }
+                  : undefined
+              }
+            >
+              {ep.still_url ? (
+                <img
+                  src={ep.still_url}
+                  alt={episodeTitle}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              ) : (
+                <div className="bg-accent/30 flex h-full w-full items-center justify-center">
+                  <Play size={28} className="text-muted-foreground/30" />
+                </div>
+              )}
+              {isCurrent && (
+                <div className="bg-primary text-primary-foreground pointer-events-none absolute top-2.5 left-2.5 z-10 flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] leading-none font-semibold tracking-[0.08em] uppercase shadow-[0_2px_8px_rgb(0_0_0/0.28)]">
+                  <span className="relative flex size-1.5">
+                    <span className="bg-primary-foreground absolute inline-flex h-full w-full animate-ping rounded-full opacity-60" />
+                    <span className="bg-primary-foreground relative inline-flex size-1.5 rounded-full" />
+                  </span>
+                  Now Viewing
+                </div>
+              )}
+              {progress != null && (
+                <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
+                  <div
+                    className="h-full rounded-full"
+                    style={{ width: `${progress}%`, background: "var(--primary)" }}
+                  />
+                </div>
+              )}
+            </div>
+          </Link>
+          <MediaItemMenu
+            contentId={ep.content_id}
+            mediaType="episode"
+            userState={toEpisodeUserState(ep.user_data)}
+            variant="wide"
+            showCollectionActions={false}
+            showWatchedShortcut
+            hasPartialProgress={progress != null}
+            longPressRef={cardRef}
+            itemTitle={episodeTitle}
+          />
+        </div>
+        <Link
+          to={`/item/${ep.content_id}`}
+          state={episodeLinkState}
+          aria-current={isCurrent ? "page" : undefined}
+          className="block"
+        >
+          <div className="text-muted-foreground/70 mt-2 flex items-center gap-2 text-xs">
+            <span>Episode {ep.episode_number}</span>
+            {ep.user_data?.played && <WatchedCheckIndicator className="ml-auto" />}
+          </div>
+          <p
+            className="truncate text-sm font-semibold"
+            style={isCurrent ? { color: "var(--primary)" } : undefined}
+          >
+            {episodeTitle}
+          </p>
+          {ep.runtime > 0 && <p className="text-muted-foreground/70 text-xs">{ep.runtime}m</p>}
+        </Link>
+      </div>
+    </li>
   );
 }

--- a/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
+++ b/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { Link } from "react-router";
 import { Play } from "lucide-react";
 import type { EpisodeListItem } from "@/api/types";
@@ -7,7 +8,7 @@ import MediaItemMenu from "@/components/MediaItemMenu";
 import CardOverlays from "@/components/overlays/CardOverlays";
 import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
 import { usePrefetchCatalogItemDetail } from "@/hooks/queries/catalogRead";
-import { overlayDataFromEpisodeListItem } from "@/lib/overlays";
+import { overlayDataFromEpisodeListItem, type CardOverlayPrefs } from "@/lib/overlays";
 import { EpisodeGridSkeleton } from "./SectionSkeletons";
 import type { EpisodeNavigationState } from "../itemDetailLayout";
 
@@ -39,110 +40,128 @@ export default function SeasonEpisodeGrid({
 
   return (
     <div className="grid grid-cols-1 gap-4 min-[460px]:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-      {episodes.map((episode) => {
-        const hasPartialProgress =
-          !episode.user_data?.played &&
-          (episode.user_data?.position_seconds ?? 0) > 0 &&
-          (episode.user_data?.duration_seconds ?? 0) > 0;
+      {episodes.map((episode) => (
+        <SeasonEpisodeCard
+          key={episode.content_id}
+          episode={episode}
+          episodeLinkState={episodeLinkState}
+          overlayPrefs={overlayPrefs}
+          onPrefetch={() => prefetchEpisodeDetail(episode.content_id)}
+        />
+      ))}
+    </div>
+  );
+}
 
-        return (
-          <div
-            key={episode.content_id}
-            className="group/card media-card"
-            onMouseEnter={() => prefetchEpisodeDetail(episode.content_id)}
-            onFocus={() => prefetchEpisodeDetail(episode.content_id)}
-            onTouchStart={() => prefetchEpisodeDetail(episode.content_id)}
-          >
-            <div className="relative">
-              <Link
-                to={`/item/${episode.content_id}`}
-                state={episodeLinkState}
-                className="group block"
-              >
-                <div className="media-card-image relative aspect-video">
-                  {episode.still_url ? (
-                    <img
-                      src={episode.still_url}
-                      alt={episode.title || `Episode ${episode.episode_number}`}
-                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-                      loading="lazy"
-                    />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center">
-                      <Play size={32} className="text-muted-foreground/30" />
-                    </div>
-                  )}
-                  {overlayPrefs && (
-                    <CardOverlays
-                      data={overlayDataFromEpisodeListItem(episode)}
-                      prefs={overlayPrefs}
-                      variant="wide"
-                    />
-                  )}
-                  {!episode.user_data?.played &&
-                    (episode.user_data?.position_seconds ?? 0) > 0 &&
-                    (episode.user_data?.duration_seconds ?? 0) > 0 && (
-                      <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
-                        <div
-                          className="progress-fill h-full rounded-full"
-                          style={{
-                            width: `${Math.max(
-                              0,
-                              Math.min(
-                                100,
-                                ((episode.user_data?.position_seconds ?? 0) /
-                                  (episode.user_data?.duration_seconds ?? 1)) *
-                                  100,
-                              ),
-                            )}%`,
-                            background: "var(--primary)",
-                          }}
-                        />
-                      </div>
-                    )}
-                </div>
-              </Link>
-              <MediaItemMenu
-                contentId={episode.content_id}
-                mediaType="episode"
-                userState={toEpisodeUserState(episode.user_data)}
-                variant="wide"
-                showCollectionActions={false}
-                showWatchedShortcut
-                hasPartialProgress={hasPartialProgress}
+function SeasonEpisodeCard({
+  episode,
+  episodeLinkState,
+  overlayPrefs,
+  onPrefetch,
+}: {
+  episode: EpisodeListItem;
+  episodeLinkState?: EpisodeNavigationState;
+  overlayPrefs: CardOverlayPrefs | null;
+  onPrefetch: () => void;
+}) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const hasPartialProgress =
+    !episode.user_data?.played &&
+    (episode.user_data?.position_seconds ?? 0) > 0 &&
+    (episode.user_data?.duration_seconds ?? 0) > 0;
+  const episodeTitle = episode.title || `Episode ${episode.episode_number}`;
+
+  return (
+    <div
+      ref={cardRef}
+      className="group/card media-card media-card-longpress"
+      onMouseEnter={onPrefetch}
+      onFocus={onPrefetch}
+      onTouchStart={onPrefetch}
+    >
+      <div className="relative">
+        <Link to={`/item/${episode.content_id}`} state={episodeLinkState} className="group block">
+          <div className="media-card-image relative aspect-video">
+            {episode.still_url ? (
+              <img
+                src={episode.still_url}
+                alt={episodeTitle}
+                className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                loading="lazy"
               />
-            </div>
-            <Link to={`/item/${episode.content_id}`} state={episodeLinkState} className="block">
-              <div className="text-muted-foreground mt-2 flex items-center gap-2 text-xs">
-                <span>Episode {episode.episode_number}</span>
-                {episode.user_data?.played && <WatchedCheckIndicator className="ml-auto" />}
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <Play size={32} className="text-muted-foreground/30" />
               </div>
-              <p className="text-foreground truncate text-sm font-semibold">
-                {episode.title || `Episode ${episode.episode_number}`}
-              </p>
-              <div className="mt-1.5 space-y-1">
-                <div className="text-muted-foreground flex items-center gap-2 text-xs">
-                  {episode.runtime > 0 && <span>{episode.runtime}m</span>}
-                  {episode.air_date && (
-                    <span>
-                      {new Intl.DateTimeFormat(undefined, {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      }).format(new Date(episode.air_date))}
-                    </span>
-                  )}
+            )}
+            {overlayPrefs && (
+              <CardOverlays
+                data={overlayDataFromEpisodeListItem(episode)}
+                prefs={overlayPrefs}
+                variant="wide"
+              />
+            )}
+            {!episode.user_data?.played &&
+              (episode.user_data?.position_seconds ?? 0) > 0 &&
+              (episode.user_data?.duration_seconds ?? 0) > 0 && (
+                <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
+                  <div
+                    className="progress-fill h-full rounded-full"
+                    style={{
+                      width: `${Math.max(
+                        0,
+                        Math.min(
+                          100,
+                          ((episode.user_data?.position_seconds ?? 0) /
+                            (episode.user_data?.duration_seconds ?? 1)) *
+                            100,
+                        ),
+                      )}%`,
+                      background: "var(--primary)",
+                    }}
+                  />
                 </div>
-                {episode.overview && (
-                  <p className="text-muted-foreground line-clamp-2 text-xs leading-relaxed">
-                    {episode.overview}
-                  </p>
-                )}
-              </div>
-            </Link>
+              )}
           </div>
-        );
-      })}
+        </Link>
+        <MediaItemMenu
+          contentId={episode.content_id}
+          mediaType="episode"
+          userState={toEpisodeUserState(episode.user_data)}
+          variant="wide"
+          showCollectionActions={false}
+          showWatchedShortcut
+          hasPartialProgress={hasPartialProgress}
+          longPressRef={cardRef}
+          itemTitle={episodeTitle}
+        />
+      </div>
+      <Link to={`/item/${episode.content_id}`} state={episodeLinkState} className="block">
+        <div className="text-muted-foreground mt-2 flex items-center gap-2 text-xs">
+          <span>Episode {episode.episode_number}</span>
+          {episode.user_data?.played && <WatchedCheckIndicator className="ml-auto" />}
+        </div>
+        <p className="text-foreground truncate text-sm font-semibold">{episodeTitle}</p>
+        <div className="mt-1.5 space-y-1">
+          <div className="text-muted-foreground flex items-center gap-2 text-xs">
+            {episode.runtime > 0 && <span>{episode.runtime}m</span>}
+            {episode.air_date && (
+              <span>
+                {new Intl.DateTimeFormat(undefined, {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                }).format(new Date(episode.air_date))}
+              </span>
+            )}
+          </div>
+          {episode.overview && (
+            <p className="text-muted-foreground line-clamp-2 text-xs leading-relaxed">
+              {episode.overview}
+            </p>
+          )}
+        </div>
+      </Link>
     </div>
   );
 }

--- a/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
+++ b/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
@@ -101,27 +101,25 @@ function SeasonEpisodeCard({
                 variant="wide"
               />
             )}
-            {!episode.user_data?.played &&
-              (episode.user_data?.position_seconds ?? 0) > 0 &&
-              (episode.user_data?.duration_seconds ?? 0) > 0 && (
-                <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
-                  <div
-                    className="progress-fill h-full rounded-full"
-                    style={{
-                      width: `${Math.max(
-                        0,
-                        Math.min(
+            {hasPartialProgress && (
+              <div className="absolute inset-x-2 bottom-1.5 h-[3px] overflow-hidden rounded-full bg-black/40">
+                <div
+                  className="progress-fill h-full rounded-full"
+                  style={{
+                    width: `${Math.max(
+                      0,
+                      Math.min(
+                        100,
+                        ((episode.user_data?.position_seconds ?? 0) /
+                          (episode.user_data?.duration_seconds ?? 1)) *
                           100,
-                          ((episode.user_data?.position_seconds ?? 0) /
-                            (episode.user_data?.duration_seconds ?? 1)) *
-                            100,
-                        ),
-                      )}%`,
-                      background: "var(--primary)",
-                    }}
-                  />
-                </div>
-              )}
+                      ),
+                    )}%`,
+                    background: "var(--primary)",
+                  }}
+                />
+              </div>
+            )}
           </div>
         </Link>
         <MediaItemMenu


### PR DESCRIPTION
## Problem

Related issue: N/A — UX follow-up to #714 / #759

Since the hybrid-pointer card-action work (#714, 82533c8b6), touch devices show every media-card overlay control at rest: the center play button, the watched/favorite quick actions, and the three-dot menu. On a phone the home screen reads as a wall of buttons over the artwork, and the interaction model diverges from the native Apple/Android clients, where cards are clean and a long press opens the context menu.

## Approach

Match the native clients on the web:

- **CSS** (`app.css`): overlay triggers are hidden at rest everywhere (`opacity: 0; pointer-events: none`). Hover reveal is scoped to `@media (any-hover: hover) and (any-pointer: fine)` — still a direct `:hover` selector so hybrid Windows devices keep working — so tap-emulated `:hover` on touch can never uncover the controls. `:focus-visible` and `[data-state="open"]` reveal them on every device, so keyboard and assistive-tech users keep a visible, hittable target. Desktop behavior is unchanged.
- **Long press** (`hooks/useLongPress.ts`, new): a 500 ms touch/pen hold on the card fires the menu; > 10 px of drift (carousel swipe, page scroll) or early lift cancels it. The platform's follow-up click and context-menu callout are suppressed (`-webkit-touch-callout: none`, plus `user-select: none` under `(pointer: coarse)` only, so mouse users can still select captions). Mouse presses are ignored — precise pointers use hover.
- **Bottom sheet** (`MediaItemMenu.tsx`): the long press opens the existing `buildMediaItemMenuModel` action set as a bottom sheet (≥ 44 px rows, safe-area padding, item title header) instead of the small dropdown. The desktop three-dot dropdown is untouched.
- All five card surfaces are wired up: `ItemCard`, `SectionItemCard`, `ContinueWatchingCard` (Continue Watching + Next Up), `EpisodeCarousel`, `SeasonEpisodeGrid`. The per-episode markup in the last two was extracted into child components solely so each card can own a ref; `git diff -w` shows the markup is otherwise unchanged.

Tap behavior is deliberately untouched: tapping a card still opens the detail page, same as a desktop click.

No API, jellycompat, or client-repo impact — this is web-only presentation. `silo-apple`/`silo-android` already behave this way, which is the point.

## Validation

- `make test-web`: 293 files / 2165 tests pass. New coverage: sheet opens on touch hold, mouse press ignored, movement cancels, early lift cancels, platform follow-up click swallowed, row runs the action and closes.
- Full gate from CONTRIBUTING.md: `go build`/`gofmt`/`go vet`/`golangci-lint --new-from-merge-base` clean, web lint 0 errors, `format:check` and `pnpm run build` pass, `verify-settings-bindings-all` / `verify-playback-fixtures` / `verify-local-paths` pass.
- `make test-go`: 125 packages ok; `internal/jellycompat` fails 2 pre-existing process-lock tests (`TestBeginWebOperationRecoversDeadProcessLock`, `TestBeginWebOperationRejectsLiveProcessLock`) on this machine. The package is untouched by this branch and the failure reproduces without the diff — environment PID-liveness issue, flagged separately.
- Manually verified on a phone over Tailscale against the shared dev deployment (Vite dev server proxying to the real backend): clean cards at rest, long-press sheet on all card surfaces, carousel swipes don't trigger it, desktop hover unchanged. Served CSS was additionally inspected in-browser to confirm the media-query gating.
- No screenshots attached; the change was exercised live on-device rather than in a headless capture. Can add captures on request.

## Risks

- Real-iOS long-press timing (our 500 ms vs. Safari's native callout) is the one path not verified on Apple hardware; the click/callout suppression window is written to tolerate either event ordering. Worth a quick check on an iPhone before release.
- Touch users lose the one-tap resume affordance of the center play button on Continue Watching; resume is now tap → detail page → play, or long-press → Play from Beginning where applicable. This mirrors tap-to-detail on the native clients' rows.

## AI Disclosure

- Tool(s): Claude Code (orchestrator + subagents)
- Model(s): claude-fable-5 (orchestration, design, diff review), claude-opus-5 (implementation), claude-sonnet-5 (validation gate run, mechanical follow-up edits)
- Involvement: Fully AI-generated, human verified (maintainer exercised the change on-device against the shared dev deployment)
- Adversarial review: independent read-only reviewer pass over the full diff targeting useLongPress lifecycle/leaks, click-suppression, Embla drag interaction, desktop/a11y regressions, CSS cascade, and the episode-card extraction. One confirmed finding — on `ContinueWatchingCard` the long-press ref covered only the artwork while text-selection suppression covered the whole card, leaving the caption a dead zone — fixed by moving the ref to the card root to match the other card surfaces. Suppression-window and listener-lifecycle suspicions were investigated and dismissed with reasoning.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added long-press support on media cards for touch and pen devices, opening an action sheet with available item actions.
  - Long-press interactions cancel safely when the pointer moves or is released early.
  - Artwork and captions on continue-watching cards now link directly to item details.

- **Improvements**
  - Card actions and play controls appear only when needed through hover, keyboard focus, or open menus.
  - Improved touch behavior by preventing unwanted browser callouts, text selection, and accidental clicks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->