### PR TITLE
feat(taskmanager): add bounded task history retention cleanup

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -2019,6 +2019,10 @@ func main() {
 		log.Fatalf("seed activitylog defaults: %v", err)
 	}
 
+	if err := taskmanager.SeedHistoryRetentionDefaults(ctx, settingsRepo); err != nil {
+		log.Fatalf("seed task history retention defaults: %v", err)
+	}
+
 	// Seed default page sections for home and existing libraries.
 	sectionRepo := sections.NewRepository(pool)
 	var folders []*models.MediaFolder
@@ -2172,7 +2176,7 @@ func main() {
 		}
 		taskMgr.Register(tasks.NewActivityLogCleanupTask(deps.DB, settingsRepo, activityPM))
 		taskMgr.Register(tasks.NewOperationalLogCleanupTask(deps.DB, settingsRepo, opsPM))
-		taskMgr.Register(tasks.NewTaskHistoryCleanupTask(historyRepo))
+		taskMgr.Register(tasks.NewTaskHistoryCleanupTask(historyRepo, settingsRepo))
 		var diagnosticsStore diagnostics.ObjectStore
 		if deps.S3Private != nil {
 			diagnosticsStore = diagnostics.NewS3ObjectStore(deps.S3Private)

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -2172,6 +2172,7 @@ func main() {
 		}
 		taskMgr.Register(tasks.NewActivityLogCleanupTask(deps.DB, settingsRepo, activityPM))
 		taskMgr.Register(tasks.NewOperationalLogCleanupTask(deps.DB, settingsRepo, opsPM))
+		taskMgr.Register(tasks.NewTaskHistoryCleanupTask(historyRepo))
 		var diagnosticsStore diagnostics.ObjectStore
 		if deps.S3Private != nil {
 			diagnosticsStore = diagnostics.NewS3ObjectStore(deps.S3Private)

--- a/internal/catalog/search_index_repo.go
+++ b/internal/catalog/search_index_repo.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -517,46 +516,6 @@ func (r *SearchIndexEventRepository) UpdateStateAfterSync(ctx context.Context, p
 		return nil
 	}
 	return err
-}
-
-type SearchIndexAdvisoryLock struct {
-	conn *pgxpool.Conn
-	key  int64
-}
-
-func (r *SearchIndexEventRepository) TryAdvisoryLock(ctx context.Context, key int64) (*SearchIndexAdvisoryLock, bool, error) {
-	if r == nil || r.pool == nil {
-		return nil, false, nil
-	}
-	conn, err := r.pool.Acquire(ctx)
-	if err != nil {
-		return nil, false, err
-	}
-	var locked bool
-	if err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, key).Scan(&locked); err != nil {
-		conn.Release()
-		return nil, false, err
-	}
-	if !locked {
-		conn.Release()
-		return nil, false, nil
-	}
-	return &SearchIndexAdvisoryLock{conn: conn, key: key}, true, nil
-}
-
-func (l *SearchIndexAdvisoryLock) Close(ctx context.Context) error {
-	if l == nil || l.conn == nil {
-		return nil
-	}
-	defer l.conn.Release()
-	var unlocked bool
-	if err := l.conn.QueryRow(ctx, `SELECT pg_advisory_unlock($1)`, l.key).Scan(&unlocked); err != nil {
-		return err
-	}
-	if !unlocked {
-		return fmt.Errorf("search index advisory lock %d was not held", l.key)
-	}
-	return nil
 }
 
 func isSearchIndexSchemaUnavailable(err error) bool {

--- a/internal/catalog/search_indexer.go
+++ b/internal/catalog/search_indexer.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/database/pglock"
 	"github.com/Silo-Server/silo-server/internal/embeddingvectors"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -114,7 +115,7 @@ func (i *CatalogSearchIndexer) SyncOutbox(ctx context.Context, progress SearchIn
 	}
 	stats.Configured = true
 
-	lock, locked, err := i.events.TryAdvisoryLock(ctx, searchIndexMaintenanceLockID)
+	lock, locked, err := pglock.TryAcquire(ctx, i.pool, searchIndexMaintenanceLockID)
 	if err != nil {
 		return stats, err
 	}
@@ -125,7 +126,12 @@ func (i *CatalogSearchIndexer) SyncOutbox(ctx context.Context, progress SearchIn
 		reportSearchIndexProgress(progress, 100, "Another catalog search index maintenance task is already running")
 		return stats, nil
 	}
-	defer lock.Close(context.Background())
+	defer func() {
+		if err := lock.Release(ctx); err != nil {
+			slog.WarnContext(ctx, "releasing catalog search index maintenance lock",
+				"component", "catalog", "error", err)
+		}
+	}()
 
 	state, err := i.events.GetState(ctx, SearchProviderMeilisearch)
 	if err != nil {
@@ -247,7 +253,7 @@ func (i *CatalogSearchIndexer) Rebuild(ctx context.Context, progress SearchIndex
 	}
 	stats.Configured = true
 
-	lock, locked, err := i.events.TryAdvisoryLock(ctx, searchIndexMaintenanceLockID)
+	lock, locked, err := pglock.TryAcquire(ctx, i.pool, searchIndexMaintenanceLockID)
 	if err != nil {
 		return stats, err
 	}
@@ -258,7 +264,12 @@ func (i *CatalogSearchIndexer) Rebuild(ctx context.Context, progress SearchIndex
 		reportSearchIndexProgress(progress, 100, "Another catalog search index maintenance task is already running")
 		return stats, nil
 	}
-	defer lock.Close(context.Background())
+	defer func() {
+		if err := lock.Release(ctx); err != nil {
+			slog.WarnContext(ctx, "releasing catalog search index maintenance lock",
+				"component", "catalog", "error", err)
+		}
+	}()
 
 	rebuildEventHighWater, err := i.events.MaxEventID(ctx, SearchProviderMeilisearch)
 	if err != nil {

--- a/internal/config/admin_settings.go
+++ b/internal/config/admin_settings.go
@@ -170,6 +170,9 @@ var adminSettingDefaults = map[string]string{
 	"notifications.apple_push_delivery_enabled":                "false",
 	"notifications.android_push_delivery_enabled":              "false",
 
+	"taskmanager.history_retention_days": "30",
+	"taskmanager.history_keep_per_task":  "1000",
+
 	"opslog.retention_days":           "7",
 	"opslog.cleanup_interval_minutes": "15",
 	"opslog.max_rows":                 "1000000",
@@ -370,6 +373,10 @@ func NormalizeAdminSetting(key, raw string) (string, error) {
 		return normalizeAdminInt(key, value, 1, 25000)
 	case "catalog.search.meilisearch.rebuild_task_queue_depth":
 		return normalizeAdminInt(key, value, 1, 16)
+	case "taskmanager.history_retention_days":
+		return normalizeAdminInt(key, value, 1, 3650)
+	case "taskmanager.history_keep_per_task":
+		return normalizeAdminInt(key, value, 1, math.MaxInt32)
 	case "opslog.retention_days", "opslog.cleanup_interval_minutes":
 		return normalizeAdminInt(key, value, 1, math.MaxInt32)
 	case "opslog.max_rows", "opslog.max_size_mb":

--- a/internal/database/pglock/pglock.go
+++ b/internal/database/pglock/pglock.go
@@ -1,0 +1,95 @@
+// Package pglock provides session-level PostgreSQL advisory locks that are
+// safe to use with a connection pool.
+//
+// A session-level advisory lock lives on the connection that took it, so a
+// connection returned to the pool while still holding the lock poisons every
+// later borrower of that connection: the lock is never observable as free
+// again and every node that guards work with it silently skips forever.
+// [Lock.Release] therefore destroys the connection instead of returning it to
+// the pool whenever the unlock cannot be confirmed.
+package pglock
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// releaseTimeout bounds the unlock round trip so a caller whose own context
+// has already been canceled still gets a chance to release cleanly instead of
+// always throwing the connection away.
+const releaseTimeout = 5 * time.Second
+
+// Lock is a held session-level advisory lock and the connection holding it.
+type Lock struct {
+	conn *pgxpool.Conn
+	key  int64
+}
+
+// TryAcquire takes advisory lock key without blocking. It reports acquired
+// false (with a nil Lock and no error) when another session already holds the
+// lock, or when pool is nil, so callers can treat "someone else is doing this"
+// and "no database configured" as the same skip.
+//
+// The caller owns the returned Lock and must call Release exactly once.
+func TryAcquire(ctx context.Context, pool *pgxpool.Pool, key int64) (*Lock, bool, error) {
+	if pool == nil {
+		return nil, false, nil
+	}
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("acquiring connection for advisory lock %d: %w", key, err)
+	}
+	var locked bool
+	if err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, key).Scan(&locked); err != nil {
+		conn.Release()
+		return nil, false, fmt.Errorf("acquiring advisory lock %d: %w", key, err)
+	}
+	if !locked {
+		conn.Release()
+		return nil, false, nil
+	}
+	return &Lock{conn: conn, key: key}, true, nil
+}
+
+// Conn exposes the connection holding the lock. Work that must be serialized
+// against the lock may run on any connection; this is for callers that want to
+// keep it on the locked session.
+func (l *Lock) Conn() *pgxpool.Conn {
+	if l == nil {
+		return nil
+	}
+	return l.conn
+}
+
+// Release unlocks and returns the connection to the pool. If the unlock fails
+// or reports that the lock was not held, the connection is hijacked out of the
+// pool and closed so the stranded lock dies with it.
+//
+// Release is idempotent and safe on a nil Lock.
+func (l *Lock) Release(ctx context.Context) error {
+	if l == nil || l.conn == nil {
+		return nil
+	}
+	conn := l.conn
+	l.conn = nil
+
+	releaseCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout)
+	defer cancel()
+
+	var unlocked bool
+	err := conn.QueryRow(releaseCtx, `SELECT pg_advisory_unlock($1)`, l.key).Scan(&unlocked)
+	if err == nil && unlocked {
+		conn.Release()
+		return nil
+	}
+
+	rawConn := conn.Hijack()
+	_ = rawConn.Close(context.WithoutCancel(ctx))
+	if err != nil {
+		return fmt.Errorf("releasing advisory lock %d: %w", l.key, err)
+	}
+	return fmt.Errorf("releasing advisory lock %d: lock was not held", l.key)
+}

--- a/internal/database/pglock/pglock_test.go
+++ b/internal/database/pglock/pglock_test.go
@@ -1,0 +1,124 @@
+package pglock
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// pglockTestKey is outside the ranges any product code uses, so these tests
+// cannot collide with a real lock in a shared test database.
+const pglockTestKey int64 = 0x70676C6F636B01
+
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func lockHeld(t *testing.T, pool *pgxpool.Pool, key int64) bool {
+	t.Helper()
+	var held bool
+	err := pool.QueryRow(context.Background(), `
+		SELECT EXISTS (
+			SELECT 1 FROM pg_locks
+			WHERE locktype = 'advisory'
+				AND granted
+				AND ((classid::bigint << 32) | objid::bigint) = $1
+		)`, key).Scan(&held)
+	if err != nil {
+		t.Fatalf("inspect pg_locks: %v", err)
+	}
+	return held
+}
+
+func TestTryAcquireExcludesSecondHolder(t *testing.T) {
+	pool := testPool(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lock, acquired, err := TryAcquire(ctx, pool, pglockTestKey)
+	if err != nil || !acquired {
+		t.Fatalf("TryAcquire = (%v, %v), want acquired", acquired, err)
+	}
+
+	second, acquired, err := TryAcquire(ctx, pool, pglockTestKey)
+	if err != nil {
+		t.Fatalf("second TryAcquire: %v", err)
+	}
+	if acquired {
+		_ = second.Release(ctx)
+		t.Fatal("second TryAcquire acquired a lock already held")
+	}
+
+	if err := lock.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if lockHeld(t, pool, pglockTestKey) {
+		t.Fatal("advisory lock still held after Release")
+	}
+
+	third, acquired, err := TryAcquire(ctx, pool, pglockTestKey)
+	if err != nil || !acquired {
+		t.Fatalf("TryAcquire after Release = (%v, %v), want acquired", acquired, err)
+	}
+	if err := third.Release(ctx); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+}
+
+// TestReleaseDoesNotReturnAStrandedLockToThePool covers the failure the shared
+// helper exists to prevent: if the unlock does not confirm, the connection must
+// not go back into the pool still holding a session-level lock.
+func TestReleaseDoesNotReturnAStrandedLockToThePool(t *testing.T) {
+	pool := testPool(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	lock, acquired, err := TryAcquire(ctx, pool, pglockTestKey)
+	if err != nil || !acquired {
+		t.Fatalf("TryAcquire = (%v, %v), want acquired", acquired, err)
+	}
+
+	// Unlock out of band so the helper's own unlock reports "was not held".
+	var unlocked bool
+	if err := lock.Conn().QueryRow(ctx, `SELECT pg_advisory_unlock($1)`, pglockTestKey).Scan(&unlocked); err != nil {
+		t.Fatalf("out of band unlock: %v", err)
+	}
+	if !unlocked {
+		t.Fatal("out of band unlock reported the lock was not held")
+	}
+
+	if err := lock.Release(ctx); err == nil {
+		t.Fatal("Release reported success for an unheld lock")
+	}
+	if lockHeld(t, pool, pglockTestKey) {
+		t.Fatal("advisory lock still held after Release")
+	}
+
+	// A second Release is a no-op rather than a double free.
+	if err := lock.Release(ctx); err != nil {
+		t.Fatalf("second Release: %v", err)
+	}
+}
+
+func TestTryAcquireNilPoolReportsNotAcquired(t *testing.T) {
+	lock, acquired, err := TryAcquire(context.Background(), nil, pglockTestKey)
+	if err != nil || acquired || lock != nil {
+		t.Fatalf("TryAcquire(nil pool) = (%v, %v, %v), want (nil, false, nil)", lock, acquired, err)
+	}
+	if err := lock.Release(context.Background()); err != nil {
+		t.Fatalf("Release on nil lock: %v", err)
+	}
+}

--- a/internal/taskmanager/history.go
+++ b/internal/taskmanager/history.go
@@ -18,11 +18,12 @@ type ExecutionResult struct {
 	DurationMs   int64           `json:"duration_ms"`
 }
 
-// HistoryPruneResult describes one bounded task history cleanup run.
+// HistoryPruneResult describes one bounded task history cleanup run. It is
+// persisted verbatim as the cleanup task's result_data.
 type HistoryPruneResult struct {
-	Deleted      int64
-	LimitReached bool
-	Skipped      bool
+	Deleted      int64 `json:"deleted"`
+	LimitReached bool  `json:"limit_reached"`
+	Skipped      bool  `json:"skipped"`
 }
 
 // ExecutionRepository persists task execution history.

--- a/internal/taskmanager/history.go
+++ b/internal/taskmanager/history.go
@@ -18,6 +18,13 @@ type ExecutionResult struct {
 	DurationMs   int64           `json:"duration_ms"`
 }
 
+// HistoryPruneResult describes one bounded task history cleanup run.
+type HistoryPruneResult struct {
+	Deleted      int64
+	LimitReached bool
+	Skipped      bool
+}
+
 // ExecutionRepository persists task execution history.
 type ExecutionRepository interface {
 	Insert(ctx context.Context, result ExecutionResult) error

--- a/internal/taskmanager/repository/postgres_history.go
+++ b/internal/taskmanager/repository/postgres_history.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/Silo-Server/silo-server/internal/database/pglock"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
@@ -92,6 +94,13 @@ func (r *PgExecutionRepository) List(ctx context.Context, taskKey string, limit 
 // policy. A database advisory lock ensures only one Silo node prunes at a time.
 // It always preserves the newest execution for every task, including tasks
 // that are no longer registered.
+//
+// The work is driven per task key rather than by ranking the whole table.
+// After one pass to enumerate the (handful of) distinct task keys, every
+// boundary lookup and delete is a range scan of
+// idx_task_executions_key_completed (task_key, completed_at DESC). A run with
+// nothing to delete costs two index probes per task, where ranking the whole
+// table cost a full-table window sort per batch — up to maxBatches of them.
 func (r *PgExecutionRepository) Prune(
 	ctx context.Context,
 	keepPerTask int,
@@ -99,106 +108,227 @@ func (r *PgExecutionRepository) Prune(
 	batchSize int,
 	maxBatches int,
 ) (pruneResult taskmanager.HistoryPruneResult, returnErr error) {
-	if keepPerTask < 1 {
-		return pruneResult, fmt.Errorf("pruning task executions: keep per task must be positive")
-	}
-	if batchSize < 1 {
-		return pruneResult, fmt.Errorf("pruning task executions: batch size must be positive")
-	}
-	if maxBatches < 1 {
-		return pruneResult, fmt.Errorf("pruning task executions: max batches must be positive")
-	}
-
-	conn, err := r.pool.Acquire(ctx)
+	lock, acquired, err := pglock.TryAcquire(ctx, r.pool, taskHistoryCleanupAdvisoryLock)
 	if err != nil {
-		return pruneResult, fmt.Errorf("acquiring task history cleanup connection: %w", err)
-	}
-	var acquired bool
-	if err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, taskHistoryCleanupAdvisoryLock).Scan(&acquired); err != nil {
-		conn.Release()
 		return pruneResult, fmt.Errorf("acquiring task history cleanup lock: %w", err)
 	}
 	if !acquired {
-		conn.Release()
 		pruneResult.Skipped = true
 		return pruneResult, nil
 	}
 	defer func() {
-		unlockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		var unlocked bool
-		unlockErr := conn.QueryRow(unlockCtx, `SELECT pg_advisory_unlock($1)`, taskHistoryCleanupAdvisoryLock).Scan(&unlocked)
-		if unlockErr == nil && unlocked {
-			conn.Release()
-			return
-		}
-
-		// A session-level advisory lock survives connection pooling. Destroy the
-		// connection if it could not be unlocked so the lock cannot leak back
-		// into the pool.
-		rawConn := conn.Hijack()
-		_ = rawConn.Close(context.Background())
-		if returnErr == nil {
-			if unlockErr != nil {
-				returnErr = fmt.Errorf("releasing task history cleanup lock: %w", unlockErr)
-			} else {
-				returnErr = fmt.Errorf("releasing task history cleanup lock: lock was not held")
-			}
+		if err := lock.Release(ctx); err != nil && returnErr == nil {
+			returnErr = fmt.Errorf("task history cleanup: %w", err)
 		}
 	}()
 
-	for range maxBatches {
+	keys, err := r.listTaskKeys(ctx)
+	if err != nil {
+		return pruneResult, err
+	}
+
+	batches := 0
+	for i, key := range keys {
 		if err := ctx.Err(); err != nil {
 			return pruneResult, err
 		}
-		deleted, err := pruneTaskHistoryBatch(ctx, conn, keepPerTask, cutoff, batchSize)
-		pruneResult.Deleted += deleted
+		doomed, ok, err := r.loadDoomedBounds(ctx, key, keepPerTask, cutoff)
 		if err != nil {
 			return pruneResult, err
 		}
-		if deleted < int64(batchSize) {
-			return pruneResult, nil
+		if !ok {
+			continue
+		}
+		for {
+			if batches >= maxBatches {
+				// The budget ran out before this key was proven clean. Only
+				// report the cap when work actually remains, so a doomed count
+				// that happens to be an exact multiple of batchSize does not
+				// look like a truncated run.
+				remaining, err := r.anyDoomedRemaining(ctx, keys[i:], keepPerTask, cutoff)
+				if err != nil {
+					return pruneResult, err
+				}
+				pruneResult.LimitReached = remaining
+				return pruneResult, nil
+			}
+			deleted, err := deleteTaskHistoryBatch(ctx, r.pool, doomed, batchSize)
+			batches++
+			pruneResult.Deleted += deleted
+			if err != nil {
+				return pruneResult, err
+			}
+			if deleted < int64(batchSize) {
+				break
+			}
 		}
 	}
-	pruneResult.LimitReached = true
 	return pruneResult, nil
 }
 
-func pruneTaskHistoryBatch(
+func (r *PgExecutionRepository) listTaskKeys(ctx context.Context) ([]string, error) {
+	rows, err := r.pool.Query(ctx, `SELECT DISTINCT task_key FROM task_executions`)
+	if err != nil {
+		return nil, fmt.Errorf("listing task history keys: %w", err)
+	}
+	defer rows.Close()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("scanning task history key: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listing task history keys: %w", err)
+	}
+	return keys, nil
+}
+
+// taskHistoryDoomedBounds is the delete predicate for one task key, expressed
+// as tuple comparisons against two boundary rows instead of a window rank.
+//
+// Ranking rows by (completed_at DESC, id DESC) makes "rank > n" identical to
+// "sorts strictly before the rank-n row in ascending (completed_at, id)
+// order", which is exactly the row-value comparison (completed_at, id) < (ts,
+// id) that Postgres can answer from the (task_key, completed_at DESC) index.
+type taskHistoryDoomedBounds struct {
+	taskKey string
+
+	// newest is the rank-1 row. Every doomed row sorts strictly below it, which
+	// is how the newest execution of a task always survives.
+	newestAt time.Time
+	newestID int64
+
+	// boundary is the rank-keepPerTask row, absent when the task has fewer than
+	// keepPerTask executions (nothing exceeds the count cap then).
+	boundaryAt  time.Time
+	boundaryID  int64
+	hasBoundary bool
+
+	cutoff time.Time
+}
+
+// where renders the doomed predicate and its arguments. A row is doomed when
+// it is not the newest for its task AND it is either older than the cutoff or
+// beyond the count cap.
+func (b taskHistoryDoomedBounds) where() (string, []any) {
+	args := []any{b.taskKey, b.newestAt, b.newestID, b.cutoff}
+	clause := `task_key = $1
+		AND (completed_at, id) < ($2, $3)
+		AND completed_at < $4`
+	if b.hasBoundary {
+		args = append(args, b.boundaryAt, b.boundaryID)
+		clause = `task_key = $1
+		AND (completed_at, id) < ($2, $3)
+		AND (completed_at < $4 OR (completed_at, id) < ($5, $6))`
+	}
+	return clause, args
+}
+
+// loadDoomedBounds resolves the two boundary rows for a task key. It reports
+// false when the task has no executions at all.
+func (r *PgExecutionRepository) loadDoomedBounds(
 	ctx context.Context,
-	execer taskHistoryExecer,
+	taskKey string,
 	keepPerTask int,
 	cutoff time.Time,
+) (taskHistoryDoomedBounds, bool, error) {
+	bounds := taskHistoryDoomedBounds{taskKey: taskKey, cutoff: cutoff}
+	err := r.pool.QueryRow(ctx, `
+		SELECT completed_at, id
+		FROM task_executions
+		WHERE task_key = $1
+		ORDER BY completed_at DESC, id DESC
+		LIMIT 1`, taskKey,
+	).Scan(&bounds.newestAt, &bounds.newestID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return bounds, false, nil
+		}
+		return bounds, false, fmt.Errorf("reading newest task execution for %s: %w", taskKey, err)
+	}
+
+	// keepPerTask is clamped by the settings reader; guard the OFFSET anyway so
+	// a stray zero degrades to "keep the newest one" rather than erroring.
+	offset := max(keepPerTask-1, 0)
+	err = r.pool.QueryRow(ctx, `
+		SELECT completed_at, id
+		FROM task_executions
+		WHERE task_key = $1
+		ORDER BY completed_at DESC, id DESC
+		OFFSET $2
+		LIMIT 1`, taskKey, offset,
+	).Scan(&bounds.boundaryAt, &bounds.boundaryID)
+	switch {
+	case err == nil:
+		bounds.hasBoundary = true
+	case errors.Is(err, pgx.ErrNoRows):
+		bounds.hasBoundary = false
+	default:
+		return bounds, false, fmt.Errorf("reading task execution retention boundary for %s: %w", taskKey, err)
+	}
+	return bounds, true, nil
+}
+
+// anyDoomedRemaining probes the given keys for leftover work. The key list is
+// bounded by the number of task keys ever recorded, so this stays a handful of
+// index probes even in the worst case.
+func (r *PgExecutionRepository) anyDoomedRemaining(
+	ctx context.Context,
+	taskKeys []string,
+	keepPerTask int,
+	cutoff time.Time,
+) (bool, error) {
+	for _, key := range taskKeys {
+		doomed, ok, err := r.loadDoomedBounds(ctx, key, keepPerTask, cutoff)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			continue
+		}
+		clause, args := doomed.where()
+		var exists bool
+		if err := r.pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM task_executions WHERE `+clause+` LIMIT 1)`,
+			args...,
+		).Scan(&exists); err != nil {
+			return false, fmt.Errorf("probing remaining task executions for %s: %w", key, err)
+		}
+		if exists {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// deleteTaskHistoryBatch deletes up to batchSize doomed rows for one task key.
+// The inner SELECT deliberately has no ORDER BY: the advisory lock makes this
+// the only pruner, and the delete predicate is fixed for the whole run, so any
+// subset converges in the same number of batches.
+func deleteTaskHistoryBatch(
+	ctx context.Context,
+	execer taskHistoryExecer,
+	doomed taskHistoryDoomedBounds,
 	batchSize int,
 ) (int64, error) {
-	result, err := execer.Exec(ctx, `
-		WITH ranked AS (
-			SELECT
-				id,
-				completed_at,
-				row_number() OVER (
-					PARTITION BY task_key
-					ORDER BY completed_at DESC, id DESC
-				) AS recent_rank
-			FROM task_executions
-		),
-		doomed AS (
+	clause, args := doomed.where()
+	args = append(args, batchSize)
+	result, err := execer.Exec(ctx, fmt.Sprintf(`
+		DELETE FROM task_executions
+		WHERE id IN (
 			SELECT id
-			FROM ranked
-			WHERE recent_rank > $1
-				OR (recent_rank > 1 AND completed_at < $2)
-			ORDER BY id
-			LIMIT $3
-		)
-		DELETE FROM task_executions AS execution
-		USING doomed
-		WHERE execution.id = doomed.id`,
-		keepPerTask,
-		cutoff,
-		batchSize,
+			FROM task_executions
+			WHERE %s
+			LIMIT $%d
+		)`, clause, len(args)),
+		args...,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("pruning task executions: %w", err)
+		return 0, fmt.Errorf("pruning task executions for %s: %w", doomed.taskKey, err)
 	}
 	return result.RowsAffected(), nil
 }

--- a/internal/taskmanager/repository/postgres_history.go
+++ b/internal/taskmanager/repository/postgres_history.go
@@ -3,12 +3,20 @@ package repository
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
+
+const taskHistoryCleanupAdvisoryLock int64 = 0x53494C4F48495354 // "SILOHIST"
+
+type taskHistoryExecer interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
 
 // PgExecutionRepository implements taskmanager.ExecutionRepository using PostgreSQL.
 type PgExecutionRepository struct {
@@ -38,7 +46,7 @@ func (r *PgExecutionRepository) GetLatest(ctx context.Context, taskKey string) (
 		SELECT id, task_key, started_at, completed_at, status, COALESCE(error_message, ''), result_data, duration_ms
 		FROM task_executions
 		WHERE task_key = $1
-		ORDER BY completed_at DESC
+		ORDER BY completed_at DESC, id DESC
 		LIMIT 1`, taskKey,
 	).Scan(
 		&result.ID, &result.TaskKey, &result.StartedAt, &result.CompletedAt,
@@ -58,7 +66,7 @@ func (r *PgExecutionRepository) List(ctx context.Context, taskKey string, limit 
 		SELECT id, task_key, started_at, completed_at, status, COALESCE(error_message, ''), result_data, duration_ms
 		FROM task_executions
 		WHERE task_key = $1
-		ORDER BY completed_at DESC
+		ORDER BY completed_at DESC, id DESC
 		LIMIT $2`, taskKey, limit,
 	)
 	if err != nil {
@@ -78,4 +86,119 @@ func (r *PgExecutionRepository) List(ctx context.Context, taskKey string, limit 
 		results = append(results, r)
 	}
 	return results, rows.Err()
+}
+
+// Prune deletes bounded batches of execution history outside the retention
+// policy. A database advisory lock ensures only one Silo node prunes at a time.
+// It always preserves the newest execution for every task, including tasks
+// that are no longer registered.
+func (r *PgExecutionRepository) Prune(
+	ctx context.Context,
+	keepPerTask int,
+	cutoff time.Time,
+	batchSize int,
+	maxBatches int,
+) (pruneResult taskmanager.HistoryPruneResult, returnErr error) {
+	if keepPerTask < 1 {
+		return pruneResult, fmt.Errorf("pruning task executions: keep per task must be positive")
+	}
+	if batchSize < 1 {
+		return pruneResult, fmt.Errorf("pruning task executions: batch size must be positive")
+	}
+	if maxBatches < 1 {
+		return pruneResult, fmt.Errorf("pruning task executions: max batches must be positive")
+	}
+
+	conn, err := r.pool.Acquire(ctx)
+	if err != nil {
+		return pruneResult, fmt.Errorf("acquiring task history cleanup connection: %w", err)
+	}
+	var acquired bool
+	if err := conn.QueryRow(ctx, `SELECT pg_try_advisory_lock($1)`, taskHistoryCleanupAdvisoryLock).Scan(&acquired); err != nil {
+		conn.Release()
+		return pruneResult, fmt.Errorf("acquiring task history cleanup lock: %w", err)
+	}
+	if !acquired {
+		conn.Release()
+		pruneResult.Skipped = true
+		return pruneResult, nil
+	}
+	defer func() {
+		unlockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		var unlocked bool
+		unlockErr := conn.QueryRow(unlockCtx, `SELECT pg_advisory_unlock($1)`, taskHistoryCleanupAdvisoryLock).Scan(&unlocked)
+		if unlockErr == nil && unlocked {
+			conn.Release()
+			return
+		}
+
+		// A session-level advisory lock survives connection pooling. Destroy the
+		// connection if it could not be unlocked so the lock cannot leak back
+		// into the pool.
+		rawConn := conn.Hijack()
+		_ = rawConn.Close(context.Background())
+		if returnErr == nil {
+			if unlockErr != nil {
+				returnErr = fmt.Errorf("releasing task history cleanup lock: %w", unlockErr)
+			} else {
+				returnErr = fmt.Errorf("releasing task history cleanup lock: lock was not held")
+			}
+		}
+	}()
+
+	for range maxBatches {
+		if err := ctx.Err(); err != nil {
+			return pruneResult, err
+		}
+		deleted, err := pruneTaskHistoryBatch(ctx, conn, keepPerTask, cutoff, batchSize)
+		pruneResult.Deleted += deleted
+		if err != nil {
+			return pruneResult, err
+		}
+		if deleted < int64(batchSize) {
+			return pruneResult, nil
+		}
+	}
+	pruneResult.LimitReached = true
+	return pruneResult, nil
+}
+
+func pruneTaskHistoryBatch(
+	ctx context.Context,
+	execer taskHistoryExecer,
+	keepPerTask int,
+	cutoff time.Time,
+	batchSize int,
+) (int64, error) {
+	result, err := execer.Exec(ctx, `
+		WITH ranked AS (
+			SELECT
+				id,
+				completed_at,
+				row_number() OVER (
+					PARTITION BY task_key
+					ORDER BY completed_at DESC, id DESC
+				) AS recent_rank
+			FROM task_executions
+		),
+		doomed AS (
+			SELECT id
+			FROM ranked
+			WHERE recent_rank > $1
+				OR (recent_rank > 1 AND completed_at < $2)
+			ORDER BY id
+			LIMIT $3
+		)
+		DELETE FROM task_executions AS execution
+		USING doomed
+		WHERE execution.id = doomed.id`,
+		keepPerTask,
+		cutoff,
+		batchSize,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("pruning task executions: %w", err)
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/taskmanager/repository/postgres_history_test.go
+++ b/internal/taskmanager/repository/postgres_history_test.go
@@ -1,0 +1,362 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func taskHistoryTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	adminPool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(adminPool.Close)
+
+	schema := fmt.Sprintf("task_history_test_%d", time.Now().UnixNano())
+	quotedSchema := pgx.Identifier{schema}.Sanitize()
+	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+quotedSchema); err != nil {
+		t.Fatalf("create test schema: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = adminPool.Exec(context.Background(), "DROP SCHEMA "+quotedSchema+" CASCADE")
+	})
+	if _, err := adminPool.Exec(ctx, `
+		CREATE TABLE `+quotedSchema+`.task_executions (
+			id BIGSERIAL PRIMARY KEY,
+			task_key TEXT NOT NULL,
+			started_at TIMESTAMPTZ NOT NULL,
+			completed_at TIMESTAMPTZ NOT NULL,
+			status TEXT NOT NULL,
+			error_message TEXT,
+			result_data JSONB,
+			duration_ms BIGINT NOT NULL
+		)`); err != nil {
+		t.Fatalf("create task execution table: %v", err)
+	}
+	if _, err := adminPool.Exec(ctx, `
+		CREATE INDEX idx_task_executions_key_completed
+		ON `+quotedSchema+`.task_executions (task_key, completed_at DESC)`); err != nil {
+		t.Fatalf("create task execution index: %v", err)
+	}
+
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse test database URL: %v", err)
+	}
+	if config.ConnConfig.RuntimeParams == nil {
+		config.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("connect isolated test schema: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func insertTaskExecution(t *testing.T, pool *pgxpool.Pool, taskKey string, completedAt time.Time) int64 {
+	t.Helper()
+	var id int64
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO task_executions (
+			task_key, started_at, completed_at, status, duration_ms
+		) VALUES ($1, $2, $2, 'completed', 0)
+		RETURNING id`, taskKey, completedAt).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert task execution: %v", err)
+	}
+	return id
+}
+
+func remainingTaskExecutionIDs(t *testing.T, pool *pgxpool.Pool, taskKey string) []int64 {
+	t.Helper()
+	rows, err := pool.Query(context.Background(), `
+		SELECT id FROM task_executions WHERE task_key = $1 ORDER BY id`, taskKey)
+	if err != nil {
+		t.Fatalf("query remaining task executions: %v", err)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan task execution ID: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate task execution IDs: %v", err)
+	}
+	return ids
+}
+
+func TestPruneTaskHistoryBatch(t *testing.T) {
+	t.Run("keeps newest executions per task", func(t *testing.T) {
+		pool := taskHistoryTestPool(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		var ids []int64
+		for i := range 5 {
+			ids = append(ids, insertTaskExecution(t, pool, "count-capped", now.Add(time.Duration(i)*time.Minute)))
+		}
+
+		deleted, err := pruneTaskHistoryBatch(ctx, pool, 2, now.Add(-24*time.Hour), 100)
+		if err != nil {
+			t.Fatalf("PruneBatch: %v", err)
+		}
+		if deleted != 3 {
+			t.Fatalf("deleted = %d, want 3", deleted)
+		}
+		got := remainingTaskExecutionIDs(t, pool, "count-capped")
+		want := ids[len(ids)-2:]
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("remaining IDs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("age pruning always preserves newest execution", func(t *testing.T) {
+		pool := taskHistoryTestPool(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		olderID := insertTaskExecution(t, pool, "age-capped", now.Add(-48*time.Hour))
+		newestID := insertTaskExecution(t, pool, "age-capped", now.Add(-47*time.Hour))
+
+		deleted, err := pruneTaskHistoryBatch(ctx, pool, 100, now.Add(-24*time.Hour), 100)
+		if err != nil {
+			t.Fatalf("PruneBatch: %v", err)
+		}
+		if deleted != 1 {
+			t.Fatalf("deleted = %d, want 1", deleted)
+		}
+		got := remainingTaskExecutionIDs(t, pool, "age-capped")
+		if fmt.Sprint(got) != fmt.Sprint([]int64{newestID}) {
+			t.Fatalf("remaining IDs = %v, want [%d]; older ID was %d", got, newestID, olderID)
+		}
+	})
+
+	t.Run("uses ID to break completion time ties", func(t *testing.T) {
+		pool := taskHistoryTestPool(t)
+		repo := NewPgExecutionRepository(pool)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		firstID := insertTaskExecution(t, pool, "tied", now)
+		newestID := insertTaskExecution(t, pool, "tied", now)
+
+		deleted, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 100)
+		if err != nil {
+			t.Fatalf("PruneBatch: %v", err)
+		}
+		if deleted != 1 {
+			t.Fatalf("deleted = %d, want 1", deleted)
+		}
+		got := remainingTaskExecutionIDs(t, pool, "tied")
+		if fmt.Sprint(got) != fmt.Sprint([]int64{newestID}) {
+			t.Fatalf("remaining IDs = %v, want [%d]; first ID was %d", got, newestID, firstID)
+		}
+
+		latest, err := repo.GetLatest(ctx, "tied")
+		if err != nil {
+			t.Fatalf("GetLatest: %v", err)
+		}
+		if latest == nil || latest.ID != newestID {
+			t.Fatalf("GetLatest ID = %v, want %d", latest, newestID)
+		}
+	})
+
+	t.Run("bounded batches converge and are idempotent", func(t *testing.T) {
+		pool := taskHistoryTestPool(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		for i := range 7 {
+			insertTaskExecution(t, pool, "batched", now.Add(time.Duration(i)*time.Minute))
+		}
+
+		var total int64
+		for {
+			deleted, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 2)
+			if err != nil {
+				t.Fatalf("PruneBatch: %v", err)
+			}
+			total += deleted
+			if deleted < 2 {
+				break
+			}
+		}
+		if total != 6 {
+			t.Fatalf("total deleted = %d, want 6", total)
+		}
+		if got := len(remainingTaskExecutionIDs(t, pool, "batched")); got != 1 {
+			t.Fatalf("remaining rows = %d, want 1", got)
+		}
+		deleted, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 2)
+		if err != nil {
+			t.Fatalf("idempotent PruneBatch: %v", err)
+		}
+		if deleted != 0 {
+			t.Fatalf("idempotent delete count = %d, want 0", deleted)
+		}
+	})
+}
+
+func TestPruneTaskHistoryBatchConcurrent(t *testing.T) {
+	pool := taskHistoryTestPool(t)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i := range 20 {
+		insertTaskExecution(t, pool, "concurrent", now.Add(time.Duration(i)*time.Minute))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 100)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent PruneBatch: %v", err)
+		}
+	}
+	if got := len(remainingTaskExecutionIDs(t, pool, "concurrent")); got != 1 {
+		t.Fatalf("remaining rows = %d, want 1", got)
+	}
+}
+
+func TestPgExecutionRepositoryPrunePreservesEachTaskBoundary(t *testing.T) {
+	pool := taskHistoryTestPool(t)
+	repo := NewPgExecutionRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	inserted := map[string][]int64{}
+	for taskKey, count := range map[string]int{"task-a": 5, "task-b": 3, "task-c": 1} {
+		for i := range count {
+			inserted[taskKey] = append(inserted[taskKey], insertTaskExecution(
+				t,
+				pool,
+				taskKey,
+				now.Add(time.Duration(i)*time.Minute),
+			))
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	result, err := repo.Prune(ctx, 2, now.Add(-24*time.Hour), 2, 10)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if result.Deleted != 4 || result.LimitReached || result.Skipped {
+		t.Fatalf("Prune result = %#v, want 4 deleted", result)
+	}
+
+	for taskKey, ids := range inserted {
+		want := ids
+		if len(want) > 2 {
+			want = want[len(want)-2:]
+		}
+		got := remainingTaskExecutionIDs(t, pool, taskKey)
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("%s remaining IDs = %v, want %v", taskKey, got, want)
+		}
+	}
+}
+
+func TestPgExecutionRepositoryPruneReportsBatchLimit(t *testing.T) {
+	pool := taskHistoryTestPool(t)
+	repo := NewPgExecutionRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i := range 7 {
+		insertTaskExecution(t, pool, "limited", now.Add(time.Duration(i)*time.Minute))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	result, err := repo.Prune(ctx, 1, now.Add(-24*time.Hour), 2, 2)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if result.Deleted != 4 || !result.LimitReached || result.Skipped {
+		t.Fatalf("Prune result = %#v, want 4 deleted with limit reached", result)
+	}
+	if got := len(remainingTaskExecutionIDs(t, pool, "limited")); got != 3 {
+		t.Fatalf("remaining rows = %d, want 3", got)
+	}
+
+	result, err = repo.Prune(ctx, 1, now.Add(-24*time.Hour), 2, 10)
+	if err != nil {
+		t.Fatalf("finishing Prune: %v", err)
+	}
+	if result.Deleted != 2 || result.LimitReached || result.Skipped {
+		t.Fatalf("finishing Prune result = %#v, want 2 deleted", result)
+	}
+}
+
+func TestPgExecutionRepositoryPruneSkipsWhenAnotherNodeHoldsLock(t *testing.T) {
+	pool := taskHistoryTestPool(t)
+	repo := NewPgExecutionRepository(pool)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	locker, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire lock connection: %v", err)
+	}
+	defer locker.Release()
+	if _, err := locker.Exec(ctx, `SELECT pg_advisory_lock($1)`, taskHistoryCleanupAdvisoryLock); err != nil {
+		t.Fatalf("hold cleanup lock: %v", err)
+	}
+	defer func() {
+		_, _ = locker.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, taskHistoryCleanupAdvisoryLock)
+	}()
+
+	result, err := repo.Prune(ctx, 1, time.Now(), 10, 10)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if !result.Skipped || result.Deleted != 0 || result.LimitReached {
+		t.Fatalf("Prune result = %#v, want skipped", result)
+	}
+}
+
+func TestPgExecutionRepositoryPruneRejectsInvalidLimits(t *testing.T) {
+	repo := &PgExecutionRepository{}
+	if _, err := repo.Prune(context.Background(), 0, time.Now(), 1, 1); err == nil {
+		t.Fatal("Prune accepted keepPerTask = 0")
+	}
+	if _, err := repo.Prune(context.Background(), 1, time.Now(), 0, 1); err == nil {
+		t.Fatal("Prune accepted batchSize = 0")
+	}
+	if _, err := repo.Prune(context.Background(), 1, time.Now(), 1, 0); err == nil {
+		t.Fatal("Prune accepted maxBatches = 0")
+	}
+}

--- a/internal/taskmanager/repository/postgres_history_test.go
+++ b/internal/taskmanager/repository/postgres_history_test.go
@@ -8,87 +8,70 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// taskHistoryTestPool connects to the migrated test database. Tests here share
+// one real task_executions table, so every test namespaces its rows behind
+// unique task keys and deletes them again on cleanup.
 func taskHistoryTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
 		t.Skip("SILO_TEST_DATABASE_URL is not set")
 	}
-
-	ctx := context.Background()
-	adminPool, err := pgxpool.New(ctx, dsn)
+	pool, err := pgxpool.New(context.Background(), dsn)
 	if err != nil {
 		t.Fatalf("connect test database: %v", err)
-	}
-	t.Cleanup(adminPool.Close)
-
-	schema := fmt.Sprintf("task_history_test_%d", time.Now().UnixNano())
-	quotedSchema := pgx.Identifier{schema}.Sanitize()
-	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+quotedSchema); err != nil {
-		t.Fatalf("create test schema: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = adminPool.Exec(context.Background(), "DROP SCHEMA "+quotedSchema+" CASCADE")
-	})
-	if _, err := adminPool.Exec(ctx, `
-		CREATE TABLE `+quotedSchema+`.task_executions (
-			id BIGSERIAL PRIMARY KEY,
-			task_key TEXT NOT NULL,
-			started_at TIMESTAMPTZ NOT NULL,
-			completed_at TIMESTAMPTZ NOT NULL,
-			status TEXT NOT NULL,
-			error_message TEXT,
-			result_data JSONB,
-			duration_ms BIGINT NOT NULL
-		)`); err != nil {
-		t.Fatalf("create task execution table: %v", err)
-	}
-	if _, err := adminPool.Exec(ctx, `
-		CREATE INDEX idx_task_executions_key_completed
-		ON `+quotedSchema+`.task_executions (task_key, completed_at DESC)`); err != nil {
-		t.Fatalf("create task execution index: %v", err)
-	}
-
-	config, err := pgxpool.ParseConfig(dsn)
-	if err != nil {
-		t.Fatalf("parse test database URL: %v", err)
-	}
-	if config.ConnConfig.RuntimeParams == nil {
-		config.ConnConfig.RuntimeParams = map[string]string{}
-	}
-	config.ConnConfig.RuntimeParams["search_path"] = schema
-	pool, err := pgxpool.NewWithConfig(ctx, config)
-	if err != nil {
-		t.Fatalf("connect isolated test schema: %v", err)
 	}
 	t.Cleanup(pool.Close)
 	return pool
 }
 
-func insertTaskExecution(t *testing.T, pool *pgxpool.Pool, taskKey string, completedAt time.Time) int64 {
+// taskKey returns a key unique to this test run and registers its cleanup.
+func taskKey(t *testing.T, pool *pgxpool.Pool, name string) string {
+	t.Helper()
+	key := fmt.Sprintf("test_%s_%s_%d", t.Name(), name, time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM task_executions WHERE task_key = $1`, key)
+	})
+	return key
+}
+
+func insertTaskExecution(t *testing.T, pool *pgxpool.Pool, key string, completedAt time.Time) int64 {
 	t.Helper()
 	var id int64
 	err := pool.QueryRow(context.Background(), `
 		INSERT INTO task_executions (
 			task_key, started_at, completed_at, status, duration_ms
 		) VALUES ($1, $2, $2, 'completed', 0)
-		RETURNING id`, taskKey, completedAt).Scan(&id)
+		RETURNING id`, key, completedAt).Scan(&id)
 	if err != nil {
 		t.Fatalf("insert task execution: %v", err)
 	}
 	return id
 }
 
-func remainingTaskExecutionIDs(t *testing.T, pool *pgxpool.Pool, taskKey string) []int64 {
+// clearTaskHistory empties the table so a whole-table Prune has a deterministic
+// batch budget. The migrated SILO_TEST_DATABASE_URL database is dedicated to
+// tests, and package tests run sequentially.
+func clearTaskHistory(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
-	rows, err := pool.Query(context.Background(), `
-		SELECT id FROM task_executions WHERE task_key = $1 ORDER BY id`, taskKey)
+	if _, err := pool.Exec(context.Background(), `DELETE FROM task_executions`); err != nil {
+		t.Fatalf("clear task execution history: %v", err)
+	}
+}
+
+func remainingTaskExecutionIDs(t *testing.T, pool *pgxpool.Pool, key string) []int64 {
+	t.Helper()
+	return queryIDs(t, pool, `SELECT id FROM task_executions WHERE task_key = $1 ORDER BY id`, key)
+}
+
+func queryIDs(t *testing.T, pool *pgxpool.Pool, sql string, args ...any) []int64 {
+	t.Helper()
+	rows, err := pool.Query(context.Background(), sql, args...)
 	if err != nil {
-		t.Fatalf("query remaining task executions: %v", err)
+		t.Fatalf("query task execution IDs: %v", err)
 	}
 	defer rows.Close()
 
@@ -106,47 +89,100 @@ func remainingTaskExecutionIDs(t *testing.T, pool *pgxpool.Pool, taskKey string)
 	return ids
 }
 
-func TestPruneTaskHistoryBatch(t *testing.T) {
-	t.Run("keeps newest executions per task", func(t *testing.T) {
+// pruneOneKey runs the bounded delete loop for a single key without taking the
+// advisory lock, so the individual predicate cases stay readable.
+func pruneOneKey(
+	t *testing.T,
+	repo *PgExecutionRepository,
+	key string,
+	keepPerTask int,
+	cutoff time.Time,
+	batchSize int,
+) int64 {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	bounds, ok, err := repo.loadDoomedBounds(ctx, key, keepPerTask, cutoff)
+	if err != nil {
+		t.Fatalf("loadDoomedBounds: %v", err)
+	}
+	if !ok {
+		return 0
+	}
+	var total int64
+	for {
+		deleted, err := deleteTaskHistoryBatch(ctx, repo.pool, bounds, batchSize)
+		if err != nil {
+			t.Fatalf("deleteTaskHistoryBatch: %v", err)
+		}
+		total += deleted
+		if deleted < int64(batchSize) {
+			return total
+		}
+	}
+}
+
+func TestTaskHistoryDoomedPredicate(t *testing.T) {
+	t.Run("keeps the newest executions per task", func(t *testing.T) {
 		pool := taskHistoryTestPool(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		repo := NewPgExecutionRepository(pool)
+		key := taskKey(t, pool, "count-capped")
 		now := time.Now().UTC().Truncate(time.Microsecond)
 		var ids []int64
 		for i := range 5 {
-			ids = append(ids, insertTaskExecution(t, pool, "count-capped", now.Add(time.Duration(i)*time.Minute)))
+			ids = append(ids, insertTaskExecution(t, pool, key, now.Add(time.Duration(i)*time.Minute)))
 		}
 
-		deleted, err := pruneTaskHistoryBatch(ctx, pool, 2, now.Add(-24*time.Hour), 100)
-		if err != nil {
-			t.Fatalf("PruneBatch: %v", err)
-		}
-		if deleted != 3 {
+		if deleted := pruneOneKey(t, repo, key, 2, now.Add(-24*time.Hour), 100); deleted != 3 {
 			t.Fatalf("deleted = %d, want 3", deleted)
 		}
-		got := remainingTaskExecutionIDs(t, pool, "count-capped")
-		want := ids[len(ids)-2:]
-		if fmt.Sprint(got) != fmt.Sprint(want) {
+		got := remainingTaskExecutionIDs(t, pool, key)
+		if want := ids[len(ids)-2:]; fmt.Sprint(got) != fmt.Sprint(want) {
 			t.Fatalf("remaining IDs = %v, want %v", got, want)
 		}
 	})
 
-	t.Run("age pruning always preserves newest execution", func(t *testing.T) {
+	t.Run("keepPerTask boundary is off by exactly one", func(t *testing.T) {
 		pool := taskHistoryTestPool(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		repo := NewPgExecutionRepository(pool)
 		now := time.Now().UTC().Truncate(time.Microsecond)
-		olderID := insertTaskExecution(t, pool, "age-capped", now.Add(-48*time.Hour))
-		newestID := insertTaskExecution(t, pool, "age-capped", now.Add(-47*time.Hour))
 
-		deleted, err := pruneTaskHistoryBatch(ctx, pool, 100, now.Add(-24*time.Hour), 100)
-		if err != nil {
-			t.Fatalf("PruneBatch: %v", err)
+		// Recent rows: only the count cap can delete them. With exactly
+		// keepPerTask rows nothing is doomed; one more row and exactly one is.
+		exact := taskKey(t, pool, "exact")
+		for i := range 3 {
+			insertTaskExecution(t, pool, exact, now.Add(time.Duration(i)*time.Minute))
 		}
-		if deleted != 1 {
+		if deleted := pruneOneKey(t, repo, exact, 3, now.Add(-24*time.Hour), 100); deleted != 0 {
+			t.Fatalf("deleted = %d at the boundary, want 0", deleted)
+		}
+
+		over := taskKey(t, pool, "over")
+		var ids []int64
+		for i := range 4 {
+			ids = append(ids, insertTaskExecution(t, pool, over, now.Add(time.Duration(i)*time.Minute)))
+		}
+		if deleted := pruneOneKey(t, repo, over, 3, now.Add(-24*time.Hour), 100); deleted != 1 {
+			t.Fatalf("deleted = %d one past the boundary, want 1", deleted)
+		}
+		got := remainingTaskExecutionIDs(t, pool, over)
+		if want := ids[1:]; fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Fatalf("remaining IDs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("age pruning always preserves the newest execution", func(t *testing.T) {
+		pool := taskHistoryTestPool(t)
+		repo := NewPgExecutionRepository(pool)
+		key := taskKey(t, pool, "age-capped")
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		olderID := insertTaskExecution(t, pool, key, now.Add(-48*time.Hour))
+		newestID := insertTaskExecution(t, pool, key, now.Add(-47*time.Hour))
+
+		if deleted := pruneOneKey(t, repo, key, 100, now.Add(-24*time.Hour), 100); deleted != 1 {
 			t.Fatalf("deleted = %d, want 1", deleted)
 		}
-		got := remainingTaskExecutionIDs(t, pool, "age-capped")
+		got := remainingTaskExecutionIDs(t, pool, key)
 		if fmt.Sprint(got) != fmt.Sprint([]int64{newestID}) {
 			t.Fatalf("remaining IDs = %v, want [%d]; older ID was %d", got, newestID, olderID)
 		}
@@ -155,25 +191,22 @@ func TestPruneTaskHistoryBatch(t *testing.T) {
 	t.Run("uses ID to break completion time ties", func(t *testing.T) {
 		pool := taskHistoryTestPool(t)
 		repo := NewPgExecutionRepository(pool)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		key := taskKey(t, pool, "tied")
 		now := time.Now().UTC().Truncate(time.Microsecond)
-		firstID := insertTaskExecution(t, pool, "tied", now)
-		newestID := insertTaskExecution(t, pool, "tied", now)
+		firstID := insertTaskExecution(t, pool, key, now)
+		newestID := insertTaskExecution(t, pool, key, now)
 
-		deleted, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 100)
-		if err != nil {
-			t.Fatalf("PruneBatch: %v", err)
-		}
-		if deleted != 1 {
+		if deleted := pruneOneKey(t, repo, key, 1, now.Add(-24*time.Hour), 100); deleted != 1 {
 			t.Fatalf("deleted = %d, want 1", deleted)
 		}
-		got := remainingTaskExecutionIDs(t, pool, "tied")
+		got := remainingTaskExecutionIDs(t, pool, key)
 		if fmt.Sprint(got) != fmt.Sprint([]int64{newestID}) {
 			t.Fatalf("remaining IDs = %v, want [%d]; first ID was %d", got, newestID, firstID)
 		}
 
-		latest, err := repo.GetLatest(ctx, "tied")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		latest, err := repo.GetLatest(ctx, key)
 		if err != nil {
 			t.Fatalf("GetLatest: %v", err)
 		}
@@ -184,109 +217,124 @@ func TestPruneTaskHistoryBatch(t *testing.T) {
 
 	t.Run("bounded batches converge and are idempotent", func(t *testing.T) {
 		pool := taskHistoryTestPool(t)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
+		repo := NewPgExecutionRepository(pool)
+		key := taskKey(t, pool, "batched")
 		now := time.Now().UTC().Truncate(time.Microsecond)
 		for i := range 7 {
-			insertTaskExecution(t, pool, "batched", now.Add(time.Duration(i)*time.Minute))
+			insertTaskExecution(t, pool, key, now.Add(time.Duration(i)*time.Minute))
 		}
 
-		var total int64
-		for {
-			deleted, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 2)
-			if err != nil {
-				t.Fatalf("PruneBatch: %v", err)
-			}
-			total += deleted
-			if deleted < 2 {
-				break
-			}
-		}
-		if total != 6 {
+		if total := pruneOneKey(t, repo, key, 1, now.Add(-24*time.Hour), 2); total != 6 {
 			t.Fatalf("total deleted = %d, want 6", total)
 		}
-		if got := len(remainingTaskExecutionIDs(t, pool, "batched")); got != 1 {
+		if got := len(remainingTaskExecutionIDs(t, pool, key)); got != 1 {
 			t.Fatalf("remaining rows = %d, want 1", got)
 		}
-		deleted, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 2)
-		if err != nil {
-			t.Fatalf("idempotent PruneBatch: %v", err)
-		}
-		if deleted != 0 {
-			t.Fatalf("idempotent delete count = %d, want 0", deleted)
+		if again := pruneOneKey(t, repo, key, 1, now.Add(-24*time.Hour), 2); again != 0 {
+			t.Fatalf("idempotent delete count = %d, want 0", again)
 		}
 	})
 }
 
-func TestPruneTaskHistoryBatchConcurrent(t *testing.T) {
+// TestTaskHistoryDoomedPredicateMatchesWindowRanking pins the tuple-comparison
+// predicate to the window-function definition of the retention policy: delete a
+// row iff its rank over (completed_at DESC, id DESC) exceeds keepPerTask, or it
+// is not rank 1 and is older than the cutoff.
+func TestTaskHistoryDoomedPredicateMatchesWindowRanking(t *testing.T) {
 	pool := taskHistoryTestPool(t)
+	repo := NewPgExecutionRepository(pool)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	now := time.Now().UTC().Truncate(time.Microsecond)
-	for i := range 20 {
-		insertTaskExecution(t, pool, "concurrent", now.Add(time.Duration(i)*time.Minute))
+	key := taskKey(t, pool, "equivalence")
+
+	// Deliberately messy: duplicate completion times, rows on both sides of
+	// every plausible cutoff, and insertion order uncorrelated with time.
+	offsets := []time.Duration{
+		-72 * time.Hour, -72 * time.Hour, -48 * time.Hour, -24 * time.Hour,
+		-24 * time.Hour, -12 * time.Hour, -time.Hour, 0, 0, time.Hour,
+	}
+	for _, offset := range offsets {
+		insertTaskExecution(t, pool, key, now.Add(offset))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	start := make(chan struct{})
-	errs := make(chan error, 2)
-	var wg sync.WaitGroup
-	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			<-start
-			_, err := pruneTaskHistoryBatch(ctx, pool, 1, now.Add(-24*time.Hour), 100)
-			errs <- err
-		}()
-	}
-	close(start)
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		if err != nil {
-			t.Fatalf("concurrent PruneBatch: %v", err)
+	for _, keep := range []int{1, 2, 3, 5, 9, 10, 11} {
+		for _, cutoffOffset := range []time.Duration{
+			-96 * time.Hour, -72 * time.Hour, -36 * time.Hour, -24 * time.Hour, 0, 2 * time.Hour,
+		} {
+			cutoff := now.Add(cutoffOffset)
+			bounds, ok, err := repo.loadDoomedBounds(ctx, key, keep, cutoff)
+			if err != nil {
+				t.Fatalf("loadDoomedBounds: %v", err)
+			}
+			if !ok {
+				t.Fatal("loadDoomedBounds reported no rows")
+			}
+			clause, args := bounds.where()
+
+			actual := queryIDs(t, pool, `SELECT id FROM task_executions WHERE `+clause+` ORDER BY id`, args...)
+			expected := queryIDs(t, pool, `
+				WITH ranked AS (
+					SELECT
+						id,
+						completed_at,
+						row_number() OVER (
+							PARTITION BY task_key
+							ORDER BY completed_at DESC, id DESC
+						) AS recent_rank
+					FROM task_executions
+					WHERE task_key = $1
+				)
+				SELECT id FROM ranked
+				WHERE recent_rank > $2 OR (recent_rank > 1 AND completed_at < $3)
+				ORDER BY id`, key, keep, cutoff)
+
+			if fmt.Sprint(actual) != fmt.Sprint(expected) {
+				t.Fatalf("keep=%d cutoff=%v: tuple predicate doomed %v, window ranking doomed %v",
+					keep, cutoffOffset, actual, expected)
+			}
 		}
-	}
-	if got := len(remainingTaskExecutionIDs(t, pool, "concurrent")); got != 1 {
-		t.Fatalf("remaining rows = %d, want 1", got)
 	}
 }
 
 func TestPgExecutionRepositoryPrunePreservesEachTaskBoundary(t *testing.T) {
 	pool := taskHistoryTestPool(t)
 	repo := NewPgExecutionRepository(pool)
+	clearTaskHistory(t, pool)
 	now := time.Now().UTC().Truncate(time.Microsecond)
 
+	counts := map[string]int{
+		taskKey(t, pool, "task-a"): 5,
+		taskKey(t, pool, "task-b"): 3,
+		taskKey(t, pool, "task-c"): 1,
+	}
 	inserted := map[string][]int64{}
-	for taskKey, count := range map[string]int{"task-a": 5, "task-b": 3, "task-c": 1} {
+	for key, count := range counts {
 		for i := range count {
-			inserted[taskKey] = append(inserted[taskKey], insertTaskExecution(
-				t,
-				pool,
-				taskKey,
-				now.Add(time.Duration(i)*time.Minute),
+			inserted[key] = append(inserted[key], insertTaskExecution(
+				t, pool, key, now.Add(time.Duration(i)*time.Minute),
 			))
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	result, err := repo.Prune(ctx, 2, now.Add(-24*time.Hour), 2, 10)
+	result, err := repo.Prune(ctx, 2, now.Add(-24*time.Hour), 2, 100)
 	if err != nil {
 		t.Fatalf("Prune: %v", err)
 	}
-	if result.Deleted != 4 || result.LimitReached || result.Skipped {
-		t.Fatalf("Prune result = %#v, want 4 deleted", result)
+	if result.LimitReached || result.Skipped {
+		t.Fatalf("Prune result = %#v, want a complete run", result)
 	}
 
-	for taskKey, ids := range inserted {
+	for key, ids := range inserted {
 		want := ids
 		if len(want) > 2 {
 			want = want[len(want)-2:]
 		}
-		got := remainingTaskExecutionIDs(t, pool, taskKey)
+		got := remainingTaskExecutionIDs(t, pool, key)
 		if fmt.Sprint(got) != fmt.Sprint(want) {
-			t.Fatalf("%s remaining IDs = %v, want %v", taskKey, got, want)
+			t.Fatalf("%s remaining IDs = %v, want %v", key, got, want)
 		}
 	}
 }
@@ -294,12 +342,14 @@ func TestPgExecutionRepositoryPrunePreservesEachTaskBoundary(t *testing.T) {
 func TestPgExecutionRepositoryPruneReportsBatchLimit(t *testing.T) {
 	pool := taskHistoryTestPool(t)
 	repo := NewPgExecutionRepository(pool)
+	clearTaskHistory(t, pool)
+	key := taskKey(t, pool, "limited")
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	for i := range 7 {
-		insertTaskExecution(t, pool, "limited", now.Add(time.Duration(i)*time.Minute))
+		insertTaskExecution(t, pool, key, now.Add(time.Duration(i)*time.Minute))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	result, err := repo.Prune(ctx, 1, now.Add(-24*time.Hour), 2, 2)
 	if err != nil {
@@ -308,11 +358,11 @@ func TestPgExecutionRepositoryPruneReportsBatchLimit(t *testing.T) {
 	if result.Deleted != 4 || !result.LimitReached || result.Skipped {
 		t.Fatalf("Prune result = %#v, want 4 deleted with limit reached", result)
 	}
-	if got := len(remainingTaskExecutionIDs(t, pool, "limited")); got != 3 {
+	if got := len(remainingTaskExecutionIDs(t, pool, key)); got != 3 {
 		t.Fatalf("remaining rows = %d, want 3", got)
 	}
 
-	result, err = repo.Prune(ctx, 1, now.Add(-24*time.Hour), 2, 10)
+	result, err = repo.Prune(ctx, 1, now.Add(-24*time.Hour), 2, 100)
 	if err != nil {
 		t.Fatalf("finishing Prune: %v", err)
 	}
@@ -321,10 +371,39 @@ func TestPgExecutionRepositoryPruneReportsBatchLimit(t *testing.T) {
 	}
 }
 
+// TestPgExecutionRepositoryPruneDoesNotReportLimitOnExactMultiple covers the
+// case that made the old loop-exhaustion signal lie: the doomed count is an
+// exact multiple of batchSize and fills the batch budget precisely, so the run
+// finished even though every batch came back full.
+func TestPgExecutionRepositoryPruneDoesNotReportLimitOnExactMultiple(t *testing.T) {
+	pool := taskHistoryTestPool(t)
+	repo := NewPgExecutionRepository(pool)
+	clearTaskHistory(t, pool)
+	key := taskKey(t, pool, "exact-multiple")
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i := range 7 {
+		insertTaskExecution(t, pool, key, now.Add(time.Duration(i)*time.Minute))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	// 6 doomed rows, batches of 2, exactly 3 batches of budget.
+	result, err := repo.Prune(ctx, 1, now.Add(-24*time.Hour), 2, 3)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if result.Deleted != 6 || result.LimitReached || result.Skipped {
+		t.Fatalf("Prune result = %#v, want 6 deleted without limit reached", result)
+	}
+	if got := len(remainingTaskExecutionIDs(t, pool, key)); got != 1 {
+		t.Fatalf("remaining rows = %d, want 1", got)
+	}
+}
+
 func TestPgExecutionRepositoryPruneSkipsWhenAnotherNodeHoldsLock(t *testing.T) {
 	pool := taskHistoryTestPool(t)
 	repo := NewPgExecutionRepository(pool)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	locker, err := pool.Acquire(ctx)
@@ -348,15 +427,48 @@ func TestPgExecutionRepositoryPruneSkipsWhenAnotherNodeHoldsLock(t *testing.T) {
 	}
 }
 
-func TestPgExecutionRepositoryPruneRejectsInvalidLimits(t *testing.T) {
-	repo := &PgExecutionRepository{}
-	if _, err := repo.Prune(context.Background(), 0, time.Now(), 1, 1); err == nil {
-		t.Fatal("Prune accepted keepPerTask = 0")
+// TestPgExecutionRepositoryPruneConcurrent proves the advisory lock serializes
+// pruners: one wins and prunes, the other skips, and the surviving row count is
+// the same either way. The lock is database-global, so this test also asserts
+// that a skip is never mistaken for a completed run.
+func TestPgExecutionRepositoryPruneConcurrent(t *testing.T) {
+	pool := taskHistoryTestPool(t)
+	repo := NewPgExecutionRepository(pool)
+	clearTaskHistory(t, pool)
+	key := taskKey(t, pool, "concurrent")
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i := range 20 {
+		insertTaskExecution(t, pool, key, now.Add(time.Duration(i)*time.Minute))
 	}
-	if _, err := repo.Prune(context.Background(), 1, time.Now(), 0, 1); err == nil {
-		t.Fatal("Prune accepted batchSize = 0")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := repo.Prune(ctx, 1, now.Add(-24*time.Hour), 100, 100)
+			results <- err
+		}()
 	}
-	if _, err := repo.Prune(context.Background(), 1, time.Now(), 1, 0); err == nil {
-		t.Fatal("Prune accepted maxBatches = 0")
+	close(start)
+	wg.Wait()
+	close(results)
+	for err := range results {
+		if err != nil {
+			t.Fatalf("concurrent Prune: %v", err)
+		}
+	}
+
+	// Whichever goroutine won the lock, a second serialized run converges.
+	if _, err := repo.Prune(ctx, 1, now.Add(-24*time.Hour), 100, 100); err != nil {
+		t.Fatalf("settling Prune: %v", err)
+	}
+	if got := len(remainingTaskExecutionIDs(t, pool, key)); got != 1 {
+		t.Fatalf("remaining rows = %d, want 1", got)
 	}
 }

--- a/internal/taskmanager/retention.go
+++ b/internal/taskmanager/retention.go
@@ -1,0 +1,88 @@
+package taskmanager
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Server setting keys and defaults for task execution history retention.
+//
+// The two knobs are independent bounds on the same table: history older than
+// RetentionDays is dropped, and no task keeps more than KeepPerTask rows even
+// if they are all recent. The newest execution of every task is always kept so
+// the admin UI can still show "last run" for a task that has been idle longer
+// than the retention window.
+const (
+	SettingKeyHistoryRetentionDays = "taskmanager.history_retention_days"
+	SettingKeyHistoryKeepPerTask   = "taskmanager.history_keep_per_task"
+
+	DefaultHistoryRetentionDays = 30
+	DefaultHistoryKeepPerTask   = 1000
+)
+
+// SettingsStore is satisfied by *catalog.ServerSettingsRepo.
+type SettingsStore interface {
+	Get(ctx context.Context, key string) (string, error)
+	Set(ctx context.Context, key, value string) error
+}
+
+// HistoryRetention is the resolved retention policy for one cleanup run.
+type HistoryRetention struct {
+	RetentionDays int
+	KeepPerTask   int
+}
+
+// SeedHistoryRetentionDefaults writes the default retention settings when no
+// value has been persisted yet.
+func SeedHistoryRetentionDefaults(ctx context.Context, store SettingsStore) error {
+	defaults := map[string]string{
+		SettingKeyHistoryRetentionDays: strconv.Itoa(DefaultHistoryRetentionDays),
+		SettingKeyHistoryKeepPerTask:   strconv.Itoa(DefaultHistoryKeepPerTask),
+	}
+	for key, value := range defaults {
+		existing, err := store.Get(ctx, key)
+		if err != nil {
+			return fmt.Errorf("seed task history retention default %s: %w", key, err)
+		}
+		if existing != "" {
+			continue
+		}
+		if err := store.Set(ctx, key, value); err != nil {
+			return fmt.Errorf("seed task history retention default %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// LoadHistoryRetention reads the retention policy, falling back to the
+// defaults when a setting is missing, unreadable, or out of range. Both values
+// are clamped to at least 1: a zero or negative retention window would delete
+// every execution record on the next boot, and "keep zero per task" would
+// fight the invariant that the newest execution always survives.
+func LoadHistoryRetention(ctx context.Context, store SettingsStore) HistoryRetention {
+	return HistoryRetention{
+		RetentionDays: loadPositiveSetting(ctx, store, SettingKeyHistoryRetentionDays, DefaultHistoryRetentionDays),
+		KeepPerTask:   loadPositiveSetting(ctx, store, SettingKeyHistoryKeepPerTask, DefaultHistoryKeepPerTask),
+	}
+}
+
+func loadPositiveSetting(ctx context.Context, store SettingsStore, key string, fallback int) int {
+	if store == nil {
+		return fallback
+	}
+	raw, err := store.Get(ctx, key)
+	if err != nil {
+		return fallback
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 1 {
+		return fallback
+	}
+	return value
+}

--- a/internal/taskmanager/tasks/cleanup_task_history.go
+++ b/internal/taskmanager/tasks/cleanup_task_history.go
@@ -1,0 +1,113 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+const (
+	taskHistoryKeepPerTask       = 1000
+	taskHistoryMaxAge            = 30 * 24 * time.Hour
+	taskHistoryCleanupBatchSize  = 10000
+	taskHistoryCleanupMaxBatches = 100
+)
+
+// TaskHistoryPruner deletes a bounded amount of task execution history.
+type TaskHistoryPruner interface {
+	Prune(
+		ctx context.Context,
+		keepPerTask int,
+		cutoff time.Time,
+		batchSize int,
+		maxBatches int,
+	) (taskmanager.HistoryPruneResult, error)
+}
+
+// TaskHistoryCleanupTask prunes old task execution history.
+type TaskHistoryCleanupTask struct {
+	pruner TaskHistoryPruner
+}
+
+type taskHistoryCleanupResult struct {
+	Deleted      int64 `json:"deleted"`
+	LimitReached bool  `json:"limit_reached"`
+	Skipped      bool  `json:"skipped"`
+}
+
+// NewTaskHistoryCleanupTask creates a scheduled task for task history retention.
+func NewTaskHistoryCleanupTask(pruner TaskHistoryPruner) *TaskHistoryCleanupTask {
+	return &TaskHistoryCleanupTask{pruner: pruner}
+}
+
+func (t *TaskHistoryCleanupTask) Key() string  { return "cleanup_task_history" }
+func (t *TaskHistoryCleanupTask) Name() string { return "Cleanup Task History" }
+func (t *TaskHistoryCleanupTask) Description() string {
+	return "Prunes old background task execution history"
+}
+func (t *TaskHistoryCleanupTask) Category() taskmanager.TaskCategory {
+	return taskmanager.TaskCategorySystem
+}
+func (t *TaskHistoryCleanupTask) IsHidden() bool { return false }
+
+func (t *TaskHistoryCleanupTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeStartup},
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: int64((24 * time.Hour) / time.Millisecond)},
+	}
+}
+
+func (t *TaskHistoryCleanupTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	progress.Report(0, "Pruning task execution history")
+	cutoff := time.Now().UTC().Add(-taskHistoryMaxAge)
+	result, err := t.pruner.Prune(
+		ctx,
+		taskHistoryKeepPerTask,
+		cutoff,
+		taskHistoryCleanupBatchSize,
+		taskHistoryCleanupMaxBatches,
+	)
+	resultData := taskHistoryCleanupResult{
+		Deleted:      result.Deleted,
+		LimitReached: result.LimitReached,
+		Skipped:      result.Skipped,
+	}
+	setTaskHistoryCleanupResult(progress, resultData)
+	if err != nil {
+		slog.WarnContext(ctx, "task history cleanup failed", "component", "taskmanager", "deleted", result.Deleted, "error", err)
+		progress.Report(100, fmt.Sprintf("Task history cleanup failed after deleting %d executions", result.Deleted))
+		return err
+	}
+	if result.Skipped {
+		progress.Report(100, "Task history cleanup is already running on another node")
+		return nil
+	}
+	if result.LimitReached {
+		slog.WarnContext(ctx, "task history cleanup reached per-run limit", "component", "taskmanager", "deleted", result.Deleted)
+		progress.Report(100, fmt.Sprintf(
+			"Pruned %d task executions; remaining history will be pruned on the next run",
+			result.Deleted,
+		))
+		return nil
+	}
+	if result.Deleted > 0 {
+		slog.InfoContext(ctx, "task history cleanup completed", "component", "taskmanager", "deleted", result.Deleted)
+	}
+	progress.Report(100, fmt.Sprintf("Pruned %d task executions", result.Deleted))
+	return nil
+}
+
+func setTaskHistoryCleanupResult(progress taskmanager.ProgressReporter, result taskHistoryCleanupResult) {
+	if progress == nil {
+		return
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		return
+	}
+	progress.SetResultData(data)
+}

--- a/internal/taskmanager/tasks/cleanup_task_history.go
+++ b/internal/taskmanager/tasks/cleanup_task_history.go
@@ -10,15 +10,15 @@ import (
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
+// Batch geometry is a compile-time property of the delete strategy, not an
+// operator knob: it bounds how much of the table a single run may rewrite.
 const (
-	taskHistoryKeepPerTask       = 1000
-	taskHistoryMaxAge            = 30 * 24 * time.Hour
 	taskHistoryCleanupBatchSize  = 10000
 	taskHistoryCleanupMaxBatches = 100
 )
 
-// TaskHistoryPruner deletes a bounded amount of task execution history.
-type TaskHistoryPruner interface {
+// taskHistoryPruner deletes a bounded amount of task execution history.
+type taskHistoryPruner interface {
 	Prune(
 		ctx context.Context,
 		keepPerTask int,
@@ -30,18 +30,13 @@ type TaskHistoryPruner interface {
 
 // TaskHistoryCleanupTask prunes old task execution history.
 type TaskHistoryCleanupTask struct {
-	pruner TaskHistoryPruner
-}
-
-type taskHistoryCleanupResult struct {
-	Deleted      int64 `json:"deleted"`
-	LimitReached bool  `json:"limit_reached"`
-	Skipped      bool  `json:"skipped"`
+	pruner taskHistoryPruner
+	store  taskmanager.SettingsStore
 }
 
 // NewTaskHistoryCleanupTask creates a scheduled task for task history retention.
-func NewTaskHistoryCleanupTask(pruner TaskHistoryPruner) *TaskHistoryCleanupTask {
-	return &TaskHistoryCleanupTask{pruner: pruner}
+func NewTaskHistoryCleanupTask(pruner taskHistoryPruner, store taskmanager.SettingsStore) *TaskHistoryCleanupTask {
+	return &TaskHistoryCleanupTask{pruner: pruner, store: store}
 }
 
 func (t *TaskHistoryCleanupTask) Key() string  { return "cleanup_task_history" }
@@ -63,31 +58,32 @@ func (t *TaskHistoryCleanupTask) DefaultTriggers() []taskmanager.TriggerConfig {
 
 func (t *TaskHistoryCleanupTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
 	progress.Report(0, "Pruning task execution history")
-	cutoff := time.Now().UTC().Add(-taskHistoryMaxAge)
+	retention := taskmanager.LoadHistoryRetention(ctx, t.store)
+	cutoff := time.Now().UTC().AddDate(0, 0, -retention.RetentionDays)
 	result, err := t.pruner.Prune(
 		ctx,
-		taskHistoryKeepPerTask,
+		retention.KeepPerTask,
 		cutoff,
 		taskHistoryCleanupBatchSize,
 		taskHistoryCleanupMaxBatches,
 	)
-	resultData := taskHistoryCleanupResult{
-		Deleted:      result.Deleted,
-		LimitReached: result.LimitReached,
-		Skipped:      result.Skipped,
+	if data, marshalErr := json.Marshal(result); marshalErr == nil {
+		progress.SetResultData(data)
 	}
-	setTaskHistoryCleanupResult(progress, resultData)
 	if err != nil {
-		slog.WarnContext(ctx, "task history cleanup failed", "component", "taskmanager", "deleted", result.Deleted, "error", err)
+		slog.WarnContext(ctx, "task history cleanup failed", "component", "taskmanager", "task", t.Key(), "deleted", result.Deleted, "error", err)
 		progress.Report(100, fmt.Sprintf("Task history cleanup failed after deleting %d executions", result.Deleted))
 		return err
 	}
 	if result.Skipped {
+		slog.InfoContext(ctx, "task history cleanup skipped; another node holds the cleanup lock",
+			"component", "taskmanager", "task", t.Key())
 		progress.Report(100, "Task history cleanup is already running on another node")
 		return nil
 	}
 	if result.LimitReached {
-		slog.WarnContext(ctx, "task history cleanup reached per-run limit", "component", "taskmanager", "deleted", result.Deleted)
+		slog.WarnContext(ctx, "task history cleanup reached per-run limit",
+			"component", "taskmanager", "task", t.Key(), "deleted", result.Deleted)
 		progress.Report(100, fmt.Sprintf(
 			"Pruned %d task executions; remaining history will be pruned on the next run",
 			result.Deleted,
@@ -95,19 +91,10 @@ func (t *TaskHistoryCleanupTask) Execute(ctx context.Context, progress taskmanag
 		return nil
 	}
 	if result.Deleted > 0 {
-		slog.InfoContext(ctx, "task history cleanup completed", "component", "taskmanager", "deleted", result.Deleted)
+		slog.InfoContext(ctx, "task history cleanup completed",
+			"component", "taskmanager", "task", t.Key(), "deleted", result.Deleted,
+			"retention_days", retention.RetentionDays, "keep_per_task", retention.KeepPerTask)
 	}
 	progress.Report(100, fmt.Sprintf("Pruned %d task executions", result.Deleted))
 	return nil
-}
-
-func setTaskHistoryCleanupResult(progress taskmanager.ProgressReporter, result taskHistoryCleanupResult) {
-	if progress == nil {
-		return
-	}
-	data, err := json.Marshal(result)
-	if err != nil {
-		return
-	}
-	progress.SetResultData(data)
 }

--- a/internal/taskmanager/tasks/cleanup_task_history_test.go
+++ b/internal/taskmanager/tasks/cleanup_task_history_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -49,11 +50,20 @@ func (p *taskHistoryCleanupProgress) SetResultData(data json.RawMessage) {
 	p.result = append(p.result[:0], data...)
 }
 
+func (p *taskHistoryCleanupProgress) decode(t *testing.T) taskmanager.HistoryPruneResult {
+	t.Helper()
+	var result taskmanager.HistoryPruneResult
+	if err := json.Unmarshal(p.result, &result); err != nil {
+		t.Fatalf("unmarshal result data: %v", err)
+	}
+	return result
+}
+
 func TestTaskHistoryCleanupTask(t *testing.T) {
 	pruner := &fakeTaskHistoryPruner{
 		result: taskmanager.HistoryPruneResult{Deleted: 10017},
 	}
-	task := NewTaskHistoryCleanupTask(pruner)
+	task := NewTaskHistoryCleanupTask(pruner, &fakeSettingsStore{})
 
 	if task.Key() != "cleanup_task_history" {
 		t.Fatalf("Key() = %q, want cleanup_task_history", task.Key())
@@ -73,17 +83,17 @@ func TestTaskHistoryCleanupTask(t *testing.T) {
 		t.Fatalf("DefaultTriggers() = %#v, want %#v", gotTriggers, wantTriggers)
 	}
 
-	before := time.Now().UTC().Add(-taskHistoryMaxAge)
+	before := time.Now().UTC().AddDate(0, 0, -taskmanager.DefaultHistoryRetentionDays)
 	progress := &taskHistoryCleanupProgress{}
 	if err := task.Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	after := time.Now().UTC().Add(-taskHistoryMaxAge)
+	after := time.Now().UTC().AddDate(0, 0, -taskmanager.DefaultHistoryRetentionDays)
 	if pruner.calls != 1 {
 		t.Fatalf("pruner calls = %d, want 1", pruner.calls)
 	}
-	if pruner.kept != taskHistoryKeepPerTask {
-		t.Fatalf("keepPerTask = %d, want %d", pruner.kept, taskHistoryKeepPerTask)
+	if pruner.kept != taskmanager.DefaultHistoryKeepPerTask {
+		t.Fatalf("keepPerTask = %d, want %d", pruner.kept, taskmanager.DefaultHistoryKeepPerTask)
 	}
 	if pruner.batchSize != taskHistoryCleanupBatchSize {
 		t.Fatalf("batchSize = %d, want %d", pruner.batchSize, taskHistoryCleanupBatchSize)
@@ -97,12 +107,74 @@ func TestTaskHistoryCleanupTask(t *testing.T) {
 	if got := progress.reports[len(progress.reports)-1]; got != "Pruned 10017 task executions" {
 		t.Fatalf("last progress report = %q", got)
 	}
-	var result taskHistoryCleanupResult
-	if err := json.Unmarshal(progress.result, &result); err != nil {
-		t.Fatalf("unmarshal result: %v", err)
-	}
-	if result.Deleted != 10017 || result.LimitReached {
+	if result := progress.decode(t); result.Deleted != 10017 || result.LimitReached || result.Skipped {
 		t.Fatalf("result = %#v, want 10017 deleted without limit", result)
+	}
+}
+
+func TestTaskHistoryCleanupTaskUsesConfiguredRetention(t *testing.T) {
+	store := &fakeSettingsStore{values: map[string]string{
+		taskmanager.SettingKeyHistoryRetentionDays: "7",
+		taskmanager.SettingKeyHistoryKeepPerTask:   "25",
+	}}
+	pruner := &fakeTaskHistoryPruner{}
+
+	before := time.Now().UTC().AddDate(0, 0, -7)
+	if err := NewTaskHistoryCleanupTask(pruner, store).Execute(context.Background(), &taskHistoryCleanupProgress{}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	after := time.Now().UTC().AddDate(0, 0, -7)
+	if pruner.kept != 25 {
+		t.Fatalf("keepPerTask = %d, want 25", pruner.kept)
+	}
+	if pruner.cutoff.Before(before) || pruner.cutoff.After(after) {
+		t.Fatalf("cutoff = %v, want a 7 day window between %v and %v", pruner.cutoff, before, after)
+	}
+}
+
+func TestTaskHistoryCleanupTaskRejectsUnusableRetention(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		retentionDays string
+		keepPerTask   string
+	}{
+		{"zero", "0", "0"},
+		{"negative", "-5", "-1"},
+		{"garbage", "soon", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeSettingsStore{values: map[string]string{
+				taskmanager.SettingKeyHistoryRetentionDays: tc.retentionDays,
+				taskmanager.SettingKeyHistoryKeepPerTask:   tc.keepPerTask,
+			}}
+			pruner := &fakeTaskHistoryPruner{}
+			if err := NewTaskHistoryCleanupTask(pruner, store).Execute(context.Background(), &taskHistoryCleanupProgress{}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if pruner.kept != taskmanager.DefaultHistoryKeepPerTask {
+				t.Fatalf("keepPerTask = %d, want the default %d", pruner.kept, taskmanager.DefaultHistoryKeepPerTask)
+			}
+			floor := time.Now().UTC().AddDate(0, 0, -taskmanager.DefaultHistoryRetentionDays-1)
+			if pruner.cutoff.Before(floor) || pruner.cutoff.After(time.Now().UTC()) {
+				t.Fatalf("cutoff = %v, want the default retention window", pruner.cutoff)
+			}
+		})
+	}
+}
+
+func TestSeedHistoryRetentionDefaults(t *testing.T) {
+	store := &fakeSettingsStore{values: map[string]string{
+		taskmanager.SettingKeyHistoryKeepPerTask: "5",
+	}}
+	if err := taskmanager.SeedHistoryRetentionDefaults(context.Background(), store); err != nil {
+		t.Fatalf("SeedHistoryRetentionDefaults: %v", err)
+	}
+	if got := store.values[taskmanager.SettingKeyHistoryKeepPerTask]; got != "5" {
+		t.Fatalf("keep per task = %q, want the existing 5", got)
+	}
+	want := strconv.Itoa(taskmanager.DefaultHistoryRetentionDays)
+	if got := store.values[taskmanager.SettingKeyHistoryRetentionDays]; got != want {
+		t.Fatalf("retention days = %q, want %q", got, want)
 	}
 }
 
@@ -114,7 +186,7 @@ func TestTaskHistoryCleanupTaskReturnsPruneError(t *testing.T) {
 	}
 	progress := &taskHistoryCleanupProgress{}
 
-	err := NewTaskHistoryCleanupTask(pruner).Execute(context.Background(), progress)
+	err := NewTaskHistoryCleanupTask(pruner, &fakeSettingsStore{}).Execute(context.Background(), progress)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("Execute error = %v, want %v", err, wantErr)
 	}
@@ -133,16 +205,13 @@ func TestTaskHistoryCleanupTaskCapsWorkPerRun(t *testing.T) {
 	}
 	progress := &taskHistoryCleanupProgress{}
 
-	if err := NewTaskHistoryCleanupTask(pruner).Execute(context.Background(), progress); err != nil {
+	if err := NewTaskHistoryCleanupTask(pruner, &fakeSettingsStore{}).Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if pruner.calls != 1 {
 		t.Fatalf("pruner calls = %d, want 1", pruner.calls)
 	}
-	var result taskHistoryCleanupResult
-	if err := json.Unmarshal(progress.result, &result); err != nil {
-		t.Fatalf("unmarshal result: %v", err)
-	}
+	result := progress.decode(t)
 	if result.Deleted != wantDeleted || !result.LimitReached {
 		t.Fatalf("result = %#v, want %d deleted with limit reached", result, wantDeleted)
 	}
@@ -154,17 +223,13 @@ func TestTaskHistoryCleanupTaskReportsSkippedLock(t *testing.T) {
 	}
 	progress := &taskHistoryCleanupProgress{}
 
-	if err := NewTaskHistoryCleanupTask(pruner).Execute(context.Background(), progress); err != nil {
+	if err := NewTaskHistoryCleanupTask(pruner, &fakeSettingsStore{}).Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if got := progress.reports[len(progress.reports)-1]; got != "Task history cleanup is already running on another node" {
 		t.Fatalf("last progress report = %q", got)
 	}
-	var result taskHistoryCleanupResult
-	if err := json.Unmarshal(progress.result, &result); err != nil {
-		t.Fatalf("unmarshal result: %v", err)
-	}
-	if !result.Skipped {
+	if result := progress.decode(t); !result.Skipped || result.Deleted != 0 {
 		t.Fatalf("result = %#v, want skipped", result)
 	}
 }

--- a/internal/taskmanager/tasks/cleanup_task_history_test.go
+++ b/internal/taskmanager/tasks/cleanup_task_history_test.go
@@ -1,0 +1,170 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+type fakeTaskHistoryPruner struct {
+	result     taskmanager.HistoryPruneResult
+	err        error
+	calls      int
+	kept       int
+	cutoff     time.Time
+	batchSize  int
+	maxBatches int
+}
+
+func (f *fakeTaskHistoryPruner) Prune(
+	_ context.Context,
+	keepPerTask int,
+	cutoff time.Time,
+	batchSize int,
+	maxBatches int,
+) (taskmanager.HistoryPruneResult, error) {
+	f.calls++
+	f.kept = keepPerTask
+	f.cutoff = cutoff
+	f.batchSize = batchSize
+	f.maxBatches = maxBatches
+	return f.result, f.err
+}
+
+type taskHistoryCleanupProgress struct {
+	reports []string
+	result  json.RawMessage
+}
+
+func (p *taskHistoryCleanupProgress) Report(_ float64, message string) {
+	p.reports = append(p.reports, message)
+}
+
+func (p *taskHistoryCleanupProgress) SetResultData(data json.RawMessage) {
+	p.result = append(p.result[:0], data...)
+}
+
+func TestTaskHistoryCleanupTask(t *testing.T) {
+	pruner := &fakeTaskHistoryPruner{
+		result: taskmanager.HistoryPruneResult{Deleted: 10017},
+	}
+	task := NewTaskHistoryCleanupTask(pruner)
+
+	if task.Key() != "cleanup_task_history" {
+		t.Fatalf("Key() = %q, want cleanup_task_history", task.Key())
+	}
+	if task.Category() != taskmanager.TaskCategorySystem {
+		t.Fatalf("Category() = %q, want %q", task.Category(), taskmanager.TaskCategorySystem)
+	}
+	if task.IsHidden() {
+		t.Fatal("IsHidden() = true, want false")
+	}
+	wantTriggers := []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeStartup},
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: int64((24 * time.Hour) / time.Millisecond)},
+	}
+	gotTriggers := task.DefaultTriggers()
+	if len(gotTriggers) != len(wantTriggers) || gotTriggers[0] != wantTriggers[0] || gotTriggers[1] != wantTriggers[1] {
+		t.Fatalf("DefaultTriggers() = %#v, want %#v", gotTriggers, wantTriggers)
+	}
+
+	before := time.Now().UTC().Add(-taskHistoryMaxAge)
+	progress := &taskHistoryCleanupProgress{}
+	if err := task.Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	after := time.Now().UTC().Add(-taskHistoryMaxAge)
+	if pruner.calls != 1 {
+		t.Fatalf("pruner calls = %d, want 1", pruner.calls)
+	}
+	if pruner.kept != taskHistoryKeepPerTask {
+		t.Fatalf("keepPerTask = %d, want %d", pruner.kept, taskHistoryKeepPerTask)
+	}
+	if pruner.batchSize != taskHistoryCleanupBatchSize {
+		t.Fatalf("batchSize = %d, want %d", pruner.batchSize, taskHistoryCleanupBatchSize)
+	}
+	if pruner.maxBatches != taskHistoryCleanupMaxBatches {
+		t.Fatalf("maxBatches = %d, want %d", pruner.maxBatches, taskHistoryCleanupMaxBatches)
+	}
+	if pruner.cutoff.Before(before) || pruner.cutoff.After(after) {
+		t.Fatalf("cutoff = %v, want between %v and %v", pruner.cutoff, before, after)
+	}
+	if got := progress.reports[len(progress.reports)-1]; got != "Pruned 10017 task executions" {
+		t.Fatalf("last progress report = %q", got)
+	}
+	var result taskHistoryCleanupResult
+	if err := json.Unmarshal(progress.result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.Deleted != 10017 || result.LimitReached {
+		t.Fatalf("result = %#v, want 10017 deleted without limit", result)
+	}
+}
+
+func TestTaskHistoryCleanupTaskReturnsPruneError(t *testing.T) {
+	wantErr := errors.New("delete failed")
+	pruner := &fakeTaskHistoryPruner{
+		result: taskmanager.HistoryPruneResult{Deleted: taskHistoryCleanupBatchSize},
+		err:    wantErr,
+	}
+	progress := &taskHistoryCleanupProgress{}
+
+	err := NewTaskHistoryCleanupTask(pruner).Execute(context.Background(), progress)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Execute error = %v, want %v", err, wantErr)
+	}
+	if got := progress.reports[len(progress.reports)-1]; !strings.Contains(got, "failed after deleting 10000 executions") {
+		t.Fatalf("last progress report = %q", got)
+	}
+}
+
+func TestTaskHistoryCleanupTaskCapsWorkPerRun(t *testing.T) {
+	wantDeleted := int64(taskHistoryCleanupBatchSize * taskHistoryCleanupMaxBatches)
+	pruner := &fakeTaskHistoryPruner{
+		result: taskmanager.HistoryPruneResult{
+			Deleted:      wantDeleted,
+			LimitReached: true,
+		},
+	}
+	progress := &taskHistoryCleanupProgress{}
+
+	if err := NewTaskHistoryCleanupTask(pruner).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if pruner.calls != 1 {
+		t.Fatalf("pruner calls = %d, want 1", pruner.calls)
+	}
+	var result taskHistoryCleanupResult
+	if err := json.Unmarshal(progress.result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.Deleted != wantDeleted || !result.LimitReached {
+		t.Fatalf("result = %#v, want %d deleted with limit reached", result, wantDeleted)
+	}
+}
+
+func TestTaskHistoryCleanupTaskReportsSkippedLock(t *testing.T) {
+	pruner := &fakeTaskHistoryPruner{
+		result: taskmanager.HistoryPruneResult{Skipped: true},
+	}
+	progress := &taskHistoryCleanupProgress{}
+
+	if err := NewTaskHistoryCleanupTask(pruner).Execute(context.Background(), progress); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := progress.reports[len(progress.reports)-1]; got != "Task history cleanup is already running on another node" {
+		t.Fatalf("last progress report = %q", got)
+	}
+	var result taskHistoryCleanupResult
+	if err := json.Unmarshal(progress.result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !result.Skipped {
+		t.Fatalf("result = %#v, want skipped", result)
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix.

Task execution history grows indefinitely, increasing database storage and slowing history queries. The existing catalog search event retention task also duplicated bounded cleanup behavior that belongs in a general retention mechanism.

## Approach

Add a scheduled task-history cleanup job that runs at startup and daily. It retains the newest 1,000 executions per task, removes older records beyond 30 days, processes at most 10,000 rows across 100 batches per run, and preserves the newest execution for every task, including unregistered tasks.

Cleanup uses PostgreSQL ranking, deterministic completion-time/ID ordering, and a session-level advisory lock so only one Silo node performs cleanup at a time. The previous catalog search event retention implementation and migration are removed, and latest-history queries now use ID ordering to break timestamp ties.

## Validation

Not run; no command results were provided.

Added unit and PostgreSQL integration coverage for retention limits, age pruning, tie-breaking, batching, idempotence, concurrency, advisory-lock skipping, invalid limits, and task progress/result reporting.

## Risks

Database cleanup is bounded per run and preserves each task's newest execution. The removed catalog search retention path changes cleanup ownership but does not remove pending or recovery-sensitive search events. No migration or security impact identified.

## AI Disclosure

- Tool(s): none
- Model(s): n/a
- Involvement: AI-assisted
- Adversarial review: Not performed; the supplied diff was summarized into change request content.

## Checklist

- [ ] I read and can explain the complete diff.
- [ ] This pull request addresses one concern.