### PR TITLE
fix(playback): keep Apple media authorization session-bound

### DIFF
--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -526,7 +526,7 @@ func (h *PlaybackHandler) loadTranscodeServeSession(r *http.Request, sessionID s
 			// recipe token. Tone-mapped cards may back a provisional capability
 			// reconstruction; plain cards just respawn the encode. Either way the
 			// atomic playback+runtime operation is the same front door.
-			card, claims := verifiedStreamCardFromToken(r.URL.Query().Get(streamTokenParam), sessionID, h.JWTSecret)
+			card, claims := verifiedStreamCardFromRequest(r, sessionID, h.JWTSecret)
 			if card != nil {
 				if videoCopyReconstructRefused(r.Context(), h.fileResolver, h.CopySafetyRacer, card) {
 					return nil, playback.SessionMissing, nil, nil, nil
@@ -542,7 +542,7 @@ func (h *PlaybackHandler) loadTranscodeServeSession(r *http.Request, sessionID s
 	}
 	// Genuine miss (e.g. after a restart): now — and only now — pay for the token
 	// decode so the recipe is available for reconstruction.
-	card, claims := verifiedStreamCardFromToken(r.URL.Query().Get(streamTokenParam), sessionID, h.JWTSecret)
+	card, claims := verifiedStreamCardFromRequest(r, sessionID, h.JWTSecret)
 	// The copy-safety verdict gates the revival before it happens, not after.
 	// Reconstruction registers the playback session against the user's stream
 	// caps, so a refusal that ran later would leave a session nobody serves
@@ -563,10 +563,23 @@ func (h *PlaybackHandler) loadTranscodeServeSession(r *http.Request, sessionID s
 	return session, status, card, claims, nil
 }
 
-// streamCardFromToken verifies a stream token and decodes its reconstruction
-// recipe, returning nil when the token is absent, unparseable/expired, or bound
-// to a different session id. Shared by the native serve handlers (PlaybackHandler
-// and StreamHandler).
+// verifiedStreamCardFromRequest returns the reconstruction recipe already
+// verified by route-scoped transport auth, or falls back to the legacy query
+// token. Shared by the native serve handlers.
+func verifiedStreamCardFromRequest(r *http.Request, sessionID, secret string) (*playback.RecipeCard, *streamtoken.Claims) {
+	if r != nil {
+		if claims := apimw.GetTransportStreamClaims(r.Context()); claims != nil && claims.SessionID == sessionID {
+			card := playback.RecipeCardFromClaims(claims)
+			return &card, claims
+		}
+		return verifiedStreamCardFromToken(r.URL.Query().Get(streamTokenParam), sessionID, secret)
+	}
+	return nil, nil
+}
+
+// verifiedStreamCardFromToken verifies a query-carried stream token and
+// decodes its reconstruction recipe, returning nil when it is absent,
+// unparseable, expired, or bound to a different session id.
 func verifiedStreamCardFromToken(tokenStr, sessionID, secret string) (*playback.RecipeCard, *streamtoken.Claims) {
 	if tokenStr == "" || secret == "" {
 		return nil, nil

--- a/internal/api/handlers/playback_transport_capability_test.go
+++ b/internal/api/handlers/playback_transport_capability_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/streamtoken"
+)
+
+type transportCapabilityBearerValidator struct{}
+
+func (transportCapabilityBearerValidator) ValidateToken(string) (*auth.Claims, error) {
+	return nil, errors.New("expired access token")
+}
+
+type transportCapabilitySessionValidator struct{}
+
+func (transportCapabilitySessionValidator) IsValid(context.Context, string) (bool, error) {
+	return false, nil
+}
+
+func TestVerifiedStreamCardFromRequestUsesHeaderCapabilityForReconstruction(t *testing.T) {
+	const secret = "transport-capability-reconstruction-secret"
+	token, err := streamtoken.Sign(streamtoken.Claims{
+		SessionID:       "playback-1",
+		MediaPath:       "/media/movie.mkv",
+		PlayMethod:      "transcode",
+		TargetCodec:     "h264",
+		OutputSubdir:    "playback-1-plan-1",
+		UserID:          7,
+		ProfileID:       "profile-1",
+		MediaFileID:     42,
+		TargetRes:       "1920x1080",
+		SegmentDuration: 6,
+	}, secret, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	authMiddleware := apimw.NewAuthMiddleware(
+		transportCapabilityBearerValidator{},
+		transportCapabilitySessionValidator{},
+		nil,
+		nil,
+	)
+	router := chi.NewRouter()
+	router.With(authMiddleware.RequireTransportAuth(secret)).Get("/stream/{session_id}", func(w http.ResponseWriter, r *http.Request) {
+		card, claims := verifiedStreamCardFromRequest(r, "playback-1", secret)
+		if card == nil || claims == nil {
+			t.Fatal("header capability did not provide a reconstruction recipe")
+		}
+		if card.SessionID != "playback-1" || card.UserID != 7 || card.MediaFileID != 42 || card.InputPath != "/media/movie.mkv" || card.TargetCodecVideo != "h264" {
+			t.Fatalf("reconstruction card = %#v", card)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/stream/playback-1", nil)
+	req.Header.Set(streamtoken.Header, token)
+	req.Header.Set("Authorization", "Bearer expired-access-token")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -48,6 +48,9 @@ const (
 	subtitleUnavailableReasonV3  = "subtitle_artifact_unavailable"
 	transcodeStartFailedReasonV3 = "transcode_start_failed"
 	seekRestorationPlayerV3      = "player_position"
+	applePlatformIOSV3           = "ios"
+	applePlatformTVOSV3          = "tvos"
+	applePlatformMacOSV3         = "macos"
 	// Failed capability fetches are memoized briefly so an unreachable node
 	// costs one timeout per window instead of one per planning request.
 	v3NodeCapabilityErrorTTL = 15 * time.Second
@@ -86,6 +89,7 @@ type v3NodeCapabilityCache struct {
 
 type preparedTransportV3 struct {
 	url                string
+	headers            map[string]string
 	nodeURL            string
 	transportID        string
 	hwAccel            string
@@ -153,10 +157,17 @@ type playbackStartSideEffectsStateV3 struct {
 // it. Both bits are resolved once from the attempt's (pinned) feature list and
 // threaded down every branch rather than re-derived per URL builder.
 type mediaAuthModeV3 struct {
-	// headerAuth is header_authenticated_media_v1: no client-visible URL
-	// carries a signed playback credential, and the client authenticates every
-	// media request with its own access token instead.
+	// headerAuth is header_authenticated_media_v1: no client-visible URL carries
+	// a signed playback credential. Ordinarily the client authenticates media
+	// requests with its own access token; sessionHeaderCapability is the bounded
+	// compatibility exception described below.
 	headerAuth bool
+	// sessionHeaderCapability keeps the signed, session-bound credential in a
+	// plan-supplied header. It is used only for clients whose media engine freezes
+	// request headers at load time, so a stale bearer cannot interrupt bytes while
+	// the API client independently refreshes. The URL remains credential-free and
+	// the response continues to honor header_authenticated_media_v1.
+	sessionHeaderCapability bool
 	// proxyEgress is authorized_media_origins_v1 negotiated on top of
 	// headerAuth: the client also honors credential-free absolute URLs on
 	// server-designated proxy origins, so media bytes need not all egress from
@@ -177,6 +188,65 @@ func headerAuthenticatedMediaV3(clientFeatures []string) mediaAuthModeV3 {
 	return mediaAuthModeV3{
 		headerAuth:  headerAuth,
 		proxyEgress: headerAuth && playback.HasFeatureV3(clientFeatures, playback.FeatureAuthorizedMediaOriginsV3),
+	}
+}
+
+// mediaAuthModeForStartV3 keeps Apple build 31 media requests independent of
+// the short-lived access token. The shared iOS/tvOS/macOS AetherEngine snapshots
+// HTTP headers when an item loads and reuses them for range reads and internal
+// reloads. An automatic episode transition can therefore retain the old bearer
+// and begin receiving 401s while buffered playback continues. A session-bound
+// header capability preserves the selected playback route and is accepted
+// before any stale Authorization header.
+func mediaAuthModeForStartV3(req playback.StartRequestV3, resolvedClientBuild string) mediaAuthModeV3 {
+	mode := headerAuthenticatedMediaV3(req.ClientFeatures)
+	ctx := req.ClientPlaybackContext
+	platform := strings.ToLower(strings.TrimSpace(ctx.Device.Platform))
+	isApplePlatform := platform == applePlatformIOSV3 || platform == applePlatformTVOSV3 || platform == applePlatformMacOSV3
+	clientBuild := strings.TrimSpace(resolvedClientBuild)
+	if clientBuild == "" {
+		clientBuild = strings.TrimSpace(ctx.AppBuild)
+	}
+	if mode.headerAuth &&
+		playback.HasFeatureV3(req.ClientFeatures, playback.FeatureDeviceQuirksV3) &&
+		isApplePlatform &&
+		clientBuild == "31" {
+		mode.proxyEgress = false
+		mode.sessionHeaderCapability = true
+	}
+	return mode
+}
+
+func mediaAuthModeForReplanV3(req playback.StartRequestV3, currentPlan playback.PlanV3) mediaAuthModeV3 {
+	mode := headerAuthenticatedMediaV3(req.ClientFeatures)
+	if currentPlan.Stream.Headers[streamtoken.Header] != "" {
+		mode.proxyEgress = false
+		mode.sessionHeaderCapability = true
+	}
+	return mode
+}
+
+func (h *PlaybackHandler) sessionCapabilityHeadersV3(mode mediaAuthModeV3, card playback.RecipeCard) map[string]string {
+	if !mode.sessionHeaderCapability {
+		return nil
+	}
+	token := h.signStreamClaims(card.ToClaims())
+	if token == "" {
+		return nil
+	}
+	return map[string]string{streamtoken.Header: token}
+}
+
+func applyPreparedTransportToPlanV3(plan *playback.PlanV3, transport preparedTransportV3) {
+	if plan == nil {
+		return
+	}
+	plan.Stream.URL = transport.url
+	if plan.Stream.Headers == nil {
+		plan.Stream.Headers = map[string]string{}
+	}
+	for name, value := range transport.headers {
+		plan.Stream.Headers[name] = value
 	}
 }
 
@@ -1171,7 +1241,7 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 	}
 	// A refused progressive remux is escalated before the decision is logged or
 	// a session is opened, so the logged route is the one that will actually run.
-	escalated, escalateErr := h.escalateRefusedProgressiveRemuxV3(r.Context(), headerAuthenticatedMediaV3(req.ClientFeatures),
+	escalated, escalateErr := h.escalateRefusedProgressiveRemuxV3(r.Context(), mediaAuthModeForStartV3(req, clientInfo.Build),
 		func() playback.PlannerInputV3 {
 			return h.plannerInputV3(r.Context(), req, requestedFile, effectiveFile, audioIndex, nil)
 		}, result)
@@ -1338,7 +1408,7 @@ func (h *PlaybackHandler) startPlannedPlaybackV3(r *http.Request, userID int, pr
 	if result.Plan == nil {
 		return playback.DecisionResponseV3{}, &transportErrorV3{reason: "internal_error", message: "The server produced no playback plan."}
 	}
-	mode := headerAuthenticatedMediaV3(req.ClientFeatures)
+	mode := mediaAuthModeForStartV3(req, clientInfo.Build)
 	if checker, ok := h.sessionMgr.(transcodePermissionChecker); ok && (result.PlayMethod == playback.PlayTranscode || result.TranscodeAudio) {
 		if err := checker.CheckTranscodingAllowed(r.Context(), userID, result.PlayMethod == playback.PlayTranscode); err != nil {
 			reason := "transcoding_disabled"
@@ -1394,7 +1464,7 @@ func (h *PlaybackHandler) startPlannedPlaybackV3(r *http.Request, userID int, pr
 		abort()
 		return playback.DecisionResponseV3{}, subtitleArtifactErrorV3("Failed to freeze the selected subtitle identity.", frozenErr)
 	}
-	result.Plan.Stream.URL = transport.url
+	applyPreparedTransportToPlanV3(result.Plan, transport)
 	if err := h.attachSubtitleArtifactV3(r.Context(), session.ID, effectiveFile, result.Plan, result.SubtitleTrackIndex, &frozenRecipe); err != nil {
 		transport.rollback()
 		abort()
@@ -1904,8 +1974,10 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			streamURL = appendPlaybackQueryV3(streamURL, "seek", strconv.FormatFloat(seek, 'f', -1, 64))
 		}
 	}
+	capabilityHeaders := h.sessionCapabilityHeadersV3(mode, identityRecipeCard(&routeSession))
 	return preparedTransportV3{
-		url: streamURL,
+		url:     streamURL,
+		headers: capabilityHeaders,
 		commit: func() {
 			if committed {
 				return
@@ -2653,10 +2725,10 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 			}
 		}
 	}
+	card := playback.NewRecipeCard(session.UserID, session.ProfileID, file.ID, "", ts.Opts())
+	card.OriginalStartedAt = session.StartedAt
 	url := fmt.Sprintf("/playback/transcode/%s/master.m3u8", session.ID)
 	if !mode.headerAuth {
-		card := playback.NewRecipeCard(session.UserID, session.ProfileID, file.ID, "", ts.Opts())
-		card.OriginalStartedAt = session.StartedAt
 		url = appendStreamToken(url, h.signSessionToken(card, mode.headerAuth))
 	}
 	committed := false
@@ -2664,6 +2736,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 	previousTransportID := remoteTransportID(session)
 	return preparedTransportV3{
 		url:         url,
+		headers:     h.sessionCapabilityHeadersV3(mode, card),
 		hwAccel:     ts.Opts().HWAccel,
 		toneMapMode: ts.Opts().ToneMapMode,
 		commit: func() {
@@ -2856,7 +2929,7 @@ func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *pla
 	previousNodeURL := session.TranscodeNodeURL
 	previousTransportID := remoteTransportID(session)
 	unlock := h.tm.LockSessionLifecycle(session.ID)
-	return preparedTransportV3{url: url, nodeURL: node.URL, transportID: transportID, hwAccel: confirmedHWAccel, toneMapMode: confirmedToneMapMode, commit: func() {
+	return preparedTransportV3{url: url, headers: h.sessionCapabilityHeadersV3(mode, card), nodeURL: node.URL, transportID: transportID, hwAccel: confirmedHWAccel, toneMapMode: confirmedToneMapMode, commit: func() {
 		if committed {
 			return
 		}
@@ -3703,7 +3776,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	// Media authentication is attempt-sticky (pinned in HandleReplanPlaybackV3),
 	// so this mode always equals the one the attempt started under: a reused
 	// transport cannot change the session's media security contract.
-	mode := headerAuthenticatedMediaV3(start.ClientFeatures)
+	mode := mediaAuthModeForReplanV3(start, record.CurrentPlan)
 	if !seekReanchor {
 		// A freshly planned replan can land on the same refused progressive
 		// remux a start would have; escalate it identically. A seek reanchor
@@ -3796,7 +3869,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 			artifactRecipe = frozenRecipe
 		}
 	}
-	result.Plan.Stream.URL = transport.url
+	applyPreparedTransportToPlanV3(result.Plan, transport)
 	if err := h.attachSubtitleArtifactV3(r.Context(), session.ID, effectiveFile, result.Plan, result.SubtitleTrackIndex, &artifactRecipe); err != nil {
 		transport.rollback()
 		return playback.DecisionResponseV3{}, *record, nil, subtitleArtifactErrorV3("Failed to prepare the selected subtitle artifact.", err)

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -220,6 +220,7 @@ func mediaAuthModeForStartV3(req playback.StartRequestV3, resolvedClientBuild st
 func mediaAuthModeForReplanV3(req playback.StartRequestV3, currentPlan playback.PlanV3) mediaAuthModeV3 {
 	mode := headerAuthenticatedMediaV3(req.ClientFeatures)
 	if currentPlan.Stream.Headers[streamtoken.Header] != "" {
+		mode.headerAuth = true
 		mode.proxyEgress = false
 		mode.sessionHeaderCapability = true
 	}

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -986,7 +986,7 @@ func TestMediaAuthModeForStartV3AppliesOnlyToAffectedAppleClient(t *testing.T) {
 }
 
 func TestMediaAuthModeForReplanV3PreservesSessionCapability(t *testing.T) {
-	req := playback.StartRequestV3{ClientFeatures: []string{playback.FeatureHeaderAuthenticatedMediaV3}}
+	req := playback.StartRequestV3{ClientFeatures: []string{playback.FeatureDeviceQuirksV3}}
 	currentPlan := playback.PlanV3{Stream: playback.StreamV3{Headers: map[string]string{streamtoken.Header: "session-capability"}}}
 
 	mode := mediaAuthModeForReplanV3(req, currentPlan)
@@ -1004,12 +1004,22 @@ func TestHandleReplanPlaybackV3CannotDowngradeHeaderAuthenticatedAttempt(t *test
 	handler.ItemAccess = allowAllPlaybackItemAccess{}
 
 	start := v3HandlerStartRequest()
-	start.ClientFeatures = append(start.ClientFeatures, playback.FeatureHeaderAuthenticatedMediaV3)
+	start.ClientFeatures = append(
+		start.ClientFeatures,
+		playback.FeatureHeaderAuthenticatedMediaV3,
+		playback.FeatureDeviceQuirksV3,
+	)
+	start.ClientPlaybackContext.Device.Platform = "ios"
+	start.ClientPlaybackContext.AppBuild = "31"
+	start.ClientPlaybackContext.FormFactor = "mobile"
 	startRR := httptest.NewRecorder()
 	handler.HandleStartPlayback(startRR, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, start))).WithContext(newAuthorizedPlaybackContext()))
 	var started playback.DecisionResponseV3
 	if startRR.Code != http.StatusCreated || json.Unmarshal(startRR.Body.Bytes(), &started) != nil || started.PlaybackPlan == nil {
 		t.Fatalf("start status=%d body=%s", startRR.Code, startRR.Body.String())
+	}
+	if started.PlaybackPlan.Stream.Headers[streamtoken.Header] == "" {
+		t.Fatal("start plan did not negotiate the session capability")
 	}
 
 	nextContext := start.ClientPlaybackContext
@@ -1035,6 +1045,9 @@ func TestHandleReplanPlaybackV3CannotDowngradeHeaderAuthenticatedAttempt(t *test
 	parsed, err := url.Parse(replanned.PlaybackPlan.Stream.URL)
 	if err != nil || parsed.IsAbs() || parsed.Query().Get(streamTokenParam) != "" {
 		t.Fatalf("replan URL = %q, want tokenless API-local route (parse error %v)", replanned.PlaybackPlan.Stream.URL, err)
+	}
+	if replanned.PlaybackPlan.Stream.Headers[streamtoken.Header] == "" {
+		t.Fatal("replan dropped the session capability header")
 	}
 	record, err := handler.PlanStoreV3.GetAttempt(context.Background(), started.SessionID)
 	if err != nil {

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -805,11 +805,17 @@ func TestHandleStartPlaybackV3ReturnsExecutableDirectPlan(t *testing.T) {
 
 func TestHandleStartPlaybackV3NegotiatesHeaderAuthenticatedDirectAndSubtitleURLs(t *testing.T) {
 	for _, test := range []struct {
-		name       string
-		optIn      bool
-		wantStream bool
+		name                 string
+		optIn                bool
+		appleBuild31         bool
+		clientBuildHeader    string
+		wantStream           bool
+		wantCapabilityHeader bool
 	}{
 		{name: "opted-in URLs carry no playback credential", optIn: true},
+		{name: "Apple build 31 uses a session-bound header credential", optIn: true, appleBuild31: true, wantCapabilityHeader: true},
+		{name: "authoritative Apple build header uses a session-bound credential", optIn: true, appleBuild31: true, clientBuildHeader: "31", wantCapabilityHeader: true},
+		{name: "later authoritative build header overrides body fallback", optIn: true, appleBuild31: true, clientBuildHeader: "32"},
 		{name: "legacy URL keeps restart token", wantStream: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -825,11 +831,25 @@ func TestHandleStartPlaybackV3NegotiatesHeaderAuthenticatedDirectAndSubtitleURLs
 			if test.optIn {
 				start.ClientFeatures = append(start.ClientFeatures, playback.FeatureHeaderAuthenticatedMediaV3)
 			}
+			if test.appleBuild31 {
+				start.ClientFeatures = append(start.ClientFeatures, playback.FeatureDeviceQuirksV3)
+				start.ClientPlaybackContext.FormFactor = "tv"
+				start.ClientPlaybackContext.AppBuild = "31"
+				start.ClientPlaybackContext.Device.Platform = "tvos"
+			}
+			if test.clientBuildHeader == "31" {
+				start.ClientPlaybackContext.AppBuild = ""
+			}
 			subtitleIndex := 0
 			start.SubtitleTrackID = playback.TrackIDV3(file.ID, "subtitle", subtitleIndex)
 			start.SubtitleTrackIndex = &subtitleIndex
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, start))).WithContext(newAuthorizedPlaybackContext())
+			if test.clientBuildHeader != "" {
+				req.Header.Set("X-Silo-Client", "Silo tvOS")
+				req.Header.Set("X-Silo-Client-Build", test.clientBuildHeader)
+			}
 			rr := httptest.NewRecorder()
-			handler.HandleStartPlayback(rr, httptest.NewRequest(http.MethodPost, "/api/v1/playback/start", strings.NewReader(marshalV3StartRequest(t, start))).WithContext(newAuthorizedPlaybackContext()))
+			handler.HandleStartPlayback(rr, req)
 
 			var response playback.DecisionResponseV3
 			if rr.Code != http.StatusCreated || json.Unmarshal(rr.Body.Bytes(), &response) != nil || response.PlaybackPlan == nil {
@@ -845,8 +865,18 @@ func TestHandleStartPlaybackV3NegotiatesHeaderAuthenticatedDirectAndSubtitleURLs
 			if got := streamURL.Query().Get(streamTokenParam); (got != "") != test.wantStream {
 				t.Fatalf("stream token present = %v for URL %q, want %v", got != "", response.PlaybackPlan.Stream.URL, test.wantStream)
 			}
-			if len(response.PlaybackPlan.Stream.Headers) != 0 {
+			capability := response.PlaybackPlan.Stream.Headers[streamtoken.Header]
+			if (capability != "") != test.wantCapabilityHeader {
+				t.Fatalf("session capability header present = %v, want %v", capability != "", test.wantCapabilityHeader)
+			}
+			if _, ok := response.PlaybackPlan.Stream.Headers["Authorization"]; ok {
 				t.Fatalf("plan persisted bearer material in headers: %#v", response.PlaybackPlan.Stream.Headers)
+			}
+			if capability != "" {
+				claims, verifyErr := streamtoken.Verify(capability, handler.JWTSecret)
+				if verifyErr != nil || claims.SessionID != response.SessionID || claims.MediaFileID != file.ID {
+					t.Fatalf("session capability claims = %#v, err = %v", claims, verifyErr)
+				}
 			}
 
 			artifact := response.PlaybackPlan.Subtitle.Artifact
@@ -863,6 +893,105 @@ func TestHandleStartPlaybackV3NegotiatesHeaderAuthenticatedDirectAndSubtitleURLs
 				t.Fatalf("server features = %v, want %q", response.ServerFeatures, playback.FeatureHeaderAuthenticatedMediaV3)
 			}
 		})
+	}
+}
+
+func TestMediaAuthModeForStartV3AppliesOnlyToAffectedAppleClient(t *testing.T) {
+	base := playback.StartRequestV3{
+		ClientFeatures: []string{
+			playback.FeatureHeaderAuthenticatedMediaV3,
+			playback.FeatureDeviceQuirksV3,
+		},
+		ClientPlaybackContext: playback.ClientPlaybackContextV3{
+			FormFactor: "tv",
+			AppBuild:   "31",
+			Device: playback.DeviceContextV3{
+				Platform: "tvos",
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name           string
+		mutate         func(*playback.StartRequestV3)
+		resolvedBuild  string
+		wantCapability bool
+	}{
+		{name: "tvOS build 31 uses session capability", wantCapability: true},
+		{
+			name: "iOS build 31 uses session capability",
+			mutate: func(req *playback.StartRequestV3) {
+				req.ClientPlaybackContext.Device.Platform = "ios"
+				req.ClientPlaybackContext.FormFactor = "mobile"
+			},
+			wantCapability: true,
+		},
+		{
+			name: "macOS build 31 uses session capability",
+			mutate: func(req *playback.StartRequestV3) {
+				req.ClientPlaybackContext.Device.Platform = "macos"
+				req.ClientPlaybackContext.FormFactor = "desktop"
+			},
+			wantCapability: true,
+		},
+		{
+			name: "later tvOS build keeps header authentication",
+			mutate: func(req *playback.StartRequestV3) {
+				req.ClientPlaybackContext.AppBuild = "32"
+			},
+		},
+		{
+			name:          "resolved build overrides the body fallback",
+			resolvedBuild: "32",
+		},
+		{
+			name:          "resolved build supplies an omitted body fallback",
+			resolvedBuild: "31",
+			mutate: func(req *playback.StartRequestV3) {
+				req.ClientPlaybackContext.AppBuild = ""
+			},
+			wantCapability: true,
+		},
+		{
+			name: "client without device quirks keeps header authentication",
+			mutate: func(req *playback.StartRequestV3) {
+				req.ClientFeatures = []string{playback.FeatureHeaderAuthenticatedMediaV3}
+			},
+		},
+		{
+			name: "non Apple client keeps header authentication",
+			mutate: func(req *playback.StartRequestV3) {
+				req.ClientPlaybackContext.Device.Platform = "android"
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := base
+			req.ClientFeatures = append([]string(nil), base.ClientFeatures...)
+			if test.mutate != nil {
+				test.mutate(&req)
+			}
+			got := mediaAuthModeForStartV3(req, test.resolvedBuild)
+			if !got.headerAuth {
+				t.Fatal("header-authenticated media contract was disabled")
+			}
+			if got.sessionHeaderCapability != test.wantCapability {
+				t.Fatalf("sessionHeaderCapability = %t, want %t", got.sessionHeaderCapability, test.wantCapability)
+			}
+			if got.sessionHeaderCapability && got.proxyEgress {
+				t.Fatal("session header capability must keep media on the API origin")
+			}
+		})
+	}
+}
+
+func TestMediaAuthModeForReplanV3PreservesSessionCapability(t *testing.T) {
+	req := playback.StartRequestV3{ClientFeatures: []string{playback.FeatureHeaderAuthenticatedMediaV3}}
+	currentPlan := playback.PlanV3{Stream: playback.StreamV3{Headers: map[string]string{streamtoken.Header: "session-capability"}}}
+
+	mode := mediaAuthModeForReplanV3(req, currentPlan)
+	if !mode.headerAuth || !mode.sessionHeaderCapability || mode.proxyEgress {
+		t.Fatalf("replan media auth mode = %#v", mode)
 	}
 }
 

--- a/internal/api/handlers/stream.go
+++ b/internal/api/handlers/stream.go
@@ -111,7 +111,7 @@ func (h *StreamHandler) HandleStream(w http.ResponseWriter, r *http.Request) {
 	// ?seek= query for remux), so no runtime beyond the Session needs rebuilding.
 	// Without a token (or signing secret) reconstruct is off, collapsing to a
 	// plain GetSession + ownership check.
-	card, claims := verifiedStreamCardFromToken(r.URL.Query().Get(streamTokenParam), sessionID, h.JWTSecret)
+	card, claims := verifiedStreamCardFromRequest(r, sessionID, h.JWTSecret)
 	session, status, reconstructed := h.TM.LoadOrReconstructSessionDetail(r.Context(), h.sessionMgr.GetSession, sessionID, userID, card)
 	switch status {
 	case playback.SessionMissing:

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -8,9 +8,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/Silo-Server/silo-server/internal/activitylog"
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/playback"
+	"github.com/Silo-Server/silo-server/internal/streamtoken"
 )
 
 // contextKey is an unexported type for context keys in this package.
@@ -18,6 +22,10 @@ type contextKey string
 
 // claimsKey is the context key for storing JWT claims.
 const claimsKey contextKey = "claims"
+
+// transportStreamClaimsKey stores the verified playback recipe carried by a
+// route-scoped stream capability. Only RequireTransportAuth sets it.
+const transportStreamClaimsKey contextKey = "transport_stream_claims"
 
 // SessionValidator checks whether a session is still valid (not revoked/expired).
 type SessionValidator interface {
@@ -150,6 +158,66 @@ func (am *AuthMiddleware) RequireAuth(next http.Handler) http.Handler {
 	})
 }
 
+// RequireTransportAuth authenticates a playback byte-delivery request. A
+// signed, unexpired stream capability bound to the path's session id is checked
+// first; ordinary access-token/API-key auth remains the fallback for older
+// clients and manually constructed requests.
+//
+// This middleware must only be mounted on playback transport routes. Stream
+// capabilities are deliberately narrower than account auth: they establish the
+// signed user/profile/media identity for one playback session, and downstream
+// handlers still compare that identity with the live session before serving.
+func (am *AuthMiddleware) RequireTransportAuth(secret string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		regularAuth := am.RequireAuth(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := r.URL.Query().Get(streamtoken.QueryParameter)
+			if token == "" {
+				token = r.Header.Get(streamtoken.Header)
+			}
+			sessionID := chi.URLParam(r, "session_id")
+			if secret != "" && token != "" {
+				claims, err := streamtoken.Verify(token, secret)
+				if err == nil && validTransportStreamClaims(claims, sessionID) {
+					authClaims := &auth.Claims{
+						UserID:    claims.UserID,
+						ProfileID: claims.ProfileID,
+						TokenType: auth.TokenTypeStream,
+					}
+					if lc := activitylog.GetLogContext(r.Context()); lc != nil {
+						uid := claims.UserID
+						lc.UserID = &uid
+					}
+					ctx := context.WithValue(r.Context(), claimsKey, authClaims)
+					ctx = context.WithValue(ctx, transportStreamClaimsKey, claims)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+			}
+
+			regularAuth.ServeHTTP(w, r)
+		})
+	}
+}
+
+func validTransportStreamClaims(claims *streamtoken.Claims, sessionID string) bool {
+	if claims == nil || sessionID == "" || claims.SessionID != sessionID || claims.UserID <= 0 || claims.MediaFileID <= 0 {
+		return false
+	}
+	switch claims.PlayMethod {
+	case "",
+		string(playback.PlayDirect),
+		string(playback.PlayRemux),
+		string(playback.PlayTranscode),
+		streamtoken.PlayMethodToneMapTranscode,
+		streamtoken.PlayMethodAudioDownmixTranscode,
+		streamtoken.PlayMethodAudioDownmixRemux:
+		return true
+	default:
+		return false
+	}
+}
+
 // RequireAdmin is a standalone HTTP middleware that checks if the authenticated
 // user has the "admin" role. It expects RequireAuth to have already placed
 // claims in the request context.
@@ -261,6 +329,13 @@ func GetClaims(ctx context.Context) *auth.Claims {
 	if !ok {
 		return nil
 	}
+	return claims
+}
+
+// GetTransportStreamClaims returns the verified recipe carried by a playback
+// transport capability. It is nil for ordinary account-authenticated requests.
+func GetTransportStreamClaims(ctx context.Context) *streamtoken.Claims {
+	claims, _ := ctx.Value(transportStreamClaimsKey).(*streamtoken.Claims)
 	return claims
 }
 

--- a/internal/api/middleware/transport_auth_test.go
+++ b/internal/api/middleware/transport_auth_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/streamtoken"
 )
@@ -28,6 +29,20 @@ func (v *transportAuthTokenValidator) ValidateToken(string) (*auth.Claims, error
 
 type transportAuthSessionValidator struct {
 	valid bool
+}
+
+type transportAuthViewerResolver struct {
+	calls int
+	err   error
+	order *[]string
+}
+
+func (r *transportAuthViewerResolver) Resolve(context.Context, access.ResolveInput) (access.Scope, error) {
+	r.calls++
+	if r.order != nil {
+		*r.order = append(*r.order, "viewer")
+	}
+	return access.Scope{}, r.err
 }
 
 func (v transportAuthSessionValidator) IsValid(context.Context, string) (bool, error) {
@@ -116,6 +131,77 @@ func TestRequireTransportAuthAcceptsVersionedPlaybackRecipes(t *testing.T) {
 				t.Fatalf("access validator calls = %d, want capability hot path", validator.calls)
 			}
 		})
+	}
+}
+
+func TestRequireTransportAuthAppliesViewerAccessOnlyToRegularAuthFallback(t *testing.T) {
+	const secret = "transport-auth-test-secret"
+	validator := &transportAuthTokenValidator{claims: &auth.Claims{
+		UserID:    7,
+		ProfileID: "profile-1",
+		SessionID: "login-session-1",
+		TokenType: auth.TokenTypeAccess,
+	}}
+	middleware := NewAuthMiddleware(validator, transportAuthSessionValidator{valid: true}, nil, nil)
+	resolver := &transportAuthViewerResolver{err: access.ErrProfileUnverified}
+	viewer := NewViewerAccessMiddleware(resolver)
+	nextCalls := 0
+
+	router := chi.NewRouter()
+	router.With(middleware.RequireTransportAuth(secret), viewer.RequireTransportViewerAccess).Get("/stream/{session_id}", func(w http.ResponseWriter, _ *http.Request) {
+		nextCalls++
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	regularReq := httptest.NewRequest(http.MethodGet, "/stream/playback-1", nil)
+	regularReq.Header.Set("Authorization", "Bearer access-token")
+	regularReq.Header.Set("X-Profile-Id", "profile-1")
+	regularRec := httptest.NewRecorder()
+	router.ServeHTTP(regularRec, regularReq)
+	if regularRec.Code != http.StatusForbidden || resolver.calls != 1 || nextCalls != 0 {
+		t.Fatalf("regular fallback status=%d viewer_calls=%d next_calls=%d", regularRec.Code, resolver.calls, nextCalls)
+	}
+
+	capabilityReq := httptest.NewRequest(http.MethodGet, "/stream/playback-1", nil)
+	capabilityReq.Header.Set(streamtoken.Header, signTransportAuthToken(t, secret, "playback-1", 7, 42, "direct", time.Hour))
+	capabilityRec := httptest.NewRecorder()
+	router.ServeHTTP(capabilityRec, capabilityReq)
+	if capabilityRec.Code != http.StatusNoContent || resolver.calls != 1 || nextCalls != 1 {
+		t.Fatalf("capability status=%d viewer_calls=%d next_calls=%d", capabilityRec.Code, resolver.calls, nextCalls)
+	}
+}
+
+func TestTransportViewerAccessRunsAfterRateLimiting(t *testing.T) {
+	validator := &transportAuthTokenValidator{claims: &auth.Claims{
+		UserID:    7,
+		ProfileID: "profile-1",
+		SessionID: "login-session-1",
+		TokenType: auth.TokenTypeAccess,
+	}}
+	middleware := NewAuthMiddleware(validator, transportAuthSessionValidator{valid: true}, nil, nil)
+	order := []string{}
+	resolver := &transportAuthViewerResolver{order: &order}
+	viewer := NewViewerAccessMiddleware(resolver)
+	rateLimit := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, "rate")
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	router := chi.NewRouter()
+	router.With(middleware.RequireTransportAuth("transport-auth-test-secret"), rateLimit, viewer.RequireTransportViewerAccess).Get("/stream/{session_id}", func(w http.ResponseWriter, _ *http.Request) {
+		order = append(order, "handler")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/stream/playback-1", nil)
+	req.Header.Set("Authorization", "Bearer access-token")
+	req.Header.Set("X-Profile-Id", "profile-1")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent || len(order) != 3 || order[0] != "rate" || order[1] != "viewer" || order[2] != "handler" {
+		t.Fatalf("status=%d middleware_order=%v", rec.Code, order)
 	}
 }
 

--- a/internal/api/middleware/transport_auth_test.go
+++ b/internal/api/middleware/transport_auth_test.go
@@ -1,0 +1,180 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/streamtoken"
+)
+
+type transportAuthTokenValidator struct {
+	claims *auth.Claims
+	err    error
+	calls  int
+}
+
+func (v *transportAuthTokenValidator) ValidateToken(string) (*auth.Claims, error) {
+	v.calls++
+	return v.claims, v.err
+}
+
+type transportAuthSessionValidator struct {
+	valid bool
+}
+
+func (v transportAuthSessionValidator) IsValid(context.Context, string) (bool, error) {
+	return v.valid, nil
+}
+
+func TestRequireTransportAuthAcceptsSessionCapabilityBeforeExpiredBearer(t *testing.T) {
+	const secret = "transport-auth-test-secret"
+	validator := &transportAuthTokenValidator{err: errors.New("expired access token")}
+	middleware := NewAuthMiddleware(validator, transportAuthSessionValidator{}, nil, nil)
+	token := signTransportAuthToken(t, secret, "playback-1", 7, 42, "direct", time.Hour)
+
+	router := chi.NewRouter()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		claims := GetClaims(r.Context())
+		if claims == nil || claims.UserID != 7 || claims.ProfileID != "profile-1" || claims.TokenType != auth.TokenTypeStream {
+			t.Fatalf("auth claims = %#v, want stream user 7", claims)
+		}
+		streamClaims := GetTransportStreamClaims(r.Context())
+		if streamClaims == nil || streamClaims.SessionID != "playback-1" || streamClaims.MediaFileID != 42 {
+			t.Fatalf("stream claims = %#v, want bound playback recipe", streamClaims)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+	router.With(middleware.RequireTransportAuth(secret)).Get("/stream/{session_id}", handler)
+	router.With(middleware.RequireTransportAuth(secret)).Head("/stream/{session_id}", handler)
+
+	for _, carrier := range []struct {
+		name  string
+		apply func(*http.Request)
+	}{
+		{
+			name: "query",
+			apply: func(req *http.Request) {
+				req.URL.RawQuery = streamtoken.QueryParameter + "=" + url.QueryEscape(token)
+			},
+		},
+		{
+			name: "header",
+			apply: func(req *http.Request) {
+				req.Header.Set(streamtoken.Header, token)
+			},
+		},
+	} {
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			req := httptest.NewRequest(method, "/stream/playback-1", nil)
+			carrier.apply(req)
+			req.Header.Set("Authorization", "Bearer expired-access-token")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("%s %s status = %d, body = %s", carrier.name, method, rec.Code, rec.Body.String())
+			}
+		}
+	}
+	if validator.calls != 0 {
+		t.Fatalf("access validator calls = %d, want capability hot path", validator.calls)
+	}
+}
+
+func TestRequireTransportAuthAcceptsVersionedPlaybackRecipes(t *testing.T) {
+	const secret = "transport-auth-test-secret"
+	for _, playMethod := range []string{
+		streamtoken.PlayMethodToneMapTranscode,
+		streamtoken.PlayMethodAudioDownmixTranscode,
+		streamtoken.PlayMethodAudioDownmixRemux,
+	} {
+		t.Run(playMethod, func(t *testing.T) {
+			validator := &transportAuthTokenValidator{err: errors.New("expired access token")}
+			middleware := NewAuthMiddleware(validator, transportAuthSessionValidator{}, nil, nil)
+			token := signTransportAuthToken(t, secret, "playback-1", 7, 42, playMethod, time.Hour)
+
+			router := chi.NewRouter()
+			router.With(middleware.RequireTransportAuth(secret)).Get("/stream/{session_id}", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/stream/playback-1", nil)
+			req.Header.Set(streamtoken.Header, token)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+			if validator.calls != 0 {
+				t.Fatalf("access validator calls = %d, want capability hot path", validator.calls)
+			}
+		})
+	}
+}
+
+func TestRequireTransportAuthRejectsInvalidCapabilityAndFallsBack(t *testing.T) {
+	const secret = "transport-auth-test-secret"
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{
+			name:  "another session",
+			token: signTransportAuthToken(t, secret, "playback-other", 7, 42, "direct", time.Hour),
+		},
+		{
+			name:  "download capability",
+			token: signTransportAuthToken(t, secret, "playback-1", 7, 42, streamtoken.PlayMethodDownload, time.Hour),
+		},
+		{
+			name:  "expired capability",
+			token: signTransportAuthToken(t, secret, "playback-1", 7, 42, "direct", -time.Hour),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			validator := &transportAuthTokenValidator{err: errors.New("expired access token")}
+			middleware := NewAuthMiddleware(validator, transportAuthSessionValidator{}, nil, nil)
+			router := chi.NewRouter()
+			router.With(middleware.RequireTransportAuth(secret)).Get("/stream/{session_id}", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/stream/playback-1", nil)
+			req.Header.Set(streamtoken.Header, test.token)
+			req.Header.Set("Authorization", "Bearer expired-access-token")
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want 401", rec.Code)
+			}
+			if validator.calls != 1 {
+				t.Fatalf("access validator calls = %d, want one fallback attempt", validator.calls)
+			}
+		})
+	}
+}
+
+func signTransportAuthToken(t *testing.T, secret, sessionID string, userID, mediaFileID int, playMethod string, ttl time.Duration) string {
+	t.Helper()
+	token, err := streamtoken.Sign(streamtoken.Claims{
+		SessionID:   sessionID,
+		UserID:      userID,
+		ProfileID:   "profile-1",
+		MediaFileID: mediaFileID,
+		PlayMethod:  playMethod,
+	}, secret, ttl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}

--- a/internal/api/middleware/viewer_access.go
+++ b/internal/api/middleware/viewer_access.go
@@ -80,3 +80,20 @@ func (m *ViewerAccessMiddleware) RequireViewerAccess(next http.Handler) http.Han
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
+
+// RequireTransportViewerAccess applies the ordinary profile gate after
+// transport authentication while allowing a verified stream capability to use
+// the profile identity signed into that capability. Mount it after transport
+// rate limiting so rejected range and segment requests do not reach the viewer
+// resolver first.
+func (m *ViewerAccessMiddleware) RequireTransportViewerAccess(next http.Handler) http.Handler {
+	validated := m.RequireViewerAccess(next)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims := GetClaims(r.Context())
+		if claims != nil && claims.TokenType == auth.TokenTypeStream {
+			next.ServeHTTP(w, r)
+			return
+		}
+		validated.ServeHTTP(w, r)
+	})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2077,6 +2077,9 @@ func NewRouter(deps Dependencies) chi.Router {
 				if deps.RateLimitMW != nil {
 					r.Use(deps.RateLimitMW.Handler)
 				}
+				if viewerAccessMiddleware != nil {
+					r.Use(viewerAccessMiddleware.RequireTransportViewerAccess)
+				}
 				if playbackHandler != nil {
 					r.Get("/playback/transcode/{session_id}/master.m3u8", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/playback/transcode/{session_id}/master.m3u8", playbackHandler.HandleGetTranscodeManifest))
 					r.Get("/playback/transcode/{session_id}/segment/{name}", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/playback/transcode/{session_id}/segment/{name}", playbackHandler.HandleGetTranscodeSegment))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2064,6 +2064,33 @@ func NewRouter(deps Dependencies) chi.Router {
 			})
 		}
 
+		// Playback byte delivery accepts a session-bound capability before falling
+		// back to account auth. Keep the capability middleware scoped to these read
+		// routes so it can never authorize playback mutations or unrelated APIs.
+		if authMiddleware != nil && (playbackHandler != nil || streamHandler != nil) {
+			streamSecret := ""
+			if deps.Config != nil {
+				streamSecret = deps.Config.Auth.JWTSecret
+			}
+			r.Group(func(r chi.Router) {
+				r.Use(authMiddleware.RequireTransportAuth(streamSecret))
+				if deps.RateLimitMW != nil {
+					r.Use(deps.RateLimitMW.Handler)
+				}
+				if playbackHandler != nil {
+					r.Get("/playback/transcode/{session_id}/master.m3u8", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/playback/transcode/{session_id}/master.m3u8", playbackHandler.HandleGetTranscodeManifest))
+					r.Get("/playback/transcode/{session_id}/segment/{name}", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/playback/transcode/{session_id}/segment/{name}", playbackHandler.HandleGetTranscodeSegment))
+				}
+				if streamHandler != nil {
+					r.Get("/stream/{session_id}", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/stream/{session_id}", streamHandler.HandleStream))
+					r.Head("/stream/{session_id}", observeNative(deps.StreamTelemetry, http.MethodHead, "/api/v1/stream/{session_id}", streamHandler.HandleStream))
+					r.Get("/stream/{session_id}/subtitles/{track}", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/stream/{session_id}/subtitles/{track}", streamHandler.HandleSubtitle))
+					r.Head("/stream/{session_id}/subtitles/{track}", observeNative(deps.StreamTelemetry, http.MethodHead, "/api/v1/stream/{session_id}/subtitles/{track}", streamHandler.HandleSubtitle))
+					r.Get("/stream/{session_id}/subtitles/{track}/fonts", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/stream/{session_id}/subtitles/{track}/fonts", streamHandler.HandleSubtitleFonts))
+				}
+			})
+		}
+
 		// All remaining routes require auth.
 		if authMiddleware != nil {
 			r.Group(func(r chi.Router) {
@@ -2689,11 +2716,6 @@ func NewRouter(deps Dependencies) chi.Router {
 
 					r.Route("/playback", func(r chi.Router) {
 						r.Get("/capability", playbackHandler.HandlePlaybackCapabilityV3)
-						// HLS transcode delivery. Legacy sessions treat the UUID
-						// as a bearer capability; negotiated V3 sessions require
-						// the authenticated owner inside the handler.
-						r.Get("/transcode/{session_id}/master.m3u8", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/playback/transcode/{session_id}/master.m3u8", playbackHandler.HandleGetTranscodeManifest))
-						r.Get("/transcode/{session_id}/segment/{name}", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/playback/transcode/{session_id}/segment/{name}", playbackHandler.HandleGetTranscodeSegment))
 
 						// Playback realtime control socket — needs auth but not profile.
 						r.Get("/sessions/{session_id}/control/ws", playbackHandler.HandleSessionWebSocket)
@@ -2729,15 +2751,6 @@ func NewRouter(deps Dependencies) chi.Router {
 							r.Post("/rooms/{room_id}/suggestions/promote", watchTogetherHandler.HandlePromoteSuggestion)
 						})
 					})
-				}
-
-				// Stream routes.
-				if streamHandler != nil {
-					r.Get("/stream/{session_id}", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/stream/{session_id}", streamHandler.HandleStream))
-					r.Head("/stream/{session_id}", observeNative(deps.StreamTelemetry, http.MethodHead, "/api/v1/stream/{session_id}", streamHandler.HandleStream))
-					r.Get("/stream/{session_id}/subtitles/{track}", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/stream/{session_id}/subtitles/{track}", streamHandler.HandleSubtitle))
-					r.Head("/stream/{session_id}/subtitles/{track}", observeNative(deps.StreamTelemetry, http.MethodHead, "/api/v1/stream/{session_id}/subtitles/{track}", streamHandler.HandleSubtitle))
-					r.Get("/stream/{session_id}/subtitles/{track}/fonts", observeNative(deps.StreamTelemetry, http.MethodGet, "/api/v1/stream/{session_id}/subtitles/{track}/fonts", streamHandler.HandleSubtitleFonts))
 				}
 
 				// Download routes.

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -37,6 +37,9 @@ const (
 	TokenTypeRefresh      = "refresh"
 	TokenTypeAPIKey       = "api_key"
 	TokenTypePluginAccess = "plugin_access"
+	// TokenTypeStream is synthesized only by the route-scoped playback transport
+	// middleware after it verifies a signed session capability.
+	TokenTypeStream = "stream"
 )
 
 const PluginAccessCookieName = "silo_plugin_access"

--- a/internal/streamtoken/token.go
+++ b/internal/streamtoken/token.go
@@ -8,6 +8,14 @@ import (
 )
 
 const (
+	// QueryParameter carries an integrated-server playback capability. Keeping
+	// the name here lets the API auth middleware and serve handlers agree without
+	// either package depending on the other.
+	QueryParameter = "st"
+	// Header carries the same session-bound capability when a client must keep
+	// credentials out of media URLs but cannot refresh a bearer captured by its
+	// media engine. It is checked before ordinary Authorization fallback.
+	Header = "X-Silo-Stream-Token"
 	// PlayMethodDownload identifies a token minted only after the API has
 	// authorized a file download. Proxy download routes reject playback tokens.
 	PlayMethodDownload = "download"


### PR DESCRIPTION
## Problem

Related issue: N/A, narrow fix

I traced a separate Apple playback authorization problem that could leave media playing from its buffer while later range requests or an internal reload used an expired bearer and entered a loading or recovery state.

The affected build uses Aether, which snapshots HTTP request headers when it loads an item. Silo's API client can refresh its access token independently, but the already-loaded player continues using the original bearer for subsequent media requests. When that bearer expires, a valid playback session can receive a `401` even though its direct-play, remux, or transcode decision is still valid.

This is separate from the Apple black-picture autoplay bug. The companion Apple PR fixes the native renderer handoff: https://github.com/Silo-Server/silo-apple/pull/202

## Approach

I kept the current tokenless `header_authenticated_media_v1` behavior for every unaffected client. For iOS, tvOS, and macOS build 31 clients that advertise the affected capabilities, the playback plan now also returns a signed, session-bound stream capability in `X-Silo-Stream-Token`.

The media URL remains credential-free. The compatibility capability is accepted before bearer fallback only on playback byte-delivery `GET` and `HEAD` routes. It is bound to the playback session, user, profile, file, expiry, and permitted playback recipe. It cannot authorize progress, replan, stop, download, administration, or unrelated API operations.

The same mode remains sticky across replans and can reconstruct the existing direct, remux, or transcode recipe after a server runtime restart. Proxy egress is disabled for this affected client path so the private header remains at the Silo origin and is not forwarded to a third-party media origin.

Regular bearer and API-key fallback requests still pass through the normal profile authorization gate. Valid signed stream capabilities use their session-bound profile identity without requiring the stale bearer. The transport rate limiter runs before profile resolution on both paths.

This does not alter route selection or force transcoding. The server still chooses direct play, remux, or transcode from the same playback plan and serves the same media bytes.

## Validation

- `GOWORK=off GOCACHE=/tmp/silo-pr791-go-cache go test ./internal/api/handlers ./internal/api/middleware ./internal/streamtoken ./internal/auth -count=1`
- `GOWORK=off GOCACHE=/tmp/silo-pr791-go-cache go vet ./internal/api/handlers ./internal/api/middleware ./internal/streamtoken ./internal/auth`
- `make verify-local-paths`
- `git diff --check`

All checks passed. The focused handler and middleware packages also include regressions for an attempted replan feature downgrade, profile rejection on ordinary bearer fallback, capability bypass of the redundant viewer lookup, and the `rate -> viewer -> handler` middleware order.

## Review findings

CodeRabbit rated the initial revision high risk and raised two valid issues:

- A capability-bearing replan did not independently restore `headerAuth`, which could allow a future caller outside the existing sticky-feature path to produce a credential-bearing URL or re-enable proxy routing. The current plan's capability header now pins header authentication, with start-to-replan coverage.
- Ordinary account-authenticated media fallback bypassed the viewer gate. The route now applies viewer access only to ordinary bearer/API-key requests while signed capabilities retain their bounded path.

The first Codex follow-up review then found that my initial viewer-gate composition performed profile resolution before rate limiting. I changed the middleware order and added an explicit ordering test. The second Codex review reported no remaining actionable correctness issues.

## Risks

The compatibility path is deliberately limited to the affected Apple platforms and build 31. Other clients retain the existing behavior. The exception can be removed after a released Apple build refreshes player media authorization safely. Device validation is still required with the companion Apple build.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: I reproduced and diagnosed the playback behavior from live sessions and server logs, separated the stale media-authorization problem from the Apple renderer lifecycle problem, and designed the session-bound compatibility boundary. I used OpenAI Codex to help trace the server and client code, implement the patch and regression tests, run the focused validation, and perform repeated independent read-only diff reviews. CodeRabbit later found two authorization-boundary issues. I verified and fixed both. A Codex follow-up found one rate-limit ordering problem in the first correction, which I also fixed and tested. The final Codex review reported no remaining actionable correctness issues.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session-bound playback capabilities for HLS, streams, subtitles, and transcoded media.
  * Playback can continue with valid session capabilities even when an account access token has expired.
  * Added support for capability authentication through request headers and query parameters.

* **Bug Fixes**
  * Improved playback reconstruction across live sessions, transcodes, remuxes, and subtitle delivery.
  * Improved Apple tvOS build 31 compatibility for direct and subtitle streams.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->