### PR TITLE
fix(playback): preserve video for Android EAC3 fallback

### DIFF
--- a/internal/playback/device_quirks_v3.go
+++ b/internal/playback/device_quirks_v3.go
@@ -3,9 +3,10 @@ package playback
 import "strings"
 
 const (
-	QuirkFireTVAFTKRTHigh10V3  = "android.fire_tv.aftkrt.h264_high10_l52_v1"
-	QuirkFireTVAFTKRTEAC3HLSV3 = "android.fire_tv.aftkrt.eac3_7_1_hls_audio_adapt_v1"
-	QuirkFireTVDV8HDR10PlusV3  = "android.fire_tv.dv8_hdr10plus_sei_v1"
+	QuirkFireTVAFTKRTHigh10V3         = "android.fire_tv.aftkrt.h264_high10_l52_v1"
+	QuirkFireTVAFTKRTEAC3HLSV3        = "android.fire_tv.aftkrt.eac3_7_1_hls_audio_adapt_v1"
+	QuirkAndroidMobileEAC3BluetoothV3 = "android.mobile.eac3_bluetooth_hls_audio_adapt_v1"
+	QuirkFireTVDV8HDR10PlusV3         = "android.fire_tv.dv8_hdr10plus_sei_v1"
 )
 
 func high10DecodeOverrideV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
@@ -35,8 +36,19 @@ func high10DecodeOverrideV3(source SourceDescriptorV3, request StartRequestV3) (
 }
 
 func hlsEAC3AudioCorrectionV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
-	if !deviceQuirkProtocolAvailableV3(request) || !isAmazonModelV3(request, "AFTKRT") ||
-		!strings.EqualFold(source.AudioCodec, "eac3") || source.AudioChannels != 8 {
+	if !deviceQuirkProtocolAvailableV3(request) || !strings.EqualFold(source.AudioCodec, "eac3") {
+		return nil, false
+	}
+	if isAndroidMobileBluetoothOutputV3(request) && source.AudioChannels >= 6 {
+		quirk := AppliedQuirkV3{
+			ID:               QuirkAndroidMobileEAC3BluetoothV3,
+			RegistryRevision: DeviceQuirkRegistryRevisionV3,
+			Action:           "audio_only_transcode",
+			Reason:           "Android mobile cannot reliably decode multichannel E-AC-3 on the observed Bluetooth output route; preserve video and adapt audio to AAC.",
+		}
+		return &quirk, true
+	}
+	if !isAmazonModelV3(request, "AFTKRT") || source.AudioChannels != 8 {
 		return nil, false
 	}
 	quirk := AppliedQuirkV3{
@@ -46,6 +58,16 @@ func hlsEAC3AudioCorrectionV3(source SourceDescriptorV3, request StartRequestV3)
 		Reason:           "AFTKRT cannot reliably consume eight-channel E-AC-3 from an HLS MPEG-TS route.",
 	}
 	return &quirk, true
+}
+
+func isAndroidMobileBluetoothOutputV3(request StartRequestV3) bool {
+	device := request.ClientPlaybackContext.Device
+	output := request.ClientPlaybackContext.Output
+	return strings.EqualFold(device.Platform, "android") &&
+		strings.EqualFold(request.ClientPlaybackContext.FormFactor, "mobile") &&
+		strings.EqualFold(output.SinkType, "bluetooth") &&
+		output.AudioPassthrough != nil &&
+		len(output.AudioPassthrough.PassthroughCodecs) == 0
 }
 
 func dv8HDR10PlusRuntimeCorrectionV3(source SourceDescriptorV3, request StartRequestV3, deliveryClass string) (*AppliedQuirkV3, bool) {

--- a/internal/playback/device_quirks_v3_test.go
+++ b/internal/playback/device_quirks_v3_test.go
@@ -73,6 +73,61 @@ func TestAFTKRTEAC3HLSCorrectionTranscodesAudioOnly(t *testing.T) {
 	}
 }
 
+func TestAndroidMobileBluetoothEAC3FallbackCopiesVideoAndAdaptsAudio(t *testing.T) {
+	file := &models.MediaFile{
+		ID: 42, FilePath: "/media/eac3.mkv", Container: "mkv", CodecVideo: "h264", CodecAudio: "eac3",
+		Resolution: "1080p", Bitrate: 5918, AudioChannels: 6,
+		VideoTracks: []models.VideoTrack{{Codec: "h264", Profile: "High", Level: 40, Width: 1920, Height: 1080, FrameRate: "24000/1001", Bitrate: 5918, BitDepth: 8, VideoRange: "SDR", VideoRangeType: "SDR"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Layout: "5.1(side)"}},
+	}
+	req := validStartRequestV3()
+	req.ClientFeatures = append(req.ClientFeatures, FeatureDeviceQuirksV3)
+	req.ClientPlaybackContext.FormFactor = "mobile"
+	req.ClientPlaybackContext.Device = DeviceContextV3{Platform: "android", Manufacturer: "Samsung", Model: "SM-S938B"}
+	req.ClientPlaybackContext.Output = OutputContextV3{
+		SinkType: "bluetooth",
+		AudioPassthrough: &AudioPassthroughV3{
+			MaxChannels:       10,
+			PassthroughCodecs: []string{},
+		},
+		OutputContextID: "3",
+	}
+	req.Capabilities.Containers = []string{"mkv"}
+	req.Capabilities.CodecsAudio = []string{"aac", "eac3"}
+	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "h264", Profiles: []string{"high"}, Levels: []int{40}, BitDepths: []int{8}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 120_000, Hardware: true}}
+	req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = DeliveryCapabilityV3{}
+
+	input := PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: testTransformationRegistryV3()}
+	direct := PlanPlaybackV3(input)
+	if direct.Plan == nil || direct.Plan.Delivery != DeliveryOriginalHTTPV3 {
+		t.Fatalf("direct = %s", ExplainPlannerResultV3(direct))
+	}
+	input.AttemptedKeys = []string{direct.Plan.PlanAttemptKey}
+	fallback := PlanPlaybackV3(input)
+	if fallback.Plan == nil || fallback.Plan.Delivery != DeliveryRemuxHLSV3 || fallback.PlayMethod != PlayRemux || fallback.TargetVideoCodec != "copy" || !fallback.TranscodeAudio || fallback.TargetAudioCodec != "aac" {
+		t.Fatalf("fallback = %s", ExplainPlannerResultV3(fallback))
+	}
+	if fallback.Plan.EffectiveRecipe.VideoCodec != "h264" || fallback.Plan.EffectiveRecipe.AudioCodec != "aac" {
+		t.Fatalf("fallback recipe = %#v", fallback.Plan.EffectiveRecipe)
+	}
+	if len(fallback.Plan.Transformations) != 1 || fallback.Plan.Transformations[0].Name != TransformationAudioToAACV3 {
+		t.Fatalf("fallback transformations = %#v", fallback.Plan.Transformations)
+	}
+	if len(fallback.Plan.AppliedQuirks) != 1 || fallback.Plan.AppliedQuirks[0].ID != QuirkAndroidMobileEAC3BluetoothV3 {
+		t.Fatalf("fallback quirks = %#v", fallback.Plan.AppliedQuirks)
+	}
+
+	req.ClientPlaybackContext.Output.SinkType = "Speaker"
+	if quirk, ok := hlsEAC3AudioCorrectionV3(SourceDescriptorFromFileV3(file, 0), req); ok || quirk != nil {
+		t.Fatalf("speaker route received Bluetooth correction: %#v", quirk)
+	}
+	req.ClientPlaybackContext.Output.SinkType = "bluetooth"
+	req.ClientPlaybackContext.FormFactor = "tv"
+	if quirk, ok := hlsEAC3AudioCorrectionV3(SourceDescriptorFromFileV3(file, 0), req); ok || quirk != nil {
+		t.Fatalf("Android TV route received mobile correction: %#v", quirk)
+	}
+}
+
 func TestFireTVDV8HDR10PlusCorrectionRequiresAdvertisedRuntime(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.VideoTracks[0].DVProfile = 8


### PR DESCRIPTION
## What I changed

I added an Android-mobile fallback for multichannel E-AC-3 on Bluetooth outputs that advertise no E-AC-3 passthrough. Direct play remains the first choice. If Android rejects that route, the next HLS plan copies the original video bitstream and converts only E-AC-3 audio to AAC. Full video transcoding remains available only if the direct-stream route also fails.

## Why

I reproduced this with the exact same media file on Android and iPhone. The iPhone direct-played H.264 High Level 4.0 with E-AC-3/Atmos and reached first frame. The Android phone advertised ample H.264 hardware support, but returned `ERROR_CODE_DECODING_FAILED` for both original HTTP and a codec-copy HLS remux. The old final fallback then re-encoded H.264 to H.264 as well as converting the audio.

That video encode did not address the observed failure and added unnecessary quality loss and compute. The deployed correction now reaches first frame as `server_remux_hls` with one transformation, `audio_to_aac`; the H.264 video is copied byte-for-byte. In media-server terms this is Direct Stream/Remux, not video transcoding.

The rule is capability-scoped rather than model-scoped: Android platform, mobile form factor, Bluetooth sink, empty passthrough set, E-AC-3, and at least six channels. It therefore covers Android mobile models reporting the same route facts. The live validation device was one Pixel 7; the test fixture uses a non-Pixel Android model to verify that planning does not depend on manufacturer or model.

## Validation

Passed against current upstream `main`:

```text
go test ./internal/playback -run 'Test(AndroidMobileBluetoothEAC3Fallback|AFTKRTEAC3HLSCorrection|DeviceQuirkProtocol)' -count=1
ok github.com/Silo-Server/silo-server/internal/playback 1.436s
```

The production fork passed its complete Go, Web, and docs GitHub Actions gates. After deployment, the live plan selected `server_remux_hls`, copied H.264, converted only audio to AAC, reached first frame, and stopped cycling.

## Scope and risk

A working direct route is never displaced. Android TV, speaker output, stereo E-AC-3, Apple clients, passthrough-capable routes, and other codecs keep existing planning. No API, schema, migration, configuration, or Jellyfin compatibility changes are included.

Source implementation and production validation: [blurbery/silo-server#51](https://github.com/blurbery/silo-server/pull/51).

Related issue: N/A — narrow fix reproduced on a live deployment.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted; I designed the capability boundary, reviewed the implementation, compared both clients on the same source, and validated the deployed route
- Adversarial review: Checked that direct play remains first, the fallback copies video, and the correction cannot activate for TV, speaker, stereo, passthrough-capable, Apple, or non-E-AC-3 routes. Focused positive and negative tests passed against current upstream main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback for E-AC-3 audio on Android mobile devices connected via Bluetooth.
  * Automatically falls back to HLS with AAC audio conversion while preserving video when required.
  * Maintains expected audio behavior for speaker outputs and Android TV devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->