### PR TITLE
fix(catalog): bound search outbox retention

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -2159,6 +2159,7 @@ func main() {
 		catalogSearchIndexer := catalog.NewCatalogSearchIndexer(deps.DB, settingsRepo)
 		taskMgr.Register(tasks.NewSyncCatalogSearchIndexTask(catalogSearchIndexer))
 		taskMgr.Register(tasks.NewRebuildCatalogSearchIndexTask(catalogSearchIndexer))
+		taskMgr.Register(tasks.NewCatalogSearchEventRetentionTask(catalog.NewSearchIndexEventRepository(deps.DB)))
 		if deps.IntroAnalyzer != nil {
 			taskMgr.Register(tasks.NewDetectIntroMarkersTask(deps.IntroAnalyzer, settingsRepo))
 		}

--- a/internal/catalog/search_index_repo.go
+++ b/internal/catalog/search_index_repo.go
@@ -447,6 +447,54 @@ func (r *SearchIndexEventRepository) MarkFailed(ctx context.Context, ids []int64
 	return err
 }
 
+// PruneProcessed deletes one bounded batch of processed outbox events older
+// than cutoff and after the caller's keyset cursor. The persisted state
+// watermark is the recovery fence. Dead letters remain observable until a
+// later successful rebuild supersedes them; pending and newer events remain.
+func (r *SearchIndexEventRepository) PruneProcessed(ctx context.Context, provider string, cutoff time.Time, afterID int64, limit int) (deleted, lastID int64, err error) {
+	if r == nil || r.pool == nil || limit <= 0 {
+		return 0, afterID, nil
+	}
+	err = r.pool.QueryRow(ctx, `
+		WITH candidates AS (
+			SELECT events.id
+			FROM catalog_search_index_events AS events
+			JOIN catalog_search_index_state AS state
+			  ON state.provider = events.provider
+			WHERE events.provider = $1
+			  AND events.id <= state.last_processed_event_id
+			  AND events.processed_at < $2
+			  AND events.id > $4
+			  AND (
+			      (events.attempts < $3 AND events.last_error = '')
+			      OR (
+			          events.attempts >= $3
+			          AND events.last_error <> ''
+			          AND state.last_rebuild_at IS NOT NULL
+			          AND state.last_rebuild_at >= events.processed_at
+			      )
+			  )
+			ORDER BY events.id
+			LIMIT $5
+			FOR UPDATE OF events SKIP LOCKED
+		), deleted AS (
+			DELETE FROM catalog_search_index_events AS events
+			USING candidates
+			WHERE events.id = candidates.id
+			RETURNING events.id
+		)
+		SELECT COUNT(*), COALESCE(MAX(id), $4)
+		FROM deleted
+	`, provider, cutoff, searchIndexEventMaxAttempts, afterID, limit).Scan(&deleted, &lastID)
+	if isSearchIndexSchemaUnavailable(err) {
+		return 0, afterID, nil
+	}
+	if err != nil {
+		return 0, afterID, err
+	}
+	return deleted, lastID, nil
+}
+
 func (r *SearchIndexEventRepository) GetState(ctx context.Context, provider string) (SearchIndexState, error) {
 	state := SearchIndexState{Provider: provider}
 	if r == nil || r.pool == nil {

--- a/internal/catalog/search_index_repo_test.go
+++ b/internal/catalog/search_index_repo_test.go
@@ -2,11 +2,15 @@ package catalog
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type recordingSearchIndexExecer struct {
@@ -100,5 +104,110 @@ func TestItemRepositoryActiveProviderDisablesSearchIndexEvents(t *testing.T) {
 	}
 	if !repo.searchIndexEvents.disabledByActiveProvider() {
 		t.Fatal("postgres active provider should disable search index event work")
+	}
+}
+
+func TestPruneProcessedSearchIndexEventsPreservesRecoveryRows(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	provider := fmt.Sprintf("retention-test-%d", time.Now().UnixNano())
+	now := time.Now().UTC()
+	rows, err := pool.Query(ctx, `
+		INSERT INTO catalog_search_index_events (
+			provider, action, content_id, attempts, processed_at, last_error, created_at
+		)
+		VALUES
+			($1, 'upsert', 'old-success', 0, $2, '', $2),
+			($1, 'upsert', 'recent-success', 0, $3, '', $3),
+			($1, 'upsert', 'pending', 0, NULL, '', $2),
+			($1, 'upsert', 'dead-letter', $4, $5, 'dead-lettered', $5),
+			($1, 'upsert', 'superseded-dead-letter', $4, $2, 'dead-lettered', $2),
+			($1, 'upsert', 'above-watermark', 0, $2, '', $2)
+		RETURNING id, content_id
+	`, provider, now.Add(-48*time.Hour), now.Add(-30*time.Minute), searchIndexEventMaxAttempts, now.Add(-30*time.Hour))
+	if err != nil {
+		t.Fatalf("seed search events: %v", err)
+	}
+	ids := make(map[string]int64)
+	for rows.Next() {
+		var id int64
+		var contentID string
+		if err := rows.Scan(&id, &contentID); err != nil {
+			t.Fatalf("scan seeded search event: %v", err)
+		}
+		ids[contentID] = id
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read seeded search events: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM catalog_search_index_events WHERE provider = $1`, provider)
+		_, _ = pool.Exec(ctx, `DELETE FROM catalog_search_index_state WHERE provider = $1`, provider)
+	})
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO catalog_search_index_state (provider, last_processed_event_id)
+		VALUES ($1, $2)
+	`, provider, ids["superseded-dead-letter"]); err != nil {
+		t.Fatalf("seed search state: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE catalog_search_index_state
+		SET last_rebuild_at = $2
+		WHERE provider = $1
+	`, provider, now.Add(-36*time.Hour)); err != nil {
+		t.Fatalf("seed rebuild watermark: %v", err)
+	}
+
+	repo := NewSearchIndexEventRepository(pool)
+	deleted, lastID, err := repo.PruneProcessed(ctx, provider, now.Add(-24*time.Hour), 0, 1)
+	if err != nil {
+		t.Fatalf("PruneProcessed returned error: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("PruneProcessed deleted %d rows, want 1", deleted)
+	}
+	deleted, _, err = repo.PruneProcessed(ctx, provider, now.Add(-24*time.Hour), lastID, 10)
+	if err != nil {
+		t.Fatalf("second PruneProcessed returned error: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("second PruneProcessed deleted %d rows, want 1 superseded dead letter", deleted)
+	}
+
+	rows, err = pool.Query(ctx, `
+		SELECT content_id
+		FROM catalog_search_index_events
+		WHERE provider = $1
+		ORDER BY id
+	`, provider)
+	if err != nil {
+		t.Fatalf("list retained search events: %v", err)
+	}
+	var retained []string
+	for rows.Next() {
+		var contentID string
+		if err := rows.Scan(&contentID); err != nil {
+			t.Fatalf("scan retained search event: %v", err)
+		}
+		retained = append(retained, contentID)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read retained search events: %v", err)
+	}
+	want := []string{"recent-success", "pending", "dead-letter", "above-watermark"}
+	if !reflect.DeepEqual(retained, want) {
+		t.Fatalf("retained events = %v, want %v", retained, want)
 	}
 }

--- a/internal/taskmanager/tasks/catalog_search_event_retention.go
+++ b/internal/taskmanager/tasks/catalog_search_event_retention.go
@@ -1,0 +1,75 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+const (
+	catalogSearchEventRetention = 24 * time.Hour
+	catalogSearchEventBatchSize = 5000
+)
+
+type catalogSearchEventPruner interface {
+	PruneProcessed(ctx context.Context, provider string, cutoff time.Time, afterID int64, limit int) (deleted, lastID int64, err error)
+}
+
+// CatalogSearchEventRetentionTask bounds processed search outbox history
+// independently of whether new events are waiting to be synced.
+type CatalogSearchEventRetentionTask struct {
+	pruner catalogSearchEventPruner
+	now    func() time.Time
+}
+
+func NewCatalogSearchEventRetentionTask(pruner catalogSearchEventPruner) *CatalogSearchEventRetentionTask {
+	return &CatalogSearchEventRetentionTask{pruner: pruner, now: time.Now}
+}
+
+func (t *CatalogSearchEventRetentionTask) Key() string { return "cleanup_catalog_search_index_events" }
+func (t *CatalogSearchEventRetentionTask) Name() string {
+	return "Cleanup Catalog Search Index Events"
+}
+func (t *CatalogSearchEventRetentionTask) Description() string {
+	return "Prunes acknowledged catalog search outbox events after the recovery window."
+}
+func (t *CatalogSearchEventRetentionTask) Category() taskmanager.TaskCategory {
+	return taskmanager.TaskCategorySystem
+}
+func (t *CatalogSearchEventRetentionTask) IsHidden() bool { return false }
+func (t *CatalogSearchEventRetentionTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeStartup},
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: int64((24 * time.Hour) / time.Millisecond)},
+	}
+}
+
+func (t *CatalogSearchEventRetentionTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	if t == nil || t.pruner == nil {
+		progress.Report(100, "Catalog search event retention is not configured")
+		return nil
+	}
+	progress.Report(0, "Pruning processed catalog search events")
+	cutoff := t.now().Add(-catalogSearchEventRetention)
+	var total int64
+	var afterID int64
+	for {
+		deleted, lastID, err := t.pruner.PruneProcessed(ctx, catalog.SearchProviderMeilisearch, cutoff, afterID, catalogSearchEventBatchSize)
+		total += deleted
+		if err != nil {
+			return fmt.Errorf("catalog search event retention (deleted %d rows): %w", total, err)
+		}
+		afterID = lastID
+		if deleted < catalogSearchEventBatchSize {
+			// SKIP LOCKED can shorten a batch; any skipped rows remain safe and
+			// become eligible again on the next daily run.
+			break
+		}
+		progress.Report(50, fmt.Sprintf("Pruned %d processed catalog search events", total))
+	}
+	progress.Report(100, fmt.Sprintf("Pruned %d processed catalog search events", total))
+	return nil
+}

--- a/internal/taskmanager/tasks/catalog_search_event_retention_test.go
+++ b/internal/taskmanager/tasks/catalog_search_event_retention_test.go
@@ -1,0 +1,91 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type retentionPrunerCall struct {
+	provider string
+	cutoff   time.Time
+	afterID  int64
+	limit    int
+}
+
+type fakeCatalogSearchEventPruner struct {
+	results []retentionPruneResult
+	err     error
+	calls   []retentionPrunerCall
+}
+
+type retentionPruneResult struct {
+	deleted int64
+	lastID  int64
+}
+
+func (p *fakeCatalogSearchEventPruner) PruneProcessed(_ context.Context, provider string, cutoff time.Time, afterID int64, limit int) (int64, int64, error) {
+	p.calls = append(p.calls, retentionPrunerCall{provider: provider, cutoff: cutoff, afterID: afterID, limit: limit})
+	if len(p.results) == 0 {
+		return 0, afterID, p.err
+	}
+	result := p.results[0]
+	p.results = p.results[1:]
+	return result.deleted, result.lastID, p.err
+}
+
+type retentionProgress struct{ message string }
+
+func (p *retentionProgress) Report(_ float64, message string) { p.message = message }
+func (*retentionProgress) SetResultData(json.RawMessage)      {}
+
+func TestCatalogSearchEventRetentionTaskPrunesInBatches(t *testing.T) {
+	now := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	pruner := &fakeCatalogSearchEventPruner{results: []retentionPruneResult{
+		{deleted: catalogSearchEventBatchSize, lastID: 7000},
+		{deleted: 3, lastID: 9000},
+	}}
+	task := NewCatalogSearchEventRetentionTask(pruner)
+	task.now = func() time.Time { return now }
+	progress := &retentionProgress{}
+
+	if err := task.Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if len(pruner.calls) != 2 {
+		t.Fatalf("PruneProcessed calls = %d, want 2", len(pruner.calls))
+	}
+	if got := pruner.calls[1]; got.limit != catalogSearchEventBatchSize {
+		t.Fatalf("second PruneProcessed call = %+v", got)
+	}
+	if got := pruner.calls[1].afterID; got != 7000 {
+		t.Fatalf("second PruneProcessed afterID = %d, want 7000", got)
+	}
+	for _, call := range pruner.calls {
+		if call.provider != "meilisearch" || call.limit != catalogSearchEventBatchSize {
+			t.Fatalf("PruneProcessed call = %+v", call)
+		}
+		if want := now.Add(-catalogSearchEventRetention); !call.cutoff.Equal(want) {
+			t.Fatalf("cutoff = %v, want %v", call.cutoff, want)
+		}
+	}
+	if !strings.Contains(progress.message, "5003") {
+		t.Fatalf("final progress message = %q, want deleted total", progress.message)
+	}
+}
+
+func TestCatalogSearchEventRetentionTaskReportsPartialFailure(t *testing.T) {
+	pruner := &fakeCatalogSearchEventPruner{
+		results: []retentionPruneResult{{deleted: catalogSearchEventBatchSize, lastID: 5000}},
+		err:     errors.New("database unavailable"),
+	}
+	task := NewCatalogSearchEventRetentionTask(pruner)
+
+	err := task.Execute(context.Background(), &retentionProgress{})
+	if err == nil || !strings.Contains(err.Error(), "deleted 5000 rows") {
+		t.Fatalf("Execute error = %v, want partial deletion count", err)
+	}
+}

--- a/migrations/catalog_search_event_retention_test.go
+++ b/migrations/catalog_search_event_retention_test.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCatalogSearchEventRetentionMigrationUsesCrashSafePartialIndexSwap(t *testing.T) {
+	migrationBytes, err := FS.ReadFile("sql/20260826231720_catalog_search_event_retention.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	migration := strings.Join(strings.Fields(string(migrationBytes)), " ")
+	for _, fragment := range []string{
+		"-- +goose NO TRANSACTION",
+		"c.relname = 'idx_catalog_search_index_events_ready' AND NOT i.indisvalid",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_catalog_search_index_events_ready",
+		"ON public.catalog_search_index_events (provider, available_at, id) WHERE processed_at IS NULL",
+		"DROP INDEX CONCURRENTLY IF EXISTS public.idx_catalog_search_index_events_pending",
+		"c.relname = 'idx_catalog_search_index_events_pending' AND NOT i.indisvalid",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_catalog_search_index_events_pending",
+		"DROP INDEX CONCURRENTLY IF EXISTS public.idx_catalog_search_index_events_ready",
+	} {
+		if !strings.Contains(migration, fragment) {
+			t.Fatalf("catalog search event retention migration missing %q", fragment)
+		}
+	}
+}

--- a/migrations/sql/20260826231720_catalog_search_event_retention.sql
+++ b/migrations/sql/20260826231720_catalog_search_event_retention.sql
@@ -1,0 +1,56 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- Keep the sync hot-path index proportional to pending work. The original
+-- index included processed_at as a key and therefore retained every completed
+-- event even though pending queries always filter processed_at IS NULL.
+-- A failed concurrent build can leave an invalid index that makes IF NOT
+-- EXISTS skip the retry. Remove only that unusable artifact first.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'idx_catalog_search_index_events_ready'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.idx_catalog_search_index_events_ready;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_catalog_search_index_events_ready
+    ON public.catalog_search_index_events (provider, available_at, id)
+    WHERE processed_at IS NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_catalog_search_index_events_pending;
+
+-- +goose Down
+-- Apply the same crash-retry guard when restoring the original index.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND c.relname = 'idx_catalog_search_index_events_pending'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.idx_catalog_search_index_events_pending;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_catalog_search_index_events_pending
+    ON public.catalog_search_index_events (provider, processed_at, available_at, id);
+
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_catalog_search_index_events_ready;


### PR DESCRIPTION
## Problem

Related issue: #783

Successful Meilisearch outbox events were marked with `processed_at` but never
deleted. Once the pending count reached zero, the minute sync task stopped
running, so cleanup attached to that path would not bound the table. Processed
rows and the non-partial pending index therefore grew indefinitely.

## Approach

- Add a startup/daily retention task that deletes processed events older than
  24 hours in 5,000-row transactions.
- Fence deletion at `catalog_search_index_state.last_processed_event_id` and
  traverse batches with an ID cursor. Pending events and events above the
  persisted watermark remain untouched.
- Keep dead letters until a successful rebuild supersedes them. They become
  eligible after the same retention window once `last_rebuild_at` proves that
  the rebuilt index no longer depends on them.
- Replace the existing pending index with a partial index over unprocessed
  rows. The concurrent migration removes invalid indexes left by an interrupted
  build before retrying.

## Validation

Passed:

```text
go build ./...
go vet ./...
go test ./internal/catalog ./internal/taskmanager/tasks ./migrations ./cmd/silo
make migrate-validate
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --new-from-merge-base=origin/main ./...
make verify-local-paths
```

The lint command reported 0 issues. It emitted one non-fatal
`generated_file_filter` warning for a removed, unrelated Codex worktree.

A disposable isolated Linux sandbox built the frontend and backend from this
implementation. Health checks passed for the container, database, API, and frontend.
The migrated database had only the partial pending index, registered both
startup and 24-hour triggers, and recorded a completed startup cleanup. The
PostgreSQL regression test deleted an old acknowledged success and a
rebuild-superseded dead letter while retaining a recent success, pending event,
unsuperseded dead letter, and event above the watermark.

`make test-go` was also run. It failed in two untouched Jellycompat process-lock
tests on the Mac:

```text
TestBeginWebOperationRecoversDeadProcessLock
TestBeginWebOperationRejectsLiveProcessLock
```

All other packages in that run passed.

## Risks

The cleanup performs real deletion, but each row must be older than 24 hours
and at or below the persisted processing watermark. The query uses bounded
transactions and `SKIP LOCKED`, so concurrent cleanup instances do not block
each other. A shortened batch can leave locked rows for the next daily run.

Deleting rows lets PostgreSQL reuse the space after vacuuming. It does not
immediately reduce the table file on disk; that would require an operation such
as `VACUUM FULL` or `pg_repack`.

## AI Disclosure

- Tool(s): T3 Code (Codex harness); Claude Code via CLIProxy
- Model(s): `gpt-5.6-sol`; `fable`
- Involvement: AI-assisted
- Adversarial review: Fable reviewed the complete diff read-only for deletion safety, concurrency, recovery semantics, PostgreSQL migration failure modes, and performance. It found a concurrent-index retry hazard, repeated batch scans, and indefinite dead-letter retention. The patch now drops invalid index artifacts before retry, uses a keyset cursor, and retains dead letters only until a successful rebuild supersedes them. Database tests and the exact CI-version lint were rerun afterward.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
