### PR TITLE
feat(catalog): persist Watchlist and Favorites browse sort per profile

### DIFF
--- a/docs/catalog-api.md
+++ b/docs/catalog-api.md
@@ -1,0 +1,28 @@
+# Catalog API
+
+## Saved browse sort
+
+`PUT /api/v1/collections/sort-preference` saves the active profile's sort for a
+library collection, user collection, Watchlist, or Favorites. The request is:
+
+```json
+{
+  "collection_kind": "watchlist",
+  "field": "added_at",
+  "order": "desc"
+}
+```
+
+`collection_kind` accepts `library`, `user`, `watchlist`, or `favorites`.
+`collection_id` is required for collection kinds and is omitted or ignored for
+Watchlist and Favorites. Personal lists accept the same non-personalized sort
+fields as the personal catalog browse; `added_at` means the date the item was
+added to the list. Personalized sorts (`progress`, `date_viewed`, and `plays`)
+are rejected, matching the browse. An empty `field` pins the profile to list
+source order. `DELETE /api/v1/collections/sort-preference?collection_kind=watchlist`
+removes the saved preference. Collection kinds also require `collection_id` on
+DELETE.
+
+When a catalog request has no explicit sort, its saved preference is applied
+before the source default. `/api/v1/catalog` reports an applied saved/default
+sort as `effective_sort`; source order omits that field.

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -59,10 +59,9 @@ type catalogResponse struct {
 	Items             []itemListResponse `json:"items"`
 	Snapshot          string             `json:"snapshot,omitempty"`
 	SearchDiagnostics *searchDiagnostics `json:"search_diagnostics,omitempty"`
-	// EffectiveSort reports the order a collection source actually resolved in
-	// once the viewer's saved override and the collection's configured default
-	// were applied. Omitted for non-collection sources and when the collection
-	// resolved in its own source order.
+	// EffectiveSort reports the order a collection or personal-list source
+	// actually resolved in after saved/default precedence was applied. Omitted
+	// for other sources and when the source kept its own order.
 	EffectiveSort *effectiveSortResponse `json:"effective_sort,omitempty"`
 }
 

--- a/internal/api/handlers/collection_sort_prefs.go
+++ b/internal/api/handlers/collection_sort_prefs.go
@@ -16,10 +16,9 @@ type collectionPreferenceLibraryReader interface {
 	GetByID(ctx context.Context, id string) (*models.LibraryCollection, error)
 }
 
-// collectionSortPreferenceRequest saves the sort a viewer chose while browsing a
-// collection. An empty Field is meaningful — it pins the viewer to the
-// collection's own source order even if its creator later configures a default.
-// To go back to following the creator's default, DELETE the preference instead.
+// collectionSortPreferenceRequest saves the sort a viewer chose while browsing
+// a collection or personal list. An empty Field pins the viewer to source order.
+// DELETE removes the preference and restores the source's default behavior.
 type collectionSortPreferenceRequest struct {
 	CollectionKind string `json:"collection_kind"`
 	CollectionID   string `json:"collection_id"`
@@ -89,19 +88,14 @@ func (h *CollectionHandler) HandleSetCollectionSortPreference(w http.ResponseWri
 
 	kind, collectionID, ok := normalizeCollectionRef(req.CollectionKind, req.CollectionID)
 	if !ok {
-		writeError(w, http.StatusBadRequest, "bad_request", "collection_kind must be 'library' or 'user' and collection_id is required")
+		writeError(w, http.StatusBadRequest, "bad_request", "collection_kind must be 'library', 'user', 'watchlist', or 'favorites'; collection_id is required for collection kinds")
 		return
 	}
 
-	field := strings.ToLower(strings.TrimSpace(req.Field))
-	order := ""
-	if field != "" {
-		qs, valid := catalog.NormalizeCollectionSort(field, req.Order, true)
-		if !valid {
-			writeError(w, http.StatusBadRequest, "bad_request", "Unsupported sort field or order for this collection")
-			return
-		}
-		field, order = qs.Field, qs.Order
+	field, order, valid := normalizeSortPreference(kind, req.Field, req.Order)
+	if !valid {
+		writeError(w, http.StatusBadRequest, "bad_request", "Unsupported sort field or order for this collection")
+		return
 	}
 
 	store, err := h.storeProvider.ForUser(r.Context(), userID)
@@ -141,6 +135,8 @@ func (h *CollectionHandler) canSaveCollectionSortPreference(
 	kind, collectionID string,
 ) bool {
 	switch kind {
+	case userstore.CollectionKindWatchlist, userstore.CollectionKindFavorites:
+		return true
 	case userstore.CollectionKindLibrary:
 		if h.LibraryCollections == nil {
 			return false
@@ -156,7 +152,7 @@ func (h *CollectionHandler) canSaveCollectionSortPreference(
 }
 
 // HandleClearCollectionSortPreference handles DELETE /collections/sort-preference,
-// returning the collection to whatever default its creator configured.
+// returning the collection or personal list to its default behavior.
 func (h *CollectionHandler) HandleClearCollectionSortPreference(w http.ResponseWriter, r *http.Request) {
 	userID := apimw.GetUserID(r.Context())
 	profileID := apimw.GetProfileID(r.Context())
@@ -164,7 +160,7 @@ func (h *CollectionHandler) HandleClearCollectionSortPreference(w http.ResponseW
 	values := r.URL.Query()
 	kind, collectionID, ok := normalizeCollectionRef(values.Get("collection_kind"), values.Get("collection_id"))
 	if !ok {
-		writeError(w, http.StatusBadRequest, "bad_request", "collection_kind must be 'library' or 'user' and collection_id is required")
+		writeError(w, http.StatusBadRequest, "bad_request", "collection_kind must be 'library', 'user', 'watchlist', or 'favorites'; collection_id is required for collection kinds")
 		return
 	}
 
@@ -184,6 +180,9 @@ func (h *CollectionHandler) HandleClearCollectionSortPreference(w http.ResponseW
 
 func normalizeCollectionRef(rawKind, rawID string) (string, string, bool) {
 	kind := strings.ToLower(strings.TrimSpace(rawKind))
+	if isPersonalSortPreferenceKind(kind) {
+		return kind, userstore.PersonalSortPreferenceCollectionID, true
+	}
 	if kind != userstore.CollectionKindLibrary && kind != userstore.CollectionKindUser {
 		return "", "", false
 	}
@@ -192,4 +191,21 @@ func normalizeCollectionRef(rawKind, rawID string) (string, string, bool) {
 		return "", "", false
 	}
 	return kind, collectionID, true
+}
+
+func isPersonalSortPreferenceKind(kind string) bool {
+	return kind == userstore.CollectionKindWatchlist || kind == userstore.CollectionKindFavorites
+}
+
+func normalizeSortPreference(kind, rawField, rawOrder string) (string, string, bool) {
+	field := strings.ToLower(strings.TrimSpace(rawField))
+	if field == "" {
+		return "", "", true
+	}
+	if isPersonalSortPreferenceKind(kind) {
+		qs, ok := catalog.NormalizePersonalSourceSort(field, rawOrder)
+		return qs.Field, qs.Order, ok
+	}
+	qs, ok := catalog.NormalizeCollectionSort(field, rawOrder, true)
+	return qs.Field, qs.Order, ok
 }

--- a/internal/api/handlers/collection_sort_prefs_test.go
+++ b/internal/api/handlers/collection_sort_prefs_test.go
@@ -221,6 +221,47 @@ func TestCollectionSortPreferenceEndpoints(t *testing.T) {
 		}
 	})
 
+	for _, kind := range []string{userstore.CollectionKindWatchlist, userstore.CollectionKindFavorites} {
+		t.Run("saves personal source sort for "+kind, func(t *testing.T) {
+			rec := put(`{"collection_kind":"` + kind + `","collection_id":"ignored","field":"added_at"}`)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+			pref, err := store.GetCollectionSortPreference(context.Background(), profileID, kind, userstore.PersonalSortPreferenceCollectionID)
+			if err != nil || pref == nil || pref.SortField != "added_at" || pref.SortOrder != "desc" {
+				t.Fatalf("stored preference = %+v, err = %v", pref, err)
+			}
+
+			// collection_id is optional and any supplied value is ignored.
+			rec = put(`{"collection_kind":"` + kind + `","field":"title","order":"asc"}`)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("omitted collection_id status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+
+			for _, field := range []string{"last_air_date", "runtime"} {
+				rec = put(`{"collection_kind":"` + kind + `","field":"` + field + `"}`)
+				if rec.Code != http.StatusOK {
+					t.Fatalf("%s status = %d, body = %s", field, rec.Code, rec.Body.String())
+				}
+			}
+
+			for _, field := range []string{"progress", "relevance", "not_a_sort"} {
+				rec = put(`{"collection_kind":"` + kind + `","field":"` + field + `"}`)
+				if rec.Code != http.StatusBadRequest {
+					t.Fatalf("unsupported %s status = %d, want 400; body = %s", field, rec.Code, rec.Body.String())
+				}
+			}
+
+			req := authed(httptest.NewRequest(http.MethodDelete,
+				"/collections/sort-preference?collection_kind="+kind, nil), userID, profileID)
+			rec = httptest.NewRecorder()
+			handler.HandleClearCollectionSortPreference(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("clear status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+
 	t.Run("clearing removes the override", func(t *testing.T) {
 		req := authed(httptest.NewRequest(http.MethodDelete,
 			"/collections/sort-preference?collection_kind=library&collection_id="+collectionID, nil), userID, profileID)
@@ -237,6 +278,35 @@ func TestCollectionSortPreferenceEndpoints(t *testing.T) {
 			t.Fatalf("preference still present after clear: %+v", pref)
 		}
 	})
+}
+
+func TestNormalizePersonalSortPreferenceRequest(t *testing.T) {
+	for _, kind := range []string{userstore.CollectionKindWatchlist, userstore.CollectionKindFavorites} {
+		if gotKind, gotID, ok := normalizeCollectionRef(kind, "ignored"); !ok || gotKind != kind || gotID != userstore.PersonalSortPreferenceCollectionID {
+			t.Fatalf("normalizeCollectionRef(%q) = %q/%q/%v", kind, gotKind, gotID, ok)
+		}
+		for _, valid := range []struct {
+			field, wantOrder string
+		}{
+			{field: "added_at", wantOrder: "desc"},
+			{field: "last_air_date", wantOrder: "desc"},
+			{field: "runtime", wantOrder: "desc"},
+		} {
+			if field, order, ok := normalizeSortPreference(kind, valid.field, ""); !ok || field != valid.field || order != valid.wantOrder {
+				t.Fatalf("normalizeSortPreference(%q, %s) = %q/%q/%v", kind, valid.field, field, order, ok)
+			}
+		}
+		for _, invalid := range []struct{ field, order string }{
+			{field: "progress"},
+			{field: "relevance"},
+			{field: "not_a_sort"},
+			{field: "title", order: "sideways"},
+		} {
+			if _, _, ok := normalizeSortPreference(kind, invalid.field, invalid.order); ok {
+				t.Fatalf("normalizeSortPreference(%q, %q, %q) accepted invalid sort", kind, invalid.field, invalid.order)
+			}
+		}
+	}
 }
 
 // TestNormalizeCollectionSortConfigForCreators covers the validation the

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -37,11 +37,10 @@ type CatalogResult struct {
 	SemanticUsed       bool
 	FallbackReason     string
 	IndexPendingEvents int
-	// EffectiveSort is the order collection sources actually resolved in, after
-	// applying the request's own sort, the viewer's saved override, and the
-	// collection's configured default in that order. An empty Field means the
-	// collection's source order. Only collection sources populate it; clients
-	// use it to show which sort is active when the request carried none.
+	// EffectiveSort is the order collection and personal-list sources actually
+	// resolved in after applying the request's own sort and any saved/default
+	// sort precedence. An empty Field means source order. Clients use it to show
+	// which sort is active when the request carried none.
 	EffectiveSort QuerySort
 }
 
@@ -664,6 +663,10 @@ func (r *CatalogResolver) resolvePersonalSource(ctx context.Context, req Catalog
 		return r.resolveHistorySourcePage(ctx, req, access)
 	}
 
+	if req.Source == CatalogSourceFavorites || req.Source == CatalogSourceWatchlist {
+		req = r.resolvePersonalSourceEffectiveSort(ctx, req, access)
+	}
+
 	store, err := r.catalogStoreForAccess(ctx, access)
 	if err != nil {
 		return nil, err
@@ -673,7 +676,36 @@ func (r *CatalogResolver) resolvePersonalSource(ctx context.Context, req Catalog
 	if err != nil {
 		return nil, err
 	}
-	return r.resolveExactOrderedItems(ctx, contentIDs, req, access)
+	result, err := r.resolveExactOrderedItems(ctx, contentIDs, req, access)
+	if err != nil {
+		return nil, err
+	}
+	if req.Source == CatalogSourceFavorites || req.Source == CatalogSourceWatchlist {
+		result.EffectiveSort = req.Query.Sort
+	}
+	return result, nil
+}
+
+// resolvePersonalSourceEffectiveSort applies personal-list precedence:
+// explicit request sort, then the profile's saved preference, then source
+// order. An added_at preference stays on the exact source-order path because
+// loadPersonalSourceIDs orders it using the list entry timestamps.
+func (r *CatalogResolver) resolvePersonalSourceEffectiveSort(ctx context.Context, req CatalogRequest, access AccessFilter) CatalogRequest {
+	if !req.UseSourceOrder || strings.TrimSpace(req.Query.Sort.Field) != "" {
+		return req
+	}
+	kind := string(req.Source)
+	pref := r.collectionSortOverride(ctx, access, kind, userstore.PersonalSortPreferenceCollectionID)
+	if pref == nil || strings.TrimSpace(pref.SortField) == "" {
+		return req
+	}
+	qs, ok := NormalizePersonalSourceSort(pref.SortField, pref.SortOrder)
+	if !ok {
+		return req
+	}
+	req.Query.Sort = qs
+	req.UseSourceOrder = qs.Field == "added_at"
+	return req
 }
 
 func (r *CatalogResolver) resolvePersonSource(ctx context.Context, req CatalogRequest, access AccessFilter) (*CatalogResult, error) {

--- a/internal/catalog/collection_sort_precedence_test.go
+++ b/internal/catalog/collection_sort_precedence_test.go
@@ -17,11 +17,15 @@ type sortPrefStore struct {
 	err  error
 	// calls records the lookups made, so tests can assert the store is not
 	// consulted when there is no user scope to consult it with.
-	calls int
+	calls        int
+	lastKind     string
+	lastTargetID string
 }
 
-func (s *sortPrefStore) GetCollectionSortPreference(_ context.Context, _, _, _ string) (*userstore.CollectionSortPreference, error) {
+func (s *sortPrefStore) GetCollectionSortPreference(_ context.Context, _, kind, collectionID string) (*userstore.CollectionSortPreference, error) {
 	s.calls++
+	s.lastKind = kind
+	s.lastTargetID = collectionID
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -185,5 +189,77 @@ func TestEffectiveCollectionSortAllowsPersonalizedOnUserCollections(t *testing.T
 	}
 	if qs.Field != "progress" || qs.Order != "desc" {
 		t.Fatalf("got %q/%q, want progress/desc", qs.Field, qs.Order)
+	}
+}
+
+func TestPersonalSourceSortPreferencePrecedence(t *testing.T) {
+	access := AccessFilter{UserID: 7, ProfileID: "profile-1"}
+	for _, source := range []CatalogSource{CatalogSourceWatchlist, CatalogSourceFavorites} {
+		t.Run(string(source), func(t *testing.T) {
+			t.Run("saved metadata sort", func(t *testing.T) {
+				store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"}}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{Source: source, UseSourceOrder: true}, access)
+				if req.UseSourceOrder || req.Query.Sort != (QuerySort{Field: "title", Order: "asc"}) {
+					t.Fatalf("resolved request = %+v, want title/asc query sort", req)
+				}
+				if store.lastKind != string(source) || store.lastTargetID != userstore.PersonalSortPreferenceCollectionID {
+					t.Fatalf("preference lookup = %q/%q, want %q/%q", store.lastKind, store.lastTargetID, source, userstore.PersonalSortPreferenceCollectionID)
+				}
+			})
+
+			t.Run("saved non-list metadata sort uses executor path", func(t *testing.T) {
+				store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "release_date", SortOrder: "desc"}}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{Source: source, UseSourceOrder: true}, access)
+				if req.UseSourceOrder || req.Query.Sort != (QuerySort{Field: "release_date", Order: "desc"}) {
+					t.Fatalf("resolved request = %+v, want release_date/desc executor path", req)
+				}
+			})
+
+			t.Run("saved added_at sort keeps list path", func(t *testing.T) {
+				store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "added_at", SortOrder: "asc"}}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{Source: source, UseSourceOrder: true}, access)
+				if !req.UseSourceOrder || req.Query.Sort != (QuerySort{Field: "added_at", Order: "asc"}) {
+					t.Fatalf("resolved request = %+v, want added_at/asc source path", req)
+				}
+			})
+
+			t.Run("explicit request wins without lookup", func(t *testing.T) {
+				store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"}}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				want := QuerySort{Field: "year", Order: "desc"}
+				req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{Source: source, Query: QueryDefinition{Sort: want}}, access)
+				if req.Query.Sort != want || store.calls != 0 {
+					t.Fatalf("resolved sort = %+v, lookups = %d; want explicit sort and zero lookups", req.Query.Sort, store.calls)
+				}
+			})
+
+			t.Run("explicit added_at wins on source path without lookup", func(t *testing.T) {
+				store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"}}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				want := QuerySort{Field: "added_at", Order: "asc"}
+				req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{
+					Source: source, Query: QueryDefinition{Sort: want}, UseSourceOrder: true,
+				}, access)
+				if req.Query.Sort != want || !req.UseSourceOrder || store.calls != 0 {
+					t.Fatalf("resolved request = %+v, lookups = %d; want explicit added_at source path", req, store.calls)
+				}
+			})
+
+			for _, pref := range []*userstore.CollectionSortPreference{
+				{SortField: "", SortOrder: ""},
+				{SortField: "retired", SortOrder: "desc"},
+				{SortField: "title", SortOrder: "sideways"},
+			} {
+				store := &sortPrefStore{pref: pref}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{Source: source, UseSourceOrder: true}, access)
+				if !req.UseSourceOrder || req.Query.Sort.Field != "" {
+					t.Fatalf("preference %+v resolved to %+v, want source order", pref, req)
+				}
+			}
+		})
 	}
 }

--- a/internal/catalog/query_definition.go
+++ b/internal/catalog/query_definition.go
@@ -214,6 +214,25 @@ func NormalizePersonalListSort(field, order string) (QuerySort, bool) {
 	return QuerySort{Field: field, Order: order}, true
 }
 
+// NormalizePersonalSourceSort validates a saved Watchlist/Favorites browse
+// preference against the same non-personalized vocabulary accepted by the
+// live personal-source catalog request.
+func NormalizePersonalSourceSort(field, order string) (QuerySort, bool) {
+	field = strings.ToLower(strings.TrimSpace(field))
+	// Relevance needs a live search query and random is not stable, so neither
+	// is meaningful as a persisted preference if they join the general set.
+	if field == "relevance" || field == "random" || !QuerySortFieldSet(false)[field] {
+		return QuerySort{}, false
+	}
+	order = strings.ToLower(strings.TrimSpace(order))
+	if order == "" {
+		order = querySortDefs[field].defaultOrder
+	} else if order != "asc" && order != "desc" {
+		return QuerySort{}, false
+	}
+	return QuerySort{Field: field, Order: order}, true
+}
+
 // NormalizeCollectionSort validates a collection's default sort (its stored
 // sort_config) or a viewer's saved override, applying the field's default order
 // when none is given. Returns false when the field or a supplied order is

--- a/internal/userdb/migrate.go
+++ b/internal/userdb/migrate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const schemaVersion = 19
+const schemaVersion = 20
 
 func runMigrations(db *sql.DB) error {
 	version, err := userVersion(db)
@@ -187,7 +187,34 @@ func runMigrations(db *sql.DB) error {
 		}
 	}
 
+	if version < 20 {
+		if err := migrateToV20(tx); err != nil {
+			return err
+		}
+		if _, err := tx.Exec("PRAGMA user_version = 20"); err != nil {
+			return fmt.Errorf("setting sqlite user_version 20: %w", err)
+		}
+	}
+
 	return tx.Commit()
+}
+
+// migrateToV20 widens collection sort preferences to include the two personal
+// catalog list sources while preserving every existing preference row.
+func migrateToV20(tx *sql.Tx) error {
+	if _, err := tx.Exec(`
+ALTER TABLE collection_sort_preferences RENAME TO collection_sort_preferences_v19;
+` + collectionSortPreferencesSchema + `
+INSERT INTO collection_sort_preferences (
+    profile_id, collection_kind, collection_id, sort_field, sort_order, updated_at
+)
+SELECT profile_id, collection_kind, collection_id, sort_field, sort_order, updated_at
+FROM collection_sort_preferences_v19;
+DROP TABLE collection_sort_preferences_v19;
+`); err != nil {
+		return fmt.Errorf("widening collection sort preference kinds: %w", err)
+	}
+	return nil
 }
 
 // migrateToV19 adds the per-profile collection sort override table. An empty

--- a/internal/userdb/migrate_v20_test.go
+++ b/internal/userdb/migrate_v20_test.go
@@ -1,0 +1,55 @@
+package userdb
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestMigrateToV20AllowsPersonalSortPreferenceKinds(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := InitSchema(db); err != nil {
+		t.Fatalf("InitSchema: %v", err)
+	}
+	if _, err := db.Exec(`
+DROP TABLE collection_sort_preferences;
+CREATE TABLE collection_sort_preferences (
+    profile_id TEXT NOT NULL,
+    collection_kind TEXT NOT NULL,
+    collection_id TEXT NOT NULL,
+    sort_field TEXT NOT NULL DEFAULT '',
+    sort_order TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (profile_id, collection_kind, collection_id),
+    CHECK (collection_kind IN ('library', 'user')),
+    CHECK (sort_order IN ('', 'asc', 'desc'))
+);
+INSERT INTO collection_sort_preferences VALUES ('profile-1', 'library', 'collection-1', 'title', 'asc', '2026-08-26T00:00:00Z');
+PRAGMA user_version = 19;
+`); err != nil {
+		t.Fatalf("seed v19 schema: %v", err)
+	}
+
+	if err := runMigrations(db); err != nil {
+		t.Fatalf("runMigrations: %v", err)
+	}
+	if _, err := db.Exec(`
+INSERT INTO collection_sort_preferences VALUES ('profile-1', 'watchlist', 'personal', 'added_at', 'desc', '2026-08-26T00:00:01Z');
+INSERT INTO collection_sort_preferences VALUES ('profile-1', 'favorites', 'personal', 'title', 'asc', '2026-08-26T00:00:02Z');
+`); err != nil {
+		t.Fatalf("insert personal preferences after migration: %v", err)
+	}
+	var field string
+	if err := db.QueryRow(`
+SELECT sort_field FROM collection_sort_preferences
+WHERE profile_id = 'profile-1' AND collection_kind = 'library' AND collection_id = 'collection-1'
+`).Scan(&field); err != nil {
+		t.Fatalf("read preserved preference: %v", err)
+	}
+	if field != "title" {
+		t.Fatalf("preserved sort_field = %q, want title", field)
+	}
+}

--- a/internal/userdb/schema.go
+++ b/internal/userdb/schema.go
@@ -132,7 +132,7 @@ CREATE TABLE IF NOT EXISTS collection_sort_preferences (
     sort_order TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL,
     PRIMARY KEY (profile_id, collection_kind, collection_id),
-    CHECK (collection_kind IN ('library', 'user')),
+    CHECK (collection_kind IN ('library', 'user', 'watchlist', 'favorites')),
     CHECK (sort_order IN ('', 'asc', 'desc'))
 );
 
@@ -562,7 +562,7 @@ CREATE INDEX user_setting_values_library_idx
 
 // collectionSortPreferencesSchema is kept as its own const (rather than only
 // inlined in Schema) so migrateToV19 can create the table on databases that
-// predate it. collection_kind separates the 'library' and 'user' id spaces.
+// predate it. collection_kind separates collection and personal-list sources.
 const collectionSortPreferencesSchema = `
 CREATE TABLE IF NOT EXISTS collection_sort_preferences (
     profile_id TEXT NOT NULL,
@@ -572,7 +572,7 @@ CREATE TABLE IF NOT EXISTS collection_sort_preferences (
     sort_order TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL,
     PRIMARY KEY (profile_id, collection_kind, collection_id),
-    CHECK (collection_kind IN ('library', 'user')),
+    CHECK (collection_kind IN ('library', 'user', 'watchlist', 'favorites')),
     CHECK (sort_order IN ('', 'asc', 'desc'))
 );`
 

--- a/internal/userstore/storetest/suite.go
+++ b/internal/userstore/storetest/suite.go
@@ -76,6 +76,22 @@ func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) use
 		t.Fatalf("UpdatedAt = %q, want RFC3339 timestamp: %v", pref.UpdatedAt, err)
 	}
 
+	for _, kind := range []string{userstore.CollectionKindWatchlist, userstore.CollectionKindFavorites} {
+		if err := store.SetCollectionSortPreference(ctx, userstore.CollectionSortPreference{
+			ProfileID:      profileID,
+			CollectionKind: kind,
+			CollectionID:   userstore.PersonalSortPreferenceCollectionID,
+			SortField:      "added_at",
+			SortOrder:      "desc",
+		}); err != nil {
+			t.Fatalf("SetCollectionSortPreference(%s): %v", kind, err)
+		}
+		personalPref, err := store.GetCollectionSortPreference(ctx, profileID, kind, userstore.PersonalSortPreferenceCollectionID)
+		if err != nil || personalPref == nil || personalPref.SortField != "added_at" {
+			t.Fatalf("GetCollectionSortPreference(%s) = %+v, err = %v", kind, personalPref, err)
+		}
+	}
+
 	for _, invalid := range []userstore.CollectionSortPreference{
 		{
 			ProfileID:      profileID,
@@ -160,6 +176,15 @@ func testCollectionSortPreferences(t *testing.T, newStore func(t *testing.T) use
 	}
 	if pref != nil {
 		t.Fatalf("stale preference survived profile recreation: %+v", pref)
+	}
+	for _, kind := range []string{userstore.CollectionKindWatchlist, userstore.CollectionKindFavorites} {
+		pref, err = store.GetCollectionSortPreference(ctx, profileID, kind, userstore.PersonalSortPreferenceCollectionID)
+		if err != nil {
+			t.Fatalf("GetCollectionSortPreference(%s after profile recreation): %v", kind, err)
+		}
+		if pref != nil {
+			t.Fatalf("%s preference survived profile recreation: %+v", kind, pref)
+		}
 	}
 }
 

--- a/internal/userstore/types.go
+++ b/internal/userstore/types.go
@@ -377,17 +377,21 @@ type SeriesPlaybackPreference struct {
 }
 
 // Collection kinds for CollectionSortPreference. Collection ids are unique
-// within a kind but not across the two id spaces, so the kind is part of the
-// preference's identity.
+// within a kind, so the kind is part of the preference's identity. Personal
+// list sources use PersonalSortPreferenceCollectionID because they have no
+// collection resource id of their own.
 const (
-	CollectionKindLibrary = "library"
-	CollectionKindUser    = "user"
+	CollectionKindLibrary   = "library"
+	CollectionKindUser      = "user"
+	CollectionKindWatchlist = "watchlist"
+	CollectionKindFavorites = "favorites"
+
+	PersonalSortPreferenceCollectionID = "personal"
 )
 
 // CollectionSortPreference records that a profile changed the sort order while
-// browsing a collection, overriding whatever default the collection's creator
-// configured. An empty SortField is a real choice — "show me this collection in
-// its own source order" — and is distinct from having no preference row at all.
+// browsing a collection or personal list. An empty SortField is a real choice
+// to use source order and is distinct from having no preference row at all.
 type CollectionSortPreference struct {
 	ProfileID      string `json:"profile_id"`
 	CollectionKind string `json:"collection_kind"`

--- a/migrations/sql/20260826140820_allow_personal_sort_preference_kinds.sql
+++ b/migrations/sql/20260826140820_allow_personal_sort_preference_kinds.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.user_collection_sort_preferences
+    DROP CONSTRAINT user_collection_sort_preferences_kind_check;
+ALTER TABLE public.user_collection_sort_preferences
+    ADD CONSTRAINT user_collection_sort_preferences_kind_check
+    CHECK (collection_kind IN ('library', 'user', 'watchlist', 'favorites'));
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DELETE FROM public.user_collection_sort_preferences
+WHERE collection_kind IN ('watchlist', 'favorites');
+ALTER TABLE public.user_collection_sort_preferences
+    DROP CONSTRAINT user_collection_sort_preferences_kind_check;
+ALTER TABLE public.user_collection_sort_preferences
+    ADD CONSTRAINT user_collection_sort_preferences_kind_check
+    CHECK (collection_kind IN ('library', 'user'));
+-- +goose StatementEnd

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -865,10 +865,9 @@ export interface CatalogResponse extends BrowseResponse {
   title?: string;
   snapshot?: string;
   /**
-   * The order a collection source actually resolved in, after the viewer's
-   * saved override and the collection's configured default were applied.
-   * Absent for non-collection sources and when the collection kept its own
-   * source order.
+   * The order a collection or personal-list source actually resolved in after
+   * saved/default precedence was applied. Absent for other sources and when
+   * the source kept its own order.
    */
   effective_sort?: QuerySort;
 }

--- a/web/src/hooks/queries/collections.ts
+++ b/web/src/hooks/queries/collections.ts
@@ -378,10 +378,9 @@ export function useDeleteUserCollectionImage() {
 }
 
 /**
- * Persists the sort a viewer picked while browsing a collection, so the choice
- * survives leaving and re-entering it. Sending an empty field pins the viewer
- * to the collection's own source order — distinct from clearing the preference,
- * which returns them to whatever default the collection's creator configured.
+ * Persists the sort a viewer picked while browsing a collection, watchlist, or
+ * favorites. Sending an empty field pins the viewer to source order — distinct
+ * from clearing a collection preference, which restores its configured default.
  *
  * Failures are deliberately silent: the sort is already applied to the current
  * view through the URL, and a toast for a preference that will be re-sent on
@@ -395,8 +394,8 @@ export function useSetCollectionSortPreference() {
     // overwriting the preference the viewer actually selected last.
     scope: { id: "collection-sort-preference" },
     mutationFn: (body: {
-      collection_kind: "library" | "user";
-      collection_id: string;
+      collection_kind: "library" | "user" | "watchlist" | "favorites";
+      collection_id?: string;
       field: string;
       order: NonNullable<CollectionSortConfig["order"]> | "";
     }) =>

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -104,6 +104,8 @@ function CatalogResults({
   const isHistorySource = state.source === "history";
   const isCollectionSource =
     state.source === "library_collection" || state.source === "user_collection";
+  const hasSavedSortPreference =
+    isCollectionSource || state.source === "watchlist" || state.source === "favorites";
   const allowPersonalizedOverlayControls = catalogSourceAllowsOverlay(state.source);
   const removeHistory = useRemoveHistory();
   const [selectionMode, setSelectionMode] = useState(false);
@@ -160,14 +162,14 @@ function CatalogResults({
     visibleRange,
     includeTotal: showExactResultCount,
   });
-  // The server resolves a collection's effective order (viewer override, then
-  // the collection's default, then source order) when the URL carries no sort.
+  // The server resolves a collection or personal list's effective order when
+  // the URL carries no sort.
   // Reflect that back into the filter bar so the menu shows what is actually
   // applied, without writing it into the URL — leaving it out of the URL is what
   // lets a later change to the saved preference take effect on the next visit.
   const effectiveSort = catalogQuery.data?.effectiveSort;
   const sortedState = useMemo(() => {
-    if (!isCollectionSource || !effectiveState.uses_source_order || !effectiveSort?.field) {
+    if (!hasSavedSortPreference || !effectiveState.uses_source_order || !effectiveSort?.field) {
       return effectiveState;
     }
     return {
@@ -179,13 +181,24 @@ function CatalogResults({
         sort: { field: effectiveSort.field, order: effectiveSort.order },
       },
     };
-  }, [effectiveSort, effectiveState, isCollectionSource]);
+  }, [effectiveSort, effectiveState, hasSavedSortPreference]);
 
   const setCollectionSortPreference = useSetCollectionSortPreference();
   const rememberCollectionSort = useCallback(
     (nextState: CatalogSearchState) => {
       const collectionId = nextState.collection_id?.trim();
-      if (!isCollectionSource || !collectionId) return;
+      let collectionKind: "library" | "user" | "watchlist" | "favorites";
+      if (nextState.source === "library_collection") {
+        if (!collectionId) return;
+        collectionKind = "library";
+      } else if (nextState.source === "user_collection") {
+        if (!collectionId) return;
+        collectionKind = "user";
+      } else if (nextState.source === "watchlist" || nextState.source === "favorites") {
+        collectionKind = nextState.source;
+      } else {
+        return;
+      }
       const nextValue = nextState.uses_source_order
         ? ""
         : querySortToSelectValue(nextState.query_definition.sort);
@@ -195,13 +208,13 @@ function CatalogResults({
       if (nextValue === currentValue) return;
       const [field, order] = nextValue ? nextValue.split(":") : ["", ""];
       setCollectionSortPreference.mutate({
-        collection_kind: nextState.source === "library_collection" ? "library" : "user",
+        collection_kind: collectionKind,
         collection_id: collectionId,
         field: field ?? "",
         order: order === "asc" || order === "desc" ? order : "",
       });
     },
-    [isCollectionSource, setCollectionSortPreference, sortedState],
+    [setCollectionSortPreference, sortedState],
   );
 
   const canRequest = useCanRequest();

--- a/web/src/pages/catalogSearchParams.test.ts
+++ b/web/src/pages/catalogSearchParams.test.ts
@@ -225,31 +225,40 @@ describe("buildCatalogHref", () => {
     ).toBe("source=query&library_id=2&sort=added_at&order=desc");
   });
 
-  it("omits the sort for watchlist source order but keeps an explicit Date Added", () => {
-    const sourceOrdered = buildCatalogApiSearchParams({
-      source: "watchlist",
-      uses_source_order: true,
-      query_definition: {
-        library_ids: [],
-        match: "all",
-        groups: [],
-        sort: { field: "added_at", order: "desc" },
-      },
-    });
-    expect(sourceOrdered.toString()).toBe("source=watchlist");
+  it.each(["watchlist", "favorites"] as const)(
+    "omits the sort for %s source order but keeps an explicit Date Added",
+    (source) => {
+      const sourceOrdered = buildCatalogApiSearchParams({
+        source,
+        uses_source_order: true,
+        query_definition: {
+          library_ids: [],
+          match: "all",
+          groups: [],
+          sort: { field: "added_at", order: "desc" },
+        },
+      });
+      expect(sourceOrdered.toString()).toBe(`source=${source}`);
 
-    const explicitAddedAt = buildCatalogApiSearchParams({
-      source: "watchlist",
-      uses_source_order: false,
-      query_definition: {
-        library_ids: [],
-        match: "all",
-        groups: [],
-        sort: { field: "added_at", order: "desc" },
-      },
-    });
-    expect(explicitAddedAt.toString()).toBe("source=watchlist&sort=added_at&order=desc");
-  });
+      const explicitAddedAt = buildCatalogApiSearchParams({
+        source,
+        uses_source_order: false,
+        query_definition: {
+          library_ids: [],
+          match: "all",
+          groups: [],
+          sort: { field: "added_at", order: "desc" },
+        },
+      });
+      expect(explicitAddedAt.toString()).toBe(`source=${source}&sort=added_at&order=desc`);
+
+      // The explicit pick must survive a URL round-trip, or the saved browse
+      // preference is written back as source order instead.
+      const reparsed = parseCatalogSearchParams(new URLSearchParams(explicitAddedAt.toString()));
+      expect(reparsed.uses_source_order).toBe(false);
+      expect(reparsed.query_definition.sort).toEqual({ field: "added_at", order: "desc" });
+    },
+  );
 
   it("does not leak a server-derived collection sort into an unrelated filter update", () => {
     const built = buildCatalogFilterSearchParams({

--- a/web/src/pages/catalogSearchParams.test.ts
+++ b/web/src/pages/catalogSearchParams.test.ts
@@ -91,7 +91,7 @@ describe("parseCatalogSearchParams", () => {
     expect(state.query_definition.sort).toEqual({ field: "title", order: "asc" });
   });
 
-  it("defaults the watchlist to source order until a sort is chosen", () => {
+  it("defaults personal saved lists to source order until a sort is chosen", () => {
     expect(parseCatalogSearchParams(params("source=watchlist")).uses_source_order).toBe(true);
     expect(parseCatalogSearchParams(params("source=watchlist&sort=title")).uses_source_order).toBe(
       false,
@@ -100,8 +100,7 @@ describe("parseCatalogSearchParams", () => {
       parseCatalogSearchParams(params("source=watchlist&sort=added_at&order=desc"))
         .uses_source_order,
     ).toBe(false);
-    // Other personal sources keep their existing behavior.
-    expect(parseCatalogSearchParams(params("source=favorites")).uses_source_order).toBe(false);
+    expect(parseCatalogSearchParams(params("source=favorites")).uses_source_order).toBe(true);
     expect(parseCatalogSearchParams(params("source=history")).uses_source_order).toBe(false);
   });
 

--- a/web/src/pages/catalogSearchParams.ts
+++ b/web/src/pages/catalogSearchParams.ts
@@ -72,9 +72,9 @@ function isCollectionSource(source: CatalogSource): boolean {
 
 // Sources whose default ordering is the stored list order rather than a sort
 // field. The watchlist's stored order can mirror a watch provider's list
-// order (e.g. MDBList) via sort_index.
+// order (e.g. MDBList) via sort_index; favorites use their entry order.
 export function catalogSourceSupportsSourceOrder(source: CatalogSource): boolean {
-  return isCollectionSource(source) || source === "watchlist";
+  return isCollectionSource(source) || source === "watchlist" || source === "favorites";
 }
 
 export function catalogSourceAllowsOverlay(source: CatalogSource): boolean {

--- a/web/src/pages/catalogSearchParams.ts
+++ b/web/src/pages/catalogSearchParams.ts
@@ -392,11 +392,11 @@ export function buildCatalogApiSearchParams(state: CatalogSearchState): URLSearc
     state.query_definition.sort.field &&
     (state.query_definition.sort.field !== "added_at" ||
       (state.source === "query" && effectiveLibraryID != null) ||
-      // Watchlist defaults to source order, so an explicit Date Added pick
+      // These sources default to source order, so an explicit Date Added pick
       // must be sent to distinguish it (the server maps it to list added-at).
-      state.source === "watchlist" ||
-      state.source === "library_collection" ||
-      state.source === "user_collection")
+      // Dropping it would round-trip back through parse as source order and
+      // save the wrong browse preference.
+      catalogSourceSupportsSourceOrder(state.source))
   ) {
     params.set("sort", state.query_definition.sort.field);
     if (state.query_definition.sort.order) {


### PR DESCRIPTION
## Problem

A sort chosen while browsing a library or user collection is saved per profile and survives leaving and re-entering the view (#489). The two personal lists were left out: **Watchlist** and **Favorites** reset to their default order on every visit, so a profile that prefers Favorites by title has to re-pick it each time.

Favorites had a second, related gap — it did not support source order at all in the web client, so there was no "no explicit sort" state for a preference to apply to.

## Approach

Widen the existing profile-scoped sort preference storage rather than adding a parallel mechanism for personal lists.

- `collection_kind` gains `watchlist` and `favorites` alongside `library` and `user`. Neither personal list has a collection resource id of its own, so both store under the sentinel `collection_id` `"personal"` (`userstore.PersonalSortPreferenceCollectionID`). `collection_id` is optional on the request for these kinds and ignored if sent.
- Personal lists validate through a new `catalog.NormalizePersonalSourceSort`, which accepts the same non-personalized vocabulary as the live personal browse. `progress`, `date_viewed`, and `plays` are rejected because they are personalized; `relevance` needs a live search query and `random` is not stable, so neither is meaningful as a persisted preference.
- Resolution precedence mirrors collections: an explicit request sort wins **without a store lookup**, then the profile's saved preference, then source order. A saved `added_at` preference stays on the list-order path because `loadPersonalSourceIDs` already orders it by the list entry timestamps; other fields fall through to the query executor.
- `effective_sort` on `/api/v1/catalog` now also reports the resolved order for personal-list sources, so the filter bar can show what is actually applied without writing it into the URL — which is what lets a later preference change take effect on the next visit.
- Web: Favorites joins the Watchlist in `catalogSourceSupportsSourceOrder`, and `rememberCollectionSort` maps each source to its preference kind explicitly instead of assuming a collection.

Migrations for both stores: a Goose migration relaxes the Postgres `user_collection_sort_preferences_kind_check` constraint, and userdb schema v20 rebuilds the SQLite table with the widened `CHECK`, copying every existing row across.

## Testing

- `go test ./internal/userdb/... ./internal/userstore/... ./internal/catalog/... ./internal/api/handlers/...` — pass.
- `npx vitest run src/pages/catalogSearchParams.test.ts` — 21 pass.
- `gofmt -l internal/` clean; `make verify-local-paths` clean.

New coverage: handler accept/reject for both personal kinds including the personalized-field rejections and the optional `collection_id`; resolver precedence for saved metadata sorts, saved `added_at`, explicit-request-wins-without-lookup, and invalid/empty preferences falling back to source order; a v19→v20 userdb migration test asserting existing rows survive and the new kinds insert; and storetest suite coverage for the personal kinds, including cleanup on profile recreation.

Not verified at runtime against a live deployment — the Postgres constraint migration in particular has only been read, not applied. Worth a dev-builder pass before merge.

## Client follow-up

`collection_kind` accepting two new values is additive and pre-lock, so no existing client breaks. Persisting Watchlist/Favorites sort is not yet wired up in \`silo-apple\` or \`silo-android\`; both should adopt it to match the web behavior. jellycompat has no equivalent saved-sort surface, so no parity work there.

\`docs/catalog-api.md\` is added to document the endpoint's contract for both kinds.

Related issue: N/A — narrow gap in the #489 feature.

## AI use

Written by Claude Opus 5 driving the implementation and tests, reviewed and validated by the author with the commands listed under Testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added saved sort preferences for Watchlist and Favorites, alongside existing library and user collections.
  * Saved preferences are automatically applied when no sort is selected.
  * Catalog controls now display the effective saved or default sort.
  * Favorites and Watchlist support source ordering and appropriate sort validation.

* **Bug Fixes**
  * Preserved existing sort preferences during database upgrades.
  * Improved handling of personal-list sorting and fallback to source order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->