### PR TITLE
fix(playback): ignore unchanged output route replans

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -237,6 +237,7 @@ body cap: 256 KiB. Body: `ReplanRequestV3`
 | `409` | `stale_playback_plan` | `failed_plan_id` is not the session's current plan, `playback_attempt_id` is not the session's attempt, or a newer replacement is already active |
 | `409` | `idempotency_key_reused` | This `replan_request_id` was used for a different replan |
 | `409` | `replan_in_progress` | A replan for this session holds the lease right now |
+| `409` | `output_route_unchanged` | A legacy output-route invalidation changed only opaque or non-planning state; the active plan remains mounted |
 | `503` | `replan_capacity_exhausted` | Server-wide concurrent replan limit (8) reached; retryable |
 | `500` | `internal_error` | Store outage |
 

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,6 +49,7 @@ const (
 	subtitleUnavailableReasonV3  = "subtitle_artifact_unavailable"
 	transcodeStartFailedReasonV3 = "transcode_start_failed"
 	seekRestorationPlayerV3      = "player_position"
+	outputRouteChangedReasonV3   = "output_route_changed"
 	// Failed capability fetches are memoized briefly so an unreachable node
 	// costs one timeout per window instead of one per planning request.
 	v3NodeCapabilityErrorTTL = 15 * time.Second
@@ -3335,6 +3337,17 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusConflict, "stale_playback_plan", "The failed plan is no longer current")
 		return
 	}
+	// Older Android clients can report a Spatializer callback as an output-route
+	// change even though the sink and every planning capability stayed the same.
+	// Replanning remounts Media3, which can fire the callback again and create a
+	// direct/remux/transcode loop. Keep the active route mounted when only the
+	// opaque route token or Spatializer runtime state changed.
+	if req.EffectiveOperation() == playback.ReplanOperationFailureRecoveryV3 &&
+		req.Failure.Classification == outputRouteChangedReasonV3 &&
+		sameLegacyOutputRouteReplanV3(record, req) {
+		writeError(w, http.StatusConflict, "output_route_unchanged", "Output route capabilities did not change")
+		return
+	}
 	response, updated, transport, replanErr := h.executeReplanV3(r, record, req)
 	if replanErr != nil {
 		if transport != nil {
@@ -3398,6 +3411,49 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 	}
 	h.raceCopySafetyV3(updated.EffectiveMediaFileID, response.PlaybackPlan)
 	writeJSON(w, http.StatusOK, response)
+}
+
+func sameLegacyOutputRouteReplanV3(record *playback.AttemptRecordV3, next playback.ReplanRequestV3) bool {
+	if record == nil {
+		return false
+	}
+	current := record.NormalizedRequest
+	if nextQuality := strings.TrimSpace(next.QualityPreference); nextQuality != "" {
+		normalized, _ := playback.NormalizeQualityV3(nextQuality)
+		if normalized != current.QualityPreference {
+			return false
+		}
+	}
+	if next.Metered != current.Metered ||
+		!reflect.DeepEqual(next.BandwidthEstimateKbps, current.BandwidthEstimateKbps) ||
+		!reflect.DeepEqual(next.BandwidthCapKbps, current.BandwidthCapKbps) ||
+		!sameSelectedTracksV3(next.SelectedTracks, record.CurrentPlan.SelectedTracks) ||
+		!reflect.DeepEqual(next.ClientFeatures, current.ClientFeatures) {
+		return false
+	}
+	currentCapabilities := current.Capabilities
+	nextCapabilities := next.Capabilities
+	currentCapabilities.AudioPassthrough = withoutSpatializerV3(currentCapabilities.AudioPassthrough)
+	nextCapabilities.AudioPassthrough = withoutSpatializerV3(nextCapabilities.AudioPassthrough)
+	if !reflect.DeepEqual(currentCapabilities, nextCapabilities) {
+		return false
+	}
+	currentContext := current.ClientPlaybackContext
+	nextContext := next.ClientPlaybackContext
+	currentContext.Output.OutputContextID = ""
+	nextContext.Output.OutputContextID = ""
+	currentContext.Output.AudioPassthrough = withoutSpatializerV3(currentContext.Output.AudioPassthrough)
+	nextContext.Output.AudioPassthrough = withoutSpatializerV3(nextContext.Output.AudioPassthrough)
+	return reflect.DeepEqual(currentContext, nextContext)
+}
+
+func withoutSpatializerV3(value *playback.AudioPassthroughV3) *playback.AudioPassthroughV3 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	copy.SpatializerEnabled = false
+	return &copy
 }
 
 // raceCopySafetyV3 resolves an unknown H.264 copy-safety verdict behind a plan
@@ -3485,7 +3541,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 				intentChange = audioSelectionDiffersFromStartV3(req.SelectedTracks, start)
 			case "subtitle_track_changed":
 				intentChange = subtitleSelectionDiffersFromStartV3(req.SelectedTracks, start)
-			case "output_route_changed":
+			case outputRouteChangedReasonV3:
 				intentChange = req.ClientPlaybackContext.Output.OutputContextID != start.ClientPlaybackContext.Output.OutputContextID
 			}
 		}

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -3427,8 +3427,18 @@ func sameLegacyOutputRouteReplanV3(record *playback.AttemptRecordV3, next playba
 	if next.Metered != current.Metered ||
 		!reflect.DeepEqual(next.BandwidthEstimateKbps, current.BandwidthEstimateKbps) ||
 		!reflect.DeepEqual(next.BandwidthCapKbps, current.BandwidthCapKbps) ||
-		!sameSelectedTracksV3(next.SelectedTracks, record.CurrentPlan.SelectedTracks) ||
 		!reflect.DeepEqual(next.ClientFeatures, current.ClientFeatures) {
+		return false
+	}
+	// Legacy failure replans may omit unchanged track identities. Only an
+	// explicitly supplied identity can prove that this callback carries a
+	// material track change; track-change operations use their own path.
+	if next.SelectedTracks.Audio != nil &&
+		!sameTrackIdentityV3(next.SelectedTracks.Audio, record.CurrentPlan.SelectedTracks.Audio) {
+		return false
+	}
+	if next.SelectedTracks.Subtitle != nil &&
+		!sameTrackIdentityV3(next.SelectedTracks.Subtitle, record.CurrentPlan.SelectedTracks.Subtitle) {
 		return false
 	}
 	currentCapabilities := current.Capabilities

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1116,8 +1116,7 @@ func TestHandleReplanPlaybackV3RejectsUnchangedOutputRoute(t *testing.T) {
 		Failure: playback.FailureV3{
 			Classification: "output_route_changed",
 		},
-		SelectedTracks: started.PlaybackPlan.SelectedTracks,
-		Capabilities:   startRequest.Capabilities,
+		Capabilities: startRequest.Capabilities,
 		ClientPlaybackContext: playback.ClientPlaybackContextV3{
 			ProtocolVersion: startRequest.ClientPlaybackContext.ProtocolVersion,
 			FormFactor:      startRequest.ClientPlaybackContext.FormFactor,
@@ -1158,7 +1157,9 @@ func TestSameLegacyOutputRouteReplanV3RequiresEveryOtherInputToMatch(t *testing.
 	record := &playback.AttemptRecordV3{
 		NormalizedRequest: start,
 		CurrentPlan: playback.PlanV3{
-			SelectedTracks: playback.SelectedTracksV3{},
+			SelectedTracks: playback.SelectedTracksV3{
+				Audio: &playback.TrackIdentityV3{ID: "audio-1"},
+			},
 		},
 	}
 	next := playback.ReplanRequestV3{
@@ -1171,8 +1172,13 @@ func TestSameLegacyOutputRouteReplanV3RequiresEveryOtherInputToMatch(t *testing.
 	next.Capabilities.AudioPassthrough = &playback.AudioPassthroughV3{PassthroughCodecs: []string{"eac3"}, SpatializerEnabled: true}
 	next.ClientPlaybackContext.Output.AudioPassthrough = &playback.AudioPassthroughV3{PassthroughCodecs: []string{"eac3"}, SpatializerEnabled: true}
 	if !sameLegacyOutputRouteReplanV3(record, next) {
-		t.Fatal("route generation and Spatializer state should be ignored")
+		t.Fatal("route generation, Spatializer state, and omitted tracks should be ignored")
 	}
+	next.SelectedTracks.Audio = &playback.TrackIdentityV3{ID: "audio-2"}
+	if sameLegacyOutputRouteReplanV3(record, next) {
+		t.Fatal("explicit audio track change should not be suppressed")
+	}
+	next.SelectedTracks = playback.SelectedTracksV3{}
 	next.Capabilities.AudioEvidence = playback.EvidenceDeclaredV3
 	if sameLegacyOutputRouteReplanV3(record, next) {
 		t.Fatal("capability evidence change should not be suppressed")

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1068,6 +1068,123 @@ func TestHandleStartPlaybackV3RejectsProfileMismatch(t *testing.T) {
 	}
 }
 
+func TestHandleReplanPlaybackV3RejectsUnchangedOutputRoute(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), testPlaybackFileResolver{file: v3HandlerFixtureFile(t)})
+	handler.SettingsRepo = &mutablePlaybackSettingsV3{values: map[string]string{}}
+	handler.ItemAccess = allowAllPlaybackItemAccess{}
+	startRequest := v3HandlerStartRequest()
+	startRequest.ClientPlaybackContext.Output = playback.OutputContextV3{
+		OutputContextID: "route-1",
+		CurrentSink:     "bluetooth",
+		SinkType:        "bluetooth",
+		AudioPassthrough: &playback.AudioPassthroughV3{
+			PassthroughCodecs:  []string{"eac3"},
+			SpatializerEnabled: false,
+			MaxChannels:        6,
+		},
+	}
+
+	startRR := httptest.NewRecorder()
+	handler.HandleStartPlayback(startRR, httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/playback/start",
+		strings.NewReader(marshalV3StartRequest(t, startRequest)),
+	).WithContext(newAuthorizedPlaybackContext()))
+	if startRR.Code != http.StatusCreated {
+		t.Fatalf("start status = %d, body = %s", startRR.Code, startRR.Body.String())
+	}
+	var started playback.DecisionResponseV3
+	if err := json.Unmarshal(startRR.Body.Bytes(), &started); err != nil || started.PlaybackPlan == nil {
+		t.Fatalf("start response: err=%v response=%#v", err, started)
+	}
+
+	output := startRequest.ClientPlaybackContext.Output
+	output.OutputContextID = "route-2"
+	output.AudioPassthrough = &playback.AudioPassthroughV3{
+		PassthroughCodecs:  []string{"eac3"},
+		SpatializerEnabled: true,
+		MaxChannels:        6,
+	}
+	replan := playback.ReplanRequestV3{
+		ProtocolVersion:   playback.ProtocolV3,
+		PlaybackAttemptID: startRequest.PlaybackAttemptID,
+		ReplanRequestID:   "unchanged-output-route-0001",
+		FailedPlanID:      started.PlaybackPlan.PlanID,
+		PlanAttemptID:     "unchanged-output-attempt-0001",
+		PlanAttemptKey:    started.PlaybackPlan.PlanAttemptKey,
+		AttemptCount:      1,
+		Failure: playback.FailureV3{
+			Classification: "output_route_changed",
+		},
+		SelectedTracks: started.PlaybackPlan.SelectedTracks,
+		Capabilities:   startRequest.Capabilities,
+		ClientPlaybackContext: playback.ClientPlaybackContextV3{
+			ProtocolVersion: startRequest.ClientPlaybackContext.ProtocolVersion,
+			FormFactor:      startRequest.ClientPlaybackContext.FormFactor,
+			AppVersion:      startRequest.ClientPlaybackContext.AppVersion,
+			Device:          startRequest.ClientPlaybackContext.Device,
+			Output:          output,
+			Deliveries:      startRequest.ClientPlaybackContext.Deliveries,
+		},
+	}
+	body, err := json.Marshal(replan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replanRequest := httptest.NewRequest(http.MethodPost, "/api/v1/playback/"+started.SessionID+"/replan", bytes.NewReader(body)).WithContext(newAuthorizedPlaybackContext())
+	replanRequest = withPlaybackRouteParam(replanRequest, "session_id", started.SessionID)
+	replanRR := httptest.NewRecorder()
+	handler.HandleReplanPlaybackV3(replanRR, replanRequest)
+	if replanRR.Code != http.StatusConflict || !strings.Contains(replanRR.Body.String(), "output_route_unchanged") {
+		t.Fatalf("replan status = %d, body = %s", replanRR.Code, replanRR.Body.String())
+	}
+
+	record, err := handler.PlanStoreV3.GetAttempt(context.Background(), started.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.CurrentPlanID != started.PlaybackPlan.PlanID || record.CurrentReplanRequestID != "" {
+		t.Fatalf("unchanged route replaced durable plan: %#v", record)
+	}
+	if got := record.NormalizedRequest.ClientPlaybackContext.Output.OutputContextID; got != "route-1" {
+		t.Fatalf("durable output context id = %q, want route-1", got)
+	}
+}
+
+func TestSameLegacyOutputRouteReplanV3RequiresEveryOtherInputToMatch(t *testing.T) {
+	start := v3HandlerStartRequest()
+	start.Capabilities.AudioPassthrough = &playback.AudioPassthroughV3{PassthroughCodecs: []string{"eac3"}}
+	start.ClientPlaybackContext.Output.AudioPassthrough = &playback.AudioPassthroughV3{PassthroughCodecs: []string{"eac3"}}
+	record := &playback.AttemptRecordV3{
+		NormalizedRequest: start,
+		CurrentPlan: playback.PlanV3{
+			SelectedTracks: playback.SelectedTracksV3{},
+		},
+	}
+	next := playback.ReplanRequestV3{
+		ClientFeatures:        append([]string(nil), start.ClientFeatures...),
+		QualityPreference:     start.QualityPreference,
+		Capabilities:          start.Capabilities,
+		ClientPlaybackContext: start.ClientPlaybackContext,
+	}
+	next.ClientPlaybackContext.Output.OutputContextID = "route-2"
+	next.Capabilities.AudioPassthrough = &playback.AudioPassthroughV3{PassthroughCodecs: []string{"eac3"}, SpatializerEnabled: true}
+	next.ClientPlaybackContext.Output.AudioPassthrough = &playback.AudioPassthroughV3{PassthroughCodecs: []string{"eac3"}, SpatializerEnabled: true}
+	if !sameLegacyOutputRouteReplanV3(record, next) {
+		t.Fatal("route generation and Spatializer state should be ignored")
+	}
+	next.Capabilities.AudioEvidence = playback.EvidenceDeclaredV3
+	if sameLegacyOutputRouteReplanV3(record, next) {
+		t.Fatal("capability evidence change should not be suppressed")
+	}
+	next.Capabilities = start.Capabilities
+	bandwidth := 12_000
+	next.BandwidthEstimateKbps = &bandwidth
+	if sameLegacyOutputRouteReplanV3(record, next) {
+		t.Fatal("bandwidth change should not be suppressed")
+	}
+}
+
 func TestPreferredAudioTrackIndexV3PropagatesSeriesPreferenceReadFailure(t *testing.T) {
 	wantErr := errors.New("audio preference store unavailable")
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))


### PR DESCRIPTION
## What I changed

I added a compatibility guard for legacy `output_route_changed` replans. When every planning input is unchanged and the request differs only in the opaque output-context ID and Spatializer state, the server returns `409 output_route_unchanged` and keeps the mounted plan and attempted-route history intact.

A real sink, HDR capability, passthrough codec, channel limit, delivery capability, quality, track, bandwidth, or other planning change still follows the normal replan path.

## Why

I traced a live Android session that repeatedly cycled through direct play, remux, and transcode. Media3 remounts triggered Spatializer callbacks, the installed client advanced its output-route generation, and the server treated each generation as a new route. That cleared the failed-plan history and reopened routes that had already failed. FFmpeg transports were healthy and were being replaced by later replans rather than crashing.

The client-side fix removes the false route change at its source. This server guard protects already-installed clients and keeps the protocol safe when an opaque route token changes without any recipe-relevant capability change.

## Validation

Passed against current upstream `main`:

```text
go test ./internal/api/handlers -run 'Test(HandleReplanPlaybackV3RejectsUnchangedOutputRoute|SameLegacyOutputRouteReplanV3RequiresEveryOtherInputToMatch)' -count=1
ok github.com/Silo-Server/silo-server/internal/api/handlers 0.980s
```

The production fork also passed its complete Go, Web, and docs GitHub Actions gates before deployment.

## Scope and risk

The equality check is intentionally strict: any material planning difference disables the guard. No schema, migration, configuration, Jellyfin compatibility, or media transport behavior changes are included.

Source implementation and production validation: [blurbery/silo-server#50](https://github.com/blurbery/silo-server/pull/50).

Related issue: N/A — narrow fix reproduced on a live deployment.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted; I reproduced the fault, chose the compatibility boundary, reviewed the final diff, and validated the deployed behavior
- Adversarial review: Compared every mutable planning field to ensure the guard cannot swallow a real output, capability, quality, track, bandwidth, or delivery change. Focused tests cover accepted opaque-token/Spatializer drift and rejection when any material input differs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary playback transport remounts when an output-route replan changes only route metadata or runtime state.
  * Such requests now return a clear `409 output_route_unchanged` response while keeping the active playback plan mounted.
  * Replanning still proceeds when meaningful playback inputs—such as capabilities, bandwidth, or track selections—have changed.

* **Documentation**
  * Documented the new response status for the playback replan endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->