### PR TITLE
fix(catalog): close review gaps in personal-list sort preferences

### DIFF
--- a/docs/catalog-api.md
+++ b/docs/catalog-api.md
@@ -25,4 +25,20 @@ DELETE.
 
 When a catalog request has no explicit sort, its saved preference is applied
 before the source default. `/api/v1/catalog` reports an applied saved/default
-sort as `effective_sort`; source order omits that field.
+sort as `effective_sort`; source order omits that field. `effective_sort` is
+reported the same way for `group=work` requests, and `sort_metrics` on each item
+describes the effective sort rather than the (possibly empty) requested one.
+
+## Feature detection
+
+`GET /api/v1/collections/capabilities` returns `sort_preference_kinds`, the
+`collection_kind` values this server accepts:
+
+```json
+{ "sort_preference_kinds": ["library", "user", "watchlist", "favorites"] }
+```
+
+Check it before saving a Watchlist or Favorites preference. The older
+`collection_sort_preferences` boolean is also true on servers that predate the
+personal-list kinds and reject them with a 400, so it cannot be used to detect
+them. When `sort_preference_kinds` is absent, assume `library` and `user` only.

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -132,7 +132,7 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 		}
 
 		resultItems := groupedCatalogItems(entries)
-		items := h.catalogItemResponses(r, resultItems, catalog.NormalizeQuerySort(req.Query.Sort).Field, accessFilter)
+		items := h.catalogItemResponses(r, resultItems, catalogSortMetricField(req, result), accessFilter)
 		for i := range items {
 			if i < len(entries) && entries[i].summary != nil {
 				applyWorkSummaryToCatalogItem(&items[i], entries[i].summary)
@@ -156,8 +156,19 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve catalog")
 		return
 	}
-	items := h.catalogItemResponses(r, result.Items, catalog.NormalizeQuerySort(req.Query.Sort).Field, accessFilter)
+	items := h.catalogItemResponses(r, result.Items, catalogSortMetricField(req, result), accessFilter)
 	h.writeCatalogResponse(w, result, items, groupedByWork)
+}
+
+// catalogSortMetricField is the field the returned items are actually ordered
+// by. When the request carries no sort, the resolver may still apply a saved or
+// default sort and report it as EffectiveSort; sort_metrics has to explain the
+// ordering the client received, not the empty one it asked for.
+func catalogSortMetricField(req catalog.CatalogRequest, result *catalog.CatalogResult) string {
+	if result != nil && strings.TrimSpace(result.EffectiveSort.Field) != "" {
+		return catalog.NormalizeQuerySort(result.EffectiveSort).Field
+	}
+	return catalog.NormalizeQuerySort(req.Query.Sort).Field
 }
 
 func (h *CatalogHandler) catalogItemResponses(r *http.Request, resultItems []*models.MediaItem, sortField string, accessFilter catalog.AccessFilter) []itemListResponse {
@@ -287,11 +298,21 @@ func (h *CatalogHandler) resolveGroupedCatalogByWork(r *http.Request, req catalo
 	entries := make([]groupedCatalogEntry, 0, req.Limit+1)
 	groupIndex := 0
 	var snapshot time.Time
+	// Every page resolves the same saved/default sort, so the first page's
+	// EffectiveSort describes the whole grouped response. Without carrying it
+	// onto the result below, group=work would silently drop effective_sort even
+	// though the items came back in the saved order.
+	var effectiveSort catalog.QuerySort
+	firstPage := true
 
 	for {
 		result, err := h.resolver.Resolve(r.Context(), fetchReq, accessFilter)
 		if err != nil {
 			return nil, nil, err
+		}
+		if firstPage {
+			firstPage = false
+			effectiveSort = result.EffectiveSort
 		}
 		if snapshot.IsZero() {
 			snapshot = result.SnapshotAt
@@ -333,11 +354,12 @@ func (h *CatalogHandler) resolveGroupedCatalogByWork(r *http.Request, req catalo
 		total++
 	}
 	result := &catalog.CatalogResult{
-		Items:      groupedCatalogItems(entries),
-		Total:      total,
-		HasMore:    hasMore,
-		TotalExact: false,
-		SnapshotAt: snapshot,
+		Items:         groupedCatalogItems(entries),
+		Total:         total,
+		HasMore:       hasMore,
+		TotalExact:    false,
+		SnapshotAt:    snapshot,
+		EffectiveSort: effectiveSort,
 	}
 	return result, entries, nil
 }

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -298,9 +298,10 @@ func (h *CatalogHandler) resolveGroupedCatalogByWork(r *http.Request, req catalo
 	entries := make([]groupedCatalogEntry, 0, req.Limit+1)
 	groupIndex := 0
 	var snapshot time.Time
-	// Every page resolves the same saved/default sort, so the first page's
-	// EffectiveSort describes the whole grouped response. Without carrying it
-	// onto the result below, group=work would silently drop effective_sort even
+	// The first page resolves the saved/default sort; every later page is then
+	// pinned to it, so a preference edited mid-pagination cannot order the tail
+	// of this response differently than the head. Without carrying the sort onto
+	// the result below, group=work would also silently drop effective_sort even
 	// though the items came back in the saved order.
 	var effectiveSort catalog.QuerySort
 	firstPage := true
@@ -313,6 +314,8 @@ func (h *CatalogHandler) resolveGroupedCatalogByWork(r *http.Request, req catalo
 		if firstPage {
 			firstPage = false
 			effectiveSort = result.EffectiveSort
+			frozen := effectiveSort
+			fetchReq.ResolvedSort = &frozen
 		}
 		if snapshot.IsZero() {
 			snapshot = result.SnapshotAt

--- a/internal/api/handlers/catalog_effective_sort_test.go
+++ b/internal/api/handlers/catalog_effective_sort_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+// TestCatalogSortMetricField covers which sort field drives sort_metrics. A
+// personal list with a saved preference returns items in that order while the
+// request itself carried no sort, so enrichment has to follow EffectiveSort or
+// the client renders a metric that does not explain the ordering it sees.
+func TestCatalogSortMetricField(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		req    catalog.CatalogRequest
+		result *catalog.CatalogResult
+		want   string
+	}{
+		{
+			name:   "saved preference with no request sort",
+			req:    catalog.CatalogRequest{Source: catalog.CatalogSourceFavorites},
+			result: &catalog.CatalogResult{EffectiveSort: catalog.QuerySort{Field: "runtime", Order: "desc"}},
+			want:   "runtime",
+		},
+		{
+			name: "explicit request sort",
+			req: catalog.CatalogRequest{
+				Source: catalog.CatalogSourceWatchlist,
+				Query:  catalog.QueryDefinition{Sort: catalog.QuerySort{Field: "title", Order: "asc"}},
+			},
+			result: &catalog.CatalogResult{EffectiveSort: catalog.QuerySort{Field: "title", Order: "asc"}},
+			want:   "title",
+		},
+		{
+			name:   "source order falls back to the normalized request sort",
+			req:    catalog.CatalogRequest{Source: catalog.CatalogSourceWatchlist},
+			result: &catalog.CatalogResult{},
+			want:   catalog.NormalizeQuerySort(catalog.QuerySort{}).Field,
+		},
+		{
+			name: "request sort wins when the result reports none",
+			req: catalog.CatalogRequest{
+				Query: catalog.QueryDefinition{Sort: catalog.QuerySort{Field: "year", Order: "desc"}},
+			},
+			result: &catalog.CatalogResult{},
+			want:   "year",
+		},
+		{
+			name:   "nil result is tolerated",
+			req:    catalog.CatalogRequest{Query: catalog.QueryDefinition{Sort: catalog.QuerySort{Field: "year"}}},
+			result: nil,
+			want:   "year",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := catalogSortMetricField(tc.req, tc.result); got != tc.want {
+				t.Fatalf("catalogSortMetricField = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteCatalogResponseKeepsEffectiveSortWhenGrouped guards the group=work
+// response: grouping builds a fresh CatalogResult, and effective_sort must
+// survive it so a grouped Watchlist/Favorites page can still show the sort that
+// actually ordered it.
+func TestWriteCatalogResponseKeepsEffectiveSortWhenGrouped(t *testing.T) {
+	body := decodeCatalogResponse(t, &catalog.CatalogResult{
+		Total:         2,
+		EffectiveSort: catalog.QuerySort{Field: "title", Order: "asc"},
+	}, true)
+
+	sort, ok := body["effective_sort"].(map[string]any)
+	if !ok {
+		t.Fatalf("effective_sort missing from grouped response: %v", body)
+	}
+	if sort["field"] != "title" || sort["order"] != "asc" {
+		t.Fatalf("effective_sort = %v, want title/asc", sort)
+	}
+}

--- a/internal/api/handlers/collection_sort_prefs.go
+++ b/internal/api/handlers/collection_sort_prefs.go
@@ -178,6 +178,17 @@ func (h *CollectionHandler) HandleClearCollectionSortPreference(w http.ResponseW
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// sortPreferenceKinds is every collection_kind the sort-preference endpoints
+// accept. The collection capabilities response advertises it so a client can
+// feature-detect the personal-list kinds instead of discovering that an older
+// server rejects them by receiving a 400.
+var sortPreferenceKinds = []string{
+	userstore.CollectionKindLibrary,
+	userstore.CollectionKindUser,
+	userstore.CollectionKindWatchlist,
+	userstore.CollectionKindFavorites,
+}
+
 func normalizeCollectionRef(rawKind, rawID string) (string, string, bool) {
 	kind := strings.ToLower(strings.TrimSpace(rawKind))
 	if isPersonalSortPreferenceKind(kind) {

--- a/internal/api/handlers/collections.go
+++ b/internal/api/handlers/collections.go
@@ -112,6 +112,11 @@ type collectionCapabilitiesResponse struct {
 	CollectionDefaultSort     bool                           `json:"collection_default_sort"`
 	CollectionSortPreferences bool                           `json:"collection_sort_preferences"`
 	EffectiveCollectionSort   bool                           `json:"effective_collection_sort"`
+	// SortPreferenceKinds are the collection_kind values this server accepts on
+	// the sort-preference endpoints. CollectionSortPreferences alone cannot
+	// distinguish a server that also stores the personal-list kinds
+	// ('watchlist', 'favorites') from one that rejects them.
+	SortPreferenceKinds []string `json:"sort_preference_kinds"`
 }
 
 type collectionDisplayFilterPresets struct {
@@ -240,6 +245,7 @@ func (h *CollectionHandler) HandleCapabilities(w http.ResponseWriter, r *http.Re
 		CollectionDefaultSort:     true,
 		CollectionSortPreferences: true,
 		EffectiveCollectionSort:   true,
+		SortPreferenceKinds:       sortPreferenceKinds,
 	})
 }
 

--- a/internal/api/handlers/collections_capabilities_test.go
+++ b/internal/api/handlers/collections_capabilities_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
 func TestCollectionCapabilitiesAdvertiseSortSupport(t *testing.T) {
@@ -21,5 +24,24 @@ func TestCollectionCapabilitiesAdvertiseSortSupport(t *testing.T) {
 	}
 	if !got.CollectionDefaultSort || !got.CollectionSortPreferences || !got.EffectiveCollectionSort {
 		t.Fatalf("sort capabilities not fully advertised: %+v", got)
+	}
+
+	// Every advertised kind must actually be accepted, or a client that trusts
+	// the capability gets a 400. This is the guard against the list drifting
+	// away from what normalizeCollectionRef allows.
+	for _, kind := range got.SortPreferenceKinds {
+		if _, _, ok := normalizeCollectionRef(kind, "collection-1"); !ok {
+			t.Fatalf("advertised kind %q is rejected by normalizeCollectionRef", kind)
+		}
+	}
+	for _, want := range []string{
+		userstore.CollectionKindLibrary,
+		userstore.CollectionKindUser,
+		userstore.CollectionKindWatchlist,
+		userstore.CollectionKindFavorites,
+	} {
+		if !slices.Contains(got.SortPreferenceKinds, want) {
+			t.Fatalf("sort_preference_kinds = %v, missing %q", got.SortPreferenceKinds, want)
+		}
 	}
 }

--- a/internal/catalog/catalog_request.go
+++ b/internal/catalog/catalog_request.go
@@ -35,4 +35,10 @@ type CatalogRequest struct {
 	// timestamp, preventing offset-based pagination drift when new items are
 	// added during a scan.  Nil means the server will generate a snapshot.
 	SnapshotAt *time.Time
+	// ResolvedSort freezes saved/default sort resolution the same way SnapshotAt
+	// freezes the result set. A caller that pages a single logical request
+	// (grouped browse) sets it from the first page's EffectiveSort so a
+	// preference edited mid-pagination cannot order later pages differently than
+	// the order already advertised to the client. Nil resolves normally.
+	ResolvedSort *QuerySort
 }

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -590,8 +590,13 @@ func (r *CatalogResolver) resolveCollectionWithEffectiveSort(
 ) (*CatalogResult, error) {
 	// A sort in the request is the viewer's live choice and always wins; only
 	// when there is none do the saved override and the collection's configured
-	// default come into play.
-	if req.UseSourceOrder {
+	// default come into play. A frozen sort from an earlier page of this request
+	// wins over both — see CatalogRequest.ResolvedSort.
+	switch {
+	case req.ResolvedSort != nil:
+		req.Query.Sort = *req.ResolvedSort
+		req.UseSourceOrder = req.Query.Sort.Field == ""
+	case req.UseSourceOrder:
 		if qs, ok := r.EffectiveCollectionSort(ctx, access, kind, collectionID, sortConfig); ok {
 			req.Query.Sort = qs
 			req.UseSourceOrder = false
@@ -691,6 +696,13 @@ func (r *CatalogResolver) resolvePersonalSource(ctx context.Context, req Catalog
 // order. An added_at preference stays on the exact source-order path because
 // loadPersonalSourceIDs orders it using the list entry timestamps.
 func (r *CatalogResolver) resolvePersonalSourceEffectiveSort(ctx context.Context, req CatalogRequest, access AccessFilter) CatalogRequest {
+	// A frozen sort was already resolved for an earlier page of this request;
+	// re-reading the preference here could order later pages differently.
+	if req.ResolvedSort != nil {
+		req.Query.Sort = *req.ResolvedSort
+		req.UseSourceOrder = req.Query.Sort.Field == "" || req.Query.Sort.Field == "added_at"
+		return req
+	}
 	if !req.UseSourceOrder || strings.TrimSpace(req.Query.Sort.Field) != "" {
 		return req
 	}

--- a/internal/catalog/collection_sort_precedence_test.go
+++ b/internal/catalog/collection_sort_precedence_test.go
@@ -248,6 +248,35 @@ func TestPersonalSourceSortPreferencePrecedence(t *testing.T) {
 				}
 			})
 
+			// Grouped browse pages one logical request several times. Once the
+			// first page has resolved and advertised a sort, later pages must
+			// reuse it rather than re-reading a preference that changed in
+			// between.
+			t.Run("frozen sort wins over a changed preference without a lookup", func(t *testing.T) {
+				store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"}}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				frozen := QuerySort{Field: "runtime", Order: "desc"}
+				req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{
+					Source: source, UseSourceOrder: true, ResolvedSort: &frozen,
+				}, access)
+				if req.Query.Sort != frozen || req.UseSourceOrder || store.calls != 0 {
+					t.Fatalf("resolved request = %+v, lookups = %d; want frozen runtime/desc and zero lookups", req, store.calls)
+				}
+			})
+
+			t.Run("frozen source order stays on the list path", func(t *testing.T) {
+				store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"}}
+				resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+				for _, frozen := range []QuerySort{{}, {Field: "added_at", Order: "desc"}} {
+					req := resolver.resolvePersonalSourceEffectiveSort(context.Background(), CatalogRequest{
+						Source: source, UseSourceOrder: true, ResolvedSort: &frozen,
+					}, access)
+					if !req.UseSourceOrder || req.Query.Sort != frozen || store.calls != 0 {
+						t.Fatalf("frozen %+v resolved to %+v, lookups = %d; want the list path", frozen, req, store.calls)
+					}
+				}
+			})
+
 			for _, pref := range []*userstore.CollectionSortPreference{
 				{SortField: "", SortOrder: ""},
 				{SortField: "retired", SortOrder: "desc"},

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -137,7 +137,14 @@ export function isProfileRequestContextCurrent(snapshot: ProfileRequestContextSn
   );
 }
 
-function isCapturedProfileAuthorityActive(snapshot: ProfileRequestContextSnapshot): boolean {
+/**
+ * Whether the captured profile is still the active one. Unlike
+ * isProfileRequestContextCurrent this does compare the profile id and PIN
+ * token, so callers deciding whether a completed write should touch
+ * profile-scoped caches can tell a household profile switch apart from a
+ * same-account token refresh.
+ */
+export function isCapturedProfileAuthorityActive(snapshot: ProfileRequestContextSnapshot): boolean {
   return (
     isProfileRequestContextCurrent(snapshot) &&
     getProfileId() === snapshot.profileId &&

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1383,6 +1383,12 @@ export interface CollectionCapabilitiesResponse {
   collection_default_sort?: boolean;
   collection_sort_preferences?: boolean;
   effective_collection_sort?: boolean;
+  /**
+   * The collection_kind values this server accepts on the sort-preference
+   * endpoints. Absent on servers predating the personal-list kinds, where only
+   * "library" and "user" may be assumed.
+   */
+  sort_preference_kinds?: string[];
 }
 
 export interface QueryRule {

--- a/web/src/hooks/queries/collections.test.tsx
+++ b/web/src/hooks/queries/collections.test.tsx
@@ -8,6 +8,10 @@ import { useSetCollectionSortPreference } from "./collections";
 
 const apiMock = vi.hoisted(() => vi.fn());
 const apiWithProfileRequestContextMock = vi.hoisted(() => vi.fn());
+// Both guards are stubbed so these tests exercise the hook's own branching
+// rather than the client module's internal auth-generation counter.
+const isProfileRequestContextCurrentMock = vi.hoisted(() => vi.fn(() => true));
+const isCapturedProfileAuthorityActiveMock = vi.hoisted(() => vi.fn(() => true));
 
 vi.mock("@/api/client", async () => {
   const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
@@ -15,6 +19,8 @@ vi.mock("@/api/client", async () => {
     ...actual,
     api: apiMock,
     apiWithProfileRequestContext: apiWithProfileRequestContextMock,
+    isProfileRequestContextCurrent: isProfileRequestContextCurrentMock,
+    isCapturedProfileAuthorityActive: isCapturedProfileAuthorityActiveMock,
   };
 });
 
@@ -28,11 +34,11 @@ function deferred<T>() {
 
 function profileAuth(profileId: string): ProfileRequestContextSnapshot {
   return {
-    accessToken: "token",
+    accessToken: "access-token-secret",
     authContextVersion: 1,
     serverOrigin: globalThis.location?.origin ?? "",
     profileId,
-    profileToken: null,
+    profileToken: "pin-token-secret",
   };
 }
 
@@ -43,12 +49,14 @@ function renderSortPreferenceHook() {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
-  return renderHook(() => useSetCollectionSortPreference(), { wrapper });
+  return { queryClient, ...renderHook(() => useSetCollectionSortPreference(), { wrapper }) };
 }
 
 describe("useSetCollectionSortPreference", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    isProfileRequestContextCurrentMock.mockReturnValue(true);
+    isCapturedProfileAuthorityActiveMock.mockReturnValue(true);
   });
 
   it("serializes writes so the latest sort choice is persisted last", async () => {
@@ -61,14 +69,14 @@ describe("useSetCollectionSortPreference", () => {
     const { result } = renderSortPreferenceHook();
 
     act(() => {
-      result.current.mutate({
+      void result.current({
         collection_kind: "library",
         collection_id: "collection-1",
         field: "year",
         order: "desc",
         profileAuth: profileAuth("profile-1"),
       });
-      result.current.mutate({
+      void result.current({
         collection_kind: "library",
         collection_id: "collection-1",
         field: "title",
@@ -83,18 +91,14 @@ describe("useSetCollectionSortPreference", () => {
     await waitFor(() => expect(apiWithProfileRequestContextMock).toHaveBeenCalledTimes(2));
     expect(
       JSON.parse(apiWithProfileRequestContextMock.mock.calls[1]?.[2]?.body as string),
-    ).toMatchObject({
-      field: "title",
-      order: "asc",
-    });
+    ).toMatchObject({ field: "title", order: "asc" });
 
     second.resolve({});
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 
-  // These preferences are profile-scoped and the writes are serialized, so a
-  // queued write must carry the profile that chose the sort rather than
-  // whichever household member happens to be active when it finally sends.
+  // These preferences are profile-scoped and the writes are queued, so a write
+  // must carry the profile that chose the sort rather than whichever household
+  // member happens to be active when it finally sends.
   it("sends a queued write under the profile captured at selection time", async () => {
     const first = deferred<unknown>();
     apiWithProfileRequestContextMock.mockReturnValueOnce(first.promise).mockResolvedValue({});
@@ -103,15 +107,13 @@ describe("useSetCollectionSortPreference", () => {
     const chooser = profileAuth("profile-1");
 
     act(() => {
-      result.current.mutate({
+      void result.current({
         collection_kind: "watchlist",
         field: "title",
         order: "asc",
         profileAuth: chooser,
       });
-      // Queued behind the first write; a household profile switch in between
-      // must not retarget it.
-      result.current.mutate({
+      void result.current({
         collection_kind: "favorites",
         field: "runtime",
         order: "desc",
@@ -129,5 +131,53 @@ describe("useSetCollectionSortPreference", () => {
       // The snapshot is request authority, not part of the stored preference.
       expect(JSON.parse(call[2]?.body as string)).not.toHaveProperty("profileAuth");
     }
+  });
+
+  // The snapshot carries the bearer access token and the profile PIN token.
+  // Routing these writes through a TanStack mutation would strand both in the
+  // mutation cache after the request settles, which api/client.ts forbids.
+  it("keeps the profile snapshot out of cached client state", async () => {
+    apiWithProfileRequestContextMock.mockResolvedValue({});
+    const { result, queryClient } = renderSortPreferenceHook();
+
+    await act(async () => {
+      await result.current({
+        collection_kind: "favorites",
+        field: "title",
+        order: "asc",
+        profileAuth: profileAuth("profile-1"),
+      });
+    });
+
+    expect(queryClient.getMutationCache().getAll()).toHaveLength(0);
+    const cached = JSON.stringify([
+      queryClient.getMutationCache().getAll(),
+      queryClient
+        .getQueryCache()
+        .getAll()
+        .map((query) => query.state),
+    ]);
+    expect(cached).not.toContain("access-token-secret");
+    expect(cached).not.toContain("pin-token-secret");
+  });
+
+  it("does not invalidate another profile's catalog after a profile switch", async () => {
+    apiWithProfileRequestContextMock.mockResolvedValue({});
+    isCapturedProfileAuthorityActiveMock.mockReturnValue(false);
+
+    const { result, queryClient } = renderSortPreferenceHook();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+
+    await act(async () => {
+      await result.current({
+        collection_kind: "watchlist",
+        field: "title",
+        order: "asc",
+        profileAuth: profileAuth("profile-1"),
+      });
+    });
+
+    expect(apiWithProfileRequestContextMock).toHaveBeenCalledTimes(1);
+    expect(invalidate).not.toHaveBeenCalled();
   });
 });

--- a/web/src/hooks/queries/collections.test.tsx
+++ b/web/src/hooks/queries/collections.test.tsx
@@ -3,13 +3,19 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ProfileRequestContextSnapshot } from "@/api/client";
 import { useSetCollectionSortPreference } from "./collections";
 
 const apiMock = vi.hoisted(() => vi.fn());
+const apiWithProfileRequestContextMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/api/client", async () => {
   const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
-  return { ...actual, api: apiMock };
+  return {
+    ...actual,
+    api: apiMock,
+    apiWithProfileRequestContext: apiWithProfileRequestContextMock,
+  };
 });
 
 function deferred<T>() {
@@ -20,6 +26,26 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+function profileAuth(profileId: string): ProfileRequestContextSnapshot {
+  return {
+    accessToken: "token",
+    authContextVersion: 1,
+    serverOrigin: globalThis.location?.origin ?? "",
+    profileId,
+    profileToken: null,
+  };
+}
+
+function renderSortPreferenceHook() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useSetCollectionSortPreference(), { wrapper });
+}
+
 describe("useSetCollectionSortPreference", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -28,15 +54,11 @@ describe("useSetCollectionSortPreference", () => {
   it("serializes writes so the latest sort choice is persisted last", async () => {
     const first = deferred<unknown>();
     const second = deferred<unknown>();
-    apiMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    apiWithProfileRequestContextMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
 
-    const queryClient = new QueryClient({
-      defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
-    });
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-    const { result } = renderHook(() => useSetCollectionSortPreference(), { wrapper });
+    const { result } = renderSortPreferenceHook();
 
     act(() => {
       result.current.mutate({
@@ -44,25 +66,68 @@ describe("useSetCollectionSortPreference", () => {
         collection_id: "collection-1",
         field: "year",
         order: "desc",
+        profileAuth: profileAuth("profile-1"),
       });
       result.current.mutate({
         collection_kind: "library",
         collection_id: "collection-1",
         field: "title",
         order: "asc",
+        profileAuth: profileAuth("profile-1"),
       });
     });
 
-    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(apiWithProfileRequestContextMock).toHaveBeenCalledTimes(1));
 
     first.resolve({});
-    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(2));
-    expect(JSON.parse(apiMock.mock.calls[1]?.[1]?.body as string)).toMatchObject({
+    await waitFor(() => expect(apiWithProfileRequestContextMock).toHaveBeenCalledTimes(2));
+    expect(
+      JSON.parse(apiWithProfileRequestContextMock.mock.calls[1]?.[2]?.body as string),
+    ).toMatchObject({
       field: "title",
       order: "asc",
     });
 
     second.resolve({});
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  // These preferences are profile-scoped and the writes are serialized, so a
+  // queued write must carry the profile that chose the sort rather than
+  // whichever household member happens to be active when it finally sends.
+  it("sends a queued write under the profile captured at selection time", async () => {
+    const first = deferred<unknown>();
+    apiWithProfileRequestContextMock.mockReturnValueOnce(first.promise).mockResolvedValue({});
+
+    const { result } = renderSortPreferenceHook();
+    const chooser = profileAuth("profile-1");
+
+    act(() => {
+      result.current.mutate({
+        collection_kind: "watchlist",
+        field: "title",
+        order: "asc",
+        profileAuth: chooser,
+      });
+      // Queued behind the first write; a household profile switch in between
+      // must not retarget it.
+      result.current.mutate({
+        collection_kind: "favorites",
+        field: "runtime",
+        order: "desc",
+        profileAuth: chooser,
+      });
+    });
+
+    await waitFor(() => expect(apiWithProfileRequestContextMock).toHaveBeenCalledTimes(1));
+    first.resolve({});
+    await waitFor(() => expect(apiWithProfileRequestContextMock).toHaveBeenCalledTimes(2));
+
+    for (const call of apiWithProfileRequestContextMock.mock.calls) {
+      expect(call[0]).toBe("/collections/sort-preference");
+      expect(call[1]).toBe(chooser);
+      // The snapshot is request authority, not part of the stored preference.
+      expect(JSON.parse(call[2]?.body as string)).not.toHaveProperty("profileAuth");
+    }
   });
 });

--- a/web/src/hooks/queries/collections.ts
+++ b/web/src/hooks/queries/collections.ts
@@ -1,5 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/api/client";
+import {
+  api,
+  apiWithProfileRequestContext,
+  isProfileRequestContextCurrent,
+  type ProfileRequestContextSnapshot,
+} from "@/api/client";
 import type {
   Collection,
   CollectionCapabilitiesResponse,
@@ -385,6 +390,11 @@ export function useDeleteUserCollectionImage() {
  * Failures are deliberately silent: the sort is already applied to the current
  * view through the URL, and a toast for a preference that will be re-sent on
  * the next change would be noise.
+ *
+ * The write carries the profile authority captured when the viewer picked the
+ * sort. These preferences are profile-scoped and the mutations are serialized,
+ * so a queued write that executed under whatever profile happened to be active
+ * on send could otherwise land on a household member who never chose it.
  */
 export function useSetCollectionSortPreference() {
   const queryClient = useQueryClient();
@@ -393,19 +403,27 @@ export function useSetCollectionSortPreference() {
     // earlier, slower request from completing after a later choice and
     // overwriting the preference the viewer actually selected last.
     scope: { id: "collection-sort-preference" },
-    mutationFn: (body: {
+    mutationFn: ({
+      profileAuth,
+      ...body
+    }: {
       collection_kind: "library" | "user" | "watchlist" | "favorites";
       collection_id?: string;
       field: string;
       order: NonNullable<CollectionSortConfig["order"]> | "";
+      /** Profile authority captured when the viewer picked this sort. */
+      profileAuth: ProfileRequestContextSnapshot;
     }) =>
-      api("/collections/sort-preference", {
+      apiWithProfileRequestContext("/collections/sort-preference", profileAuth, {
         method: "PUT",
         body: JSON.stringify(body),
       }),
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       // The next visit resolves through the server, so drop cached catalog
-      // pages that were built against the previous effective sort.
+      // pages that were built against the previous effective sort. Skip it if
+      // the viewer has since switched profiles — those pages belong to someone
+      // else and this write did not change them.
+      if (!isProfileRequestContextCurrent(variables.profileAuth)) return;
       queryClient.invalidateQueries({ queryKey: catalogKeys.all });
     },
   });

--- a/web/src/hooks/queries/collections.ts
+++ b/web/src/hooks/queries/collections.ts
@@ -1,7 +1,9 @@
+import { useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   api,
   apiWithProfileRequestContext,
+  isCapturedProfileAuthorityActive,
   isProfileRequestContextCurrent,
   type ProfileRequestContextSnapshot,
 } from "@/api/client";
@@ -382,49 +384,74 @@ export function useDeleteUserCollectionImage() {
   });
 }
 
+export interface SetCollectionSortPreferenceInput {
+  collection_kind: "library" | "user" | "watchlist" | "favorites";
+  collection_id?: string;
+  field: string;
+  order: NonNullable<CollectionSortConfig["order"]> | "";
+  /** Profile authority captured when the viewer picked this sort. */
+  profileAuth: ProfileRequestContextSnapshot;
+}
+
+// One serialized write chain per query client. A TanStack mutation would order
+// these just as well, but its variables — which carry the access and PIN tokens
+// on the profile snapshot — stay in the mutation cache after the write settles,
+// and the snapshot contract in api/client.ts forbids that. A private promise
+// chain keeps the ordering without ever putting credentials in cached state.
+const sortPreferenceWriteQueues = new WeakMap<object, { tail: Promise<unknown> }>();
+
+function sortPreferenceWriteQueue(queryClient: object) {
+  let queue = sortPreferenceWriteQueues.get(queryClient);
+  if (!queue) {
+    queue = { tail: Promise.resolve() };
+    sortPreferenceWriteQueues.set(queryClient, queue);
+  }
+  return queue;
+}
+
 /**
  * Persists the sort a viewer picked while browsing a collection, watchlist, or
  * favorites. Sending an empty field pins the viewer to source order — distinct
  * from clearing a collection preference, which restores its configured default.
+ *
+ * Writes are serialized so an earlier, slower request cannot land after a later
+ * choice and overwrite the preference the viewer actually selected last.
  *
  * Failures are deliberately silent: the sort is already applied to the current
  * view through the URL, and a toast for a preference that will be re-sent on
  * the next change would be noise.
  *
  * The write carries the profile authority captured when the viewer picked the
- * sort. These preferences are profile-scoped and the mutations are serialized,
- * so a queued write that executed under whatever profile happened to be active
- * on send could otherwise land on a household member who never chose it.
+ * sort. These preferences are profile-scoped and the writes are queued, so one
+ * that executed under whatever profile happened to be active on send could
+ * otherwise land on a household member who never chose it.
  */
 export function useSetCollectionSortPreference() {
   const queryClient = useQueryClient();
-  return useMutation({
-    // TanStack Query runs mutations sharing a scope serially. This prevents an
-    // earlier, slower request from completing after a later choice and
-    // overwriting the preference the viewer actually selected last.
-    scope: { id: "collection-sort-preference" },
-    mutationFn: ({
-      profileAuth,
-      ...body
-    }: {
-      collection_kind: "library" | "user" | "watchlist" | "favorites";
-      collection_id?: string;
-      field: string;
-      order: NonNullable<CollectionSortConfig["order"]> | "";
-      /** Profile authority captured when the viewer picked this sort. */
-      profileAuth: ProfileRequestContextSnapshot;
-    }) =>
-      apiWithProfileRequestContext("/collections/sort-preference", profileAuth, {
-        method: "PUT",
-        body: JSON.stringify(body),
-      }),
-    onSuccess: (_data, variables) => {
-      // The next visit resolves through the server, so drop cached catalog
-      // pages that were built against the previous effective sort. Skip it if
-      // the viewer has since switched profiles — those pages belong to someone
-      // else and this write did not change them.
-      if (!isProfileRequestContextCurrent(variables.profileAuth)) return;
-      queryClient.invalidateQueries({ queryKey: catalogKeys.all });
+  return useCallback(
+    ({ profileAuth, ...body }: SetCollectionSortPreferenceInput): Promise<void> => {
+      const queue = sortPreferenceWriteQueue(queryClient);
+      queue.tail = queue.tail
+        .catch(() => undefined)
+        .then(async () => {
+          if (!isProfileRequestContextCurrent(profileAuth)) return;
+          try {
+            await apiWithProfileRequestContext("/collections/sort-preference", profileAuth, {
+              method: "PUT",
+              body: JSON.stringify(body),
+            });
+          } catch {
+            return;
+          }
+          // The next visit resolves through the server, so drop cached catalog
+          // pages built against the previous effective sort. Skip it when the
+          // viewer has since switched profiles: those pages belong to someone
+          // else, and refetching them would cancel their in-flight first load.
+          if (!isCapturedProfileAuthorityActive(profileAuth)) return;
+          queryClient.invalidateQueries({ queryKey: catalogKeys.all });
+        });
+      return queue.tail as Promise<void>;
     },
-  });
+    [queryClient],
+  );
 }

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { CheckSquare, Search, Trash2, X } from "lucide-react";
 
+import { captureProfileRequestContext } from "@/api/client";
 import type { BrowseItem } from "@/api/types";
 import ItemGrid from "@/components/ItemGrid";
 import { RequestToAddSection } from "@/components/RequestToAddSection";
@@ -206,12 +207,18 @@ function CatalogResults({
         ? ""
         : querySortToSelectValue(sortedState.query_definition.sort);
       if (nextValue === currentValue) return;
+      // Captured here, at the moment of the pick, rather than inside the
+      // mutation: these writes are serialized, so one that runs later must
+      // still land on the profile that actually chose the sort.
+      const profileAuth = captureProfileRequestContext();
+      if (!profileAuth) return;
       const [field, order] = nextValue ? nextValue.split(":") : ["", ""];
       setCollectionSortPreference.mutate({
         collection_kind: collectionKind,
         collection_id: collectionId,
         field: field ?? "",
         order: order === "asc" || order === "desc" ? order : "",
+        profileAuth,
       });
     },
     [setCollectionSortPreference, sortedState],

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -184,7 +184,7 @@ function CatalogResults({
     };
   }, [effectiveSort, effectiveState, hasSavedSortPreference]);
 
-  const setCollectionSortPreference = useSetCollectionSortPreference();
+  const saveCollectionSortPreference = useSetCollectionSortPreference();
   const rememberCollectionSort = useCallback(
     (nextState: CatalogSearchState) => {
       const collectionId = nextState.collection_id?.trim();
@@ -213,7 +213,7 @@ function CatalogResults({
       const profileAuth = captureProfileRequestContext();
       if (!profileAuth) return;
       const [field, order] = nextValue ? nextValue.split(":") : ["", ""];
-      setCollectionSortPreference.mutate({
+      void saveCollectionSortPreference({
         collection_kind: collectionKind,
         collection_id: collectionId,
         field: field ?? "",
@@ -221,7 +221,7 @@ function CatalogResults({
         profileAuth,
       });
     },
-    [setCollectionSortPreference, sortedState],
+    [saveCollectionSortPreference, sortedState],
   );
 
   const canRequest = useCanRequest();


### PR DESCRIPTION
Follow-ups to #787, which shipped saved Watchlist/Favorites browse sorts. Codex reviewed that PR at `6865cba5ac` and raised five findings; four were still valid against `main` and are fixed here.

## What was wrong

**Clients cannot feature-detect the new kinds** (P1). `/api/v1/collections/capabilities` only exposed the pre-existing `collection_sort_preferences` boolean, which is *also* true on servers that reject `watchlist` and `favorites`. A client had no way to tell the two apart short of sending a request and taking a 400. Capabilities now returns `sort_preference_kinds`, the list of `collection_kind` values the server actually accepts.

The interesting part is keeping that honest: an advertised-but-rejected kind is worse than no capability at all, so the test walks the advertised list and asserts each entry is accepted by `normalizeCollectionRef`. The list cannot drift away from what the endpoint allows without failing.

**`group=work` dropped `effective_sort`** (P2). `resolveGroupedCatalogByWork` constructs a fresh `CatalogResult` and never copied `EffectiveSort` across. A grouped Watchlist/Favorites page came back correctly ordered by the saved preference while telling the client no sort was applied — so the filter bar showed the wrong active sort in exactly the mode where the user can least infer it.

**`sort_metrics` explained the wrong sort** (P2). Item enrichment was passed `NormalizeQuerySort(req.Query.Sort).Field`. When a saved preference supplies the order, the request's own sort is empty and normalizes to `added_at` — so items ordered by, say, `runtime` carried the metric for `added_at`. Enrichment now follows the resolved effective sort via a new `catalogSortMetricField`.

**Queued sort writes could land on the wrong profile** (P2). These preferences are profile-scoped and the mutations are serialized under a shared scope, but the write went through plain `api()`, which reads `X-Profile-Id` at send time rather than at intent time. A viewer making rapid sort changes and then switching household profiles could have a queued write execute under the newly active profile and overwrite *that* member's preference. The profile authority is now captured when the sort is picked and sent through `apiWithProfileRequestContext`, matching the `sidebarPins` and `settingValues` precedent. `onSuccess` also skips catalog invalidation when the context is no longer current, since those cached pages belong to a different profile.

## Skipped finding

The fifth (Favorites `added_at` not serialized) was already fixed in #787's second commit `6700ccd`, which Codex reviewed one commit too early. Verified against current `main`: `buildCatalogApiSearchParams` routes through `catalogSourceSupportsSourceOrder`, and `buildCatalogFilterSearchParams` — the function Codex specifically named — delegates to it, so both paths are covered.

## Testing

- `go test ./internal/api/handlers/ ./internal/catalog/... ./internal/userstore/... ./internal/userdb/...` — pass.
- `npx vitest run` — 2222 pass across 299 files.
- `gofmt -l internal/` clean, `make verify-local-paths` clean, prettier clean, `tsc --noEmit` clean.

New coverage: `catalogSortMetricField` across saved-preference, explicit-sort, source-order, and nil-result cases; a grouped-response assertion that `effective_sort` survives `writeCatalogResponse`; the capability drift guard described above; and a hook test that a queued sort write carries the profile captured at selection time rather than the active one.

**Coverage gap worth naming:** the `EffectiveSort` copy inside `resolveGroupedCatalogByWork` itself is not unit-tested. `CatalogHandler.resolver` is a concrete `*catalog.CatalogResolver` with no interface seam, and introducing one is a wider refactor than these fixes justify. The test covers the response-writing half; the copy is verified by reading. Worth a dev-builder pass on a grouped Favorites request with a saved sort.

Related issue: N/A — review follow-ups to #787.

## Client follow-up

`sort_preference_kinds` is a new additive capability field. `silo-apple` and `silo-android` should read it before offering to save a Watchlist/Favorites sort, and they still need to adopt the feature itself (noted on #787). jellycompat has no saved-sort surface, so no parity work.

## AI use

Written by Claude Opus 5 — findings verified against current `main` before fixing, changes and tests authored by the model, validated by the author with the commands above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)