### PR TITLE
fix(playback): refresh incomplete skip markers

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -3424,7 +3424,7 @@ func reloadMarkerPluginProviders(
 				return fmt.Errorf("decode marker provider capability %d/%s: %w", installation.ID, capability.ID, err)
 			}
 			metadataMap := markerCapabilityMetadata(descriptor)
-			provider, err := markers.NewPluginProvider(markers.PluginProviderOptions{
+			pluginProvider, err := markers.NewPluginProvider(markers.PluginProviderOptions{
 				InstallationID:      installation.ID,
 				CapabilityID:        capability.ID,
 				DisplayName:         firstNonEmptyMarkerText(descriptor.GetDisplayName(), capability.ID),
@@ -3433,6 +3433,10 @@ func reloadMarkerPluginProviders(
 			}, resolver)
 			if err != nil {
 				return err
+			}
+			var provider markers.Provider = pluginProvider
+			if !markers.PluginSupportsContributionFromMetadata(metadataMap) {
+				provider = markers.NewReadOnlyPluginProvider(pluginProvider)
 			}
 			providers = append(providers, provider)
 

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -217,29 +217,32 @@ type PlaybackHandler struct {
 	// CopySafetyRacer resolves an unknown H.264 copy-safety verdict behind an
 	// already-issued stream-copy plan. Optional: without it an unknown verdict
 	// simply stays unknown and the copy route is never withdrawn.
-	CopySafetyRacer        PlaybackCopySafetyRacer
-	ChapterThumbnailQueuer PlaybackChapterThumbnailQueuer
-	IntroAnalyzer          IntroEpisodeAnalyzer
-	IntroRepository        PlaybackIntroEligibilityChecker
-	MarkerRegistry         *markers.Registry
-	MarkerResolver         markers.ExternalIDResolver
-	MarkerUpserter         PlaybackMarkerUpserter
-	MarkerUpdateNotifier   PlaybackMarkerUpdateNotifier
-	MarkerLazyContext      context.Context
-	MarkerLazyInFlight     sync.Map
-	SubtitleRepo           subtitles.Repository // optional; enables downloaded subtitles in playback
-	RealtimeHub            *playback.RealtimeHub
-	CommandTracker         *playback.CommandTracker
-	CommandDispatcher      *playback.CommandDispatcher
+	CopySafetyRacer           PlaybackCopySafetyRacer
+	ChapterThumbnailQueuer    PlaybackChapterThumbnailQueuer
+	IntroAnalyzer             IntroEpisodeAnalyzer
+	IntroRepository           PlaybackIntroEligibilityChecker
+	MarkerRegistry            *markers.Registry
+	MarkerResolver            markers.ExternalIDResolver
+	MarkerUpserter            PlaybackMarkerUpserter
+	MarkerUpdateNotifier      PlaybackMarkerUpdateNotifier
+	MarkerLazyContext         context.Context
+	MarkerLazyInFlight        sync.Map
+	markerLazyOnlineAttemptMu sync.Mutex
+	markerLazyOnlineAttempts  map[int]time.Time
+	SubtitleRepo              subtitles.Repository // optional; enables downloaded subtitles in playback
+	RealtimeHub               *playback.RealtimeHub
+	CommandTracker            *playback.CommandTracker
+	CommandDispatcher         *playback.CommandDispatcher
 	// PlaybackConfig returns the current playback config (ffmpeg path,
 	// hwaccel, transcode dir). Wired to the live config in integrated mode
 	// so admin changes apply to newly started transcodes. Read it through
 	// playbackConfig(), which falls back to defaults when unset.
-	PlaybackConfig    func() config.PlaybackConfig
-	FFmpegLogSink     playback.FFmpegLogSink
-	copySeekAnchor    copySeekAnchorResolver
-	realtimeCommandMu sync.Mutex
-	realtimeCommands  map[string]playbackCommandRecord
+	PlaybackConfig       func() config.PlaybackConfig
+	FFmpegLogSink        playback.FFmpegLogSink
+	copySeekAnchor       copySeekAnchorResolver
+	realtimeConnectionMu sync.Mutex
+	realtimeCommandMu    sync.Mutex
+	realtimeCommands     map[string]playbackCommandRecord
 	// tm owns the transcode-session lifecycle (live map, recipe cards, and
 	// restart reconstruct) shared with the jellycompat handler. The handler
 	// delegates all transcode-session and recipe operations to it.

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -228,7 +228,7 @@ type PlaybackHandler struct {
 	MarkerLazyContext         context.Context
 	MarkerLazyInFlight        sync.Map
 	markerLazyOnlineAttemptMu sync.Mutex
-	markerLazyOnlineAttempts  map[int]time.Time
+	markerLazyOnlineAttempts  map[playbackLazyOnlineAttemptKey]time.Time
 	SubtitleRepo              subtitles.Repository // optional; enables downloaded subtitles in playback
 	RealtimeHub               *playback.RealtimeHub
 	CommandTracker            *playback.CommandTracker

--- a/internal/api/handlers/playback_lazy_markers.go
+++ b/internal/api/handlers/playback_lazy_markers.go
@@ -12,7 +12,10 @@ import (
 	"github.com/Silo-Server/silo-server/internal/scanner"
 )
 
-const playbackLazyMarkerTimeout = 10 * time.Minute
+const (
+	playbackLazyMarkerTimeout       = 10 * time.Minute
+	playbackLazyOnlineRetryInterval = 30 * time.Minute
+)
 
 type PlaybackIntroEligibilityChecker interface {
 	IntroDetectionEligibleForPlayback(ctx context.Context, fileID int) (bool, error)
@@ -84,7 +87,10 @@ func (h *PlaybackHandler) maybeQueueLazyPlaybackMarkers(
 	hasOnline := h.hasOnlineMarkerProviders()
 	shouldRunLocal := markers.ShouldRunLocal(mode)
 	shouldRunOnline := (mode == markers.ModeOnline || mode == markers.ModeBoth) && hasOnline
-	if shouldRunOnline && hasCompletePlaybackSkipMarkers(file) {
+	if shouldRunOnline && hasCompleteOnlinePlaybackSkipMarkers(file) {
+		shouldRunOnline = false
+	}
+	if shouldRunOnline && h.hasRecentOnlineMarkerAttempt(file.ID, time.Now()) {
 		shouldRunOnline = false
 	}
 
@@ -172,6 +178,7 @@ func (h *PlaybackHandler) runLazyPlaybackMarkers(
 		"mode", mode)
 
 	if runOnline {
+		h.recordOnlineMarkerAttempt(file.ID, time.Now())
 		wrote, err := h.fetchOnlineMarkersForPlayback(ctx, file)
 		if err != nil {
 			slog.Warn("playback lazy markers: online fetch failed",
@@ -179,7 +186,7 @@ func (h *PlaybackHandler) runLazyPlaybackMarkers(
 				"file_id", file.ID,
 				"episode_id", file.EpisodeID,
 				"mode", mode,
-				"error", err.Error())
+				"error", err)
 		}
 		if wrote {
 			if refreshed := h.reloadPlaybackMarkerFile(ctx, file.ID); hasAnyMarker(refreshed) {
@@ -320,18 +327,66 @@ func (h *PlaybackHandler) notifyPlaybackMarkers(
 		"mode", mode)
 }
 
-// hasCompletePlaybackSkipMarkers reports whether the two playback skip
-// segments supplied by online marker providers are already populated. A
-// partial online result must remain eligible: TheIntroDB can gain a missing
-// intro or credits marker after the first playback, and the next fresh
-// playback session is the inexpensive opportunity to fill it for every user.
-// Provider-side caching prevents repeated external requests for a recent miss.
-func hasCompletePlaybackSkipMarkers(file *models.MediaFile) bool {
+// hasCompleteOnlinePlaybackSkipMarkers reports whether both playback skip
+// segments are populated by a source that online lookup cannot improve. Local
+// scanner and S3 ranges remain eligible because online providers outrank them.
+func hasCompleteOnlinePlaybackSkipMarkers(file *models.MediaFile) bool {
 	if file == nil {
 		return false
 	}
+	isDurableOnlineSource := func(segmentSource *string) bool {
+		source := segmentSource
+		if source == nil {
+			source = file.MarkersSource
+		}
+		if source == nil {
+			return false
+		}
+		switch *source {
+		case models.MarkerSourceOnline, models.MarkerSourcePlugin, models.MarkerSourceManual:
+			return true
+		default:
+			return false
+		}
+	}
 	return file.IntroStart != nil && file.IntroEnd != nil &&
-		file.CreditsStart != nil && file.CreditsEnd != nil
+		file.CreditsStart != nil && file.CreditsEnd != nil &&
+		isDurableOnlineSource(file.IntroMarkersSource) &&
+		isDurableOnlineSource(file.CreditsMarkersSource)
+}
+
+func (h *PlaybackHandler) hasRecentOnlineMarkerAttempt(fileID int, now time.Time) bool {
+	if h == nil || fileID <= 0 {
+		return false
+	}
+	h.markerLazyOnlineAttemptMu.Lock()
+	defer h.markerLazyOnlineAttemptMu.Unlock()
+	attemptedAt, ok := h.markerLazyOnlineAttempts[fileID]
+	if !ok {
+		return false
+	}
+	if now.Sub(attemptedAt) >= playbackLazyOnlineRetryInterval {
+		delete(h.markerLazyOnlineAttempts, fileID)
+		return false
+	}
+	return true
+}
+
+func (h *PlaybackHandler) recordOnlineMarkerAttempt(fileID int, attemptedAt time.Time) {
+	if h == nil || fileID <= 0 {
+		return
+	}
+	h.markerLazyOnlineAttemptMu.Lock()
+	defer h.markerLazyOnlineAttemptMu.Unlock()
+	if h.markerLazyOnlineAttempts == nil {
+		h.markerLazyOnlineAttempts = make(map[int]time.Time)
+	}
+	for cachedFileID, cachedAt := range h.markerLazyOnlineAttempts {
+		if attemptedAt.Sub(cachedAt) >= playbackLazyOnlineRetryInterval {
+			delete(h.markerLazyOnlineAttempts, cachedFileID)
+		}
+	}
+	h.markerLazyOnlineAttempts[fileID] = attemptedAt
 }
 
 // hasAnyMarker reports whether the file has at least one populated marker

--- a/internal/api/handlers/playback_lazy_markers.go
+++ b/internal/api/handlers/playback_lazy_markers.go
@@ -84,7 +84,7 @@ func (h *PlaybackHandler) maybeQueueLazyPlaybackMarkers(
 	hasOnline := h.hasOnlineMarkerProviders()
 	shouldRunLocal := markers.ShouldRunLocal(mode)
 	shouldRunOnline := (mode == markers.ModeOnline || mode == markers.ModeBoth) && hasOnline
-	if shouldRunOnline && hasOnlineSourcedMarkers(file) {
+	if shouldRunOnline && hasCompletePlaybackSkipMarkers(file) {
 		shouldRunOnline = false
 	}
 
@@ -179,7 +179,7 @@ func (h *PlaybackHandler) runLazyPlaybackMarkers(
 				"file_id", file.ID,
 				"episode_id", file.EpisodeID,
 				"mode", mode,
-				"error", err)
+				"error", err.Error())
 		}
 		if wrote {
 			if refreshed := h.reloadPlaybackMarkerFile(ctx, file.ID); hasAnyMarker(refreshed) {
@@ -320,31 +320,18 @@ func (h *PlaybackHandler) notifyPlaybackMarkers(
 		"mode", mode)
 }
 
-// hasOnlineSourcedMarkers reports whether the file already has at least one
-// marker written by a non-local source. We short-circuit lazy online fetch
-// in that case to avoid refetching every playback start — TheIntroDB often
-// returns only intro+credits and never recap/preview for a given episode, so
-// requiring all four kinds before skipping would loop forever on partial data.
-// Markers from the scanner/s3 path remain refetchable since online sources
-// outrank them.
-func hasOnlineSourcedMarkers(file *models.MediaFile) bool {
+// hasCompletePlaybackSkipMarkers reports whether the two playback skip
+// segments supplied by online marker providers are already populated. A
+// partial online result must remain eligible: TheIntroDB can gain a missing
+// intro or credits marker after the first playback, and the next fresh
+// playback session is the inexpensive opportunity to fill it for every user.
+// Provider-side caching prevents repeated external requests for a recent miss.
+func hasCompletePlaybackSkipMarkers(file *models.MediaFile) bool {
 	if file == nil {
 		return false
 	}
-	isOnlineSource := func(source *string) bool {
-		if source == nil {
-			return false
-		}
-		switch *source {
-		case models.MarkerSourceOnline, models.MarkerSourcePlugin, models.MarkerSourceManual:
-			return true
-		}
-		return false
-	}
-	return isOnlineSource(file.IntroMarkersSource) ||
-		isOnlineSource(file.CreditsMarkersSource) ||
-		isOnlineSource(file.RecapMarkersSource) ||
-		isOnlineSource(file.PreviewMarkersSource)
+	return file.IntroStart != nil && file.IntroEnd != nil &&
+		file.CreditsStart != nil && file.CreditsEnd != nil
 }
 
 // hasAnyMarker reports whether the file has at least one populated marker

--- a/internal/api/handlers/playback_lazy_markers.go
+++ b/internal/api/handlers/playback_lazy_markers.go
@@ -90,7 +90,7 @@ func (h *PlaybackHandler) maybeQueueLazyPlaybackMarkers(
 	if shouldRunOnline && hasCompleteOnlinePlaybackSkipMarkers(file) {
 		shouldRunOnline = false
 	}
-	if shouldRunOnline && h.hasRecentOnlineMarkerAttempt(file.ID, time.Now()) {
+	if shouldRunOnline && h.hasRecentOnlineMarkerAttempt(file, time.Now()) {
 		shouldRunOnline = false
 	}
 
@@ -178,7 +178,7 @@ func (h *PlaybackHandler) runLazyPlaybackMarkers(
 		"mode", mode)
 
 	if runOnline {
-		h.recordOnlineMarkerAttempt(file.ID, time.Now())
+		h.recordOnlineMarkerAttempt(file, time.Now())
 		wrote, err := h.fetchOnlineMarkersForPlayback(ctx, file)
 		if err != nil {
 			slog.Warn("playback lazy markers: online fetch failed",
@@ -355,38 +355,52 @@ func hasCompleteOnlinePlaybackSkipMarkers(file *models.MediaFile) bool {
 		isDurableOnlineSource(file.CreditsMarkersSource)
 }
 
-func (h *PlaybackHandler) hasRecentOnlineMarkerAttempt(fileID int, now time.Time) bool {
-	if h == nil || fileID <= 0 {
+type playbackLazyOnlineAttemptKey struct {
+	fileID   int
+	fileHash string
+}
+
+func playbackLazyOnlineAttemptKeyFor(file *models.MediaFile) (playbackLazyOnlineAttemptKey, bool) {
+	if file == nil || file.ID <= 0 {
+		return playbackLazyOnlineAttemptKey{}, false
+	}
+	return playbackLazyOnlineAttemptKey{fileID: file.ID, fileHash: strings.TrimSpace(file.FileHash)}, true
+}
+
+func (h *PlaybackHandler) hasRecentOnlineMarkerAttempt(file *models.MediaFile, now time.Time) bool {
+	key, ok := playbackLazyOnlineAttemptKeyFor(file)
+	if h == nil || !ok {
 		return false
 	}
 	h.markerLazyOnlineAttemptMu.Lock()
 	defer h.markerLazyOnlineAttemptMu.Unlock()
-	attemptedAt, ok := h.markerLazyOnlineAttempts[fileID]
+	attemptedAt, ok := h.markerLazyOnlineAttempts[key]
 	if !ok {
 		return false
 	}
 	if now.Sub(attemptedAt) >= playbackLazyOnlineRetryInterval {
-		delete(h.markerLazyOnlineAttempts, fileID)
+		delete(h.markerLazyOnlineAttempts, key)
 		return false
 	}
 	return true
 }
 
-func (h *PlaybackHandler) recordOnlineMarkerAttempt(fileID int, attemptedAt time.Time) {
-	if h == nil || fileID <= 0 {
+func (h *PlaybackHandler) recordOnlineMarkerAttempt(file *models.MediaFile, attemptedAt time.Time) {
+	key, ok := playbackLazyOnlineAttemptKeyFor(file)
+	if h == nil || !ok {
 		return
 	}
 	h.markerLazyOnlineAttemptMu.Lock()
 	defer h.markerLazyOnlineAttemptMu.Unlock()
 	if h.markerLazyOnlineAttempts == nil {
-		h.markerLazyOnlineAttempts = make(map[int]time.Time)
+		h.markerLazyOnlineAttempts = make(map[playbackLazyOnlineAttemptKey]time.Time)
 	}
-	for cachedFileID, cachedAt := range h.markerLazyOnlineAttempts {
+	for cachedKey, cachedAt := range h.markerLazyOnlineAttempts {
 		if attemptedAt.Sub(cachedAt) >= playbackLazyOnlineRetryInterval {
-			delete(h.markerLazyOnlineAttempts, cachedFileID)
+			delete(h.markerLazyOnlineAttempts, cachedKey)
 		}
 	}
-	h.markerLazyOnlineAttempts[fileID] = attemptedAt
+	h.markerLazyOnlineAttempts[key] = attemptedAt
 }
 
 // hasAnyMarker reports whether the file has at least one populated marker

--- a/internal/api/handlers/playback_lazy_markers_test.go
+++ b/internal/api/handlers/playback_lazy_markers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/markers"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/playback"
+	"github.com/Silo-Server/silo-server/internal/scanner"
 )
 
 type fakePlaybackMarkerProvider struct{}
@@ -19,6 +20,34 @@ func (fakePlaybackMarkerProvider) ID() string { return "fake-online" }
 
 func (fakePlaybackMarkerProvider) FetchMarkers(context.Context, markers.Request) (markers.Result, error) {
 	return markers.Result{}, nil
+}
+
+type recordingPlaybackMarkerProvider struct {
+	calls chan markers.Request
+}
+
+func (p recordingPlaybackMarkerProvider) ID() string { return "recording-online" }
+
+func (p recordingPlaybackMarkerProvider) FetchMarkers(_ context.Context, req markers.Request) (markers.Result, error) {
+	p.calls <- req
+	return markers.Result{}, nil
+}
+
+type fakePlaybackExternalIDResolver struct{}
+
+func (fakePlaybackExternalIDResolver) ResolveForFile(context.Context, *models.MediaFile) (markers.ExternalIDs, error) {
+	return markers.ExternalIDs{
+		Kind:          markers.ItemKindEpisode,
+		TmdbID:        "123",
+		SeasonNumber:  1,
+		EpisodeNumber: 2,
+	}, nil
+}
+
+type fakePlaybackMarkerUpserter struct{}
+
+func (fakePlaybackMarkerUpserter) UpsertMarkers(context.Context, int, scanner.MarkerUpdate) (bool, error) {
+	return false, nil
 }
 
 type fakePlaybackIntroAnalyzer struct {
@@ -306,6 +335,41 @@ func TestMaybeQueueLazyPlaybackMarkersOnlineModeWithProviderDoesNotRunLocalAnaly
 	}
 }
 
+func TestMaybeQueueLazyPlaybackMarkersOnlineRetriesPartialSkipMarkers(t *testing.T) {
+	start := 10.0
+	end := 60.0
+	file := lazyMarkerTestFile()
+	file.IntroStart = &start
+	file.IntroEnd = &end
+
+	calls := make(chan markers.Request, 1)
+	registry := markers.NewRegistry(slog.Default())
+	if err := registry.Register(recordingPlaybackMarkerProvider{calls: calls}); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0), &fakePlaybackMarkerFileResolver{file: file})
+	handler.SettingsRepo = testPlaybackSettingsRepo{values: map[string]string{
+		markers.SettingLazyPlayback: "true",
+		markers.SettingMode:         "online",
+	}}
+	handler.IntroRepository = fakePlaybackIntroEligibility{eligible: true}
+	handler.MarkerRegistry = registry
+	handler.MarkerResolver = fakePlaybackExternalIDResolver{}
+	handler.MarkerUpserter = fakePlaybackMarkerUpserter{}
+	handler.MarkerLazyContext = context.Background()
+
+	handler.maybeQueueLazyPlaybackMarkers(context.Background(), &playback.Session{ID: "session-1"}, file)
+
+	select {
+	case req := <-calls:
+		if req.ExternalIDs[markers.ExternalIDKeyTMDB] != "123" {
+			t.Fatalf("TMDB id = %q, want 123", req.ExternalIDs[markers.ExternalIDKeyTMDB])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("partial markers did not trigger online lookup")
+	}
+}
+
 func TestMaybeQueueLazyPlaybackMarkersAnalyzerSuccessWithoutMarkerDoesNotEmitUpdate(t *testing.T) {
 	analyzer := &fakePlaybackIntroAnalyzer{started: make(chan struct{}, 1)}
 	file := lazyMarkerTestFile()
@@ -349,5 +413,46 @@ func lazyMarkerTestFile() *models.MediaFile {
 		EpisodeID:     "episode-1",
 		MediaFolderID: 7,
 		Duration:      1800,
+	}
+}
+
+func TestHasCompletePlaybackSkipMarkers(t *testing.T) {
+	start := 10.0
+	introEnd := 60.0
+	creditsStart := 1700.0
+	creditsEnd := 1800.0
+
+	tests := []struct {
+		name string
+		file *models.MediaFile
+		want bool
+	}{
+		{name: "nil file", file: nil, want: false},
+		{
+			name: "intro only remains eligible",
+			file: &models.MediaFile{IntroStart: &start, IntroEnd: &introEnd},
+			want: false,
+		},
+		{
+			name: "credits only remains eligible",
+			file: &models.MediaFile{CreditsStart: &creditsStart, CreditsEnd: &creditsEnd},
+			want: false,
+		},
+		{
+			name: "both skip markers stop lookup",
+			file: &models.MediaFile{
+				IntroStart: &start, IntroEnd: &introEnd,
+				CreditsStart: &creditsStart, CreditsEnd: &creditsEnd,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCompletePlaybackSkipMarkers(tt.file); got != tt.want {
+				t.Fatalf("hasCompletePlaybackSkipMarkers() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/api/handlers/playback_lazy_markers_test.go
+++ b/internal/api/handlers/playback_lazy_markers_test.go
@@ -499,23 +499,29 @@ func TestHasCompleteOnlinePlaybackSkipMarkers(t *testing.T) {
 func TestPlaybackLazyOnlineAttemptCooldown(t *testing.T) {
 	handler := &PlaybackHandler{}
 	now := time.Unix(1_700_000_000, 0)
+	file := &models.MediaFile{ID: 42, FileHash: "old-hash"}
 
-	if handler.hasRecentOnlineMarkerAttempt(42, now) {
+	if handler.hasRecentOnlineMarkerAttempt(file, now) {
 		t.Fatal("missing attempt reported as recent")
 	}
-	handler.recordOnlineMarkerAttempt(42, now)
-	if !handler.hasRecentOnlineMarkerAttempt(42, now.Add(playbackLazyOnlineRetryInterval-time.Second)) {
+	handler.recordOnlineMarkerAttempt(file, now)
+	if !handler.hasRecentOnlineMarkerAttempt(file, now.Add(playbackLazyOnlineRetryInterval-time.Second)) {
 		t.Fatal("attempt inside retry interval was not throttled")
 	}
-	if handler.hasRecentOnlineMarkerAttempt(42, now.Add(playbackLazyOnlineRetryInterval)) {
+	replacement := &models.MediaFile{ID: file.ID, FileHash: "new-hash"}
+	if handler.hasRecentOnlineMarkerAttempt(replacement, now.Add(time.Second)) {
+		t.Fatal("replacement file version inherited the old version's cooldown")
+	}
+	if handler.hasRecentOnlineMarkerAttempt(file, now.Add(playbackLazyOnlineRetryInterval)) {
 		t.Fatal("expired attempt remained throttled")
 	}
-	if _, ok := handler.markerLazyOnlineAttempts[42]; ok {
+	if _, ok := handler.markerLazyOnlineAttempts[playbackLazyOnlineAttemptKey{fileID: file.ID, fileHash: file.FileHash}]; ok {
 		t.Fatal("expired attempt was not removed")
 	}
-	handler.recordOnlineMarkerAttempt(1, now.Add(-playbackLazyOnlineRetryInterval))
-	handler.recordOnlineMarkerAttempt(2, now)
-	if _, ok := handler.markerLazyOnlineAttempts[1]; ok {
+	expired := &models.MediaFile{ID: 1}
+	handler.recordOnlineMarkerAttempt(expired, now.Add(-playbackLazyOnlineRetryInterval))
+	handler.recordOnlineMarkerAttempt(&models.MediaFile{ID: 2}, now)
+	if _, ok := handler.markerLazyOnlineAttempts[playbackLazyOnlineAttemptKey{fileID: expired.ID}]; ok {
 		t.Fatal("recording an attempt did not prune expired entries")
 	}
 }

--- a/internal/api/handlers/playback_lazy_markers_test.go
+++ b/internal/api/handlers/playback_lazy_markers_test.go
@@ -416,11 +416,14 @@ func lazyMarkerTestFile() *models.MediaFile {
 	}
 }
 
-func TestHasCompletePlaybackSkipMarkers(t *testing.T) {
+func TestHasCompleteOnlinePlaybackSkipMarkers(t *testing.T) {
 	start := 10.0
 	introEnd := 60.0
 	creditsStart := 1700.0
 	creditsEnd := 1800.0
+	online := models.MarkerSourceOnline
+	plugin := models.MarkerSourcePlugin
+	scannerSource := models.MarkerSourceScanner
 
 	tests := []struct {
 		name string
@@ -439,10 +442,46 @@ func TestHasCompletePlaybackSkipMarkers(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "both skip markers stop lookup",
+			name: "unattributed complete markers remain eligible",
 			file: &models.MediaFile{
 				IntroStart: &start, IntroEnd: &introEnd,
 				CreditsStart: &creditsStart, CreditsEnd: &creditsEnd,
+			},
+			want: false,
+		},
+		{
+			name: "scanner markers remain eligible for online upgrade",
+			file: &models.MediaFile{
+				IntroStart: &start, IntroEnd: &introEnd,
+				CreditsStart: &creditsStart, CreditsEnd: &creditsEnd,
+				IntroMarkersSource: &scannerSource, CreditsMarkersSource: &scannerSource,
+			},
+			want: false,
+		},
+		{
+			name: "mixed online and scanner markers remain eligible",
+			file: &models.MediaFile{
+				IntroStart: &start, IntroEnd: &introEnd,
+				CreditsStart: &creditsStart, CreditsEnd: &creditsEnd,
+				IntroMarkersSource: &online, CreditsMarkersSource: &scannerSource,
+			},
+			want: false,
+		},
+		{
+			name: "complete online and plugin markers stop lookup",
+			file: &models.MediaFile{
+				IntroStart: &start, IntroEnd: &introEnd,
+				CreditsStart: &creditsStart, CreditsEnd: &creditsEnd,
+				IntroMarkersSource: &online, CreditsMarkersSource: &plugin,
+			},
+			want: true,
+		},
+		{
+			name: "legacy shared online source stops lookup",
+			file: &models.MediaFile{
+				IntroStart: &start, IntroEnd: &introEnd,
+				CreditsStart: &creditsStart, CreditsEnd: &creditsEnd,
+				MarkersSource: &online,
 			},
 			want: true,
 		},
@@ -450,9 +489,33 @@ func TestHasCompletePlaybackSkipMarkers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := hasCompletePlaybackSkipMarkers(tt.file); got != tt.want {
-				t.Fatalf("hasCompletePlaybackSkipMarkers() = %v, want %v", got, tt.want)
+			if got := hasCompleteOnlinePlaybackSkipMarkers(tt.file); got != tt.want {
+				t.Fatalf("hasCompleteOnlinePlaybackSkipMarkers() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPlaybackLazyOnlineAttemptCooldown(t *testing.T) {
+	handler := &PlaybackHandler{}
+	now := time.Unix(1_700_000_000, 0)
+
+	if handler.hasRecentOnlineMarkerAttempt(42, now) {
+		t.Fatal("missing attempt reported as recent")
+	}
+	handler.recordOnlineMarkerAttempt(42, now)
+	if !handler.hasRecentOnlineMarkerAttempt(42, now.Add(playbackLazyOnlineRetryInterval-time.Second)) {
+		t.Fatal("attempt inside retry interval was not throttled")
+	}
+	if handler.hasRecentOnlineMarkerAttempt(42, now.Add(playbackLazyOnlineRetryInterval)) {
+		t.Fatal("expired attempt remained throttled")
+	}
+	if _, ok := handler.markerLazyOnlineAttempts[42]; ok {
+		t.Fatal("expired attempt was not removed")
+	}
+	handler.recordOnlineMarkerAttempt(1, now.Add(-playbackLazyOnlineRetryInterval))
+	handler.recordOnlineMarkerAttempt(2, now)
+	if _, ok := handler.markerLazyOnlineAttempts[1]; ok {
+		t.Fatal("recording an attempt did not prune expired entries")
 	}
 }

--- a/internal/api/handlers/session_ws.go
+++ b/internal/api/handlers/session_ws.go
@@ -25,6 +25,14 @@ type sessionRealtimeConn struct {
 	writeMu sync.Mutex
 }
 
+type sessionRealtimeClient struct {
+	handler       *PlaybackHandler
+	connectionCtx context.Context
+	registration  *playback.RealtimeRegistration
+	sessionID     string
+	helloReceived bool
+}
+
 func (c *sessionRealtimeConn) WriteJSON(v any) error {
 	if c == nil || c.conn == nil {
 		return playback.ErrRealtimeConnectionNotFound
@@ -85,7 +93,7 @@ func (h *PlaybackHandler) HandleSessionWebSocket(w http.ResponseWriter, r *http.
 	}
 
 	realtimeConn := &sessionRealtimeConn{conn: conn}
-	registration := h.RealtimeHub.Register(sessionID, realtimeConn)
+	registration := h.registerSessionRealtimeConnection(sessionID, realtimeConn)
 	if registration == nil {
 		conn.Close()
 		slog.WarnContext(r.Context(), "failed to register realtime websocket", "component", "api", "session", sessionID, "playback_session_id", sessionID)
@@ -96,84 +104,86 @@ func (h *PlaybackHandler) HandleSessionWebSocket(w http.ResponseWriter, r *http.
 	ctx, cancelRead := context.WithCancel(r.Context())
 	defer func() {
 		cancelRead()
-		if h.RealtimeHub.Unregister(registration) && h.setRealtimeConnectionState(sessionID, false) {
-			h.syncSessionsNow(context.Background(), "realtime_disconnect")
-		}
+		h.unregisterSessionRealtimeConnection(sessionID, registration)
 		_ = conn.Close()
 	}()
 
 	startWebSocketPingLoop(ctx, realtimeConn.WritePing)
-	helloReceived := false
+	client := &sessionRealtimeClient{
+		handler:       h,
+		connectionCtx: ctx,
+		registration:  registration,
+		sessionID:     sessionID,
+	}
 
 	for {
 		_, data, err := conn.ReadMessage()
 		if err != nil {
 			break
 		}
-		sendMarkerSnapshot, err := h.handleRealtimeClientMessage(sessionID, data, &helloReceived)
-		if err != nil {
+		if err := client.handleMessage(data); err != nil {
 			slog.WarnContext(r.Context(), "invalid realtime client message", "component", "api", "session", sessionID, "playback_session_id", sessionID, "error", err)
-			continue
-		}
-		if sendMarkerSnapshot {
-			go h.sendCurrentMarkerSnapshot(ctx, registration, sessionID)
 		}
 	}
 }
 
-func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []byte, helloReceived *bool) (bool, error) {
+func (c *sessionRealtimeClient) handleMessage(data []byte) error {
+	if c == nil || c.handler == nil || c.sessionID == "" {
+		return playback.ErrInvalidRealtimePayload
+	}
+	h := c.handler
+	sessionID := c.sessionID
 	var base realtimeClientMessage
 	if err := json.Unmarshal(data, &base); err != nil {
-		return false, err
+		return err
 	}
 
 	switch base.Type {
 	case playback.RealtimeMessageTypeHello:
 		var hello playback.HelloEnvelope
 		if err := json.Unmarshal(data, &hello); err != nil {
-			return false, err
+			return err
 		}
 		if err := hello.Validate(); err != nil {
-			return false, err
+			return err
 		}
 		if hello.SessionID != sessionID {
-			return false, playback.ErrInvalidRealtimePayload
+			return playback.ErrInvalidRealtimePayload
 		}
-		sendMarkerSnapshot := helloReceived == nil || !*helloReceived
-		if helloReceived != nil {
-			*helloReceived = true
-		}
-		if h.setRealtimeConnectionState(sessionID, true) {
-			h.syncSessionsNow(context.Background(), "realtime_hello")
-		}
+		firstHello := !c.helloReceived
+		c.helloReceived = true
+		h.markSessionRealtimeReady(sessionID, c.registration)
 		h.touchSessionActivity(sessionID)
-		return sendMarkerSnapshot, nil
+		if firstHello {
+			go h.sendCurrentMarkerSnapshot(c.connectionCtx, c.registration, sessionID)
+		}
+		return nil
 	case playback.RealtimeMessageTypeAck:
 		var ack playback.AckEnvelope
 		if err := json.Unmarshal(data, &ack); err != nil {
-			return false, err
+			return err
 		}
 		if err := ack.Validate(); err != nil {
-			return false, err
+			return err
 		}
 		if ack.SessionID != sessionID {
-			return false, playback.ErrInvalidRealtimePayload
+			return playback.ErrInvalidRealtimePayload
 		}
 		h.touchSessionActivity(sessionID)
 		if h.CommandTracker != nil {
 			h.CommandTracker.Ack(ack.CommandID)
 		}
-		return false, nil
+		return nil
 	case playback.RealtimeMessageTypeResult:
 		var result playback.ResultEnvelope
 		if err := json.Unmarshal(data, &result); err != nil {
-			return false, err
+			return err
 		}
 		if err := result.Validate(); err != nil {
-			return false, err
+			return err
 		}
 		if result.SessionID != sessionID {
-			return false, playback.ErrInvalidRealtimePayload
+			return playback.ErrInvalidRealtimePayload
 		}
 		h.touchSessionActivity(sessionID)
 		// Establish ownership before mutating anything: a result naming another
@@ -183,13 +193,13 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 		// is normal traffic.
 		record, ok := h.getRealtimeCommand(result.CommandID)
 		if ok && record.SessionID != sessionID {
-			return false, playback.ErrInvalidRealtimePayload
+			return playback.ErrInvalidRealtimePayload
 		}
 		if h.CommandTracker != nil {
 			h.CommandTracker.Result(result.CommandID)
 		}
 		if !ok {
-			return false, nil
+			return nil
 		}
 		h.forgetRealtimeCommand(result.CommandID)
 		if result.Status != playback.RealtimeResultStatusCompleted {
@@ -205,7 +215,7 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 					slog.Error("failed to stop playback after a rejected plan invalidation", "session", sessionID, "playback_session_id", sessionID, "error", err)
 				}
 			}
-			return false, nil
+			return nil
 		}
 		switch record.Name {
 		case playback.CommandStop, playback.CommandTerminate:
@@ -217,9 +227,50 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 			// Completion means the client replanned itself; the session stays
 			// alive on its replacement plan and nothing else is required here.
 		}
-		return false, nil
+		return nil
 	default:
-		return false, playback.ErrInvalidRealtimePayload
+		return playback.ErrInvalidRealtimePayload
+	}
+}
+
+func (h *PlaybackHandler) registerSessionRealtimeConnection(
+	sessionID string,
+	conn playback.RealtimeConnection,
+) *playback.RealtimeRegistration {
+	h.realtimeConnectionMu.Lock()
+	defer h.realtimeConnectionMu.Unlock()
+	registration := h.RealtimeHub.Register(sessionID, conn)
+	if registration != nil && h.setRealtimeConnectionState(sessionID, false) {
+		h.syncSessionsNow(context.Background(), "realtime_pending_hello")
+	}
+	return registration
+}
+
+func (h *PlaybackHandler) markSessionRealtimeReady(
+	sessionID string,
+	registration *playback.RealtimeRegistration,
+) {
+	h.realtimeConnectionMu.Lock()
+	defer h.realtimeConnectionMu.Unlock()
+	if !h.RealtimeHub.HasRegistration(registration) {
+		return
+	}
+	if h.setRealtimeConnectionState(sessionID, true) {
+		h.syncSessionsNow(context.Background(), "realtime_hello")
+	}
+}
+
+func (h *PlaybackHandler) unregisterSessionRealtimeConnection(
+	sessionID string,
+	registration *playback.RealtimeRegistration,
+) {
+	h.realtimeConnectionMu.Lock()
+	defer h.realtimeConnectionMu.Unlock()
+	if !h.RealtimeHub.Unregister(registration) || h.RealtimeHub.HasConnection(sessionID) {
+		return
+	}
+	if h.setRealtimeConnectionState(sessionID, false) {
+		h.syncSessionsNow(context.Background(), "realtime_disconnect")
 	}
 }
 
@@ -229,7 +280,7 @@ type playbackMarkerSnapshotNotifier interface {
 		registration *playback.RealtimeRegistration,
 		fileID int,
 		loader playback.MarkerSnapshotFileLoader,
-	) error
+	) (bool, error)
 }
 
 func (h *PlaybackHandler) sendCurrentMarkerSnapshot(
@@ -242,6 +293,9 @@ func (h *PlaybackHandler) sendCurrentMarkerSnapshot(
 	}
 	notifier, ok := h.MarkerUpdateNotifier.(playbackMarkerSnapshotNotifier)
 	if !ok {
+		slog.DebugContext(connectionCtx, "playback marker snapshot unavailable", "component", "api",
+			"session", sessionID, "playback_session_id", sessionID,
+			"reason", "notifier does not support persisted snapshots")
 		return
 	}
 	session, err := h.sessionMgr.GetSession(sessionID)
@@ -250,9 +304,16 @@ func (h *PlaybackHandler) sendCurrentMarkerSnapshot(
 	}
 	ctx, cancel := context.WithTimeout(connectionCtx, 3*time.Second)
 	defer cancel()
-	if err := notifier.SendSessionSnapshotFromLoader(ctx, registration, session.MediaFileID, h.fileResolver); err != nil {
+	sent, err := notifier.SendSessionSnapshotFromLoader(ctx, registration, session.MediaFileID, h.fileResolver)
+	if err != nil {
 		slog.DebugContext(ctx, "playback marker snapshot unavailable", "component", "api",
 			"session", sessionID, "playback_session_id", sessionID,
 			"file_id", session.MediaFileID, "error", err)
+		return
+	}
+	if !sent {
+		slog.DebugContext(ctx, "playback marker snapshot skipped", "component", "api",
+			"session", sessionID, "playback_session_id", sessionID,
+			"file_id", session.MediaFileID)
 	}
 }

--- a/internal/api/handlers/session_ws.go
+++ b/internal/api/handlers/session_ws.go
@@ -104,68 +104,77 @@ func (h *PlaybackHandler) HandleSessionWebSocket(w http.ResponseWriter, r *http.
 	ctx, cancelRead := context.WithCancel(r.Context())
 	defer cancelRead()
 	startWebSocketPingLoop(ctx, realtimeConn.WritePing)
+	helloReceived := false
 
 	for {
 		_, data, err := conn.ReadMessage()
 		if err != nil {
 			break
 		}
-		if err := h.handleRealtimeClientMessage(sessionID, data); err != nil {
+		sendMarkerSnapshot, err := h.handleRealtimeClientMessage(sessionID, data, &helloReceived)
+		if err != nil {
 			slog.WarnContext(r.Context(), "invalid realtime client message", "component", "api", "session", sessionID, "playback_session_id", sessionID, "error", err)
+			continue
+		}
+		if sendMarkerSnapshot {
+			go h.sendCurrentMarkerSnapshot(sessionID)
 		}
 	}
 }
 
-func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []byte) error {
+func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []byte, helloReceived *bool) (bool, error) {
 	var base realtimeClientMessage
 	if err := json.Unmarshal(data, &base); err != nil {
-		return err
+		return false, err
 	}
 
 	switch base.Type {
 	case playback.RealtimeMessageTypeHello:
 		var hello playback.HelloEnvelope
 		if err := json.Unmarshal(data, &hello); err != nil {
-			return err
+			return false, err
 		}
 		if err := hello.Validate(); err != nil {
-			return err
+			return false, err
 		}
 		if hello.SessionID != sessionID {
-			return playback.ErrInvalidRealtimePayload
+			return false, playback.ErrInvalidRealtimePayload
+		}
+		sendMarkerSnapshot := helloReceived == nil || !*helloReceived
+		if helloReceived != nil {
+			*helloReceived = true
 		}
 		if h.setRealtimeConnectionState(sessionID, true) {
 			h.syncSessionsNow(context.Background(), "realtime_hello")
-			go h.sendCurrentMarkerSnapshot(sessionID)
 		}
 		h.touchSessionActivity(sessionID)
-		return nil
+		return sendMarkerSnapshot, nil
 	case playback.RealtimeMessageTypeAck:
 		var ack playback.AckEnvelope
 		if err := json.Unmarshal(data, &ack); err != nil {
-			return err
+			return false, err
 		}
 		if err := ack.Validate(); err != nil {
-			return err
+			return false, err
 		}
 		if ack.SessionID != sessionID {
-			return playback.ErrInvalidRealtimePayload
+			return false, playback.ErrInvalidRealtimePayload
 		}
 		h.touchSessionActivity(sessionID)
 		if h.CommandTracker != nil {
 			h.CommandTracker.Ack(ack.CommandID)
 		}
-		return nil
+		return false, nil
 	case playback.RealtimeMessageTypeResult:
 		var result playback.ResultEnvelope
 		if err := json.Unmarshal(data, &result); err != nil {
-			return err
+			return false, err
 		}
 		if err := result.Validate(); err != nil {
-			return err
+			return false, err
 		}
 		if result.SessionID != sessionID {
-			return playback.ErrInvalidRealtimePayload
+			return false, playback.ErrInvalidRealtimePayload
 		}
 		h.touchSessionActivity(sessionID)
 		// Establish ownership before mutating anything: a result naming another
@@ -175,13 +184,13 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 		// is normal traffic.
 		record, ok := h.getRealtimeCommand(result.CommandID)
 		if ok && record.SessionID != sessionID {
-			return playback.ErrInvalidRealtimePayload
+			return false, playback.ErrInvalidRealtimePayload
 		}
 		if h.CommandTracker != nil {
 			h.CommandTracker.Result(result.CommandID)
 		}
 		if !ok {
-			return nil
+			return false, nil
 		}
 		h.forgetRealtimeCommand(result.CommandID)
 		if result.Status != playback.RealtimeResultStatusCompleted {
@@ -197,7 +206,7 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 					slog.Error("failed to stop playback after a rejected plan invalidation", "session", sessionID, "playback_session_id", sessionID, "error", err)
 				}
 			}
-			return nil
+			return false, nil
 		}
 		switch record.Name {
 		case playback.CommandStop, playback.CommandTerminate:
@@ -209,9 +218,9 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 			// Completion means the client replanned itself; the session stays
 			// alive on its replacement plan and nothing else is required here.
 		}
-		return nil
+		return false, nil
 	default:
-		return playback.ErrInvalidRealtimePayload
+		return false, playback.ErrInvalidRealtimePayload
 	}
 }
 

--- a/internal/api/handlers/session_ws.go
+++ b/internal/api/handlers/session_ws.go
@@ -136,9 +136,9 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 		}
 		if h.setRealtimeConnectionState(sessionID, true) {
 			h.syncSessionsNow(context.Background(), "realtime_hello")
+			go h.sendCurrentMarkerSnapshot(sessionID)
 		}
 		h.touchSessionActivity(sessionID)
-		go h.sendCurrentMarkerSnapshot(sessionID)
 		return nil
 	case playback.RealtimeMessageTypeAck:
 		var ack playback.AckEnvelope

--- a/internal/api/handlers/session_ws.go
+++ b/internal/api/handlers/session_ws.go
@@ -92,17 +92,16 @@ func (h *PlaybackHandler) HandleSessionWebSocket(w http.ResponseWriter, r *http.
 		return
 	}
 
+	configureWebSocket(conn)
+	ctx, cancelRead := context.WithCancel(r.Context())
 	defer func() {
-		if h.setRealtimeConnectionState(sessionID, false) {
+		cancelRead()
+		if h.RealtimeHub.Unregister(registration) && h.setRealtimeConnectionState(sessionID, false) {
 			h.syncSessionsNow(context.Background(), "realtime_disconnect")
 		}
-		h.RealtimeHub.Unregister(registration)
 		_ = conn.Close()
 	}()
 
-	configureWebSocket(conn)
-	ctx, cancelRead := context.WithCancel(r.Context())
-	defer cancelRead()
 	startWebSocketPingLoop(ctx, realtimeConn.WritePing)
 	helloReceived := false
 
@@ -117,7 +116,7 @@ func (h *PlaybackHandler) HandleSessionWebSocket(w http.ResponseWriter, r *http.
 			continue
 		}
 		if sendMarkerSnapshot {
-			go h.sendCurrentMarkerSnapshot(sessionID)
+			go h.sendCurrentMarkerSnapshot(ctx, registration, sessionID)
 		}
 	}
 }
@@ -227,13 +226,17 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 type playbackMarkerSnapshotNotifier interface {
 	SendSessionSnapshotFromLoader(
 		ctx context.Context,
-		sessionID string,
+		registration *playback.RealtimeRegistration,
 		fileID int,
 		loader playback.MarkerSnapshotFileLoader,
 	) error
 }
 
-func (h *PlaybackHandler) sendCurrentMarkerSnapshot(sessionID string) {
+func (h *PlaybackHandler) sendCurrentMarkerSnapshot(
+	connectionCtx context.Context,
+	registration *playback.RealtimeRegistration,
+	sessionID string,
+) {
 	if h == nil || h.fileResolver == nil || h.MarkerUpdateNotifier == nil {
 		return
 	}
@@ -245,9 +248,9 @@ func (h *PlaybackHandler) sendCurrentMarkerSnapshot(sessionID string) {
 	if err != nil || session == nil || session.MediaFileID <= 0 {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(connectionCtx, 3*time.Second)
 	defer cancel()
-	if err := notifier.SendSessionSnapshotFromLoader(ctx, sessionID, session.MediaFileID, h.fileResolver); err != nil {
+	if err := notifier.SendSessionSnapshotFromLoader(ctx, registration, session.MediaFileID, h.fileResolver); err != nil {
 		slog.DebugContext(ctx, "playback marker snapshot unavailable", "component", "api",
 			"session", sessionID, "playback_session_id", sessionID,
 			"file_id", session.MediaFileID, "error", err)

--- a/internal/api/handlers/session_ws.go
+++ b/internal/api/handlers/session_ws.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
@@ -137,6 +138,7 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 			h.syncSessionsNow(context.Background(), "realtime_hello")
 		}
 		h.touchSessionActivity(sessionID)
+		go h.sendCurrentMarkerSnapshot(sessionID)
 		return nil
 	case playback.RealtimeMessageTypeAck:
 		var ack playback.AckEnvelope
@@ -210,5 +212,35 @@ func (h *PlaybackHandler) handleRealtimeClientMessage(sessionID string, data []b
 		return nil
 	default:
 		return playback.ErrInvalidRealtimePayload
+	}
+}
+
+type playbackMarkerSnapshotNotifier interface {
+	SendSessionSnapshotFromLoader(
+		ctx context.Context,
+		sessionID string,
+		fileID int,
+		loader playback.MarkerSnapshotFileLoader,
+	) error
+}
+
+func (h *PlaybackHandler) sendCurrentMarkerSnapshot(sessionID string) {
+	if h == nil || h.fileResolver == nil || h.MarkerUpdateNotifier == nil {
+		return
+	}
+	notifier, ok := h.MarkerUpdateNotifier.(playbackMarkerSnapshotNotifier)
+	if !ok {
+		return
+	}
+	session, err := h.sessionMgr.GetSession(sessionID)
+	if err != nil || session == nil || session.MediaFileID <= 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := notifier.SendSessionSnapshotFromLoader(ctx, sessionID, session.MediaFileID, h.fileResolver); err != nil {
+		slog.DebugContext(ctx, "playback marker snapshot unavailable", "component", "api",
+			"session", sessionID, "playback_session_id", sessionID,
+			"file_id", session.MediaFileID, "error", err)
 	}
 }

--- a/internal/api/handlers/session_ws_plan_invalidated_test.go
+++ b/internal/api/handlers/session_ws_plan_invalidated_test.go
@@ -38,9 +38,10 @@ func TestRealtimeRejectedPlanInvalidationStopsSession(t *testing.T) {
 	}
 	handler.rememberRealtimeCommand("cmd-1", session.ID, playback.CommandPlanInvalidated)
 
-	if _, err := handler.handleRealtimeClientMessage(session.ID,
-		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusRejected), nil); err != nil {
-		t.Fatalf("handleRealtimeClientMessage: %v", err)
+	client := testSessionRealtimeClient(handler, session.ID)
+	if err := client.handleMessage(
+		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusRejected)); err != nil {
+		t.Fatalf("handleMessage: %v", err)
 	}
 
 	if _, err := sessionMgr.GetSession(session.ID); err == nil {
@@ -62,9 +63,10 @@ func TestRealtimeCompletedPlanInvalidationKeepsSession(t *testing.T) {
 	}
 	handler.rememberRealtimeCommand("cmd-1", session.ID, playback.CommandPlanInvalidated)
 
-	if _, err := handler.handleRealtimeClientMessage(session.ID,
-		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusCompleted), nil); err != nil {
-		t.Fatalf("handleRealtimeClientMessage: %v", err)
+	client := testSessionRealtimeClient(handler, session.ID)
+	if err := client.handleMessage(
+		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusCompleted)); err != nil {
+		t.Fatalf("handleMessage: %v", err)
 	}
 
 	if _, err := sessionMgr.GetSession(session.ID); err != nil {
@@ -97,10 +99,11 @@ func TestRealtimeResultForOtherSessionCommandLeavesTrackerArmed(t *testing.T) {
 	fired := make(chan struct{})
 	handler.CommandTracker.Track("cmd-1", 20*time.Millisecond, func() { close(fired) })
 
-	_, err = handler.handleRealtimeClientMessage(sessionA.ID,
-		realtimeResultMessage(t, sessionA.ID, "cmd-1", playback.RealtimeResultStatusCompleted), nil)
+	client := testSessionRealtimeClient(handler, sessionA.ID)
+	err = client.handleMessage(
+		realtimeResultMessage(t, sessionA.ID, "cmd-1", playback.RealtimeResultStatusCompleted))
 	if !errors.Is(err, playback.ErrInvalidRealtimePayload) {
-		t.Fatalf("handleRealtimeClientMessage: %v, want ErrInvalidRealtimePayload", err)
+		t.Fatalf("handleMessage: %v, want ErrInvalidRealtimePayload", err)
 	}
 
 	if _, ok := handler.getRealtimeCommand("cmd-1"); !ok {

--- a/internal/api/handlers/session_ws_plan_invalidated_test.go
+++ b/internal/api/handlers/session_ws_plan_invalidated_test.go
@@ -38,8 +38,8 @@ func TestRealtimeRejectedPlanInvalidationStopsSession(t *testing.T) {
 	}
 	handler.rememberRealtimeCommand("cmd-1", session.ID, playback.CommandPlanInvalidated)
 
-	if err := handler.handleRealtimeClientMessage(session.ID,
-		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusRejected)); err != nil {
+	if _, err := handler.handleRealtimeClientMessage(session.ID,
+		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusRejected), nil); err != nil {
 		t.Fatalf("handleRealtimeClientMessage: %v", err)
 	}
 
@@ -62,8 +62,8 @@ func TestRealtimeCompletedPlanInvalidationKeepsSession(t *testing.T) {
 	}
 	handler.rememberRealtimeCommand("cmd-1", session.ID, playback.CommandPlanInvalidated)
 
-	if err := handler.handleRealtimeClientMessage(session.ID,
-		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusCompleted)); err != nil {
+	if _, err := handler.handleRealtimeClientMessage(session.ID,
+		realtimeResultMessage(t, session.ID, "cmd-1", playback.RealtimeResultStatusCompleted), nil); err != nil {
 		t.Fatalf("handleRealtimeClientMessage: %v", err)
 	}
 
@@ -97,8 +97,8 @@ func TestRealtimeResultForOtherSessionCommandLeavesTrackerArmed(t *testing.T) {
 	fired := make(chan struct{})
 	handler.CommandTracker.Track("cmd-1", 20*time.Millisecond, func() { close(fired) })
 
-	err = handler.handleRealtimeClientMessage(sessionA.ID,
-		realtimeResultMessage(t, sessionA.ID, "cmd-1", playback.RealtimeResultStatusCompleted))
+	_, err = handler.handleRealtimeClientMessage(sessionA.ID,
+		realtimeResultMessage(t, sessionA.ID, "cmd-1", playback.RealtimeResultStatusCompleted), nil)
 	if !errors.Is(err, playback.ErrInvalidRealtimePayload) {
 		t.Fatalf("handleRealtimeClientMessage: %v, want ErrInvalidRealtimePayload", err)
 	}

--- a/internal/api/handlers/session_ws_test.go
+++ b/internal/api/handlers/session_ws_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,16 @@ import (
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/streamtelemetry"
 )
+
+type countingPlaybackFileResolver struct {
+	file  *models.MediaFile
+	calls chan struct{}
+}
+
+func (r countingPlaybackFileResolver) GetByID(_ context.Context, _ int) (*models.MediaFile, error) {
+	r.calls <- struct{}{}
+	return r.file, nil
+}
 
 func TestHandleSessionWebSocket_RequiresHelloBeforeRealtimeReady(t *testing.T) {
 	sessionMgr := playback.NewSessionManager(0, 0)
@@ -139,6 +150,50 @@ func TestSendCurrentMarkerSnapshotLoadsPersistedSharedMarkers(t *testing.T) {
 	}
 	if payload.Credits == nil || payload.Credits.Start != creditsStart || payload.Credits.End != creditsEnd {
 		t.Fatalf("credits snapshot = %#v, want persisted credits", payload.Credits)
+	}
+}
+
+func TestHandleRealtimeClientMessageSendsMarkerSnapshotOnlyOnInitialHello(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	resolver := countingPlaybackFileResolver{
+		file:  &models.MediaFile{ID: 100},
+		calls: make(chan struct{}, 2),
+	}
+	handler := NewPlaybackHandler(sessionMgr, resolver)
+	handler.RealtimeHub = playback.NewRealtimeHub()
+	handler.MarkerUpdateNotifier = playback.NewMarkerUpdateNotifier(sessionMgr, handler.RealtimeHub)
+	hello, err := json.Marshal(playback.HelloEnvelope{
+		Type:      playback.RealtimeMessageTypeHello,
+		SessionID: session.ID,
+		Client: playback.HelloClientInfo{
+			Name:    "ios",
+			Version: "1.0.0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(hello): %v", err)
+	}
+
+	if err := handler.handleRealtimeClientMessage(session.ID, hello); err != nil {
+		t.Fatalf("first hello: %v", err)
+	}
+	if err := handler.handleRealtimeClientMessage(session.ID, hello); err != nil {
+		t.Fatalf("second hello: %v", err)
+	}
+
+	select {
+	case <-resolver.calls:
+	case <-time.After(time.Second):
+		t.Fatal("initial hello did not load a marker snapshot")
+	}
+	select {
+	case <-resolver.calls:
+		t.Fatal("repeated hello loaded a second marker snapshot")
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 

--- a/internal/api/handlers/session_ws_test.go
+++ b/internal/api/handlers/session_ws_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -121,7 +122,7 @@ func TestSendCurrentMarkerSnapshotLoadsPersistedSharedMarkers(t *testing.T) {
 	}
 	defer handler.RealtimeHub.Unregister(registration)
 
-	handler.sendCurrentMarkerSnapshot(session.ID)
+	handler.sendCurrentMarkerSnapshot(context.Background(), registration, session.ID)
 
 	if len(conn.messages) != 1 {
 		t.Fatalf("snapshot messages = %d, want 1", len(conn.messages))

--- a/internal/api/handlers/session_ws_test.go
+++ b/internal/api/handlers/session_ws_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,7 @@ import (
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/streamtelemetry"
 )
@@ -90,6 +92,54 @@ func TestHandleSessionWebSocket_RequiresHelloBeforeRealtimeReady(t *testing.T) {
 
 	waitForPlaybackRealtimeState(t, sessionMgr, session.ID, false)
 	waitForTelemetryRealtimeState(t, handler.StreamTelemetry, session.ID, false)
+}
+
+func TestSendCurrentMarkerSnapshotLoadsPersistedSharedMarkers(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	introStart, introEnd := 4.0, 58.0
+	creditsStart, creditsEnd := 3500.0, 3600.0
+	resolver := mapPlaybackFileResolver{files: map[int]*models.MediaFile{
+		100: {
+			ID:           100,
+			IntroStart:   &introStart,
+			IntroEnd:     &introEnd,
+			CreditsStart: &creditsStart,
+			CreditsEnd:   &creditsEnd,
+		},
+	}}
+	handler := NewPlaybackHandler(sessionMgr, resolver)
+	handler.RealtimeHub = playback.NewRealtimeHub()
+	handler.MarkerUpdateNotifier = playback.NewMarkerUpdateNotifier(sessionMgr, handler.RealtimeHub)
+	conn := &adminPlaybackControlTestConn{}
+	registration := handler.RealtimeHub.Register(session.ID, conn)
+	if registration == nil {
+		t.Fatal("expected realtime registration")
+	}
+	defer handler.RealtimeHub.Unregister(registration)
+
+	handler.sendCurrentMarkerSnapshot(session.ID)
+
+	if len(conn.messages) != 1 {
+		t.Fatalf("snapshot messages = %d, want 1", len(conn.messages))
+	}
+	event, ok := conn.messages[0].(playback.EventEnvelope)
+	if !ok {
+		t.Fatalf("message type = %T, want playback.EventEnvelope", conn.messages[0])
+	}
+	var payload playback.MarkersUpdatedPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(payload): %v", err)
+	}
+	if payload.Intro == nil || payload.Intro.Start != introStart || payload.Intro.End != introEnd {
+		t.Fatalf("intro snapshot = %#v, want persisted intro", payload.Intro)
+	}
+	if payload.Credits == nil || payload.Credits.Start != creditsStart || payload.Credits.End != creditsEnd {
+		t.Fatalf("credits snapshot = %#v, want persisted credits", payload.Credits)
+	}
 }
 
 func waitForTelemetryRealtimeState(t *testing.T, registry *streamtelemetry.Registry, sessionID string, want bool) {

--- a/internal/api/handlers/session_ws_test.go
+++ b/internal/api/handlers/session_ws_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,16 +17,6 @@ import (
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/streamtelemetry"
 )
-
-type countingPlaybackFileResolver struct {
-	file  *models.MediaFile
-	calls chan struct{}
-}
-
-func (r countingPlaybackFileResolver) GetByID(_ context.Context, _ int) (*models.MediaFile, error) {
-	r.calls <- struct{}{}
-	return r.file, nil
-}
 
 func TestHandleSessionWebSocket_RequiresHelloBeforeRealtimeReady(t *testing.T) {
 	sessionMgr := playback.NewSessionManager(0, 0)
@@ -153,19 +142,13 @@ func TestSendCurrentMarkerSnapshotLoadsPersistedSharedMarkers(t *testing.T) {
 	}
 }
 
-func TestHandleRealtimeClientMessageSendsMarkerSnapshotOnlyOnInitialHello(t *testing.T) {
+func TestHandleRealtimeClientMessageRequestsMarkerSnapshotOncePerConnection(t *testing.T) {
 	sessionMgr := playback.NewSessionManager(0, 0)
 	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
-	resolver := countingPlaybackFileResolver{
-		file:  &models.MediaFile{ID: 100},
-		calls: make(chan struct{}, 2),
-	}
-	handler := NewPlaybackHandler(sessionMgr, resolver)
-	handler.RealtimeHub = playback.NewRealtimeHub()
-	handler.MarkerUpdateNotifier = playback.NewMarkerUpdateNotifier(sessionMgr, handler.RealtimeHub)
+	handler := NewPlaybackHandler(sessionMgr)
 	hello, err := json.Marshal(playback.HelloEnvelope{
 		Type:      playback.RealtimeMessageTypeHello,
 		SessionID: session.ID,
@@ -178,22 +161,29 @@ func TestHandleRealtimeClientMessageSendsMarkerSnapshotOnlyOnInitialHello(t *tes
 		t.Fatalf("json.Marshal(hello): %v", err)
 	}
 
-	if err := handler.handleRealtimeClientMessage(session.ID, hello); err != nil {
+	helloReceived := false
+	sendMarkerSnapshot, err := handler.handleRealtimeClientMessage(session.ID, hello, &helloReceived)
+	if err != nil {
 		t.Fatalf("first hello: %v", err)
 	}
-	if err := handler.handleRealtimeClientMessage(session.ID, hello); err != nil {
+	if !sendMarkerSnapshot {
+		t.Fatal("initial hello did not request a marker snapshot")
+	}
+	sendMarkerSnapshot, err = handler.handleRealtimeClientMessage(session.ID, hello, &helloReceived)
+	if err != nil {
 		t.Fatalf("second hello: %v", err)
 	}
-
-	select {
-	case <-resolver.calls:
-	case <-time.After(time.Second):
-		t.Fatal("initial hello did not load a marker snapshot")
+	if sendMarkerSnapshot {
+		t.Fatal("repeated hello requested a second marker snapshot")
 	}
-	select {
-	case <-resolver.calls:
-		t.Fatal("repeated hello loaded a second marker snapshot")
-	case <-time.After(100 * time.Millisecond):
+
+	replacementHelloReceived := false
+	sendMarkerSnapshot, err = handler.handleRealtimeClientMessage(session.ID, hello, &replacementHelloReceived)
+	if err != nil {
+		t.Fatalf("replacement connection hello: %v", err)
+	}
+	if !sendMarkerSnapshot {
+		t.Fatal("replacement connection did not request a fresh marker snapshot")
 	}
 }
 

--- a/internal/api/handlers/session_ws_test.go
+++ b/internal/api/handlers/session_ws_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +20,42 @@ import (
 	"github.com/Silo-Server/silo-server/internal/streamtelemetry"
 )
 
+func testSessionRealtimeClient(handler *PlaybackHandler, sessionID string) *sessionRealtimeClient {
+	return &sessionRealtimeClient{
+		handler:       handler,
+		connectionCtx: context.Background(),
+		sessionID:     sessionID,
+	}
+}
+
+type recordingMarkerSnapshotNotifier struct {
+	calls atomic.Int32
+}
+
+func (n *recordingMarkerSnapshotNotifier) MarkersUpdated(context.Context, *models.MediaFile) {}
+
+func (n *recordingMarkerSnapshotNotifier) SendSessionSnapshotFromLoader(
+	context.Context,
+	*playback.RealtimeRegistration,
+	int,
+	playback.MarkerSnapshotFileLoader,
+) (bool, error) {
+	n.calls.Add(1)
+	return true, nil
+}
+
+func waitForMarkerSnapshotCalls(t *testing.T, notifier *recordingMarkerSnapshotNotifier, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if notifier.calls.Load() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("marker snapshot calls = %d, want %d", notifier.calls.Load(), want)
+}
+
 func TestHandleSessionWebSocket_RequiresHelloBeforeRealtimeReady(t *testing.T) {
 	sessionMgr := playback.NewSessionManager(0, 0)
 	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)
@@ -26,8 +63,12 @@ func TestHandleSessionWebSocket_RequiresHelloBeforeRealtimeReady(t *testing.T) {
 		t.Fatalf("StartSession: %v", err)
 	}
 
-	handler := NewPlaybackHandler(sessionMgr)
+	handler := NewPlaybackHandler(sessionMgr, mapPlaybackFileResolver{files: map[int]*models.MediaFile{
+		100: {ID: 100},
+	}})
 	handler.RealtimeHub = playback.NewRealtimeHub()
+	notifier := &recordingMarkerSnapshotNotifier{}
+	handler.MarkerUpdateNotifier = notifier
 	telemetryConfig := streamtelemetry.DefaultConfig("websocket-test")
 	telemetryConfig.Enabled = true
 	handler.StreamTelemetry = streamtelemetry.NewRegistry(telemetryConfig, streamtelemetry.NewLocalStore(), nil)
@@ -143,13 +184,43 @@ func TestSendCurrentMarkerSnapshotLoadsPersistedSharedMarkers(t *testing.T) {
 	}
 }
 
-func TestHandleRealtimeClientMessageRequestsMarkerSnapshotOncePerConnection(t *testing.T) {
+func TestSendCurrentMarkerSnapshotSkipsEmptyPersistedMarkers(t *testing.T) {
 	sessionMgr := playback.NewSessionManager(0, 0)
 	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)
 	if err != nil {
 		t.Fatalf("StartSession: %v", err)
 	}
-	handler := NewPlaybackHandler(sessionMgr)
+	handler := NewPlaybackHandler(sessionMgr, mapPlaybackFileResolver{files: map[int]*models.MediaFile{
+		100: {ID: 100},
+	}})
+	handler.RealtimeHub = playback.NewRealtimeHub()
+	handler.MarkerUpdateNotifier = playback.NewMarkerUpdateNotifier(sessionMgr, handler.RealtimeHub)
+	conn := &adminPlaybackControlTestConn{}
+	registration := handler.RealtimeHub.Register(session.ID, conn)
+	if registration == nil {
+		t.Fatal("expected realtime registration")
+	}
+	defer handler.RealtimeHub.Unregister(registration)
+
+	handler.sendCurrentMarkerSnapshot(context.Background(), registration, session.ID)
+
+	if len(conn.messages) != 0 {
+		t.Fatalf("snapshot messages = %d, want none for an empty marker row", len(conn.messages))
+	}
+}
+
+func TestSessionRealtimeClientRequestsMarkerSnapshotOncePerConnection(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	handler := NewPlaybackHandler(sessionMgr, mapPlaybackFileResolver{files: map[int]*models.MediaFile{
+		100: {ID: 100},
+	}})
+	handler.RealtimeHub = playback.NewRealtimeHub()
+	notifier := &recordingMarkerSnapshotNotifier{}
+	handler.MarkerUpdateNotifier = notifier
 	hello, err := json.Marshal(playback.HelloEnvelope{
 		Type:      playback.RealtimeMessageTypeHello,
 		SessionID: session.ID,
@@ -162,30 +233,75 @@ func TestHandleRealtimeClientMessageRequestsMarkerSnapshotOncePerConnection(t *t
 		t.Fatalf("json.Marshal(hello): %v", err)
 	}
 
-	helloReceived := false
-	sendMarkerSnapshot, err := handler.handleRealtimeClientMessage(session.ID, hello, &helloReceived)
-	if err != nil {
+	registration := handler.registerSessionRealtimeConnection(session.ID, &adminPlaybackControlTestConn{})
+	client := testSessionRealtimeClient(handler, session.ID)
+	client.registration = registration
+	if err := client.handleMessage(hello); err != nil {
 		t.Fatalf("first hello: %v", err)
 	}
-	if !sendMarkerSnapshot {
-		t.Fatal("initial hello did not request a marker snapshot")
+	if !client.helloReceived {
+		t.Fatal("initial hello was not recorded")
 	}
-	sendMarkerSnapshot, err = handler.handleRealtimeClientMessage(session.ID, hello, &helloReceived)
-	if err != nil {
+	waitForMarkerSnapshotCalls(t, notifier, 1)
+	if err := client.handleMessage(hello); err != nil {
 		t.Fatalf("second hello: %v", err)
 	}
-	if sendMarkerSnapshot {
-		t.Fatal("repeated hello requested a second marker snapshot")
+	if got := notifier.calls.Load(); got != 1 {
+		t.Fatalf("snapshot calls after repeated hello = %d, want 1", got)
 	}
 
-	replacementHelloReceived := false
-	sendMarkerSnapshot, err = handler.handleRealtimeClientMessage(session.ID, hello, &replacementHelloReceived)
-	if err != nil {
+	replacementRegistration := handler.registerSessionRealtimeConnection(session.ID, &adminPlaybackControlTestConn{})
+	replacement := testSessionRealtimeClient(handler, session.ID)
+	replacement.registration = replacementRegistration
+	if err := replacement.handleMessage(hello); err != nil {
 		t.Fatalf("replacement connection hello: %v", err)
 	}
-	if !sendMarkerSnapshot {
-		t.Fatal("replacement connection did not request a fresh marker snapshot")
+	if !replacement.helloReceived {
+		t.Fatal("replacement connection did not record its own hello")
 	}
+	waitForMarkerSnapshotCalls(t, notifier, 2)
+}
+
+func TestReplacementConnectionOwnsRealtimeReadiness(t *testing.T) {
+	sessionMgr := playback.NewSessionManager(0, 0)
+	session, err := sessionMgr.StartSession(1, "profile-1", 100, playback.PlayDirect, false)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	handler := NewPlaybackHandler(sessionMgr)
+	handler.RealtimeHub = playback.NewRealtimeHub()
+	hello, err := json.Marshal(playback.HelloEnvelope{
+		Type: playback.RealtimeMessageTypeHello, SessionID: session.ID,
+		Client: playback.HelloClientInfo{Name: "ios", Version: "1.0.0"},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(hello): %v", err)
+	}
+
+	oldRegistration := handler.registerSessionRealtimeConnection(session.ID, &adminPlaybackControlTestConn{})
+	oldClient := testSessionRealtimeClient(handler, session.ID)
+	oldClient.registration = oldRegistration
+	if err := oldClient.handleMessage(hello); err != nil {
+		t.Fatalf("old hello: %v", err)
+	}
+	waitForPlaybackRealtimeState(t, sessionMgr, session.ID, true)
+
+	newRegistration := handler.registerSessionRealtimeConnection(session.ID, &adminPlaybackControlTestConn{})
+	got, err := sessionMgr.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession before replacement hello: %v", err)
+	}
+	if got.HasRealtimeConnection {
+		t.Fatal("replacement socket was ready before its own hello")
+	}
+
+	newClient := testSessionRealtimeClient(handler, session.ID)
+	newClient.registration = newRegistration
+	if err := newClient.handleMessage(hello); err != nil {
+		t.Fatalf("replacement hello: %v", err)
+	}
+	handler.unregisterSessionRealtimeConnection(session.ID, oldRegistration)
+	waitForPlaybackRealtimeState(t, sessionMgr, session.ID, true)
 }
 
 func waitForTelemetryRealtimeState(t *testing.T, registry *streamtelemetry.Registry, sessionID string, want bool) {

--- a/internal/markers/plugin_provider.go
+++ b/internal/markers/plugin_provider.go
@@ -72,6 +72,42 @@ type PluginProvider struct {
 
 var _ Submitter = (*PluginProvider)(nil)
 
+// ReadOnlyPluginProvider exposes only the marker Provider surface for plugin
+// capabilities that declare supports_contribution=false. Keeping the submit
+// methods off this wrapper makes the existing Submitter type assertion reflect
+// the capability manifest instead of the shared gRPC service shape.
+type ReadOnlyPluginProvider struct {
+	inner *PluginProvider
+}
+
+var _ Provider = (*ReadOnlyPluginProvider)(nil)
+var _ DescribedProvider = (*ReadOnlyPluginProvider)(nil)
+
+func NewReadOnlyPluginProvider(inner *PluginProvider) *ReadOnlyPluginProvider {
+	return &ReadOnlyPluginProvider{inner: inner}
+}
+
+func (p *ReadOnlyPluginProvider) ID() string {
+	if p == nil || p.inner == nil {
+		return ""
+	}
+	return p.inner.ID()
+}
+
+func (p *ReadOnlyPluginProvider) FetchMarkers(ctx context.Context, req Request) (Result, error) {
+	if p == nil || p.inner == nil {
+		return Result{}, nil
+	}
+	return p.inner.FetchMarkers(ctx, req)
+}
+
+func (p *ReadOnlyPluginProvider) ProviderDescription() ProviderDescriptor {
+	if p == nil || p.inner == nil {
+		return ProviderDescriptor{}
+	}
+	return p.inner.ProviderDescription()
+}
+
 func NewPluginProvider(opts PluginProviderOptions, resolver pluginMarkerResolver) (*PluginProvider, error) {
 	if resolver == nil {
 		return nil, fmt.Errorf("plugin marker resolver is required")
@@ -458,5 +494,24 @@ func PluginDefaultFetchPriorityFromMetadata(metadata map[string]any) (int, bool)
 		return parsed, err == nil
 	default:
 		return 0, false
+	}
+}
+
+// PluginSupportsContributionFromMetadata preserves the historical submitter
+// behavior unless a plugin explicitly opts out. This keeps existing manifests
+// compatible while allowing anonymous, fetch-only providers.
+func PluginSupportsContributionFromMetadata(metadata map[string]any) bool {
+	raw, ok := metadata["supports_contribution"]
+	if !ok {
+		return true
+	}
+	switch typed := raw.(type) {
+	case bool:
+		return typed
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(typed))
+		return err != nil || parsed
+	default:
+		return true
 	}
 }

--- a/internal/markers/plugin_provider_test.go
+++ b/internal/markers/plugin_provider_test.go
@@ -234,3 +234,53 @@ func TestPluginProviderSubmitKeepsOtherErrorsRetryable(t *testing.T) {
 		t.Fatalf("error = %+v, want retryable provider error", conflict)
 	}
 }
+
+func TestReadOnlyPluginProviderDoesNotImplementSubmitter(t *testing.T) {
+	client := &fakePluginMarkerClient{fetchResp: &pluginv1.FetchMarkersResponse{}}
+	inner, err := NewPluginProviderWithClientFactory(PluginProviderOptions{
+		InstallationID: 42,
+		CapabilityID:   "public-markers",
+		DisplayName:    "Public markers",
+		PluginID:       "silo.public-markers",
+	}, func(context.Context, int, string) (pluginMarkerClient, error) {
+		return client, nil
+	})
+	if err != nil {
+		t.Fatalf("NewPluginProviderWithClientFactory: %v", err)
+	}
+	provider := NewReadOnlyPluginProvider(inner)
+	if _, ok := any(provider).(Submitter); ok {
+		t.Fatal("read-only plugin provider unexpectedly implements Submitter")
+	}
+	if _, err := provider.FetchMarkers(context.Background(), Request{Kind: ItemKindEpisode}); err != nil {
+		t.Fatalf("FetchMarkers: %v", err)
+	}
+	if client.fetchReq == nil {
+		t.Fatal("FetchMarkers was not delegated")
+	}
+	description := provider.ProviderDescription()
+	if description.ID != "plugin:42:public-markers" || description.DisplayName != "Public markers" {
+		t.Fatalf("description = %+v", description)
+	}
+}
+
+func TestPluginSupportsContributionFromMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]any
+		want     bool
+	}{
+		{name: "legacy default", metadata: nil, want: true},
+		{name: "explicit true", metadata: map[string]any{"supports_contribution": true}, want: true},
+		{name: "explicit false", metadata: map[string]any{"supports_contribution": false}, want: false},
+		{name: "string false", metadata: map[string]any{"supports_contribution": "false"}, want: false},
+		{name: "invalid stays compatible", metadata: map[string]any{"supports_contribution": 0}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PluginSupportsContributionFromMetadata(tt.metadata); got != tt.want {
+				t.Fatalf("PluginSupportsContributionFromMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/markers/types.go
+++ b/internal/markers/types.go
@@ -459,6 +459,9 @@ func firstNonEmpty(values ...string) string {
 }
 
 func (r *Registry) logProviderError(providerID string, req Request, err error) {
+	if err == nil {
+		return
+	}
 	logger := slog.Default()
 	if r != nil && r.logger != nil {
 		logger = r.logger
@@ -467,7 +470,7 @@ func (r *Registry) logProviderError(providerID string, req Request, err error) {
 		"provider", providerID,
 		"kind", req.Kind,
 		"external_ids", sanitizeExternalIDs(req.ExternalIDs),
-		"error", err.Error(),
+		"error", err,
 	)
 }
 

--- a/internal/markers/types.go
+++ b/internal/markers/types.go
@@ -467,7 +467,7 @@ func (r *Registry) logProviderError(providerID string, req Request, err error) {
 		"provider", providerID,
 		"kind", req.Kind,
 		"external_ids", sanitizeExternalIDs(req.ExternalIDs),
-		"error", err,
+		"error", err.Error(),
 	)
 }
 

--- a/internal/playback/marker_update_notifier.go
+++ b/internal/playback/marker_update_notifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -16,6 +17,17 @@ type markerUpdateSessionLookup interface {
 type MarkerUpdateNotifier struct {
 	sessions markerUpdateSessionLookup
 	hub      *RealtimeHub
+	// A small fixed lock set serializes each file's persisted snapshot read
+	// with provider-update delivery. This prevents an older partial snapshot
+	// from landing after a newer markers_updated event without growing a lock
+	// map for every file in a large library.
+	fileLocks [64]sync.Mutex
+}
+
+// MarkerSnapshotFileLoader loads the persisted media-file marker row used for
+// a reconnect snapshot.
+type MarkerSnapshotFileLoader interface {
+	GetByID(ctx context.Context, fileID int) (*models.MediaFile, error)
 }
 
 func NewMarkerUpdateNotifier(sessions markerUpdateSessionLookup, hub *RealtimeHub) *MarkerUpdateNotifier {
@@ -32,45 +44,89 @@ func (n *MarkerUpdateNotifier) MarkersUpdated(ctx context.Context, file *models.
 	if n == nil || file == nil || file.ID <= 0 {
 		return
 	}
+	lock := n.fileLock(file.ID)
+	lock.Lock()
+	defer lock.Unlock()
 
+	for _, session := range n.sessions.GetSessionsByMediaFileID(file.ID) {
+		if session == nil || session.ID == "" || !session.HasRealtimeConnection {
+			continue
+		}
+		n.sendSessionSnapshotLocked(ctx, session.ID, file)
+	}
+}
+
+// SendSessionSnapshot sends the current persisted marker ranges to one live
+// playback session. Calling it after the client's hello closes the race where
+// lazy marker discovery finishes before the websocket is control-ready.
+func (n *MarkerUpdateNotifier) SendSessionSnapshot(ctx context.Context, sessionID string, file *models.MediaFile) {
+	if n == nil || n.hub == nil || sessionID == "" || file == nil || file.ID <= 0 {
+		return
+	}
+	lock := n.fileLock(file.ID)
+	lock.Lock()
+	defer lock.Unlock()
+	n.sendSessionSnapshotLocked(ctx, sessionID, file)
+}
+
+// SendSessionSnapshotFromLoader holds the same per-file ordering lock across
+// the database read and websocket send used by MarkersUpdated. A concurrent
+// provider write therefore lands either wholly before this fresh read or
+// wholly after this snapshot, never as a newer event followed by stale data.
+func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
+	ctx context.Context,
+	sessionID string,
+	fileID int,
+	loader MarkerSnapshotFileLoader,
+) error {
+	if n == nil || n.hub == nil || sessionID == "" || fileID <= 0 || loader == nil {
+		return nil
+	}
+	lock := n.fileLock(fileID)
+	lock.Lock()
+	defer lock.Unlock()
+	file, err := loader.GetByID(ctx, fileID)
+	if err != nil || file == nil {
+		return err
+	}
+	n.sendSessionSnapshotLocked(ctx, sessionID, file)
+	return nil
+}
+
+func (n *MarkerUpdateNotifier) fileLock(fileID int) *sync.Mutex {
+	return &n.fileLocks[uint(fileID)%uint(len(n.fileLocks))]
+}
+
+func (n *MarkerUpdateNotifier) sendSessionSnapshotLocked(ctx context.Context, sessionID string, file *models.MediaFile) {
 	rangePayload := func(start, end *float64) *TimeRangePayload {
 		if start == nil || end == nil {
 			return nil
 		}
 		return &TimeRangePayload{Start: *start, End: *end}
 	}
-	intro := rangePayload(file.IntroStart, file.IntroEnd)
-	credits := rangePayload(file.CreditsStart, file.CreditsEnd)
-	recap := rangePayload(file.RecapStart, file.RecapEnd)
-	preview := rangePayload(file.PreviewStart, file.PreviewEnd)
-
-	for _, session := range n.sessions.GetSessionsByMediaFileID(file.ID) {
-		if session == nil || session.ID == "" || !session.HasRealtimeConnection {
-			continue
-		}
-		event, err := NewMarkersUpdatedEvent(session.ID, file.ID, intro, credits, recap, preview)
-		if err != nil {
-			slog.WarnContext(ctx,
-				"failed to encode markers updated realtime event", "component", "playback",
-				"session_id",
-				session.ID,
-				"file_id",
-				file.ID,
-				"error",
-				err,
-			)
-			continue
-		}
-		if err := n.hub.Send(session.ID, event); err != nil && !errors.Is(err, ErrRealtimeConnectionNotFound) {
-			slog.WarnContext(ctx,
-				"failed to deliver markers updated realtime event", "component", "playback",
-				"session_id",
-				session.ID,
-				"file_id",
-				file.ID,
-				"error",
-				err,
-			)
-		}
+	event, err := NewMarkersUpdatedEvent(
+		sessionID,
+		file.ID,
+		rangePayload(file.IntroStart, file.IntroEnd),
+		rangePayload(file.CreditsStart, file.CreditsEnd),
+		rangePayload(file.RecapStart, file.RecapEnd),
+		rangePayload(file.PreviewStart, file.PreviewEnd),
+	)
+	if err != nil {
+		slog.WarnContext(ctx,
+			"failed to encode markers updated realtime event", "component", "playback",
+			"session_id", sessionID,
+			"file_id", file.ID,
+			"error", err,
+		)
+		return
+	}
+	if err := n.hub.Send(sessionID, event); err != nil && !errors.Is(err, ErrRealtimeConnectionNotFound) {
+		slog.WarnContext(ctx,
+			"failed to deliver markers updated realtime event", "component", "playback",
+			"session_id", sessionID,
+			"file_id", file.ID,
+			"error", err,
+		)
 	}
 }

--- a/internal/playback/marker_update_notifier.go
+++ b/internal/playback/marker_update_notifier.go
@@ -13,6 +13,35 @@ type markerUpdateSessionLookup interface {
 	GetSessionsByMediaFileID(fileID int) []*Session
 }
 
+type markerFileLock struct {
+	once  sync.Once
+	token chan struct{}
+}
+
+func (l *markerFileLock) initialize() {
+	l.token = make(chan struct{}, 1)
+	l.token <- struct{}{}
+}
+
+func (l *markerFileLock) lock() {
+	l.once.Do(l.initialize)
+	<-l.token
+}
+
+func (l *markerFileLock) lockContext(ctx context.Context) bool {
+	l.once.Do(l.initialize)
+	select {
+	case <-ctx.Done():
+		return false
+	case <-l.token:
+		return true
+	}
+}
+
+func (l *markerFileLock) unlock() {
+	l.token <- struct{}{}
+}
+
 // MarkerUpdateNotifier publishes live marker updates to active playback sessions.
 type MarkerUpdateNotifier struct {
 	sessions markerUpdateSessionLookup
@@ -21,7 +50,7 @@ type MarkerUpdateNotifier struct {
 	// with provider-update delivery. This prevents an older partial snapshot
 	// from landing after a newer markers_updated event without growing a lock
 	// map for every file in a large library.
-	fileLocks [64]sync.Mutex
+	fileLocks [64]markerFileLock
 }
 
 // MarkerSnapshotFileLoader loads the persisted media-file marker row used for
@@ -45,8 +74,8 @@ func (n *MarkerUpdateNotifier) MarkersUpdated(ctx context.Context, file *models.
 		return
 	}
 	lock := n.fileLock(file.ID)
-	lock.Lock()
-	defer lock.Unlock()
+	lock.lock()
+	defer lock.unlock()
 
 	for _, session := range n.sessions.GetSessionsByMediaFileID(file.ID) {
 		if session == nil || session.ID == "" || !session.HasRealtimeConnection {
@@ -64,8 +93,8 @@ func (n *MarkerUpdateNotifier) SendSessionSnapshot(ctx context.Context, sessionI
 		return
 	}
 	lock := n.fileLock(file.ID)
-	lock.Lock()
-	defer lock.Unlock()
+	lock.lock()
+	defer lock.unlock()
 	n.sendSessionSnapshotLocked(ctx, sessionID, file)
 }
 
@@ -82,9 +111,23 @@ func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
 	if n == nil || n.hub == nil || registration == nil || registration.SessionID() == "" || fileID <= 0 || loader == nil {
 		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !n.hub.HasRegistration(registration) {
+		return nil
+	}
 	lock := n.fileLock(fileID)
-	lock.Lock()
-	defer lock.Unlock()
+	if !lock.lockContext(ctx) {
+		return ctx.Err()
+	}
+	defer lock.unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !n.hub.HasRegistration(registration) {
+		return nil
+	}
 	file, err := loader.GetByID(ctx, fileID)
 	if err != nil || file == nil {
 		return err
@@ -93,7 +136,7 @@ func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
 	return nil
 }
 
-func (n *MarkerUpdateNotifier) fileLock(fileID int) *sync.Mutex {
+func (n *MarkerUpdateNotifier) fileLock(fileID int) *markerFileLock {
 	return &n.fileLocks[uint(fileID)%uint(len(n.fileLocks))]
 }
 

--- a/internal/playback/marker_update_notifier.go
+++ b/internal/playback/marker_update_notifier.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -13,46 +14,26 @@ type markerUpdateSessionLookup interface {
 	GetSessionsByMediaFileID(fileID int) []*Session
 }
 
-type markerFileLock struct {
-	once  sync.Once
-	token chan struct{}
+type markerFileState struct {
+	mu    sync.Mutex
+	epoch atomic.Uint64
+	refs  int
 }
 
-func (l *markerFileLock) initialize() {
-	l.token = make(chan struct{}, 1)
-	l.token <- struct{}{}
-}
-
-func (l *markerFileLock) lock() {
-	l.once.Do(l.initialize)
-	<-l.token
-}
-
-func (l *markerFileLock) lockContext(ctx context.Context, registrationDone <-chan struct{}) bool {
-	l.once.Do(l.initialize)
-	select {
-	case <-ctx.Done():
-		return false
-	case <-registrationDone:
-		return false
-	case <-l.token:
-		return true
-	}
-}
-
-func (l *markerFileLock) unlock() {
-	l.token <- struct{}{}
+type markerSnapshotPayload struct {
+	fileID  int
+	intro   *TimeRangePayload
+	credits *TimeRangePayload
+	recap   *TimeRangePayload
+	preview *TimeRangePayload
 }
 
 // MarkerUpdateNotifier publishes live marker updates to active playback sessions.
 type MarkerUpdateNotifier struct {
 	sessions markerUpdateSessionLookup
 	hub      *RealtimeHub
-	// A small fixed lock set serializes each file's persisted snapshot read
-	// with provider-update delivery. This prevents an older partial snapshot
-	// from landing after a newer markers_updated event without growing a lock
-	// map for every file in a large library.
-	fileLocks [64]markerFileLock
+	stateMu  sync.Mutex
+	states   map[int]*markerFileState
 }
 
 // MarkerSnapshotFileLoader loads the persisted media-file marker row used for
@@ -68,6 +49,7 @@ func NewMarkerUpdateNotifier(sessions markerUpdateSessionLookup, hub *RealtimeHu
 	return &MarkerUpdateNotifier{
 		sessions: sessions,
 		hub:      hub,
+		states:   make(map[int]*markerFileState),
 	}
 }
 
@@ -75,128 +57,164 @@ func (n *MarkerUpdateNotifier) MarkersUpdated(ctx context.Context, file *models.
 	if n == nil || file == nil || file.ID <= 0 {
 		return
 	}
-	lock := n.fileLock(file.ID)
-	lock.lock()
-	defer lock.unlock()
 
+	state := n.acquireFileState(file.ID)
+	state.mu.Lock()
+	epoch := state.epoch.Add(1)
+	payload := markerSnapshotPayloadFromFile(file)
+	state.mu.Unlock()
+
+	sessionIDs := make([]string, 0)
 	for _, session := range n.sessions.GetSessionsByMediaFileID(file.ID) {
 		if session == nil || session.ID == "" || !session.HasRealtimeConnection {
 			continue
 		}
-		n.sendSessionSnapshotLocked(ctx, session.ID, file)
+		sessionIDs = append(sessionIDs, session.ID)
 	}
-}
-
-// SendSessionSnapshot sends the current persisted marker ranges to one live
-// playback session. Calling it after the client's hello closes the race where
-// lazy marker discovery finishes before the websocket is control-ready.
-func (n *MarkerUpdateNotifier) SendSessionSnapshot(ctx context.Context, sessionID string, file *models.MediaFile) {
-	if n == nil || n.hub == nil || sessionID == "" || file == nil || file.ID <= 0 {
+	if len(sessionIDs) == 0 {
+		n.releaseFileState(file.ID, state)
 		return
 	}
-	lock := n.fileLock(file.ID)
-	lock.lock()
-	defer lock.unlock()
-	n.sendSessionSnapshotLocked(ctx, sessionID, file)
+
+	logCtx := context.Background()
+	if ctx != nil {
+		logCtx = context.WithoutCancel(ctx)
+	}
+	go func() {
+		defer n.releaseFileState(file.ID, state)
+		for _, sessionID := range sessionIDs {
+			n.sendCurrentEpochToSession(logCtx, state, epoch, sessionID, payload)
+		}
+	}()
 }
 
-// SendSessionSnapshotFromLoader holds the same per-file ordering lock across
-// the database read and websocket send used by MarkersUpdated. A concurrent
-// provider write therefore lands either wholly before this fresh read or
-// wholly after this snapshot, never as a newer event followed by stale data.
+// SendSessionSnapshotFromLoader reads a persisted snapshot while holding the
+// file state, then sends it only if no newer MarkersUpdated call won the race.
+// WebSocket I/O happens after the state lock is released.
 func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
 	ctx context.Context,
 	registration *RealtimeRegistration,
 	fileID int,
 	loader MarkerSnapshotFileLoader,
-) error {
+) (bool, error) {
 	if n == nil || n.hub == nil || registration == nil || registration.SessionID() == "" || fileID <= 0 || loader == nil {
-		return nil
+		return false, nil
 	}
 	if err := ctx.Err(); err != nil {
-		return err
+		return false, err
 	}
 	if !n.hub.HasRegistration(registration) {
-		return nil
+		return false, nil
 	}
-	lock := n.fileLock(fileID)
-	if !lock.lockContext(ctx, registration.Done()) {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		return nil
-	}
-	defer lock.unlock()
+
+	state := n.acquireFileState(fileID)
+	defer n.releaseFileState(fileID, state)
+	state.mu.Lock()
 	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if !n.hub.HasRegistration(registration) {
-		return nil
+		state.mu.Unlock()
+		return false, err
 	}
 	file, err := loader.GetByID(ctx, fileID)
-	if err != nil || file == nil {
-		return err
+	if err != nil {
+		state.mu.Unlock()
+		return false, err
 	}
-	n.sendSessionSnapshotToRegistrationLocked(ctx, registration, file)
-	return nil
-}
-
-func (n *MarkerUpdateNotifier) fileLock(fileID int) *markerFileLock {
-	return &n.fileLocks[uint(fileID)%uint(len(n.fileLocks))]
-}
-
-func (n *MarkerUpdateNotifier) sendSessionSnapshotLocked(ctx context.Context, sessionID string, file *models.MediaFile) {
-	n.sendSessionSnapshotWithLocked(ctx, sessionID, file, func(event any) error {
-		return n.hub.Send(sessionID, event)
+	epoch := state.epoch.Load()
+	payload := markerSnapshotPayloadFromFile(file)
+	state.mu.Unlock()
+	if file == nil || !payload.hasAnyMarker() {
+		return false, nil
+	}
+	event, err := payload.event(registration.SessionID())
+	if err != nil {
+		return false, err
+	}
+	sent, err := n.hub.sendRegisteredIf(registration, event, func() bool {
+		return state.epoch.Load() == epoch
 	})
+	if errors.Is(err, ErrRealtimeConnectionNotFound) {
+		return false, nil
+	}
+	return sent, err
 }
 
-func (n *MarkerUpdateNotifier) sendSessionSnapshotToRegistrationLocked(
-	ctx context.Context,
-	registration *RealtimeRegistration,
-	file *models.MediaFile,
-) {
-	sessionID := registration.SessionID()
-	n.sendSessionSnapshotWithLocked(ctx, sessionID, file, func(event any) error {
-		return n.hub.SendRegistered(registration, event)
-	})
+func (n *MarkerUpdateNotifier) acquireFileState(fileID int) *markerFileState {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+	state := n.states[fileID]
+	if state == nil {
+		state = &markerFileState{}
+		n.states[fileID] = state
+	}
+	state.refs++
+	return state
 }
 
-func (n *MarkerUpdateNotifier) sendSessionSnapshotWithLocked(
+func (n *MarkerUpdateNotifier) releaseFileState(fileID int, state *markerFileState) {
+	n.stateMu.Lock()
+	defer n.stateMu.Unlock()
+	if current := n.states[fileID]; current != state {
+		return
+	}
+	state.refs--
+	if state.refs == 0 {
+		delete(n.states, fileID)
+	}
+}
+
+func (n *MarkerUpdateNotifier) sendCurrentEpochToSession(
 	ctx context.Context,
+	state *markerFileState,
+	epoch uint64,
 	sessionID string,
-	file *models.MediaFile,
-	send func(any) error,
+	payload markerSnapshotPayload,
 ) {
+	event, err := payload.event(sessionID)
+	if err != nil {
+		slog.WarnContext(ctx,
+			"failed to encode markers updated realtime event", "component", "playback",
+			"session_id", sessionID,
+			"file_id", payload.fileID,
+			"error", err,
+		)
+		return
+	}
+	_, err = n.hub.sendIf(sessionID, event, func() bool {
+		return state.epoch.Load() == epoch
+	})
+	if err != nil && !errors.Is(err, ErrRealtimeConnectionNotFound) {
+		slog.WarnContext(ctx,
+			"failed to deliver markers updated realtime event", "component", "playback",
+			"session_id", sessionID,
+			"file_id", payload.fileID,
+			"error", err,
+		)
+	}
+}
+
+func markerSnapshotPayloadFromFile(file *models.MediaFile) markerSnapshotPayload {
+	if file == nil {
+		return markerSnapshotPayload{}
+	}
 	rangePayload := func(start, end *float64) *TimeRangePayload {
 		if start == nil || end == nil {
 			return nil
 		}
 		return &TimeRangePayload{Start: *start, End: *end}
 	}
-	event, err := NewMarkersUpdatedEvent(
-		sessionID,
-		file.ID,
-		rangePayload(file.IntroStart, file.IntroEnd),
-		rangePayload(file.CreditsStart, file.CreditsEnd),
-		rangePayload(file.RecapStart, file.RecapEnd),
-		rangePayload(file.PreviewStart, file.PreviewEnd),
-	)
-	if err != nil {
-		slog.WarnContext(ctx,
-			"failed to encode markers updated realtime event", "component", "playback",
-			"session_id", sessionID,
-			"file_id", file.ID,
-			"error", err,
-		)
-		return
+	return markerSnapshotPayload{
+		fileID:  file.ID,
+		intro:   rangePayload(file.IntroStart, file.IntroEnd),
+		credits: rangePayload(file.CreditsStart, file.CreditsEnd),
+		recap:   rangePayload(file.RecapStart, file.RecapEnd),
+		preview: rangePayload(file.PreviewStart, file.PreviewEnd),
 	}
-	if err := send(event); err != nil && !errors.Is(err, ErrRealtimeConnectionNotFound) {
-		slog.WarnContext(ctx,
-			"failed to deliver markers updated realtime event", "component", "playback",
-			"session_id", sessionID,
-			"file_id", file.ID,
-			"error", err,
-		)
-	}
+}
+
+func (p markerSnapshotPayload) hasAnyMarker() bool {
+	return p.intro != nil || p.credits != nil || p.recap != nil || p.preview != nil
+}
+
+func (p markerSnapshotPayload) event(sessionID string) (EventEnvelope, error) {
+	return NewMarkersUpdatedEvent(sessionID, p.fileID, p.intro, p.credits, p.recap, p.preview)
 }

--- a/internal/playback/marker_update_notifier.go
+++ b/internal/playback/marker_update_notifier.go
@@ -15,9 +15,34 @@ type markerUpdateSessionLookup interface {
 }
 
 type markerFileState struct {
-	mu    sync.Mutex
+	token chan struct{}
 	epoch atomic.Uint64
 	refs  int
+}
+
+func newMarkerFileState() *markerFileState {
+	state := &markerFileState{token: make(chan struct{}, 1)}
+	state.token <- struct{}{}
+	return state
+}
+
+func (s *markerFileState) lock() {
+	<-s.token
+}
+
+func (s *markerFileState) lockContext(ctx context.Context, registrationDone <-chan struct{}) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-registrationDone:
+		return false
+	case <-s.token:
+		return true
+	}
+}
+
+func (s *markerFileState) unlock() {
+	s.token <- struct{}{}
 }
 
 type markerSnapshotPayload struct {
@@ -59,10 +84,10 @@ func (n *MarkerUpdateNotifier) MarkersUpdated(ctx context.Context, file *models.
 	}
 
 	state := n.acquireFileState(file.ID)
-	state.mu.Lock()
+	state.lock()
 	epoch := state.epoch.Add(1)
 	payload := markerSnapshotPayloadFromFile(file)
-	state.mu.Unlock()
+	state.unlock()
 
 	sessionIDs := make([]string, 0)
 	for _, session := range n.sessions.GetSessionsByMediaFileID(file.ID) {
@@ -109,19 +134,28 @@ func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
 
 	state := n.acquireFileState(fileID)
 	defer n.releaseFileState(fileID, state)
-	state.mu.Lock()
+	if !state.lockContext(ctx, registration.Done()) {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
 	if err := ctx.Err(); err != nil {
-		state.mu.Unlock()
+		state.unlock()
 		return false, err
+	}
+	if !n.hub.HasRegistration(registration) {
+		state.unlock()
+		return false, nil
 	}
 	file, err := loader.GetByID(ctx, fileID)
 	if err != nil {
-		state.mu.Unlock()
+		state.unlock()
 		return false, err
 	}
 	epoch := state.epoch.Load()
 	payload := markerSnapshotPayloadFromFile(file)
-	state.mu.Unlock()
+	state.unlock()
 	if file == nil || !payload.hasAnyMarker() {
 		return false, nil
 	}
@@ -143,7 +177,7 @@ func (n *MarkerUpdateNotifier) acquireFileState(fileID int) *markerFileState {
 	defer n.stateMu.Unlock()
 	state := n.states[fileID]
 	if state == nil {
-		state = &markerFileState{}
+		state = newMarkerFileState()
 		n.states[fileID] = state
 	}
 	state.refs++

--- a/internal/playback/marker_update_notifier.go
+++ b/internal/playback/marker_update_notifier.go
@@ -28,10 +28,12 @@ func (l *markerFileLock) lock() {
 	<-l.token
 }
 
-func (l *markerFileLock) lockContext(ctx context.Context) bool {
+func (l *markerFileLock) lockContext(ctx context.Context, registrationDone <-chan struct{}) bool {
 	l.once.Do(l.initialize)
 	select {
 	case <-ctx.Done():
+		return false
+	case <-registrationDone:
 		return false
 	case <-l.token:
 		return true
@@ -118,8 +120,11 @@ func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
 		return nil
 	}
 	lock := n.fileLock(fileID)
-	if !lock.lockContext(ctx) {
-		return ctx.Err()
+	if !lock.lockContext(ctx, registration.Done()) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return nil
 	}
 	defer lock.unlock()
 	if err := ctx.Err(); err != nil {

--- a/internal/playback/marker_update_notifier.go
+++ b/internal/playback/marker_update_notifier.go
@@ -75,11 +75,11 @@ func (n *MarkerUpdateNotifier) SendSessionSnapshot(ctx context.Context, sessionI
 // wholly after this snapshot, never as a newer event followed by stale data.
 func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
 	ctx context.Context,
-	sessionID string,
+	registration *RealtimeRegistration,
 	fileID int,
 	loader MarkerSnapshotFileLoader,
 ) error {
-	if n == nil || n.hub == nil || sessionID == "" || fileID <= 0 || loader == nil {
+	if n == nil || n.hub == nil || registration == nil || registration.SessionID() == "" || fileID <= 0 || loader == nil {
 		return nil
 	}
 	lock := n.fileLock(fileID)
@@ -89,7 +89,7 @@ func (n *MarkerUpdateNotifier) SendSessionSnapshotFromLoader(
 	if err != nil || file == nil {
 		return err
 	}
-	n.sendSessionSnapshotLocked(ctx, sessionID, file)
+	n.sendSessionSnapshotToRegistrationLocked(ctx, registration, file)
 	return nil
 }
 
@@ -98,6 +98,28 @@ func (n *MarkerUpdateNotifier) fileLock(fileID int) *sync.Mutex {
 }
 
 func (n *MarkerUpdateNotifier) sendSessionSnapshotLocked(ctx context.Context, sessionID string, file *models.MediaFile) {
+	n.sendSessionSnapshotWithLocked(ctx, sessionID, file, func(event any) error {
+		return n.hub.Send(sessionID, event)
+	})
+}
+
+func (n *MarkerUpdateNotifier) sendSessionSnapshotToRegistrationLocked(
+	ctx context.Context,
+	registration *RealtimeRegistration,
+	file *models.MediaFile,
+) {
+	sessionID := registration.SessionID()
+	n.sendSessionSnapshotWithLocked(ctx, sessionID, file, func(event any) error {
+		return n.hub.SendRegistered(registration, event)
+	})
+}
+
+func (n *MarkerUpdateNotifier) sendSessionSnapshotWithLocked(
+	ctx context.Context,
+	sessionID string,
+	file *models.MediaFile,
+	send func(any) error,
+) {
 	rangePayload := func(start, end *float64) *TimeRangePayload {
 		if start == nil || end == nil {
 			return nil
@@ -121,7 +143,7 @@ func (n *MarkerUpdateNotifier) sendSessionSnapshotLocked(ctx context.Context, se
 		)
 		return
 	}
-	if err := n.hub.Send(sessionID, event); err != nil && !errors.Is(err, ErrRealtimeConnectionNotFound) {
+	if err := send(event); err != nil && !errors.Is(err, ErrRealtimeConnectionNotFound) {
 		slog.WarnContext(ctx,
 			"failed to deliver markers updated realtime event", "component", "playback",
 			"session_id", sessionID,

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -303,6 +304,7 @@ func TestQueuedStaleMarkerSnapshotDoesNotLoadFile(t *testing.T) {
 
 	lock := notifier.fileLock(100)
 	lock.lock()
+	defer lock.unlock()
 	observed := make(chan struct{})
 	loaderCalled := make(chan struct{})
 	done := make(chan error, 1)
@@ -316,18 +318,19 @@ func TestQueuedStaleMarkerSnapshotDoesNotLoadFile(t *testing.T) {
 	}()
 	<-observed
 
-	if !hub.Unregister(oldRegistration) {
-		t.Fatal("old connection did not unregister")
-	}
 	newRegistration := hub.Register(session.ID, &dispatchTestConn{})
 	if newRegistration == nil {
 		t.Fatal("replacement registration is nil")
 	}
 	defer hub.Unregister(newRegistration)
-	lock.unlock()
 
-	if err := <-done; err != nil {
-		t.Fatalf("SendSessionSnapshotFromLoader: %v", err)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SendSessionSnapshotFromLoader: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stale queued snapshot did not stop after replacement")
 	}
 	select {
 	case <-loaderCalled:

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -171,7 +171,7 @@ func TestMarkerUpdateNotifierOrdersPersistedSnapshotBeforeConcurrentUpdate(t *te
 	snapshotDone := make(chan struct{})
 	go func() {
 		defer close(snapshotDone)
-		_ = notifier.SendSessionSnapshotFromLoader(context.Background(), session.ID, 100, blockingMarkerSnapshotLoader{
+		_ = notifier.SendSessionSnapshotFromLoader(context.Background(), registration, 100, blockingMarkerSnapshotLoader{
 			file: &models.MediaFile{
 				ID:         100,
 				IntroStart: &oldIntroStart,
@@ -218,5 +218,54 @@ func TestMarkerUpdateNotifierOrdersPersistedSnapshotBeforeConcurrentUpdate(t *te
 	}
 	if got := markerStart(conn.messages[1]); got != newIntroStart {
 		t.Fatalf("second marker start = %v, want new update %v", got, newIntroStart)
+	}
+}
+
+func TestMarkerSnapshotFromReplacedConnectionDoesNotReachReplacement(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
+	hub := NewRealtimeHub()
+	oldConn := &dispatchTestConn{}
+	oldRegistration := hub.Register(session.ID, oldConn)
+	notifier := NewMarkerUpdateNotifier(sessions, hub)
+
+	introStart, introEnd := 1.0, 50.0
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	snapshotDone := make(chan error, 1)
+	go func() {
+		snapshotDone <- notifier.SendSessionSnapshotFromLoader(
+			context.Background(),
+			oldRegistration,
+			100,
+			blockingMarkerSnapshotLoader{
+				file: &models.MediaFile{
+					ID:         100,
+					IntroStart: &introStart,
+					IntroEnd:   &introEnd,
+				},
+				entered: entered,
+				release: release,
+			},
+		)
+	}()
+	<-entered
+
+	newConn := &dispatchTestConn{}
+	newRegistration := hub.Register(session.ID, newConn)
+	if newRegistration == nil {
+		t.Fatal("replacement registration is nil")
+	}
+	defer hub.Unregister(newRegistration)
+	close(release)
+	if err := <-snapshotDone; err != nil {
+		t.Fatalf("SendSessionSnapshotFromLoader: %v", err)
+	}
+
+	if len(oldConn.messages) != 0 {
+		t.Fatalf("old connection messages = %d, want 0", len(oldConn.messages))
+	}
+	if len(newConn.messages) != 0 {
+		t.Fatalf("replacement connection messages = %d, want 0", len(newConn.messages))
 	}
 }

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+type blockingMarkerSnapshotLoader struct {
+	file    *models.MediaFile
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (l blockingMarkerSnapshotLoader) GetByID(context.Context, int) (*models.MediaFile, error) {
+	close(l.entered)
+	<-l.release
+	return l.file, nil
+}
+
 func TestMarkerUpdateNotifierTargetsMatchingSessions(t *testing.T) {
 	sessions := NewSessionManager(0, 0)
 	matchA, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
@@ -109,5 +121,102 @@ func TestMarkerUpdateNotifierSendsAllClearedMarkers(t *testing.T) {
 	}
 	if payload.Intro != nil || payload.Credits != nil || payload.Recap != nil || payload.Preview != nil {
 		t.Fatalf("payload markers = %#v, want all nil", payload)
+	}
+}
+
+func TestMarkerUpdateNotifierSendsSnapshotToOnlyRequestedSession(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	sessionA, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
+	sessionB, _ := sessions.StartSession(2, "profile-b", 100, PlayDirect, false)
+
+	hub := NewRealtimeHub()
+	connA := &dispatchTestConn{}
+	connB := &dispatchTestConn{}
+	regA := hub.Register(sessionA.ID, connA)
+	regB := hub.Register(sessionB.ID, connB)
+	defer hub.Unregister(regA)
+	defer hub.Unregister(regB)
+
+	introStart := 3.0
+	introEnd := 64.0
+	notifier := NewMarkerUpdateNotifier(sessions, hub)
+	notifier.SendSessionSnapshot(context.Background(), sessionA.ID, &models.MediaFile{
+		ID:         100,
+		IntroStart: &introStart,
+		IntroEnd:   &introEnd,
+	})
+
+	if len(connA.messages) != 1 {
+		t.Fatalf("requested session messages = %d, want 1", len(connA.messages))
+	}
+	if len(connB.messages) != 0 {
+		t.Fatalf("other session messages = %d, want 0", len(connB.messages))
+	}
+}
+
+func TestMarkerUpdateNotifierOrdersPersistedSnapshotBeforeConcurrentUpdate(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
+	_ = sessions.SetRealtimeConnection(session.ID, true)
+	hub := NewRealtimeHub()
+	conn := &dispatchTestConn{}
+	registration := hub.Register(session.ID, conn)
+	defer hub.Unregister(registration)
+	notifier := NewMarkerUpdateNotifier(sessions, hub)
+
+	oldIntroStart, oldIntroEnd := 1.0, 50.0
+	newIntroStart, newIntroEnd := 2.0, 60.0
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	snapshotDone := make(chan struct{})
+	go func() {
+		defer close(snapshotDone)
+		_ = notifier.SendSessionSnapshotFromLoader(context.Background(), session.ID, 100, blockingMarkerSnapshotLoader{
+			file: &models.MediaFile{
+				ID:         100,
+				IntroStart: &oldIntroStart,
+				IntroEnd:   &oldIntroEnd,
+			},
+			entered: entered,
+			release: release,
+		})
+	}()
+	<-entered
+
+	updateDone := make(chan struct{})
+	go func() {
+		defer close(updateDone)
+		notifier.MarkersUpdated(context.Background(), &models.MediaFile{
+			ID:         100,
+			IntroStart: &newIntroStart,
+			IntroEnd:   &newIntroEnd,
+		})
+	}()
+	close(release)
+	<-snapshotDone
+	<-updateDone
+
+	if len(conn.messages) != 2 {
+		t.Fatalf("messages = %d, want snapshot then update", len(conn.messages))
+	}
+	markerStart := func(message any) float64 {
+		event, ok := message.(EventEnvelope)
+		if !ok {
+			t.Fatalf("message type = %T, want EventEnvelope", message)
+		}
+		var payload MarkersUpdatedPayload
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("json.Unmarshal(payload): %v", err)
+		}
+		if payload.Intro == nil {
+			t.Fatal("intro payload is nil")
+		}
+		return payload.Intro.Start
+	}
+	if got := markerStart(conn.messages[0]); got != oldIntroStart {
+		t.Fatalf("first marker start = %v, want old snapshot %v", got, oldIntroStart)
+	}
+	if got := markerStart(conn.messages[1]); got != newIntroStart {
+		t.Fatalf("second marker start = %v, want new update %v", got, newIntroStart)
 	}
 }

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -3,6 +3,7 @@ package playback
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -12,6 +13,26 @@ type blockingMarkerSnapshotLoader struct {
 	file    *models.MediaFile
 	entered chan struct{}
 	release chan struct{}
+}
+
+type observedDoneContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *observedDoneContext) Done() <-chan struct{} {
+	c.once.Do(func() { close(c.observed) })
+	return c.Context.Done()
+}
+
+type observedMarkerSnapshotLoader struct {
+	called chan struct{}
+}
+
+func (l observedMarkerSnapshotLoader) GetByID(context.Context, int) (*models.MediaFile, error) {
+	close(l.called)
+	return &models.MediaFile{ID: 100}, nil
 }
 
 func (l blockingMarkerSnapshotLoader) GetByID(context.Context, int) (*models.MediaFile, error) {
@@ -270,5 +291,84 @@ func TestMarkerSnapshotFromReplacedConnectionDoesNotReachReplacement(t *testing.
 	}
 	if len(newConn.messages) != 0 {
 		t.Fatalf("replacement connection messages = %d, want 0", len(newConn.messages))
+	}
+}
+
+func TestQueuedStaleMarkerSnapshotDoesNotLoadFile(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
+	hub := NewRealtimeHub()
+	oldRegistration := hub.Register(session.ID, &dispatchTestConn{})
+	notifier := NewMarkerUpdateNotifier(sessions, hub)
+
+	lock := notifier.fileLock(100)
+	lock.lock()
+	observed := make(chan struct{})
+	loaderCalled := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- notifier.SendSessionSnapshotFromLoader(
+			&observedDoneContext{Context: context.Background(), observed: observed},
+			oldRegistration,
+			100,
+			observedMarkerSnapshotLoader{called: loaderCalled},
+		)
+	}()
+	<-observed
+
+	if !hub.Unregister(oldRegistration) {
+		t.Fatal("old connection did not unregister")
+	}
+	newRegistration := hub.Register(session.ID, &dispatchTestConn{})
+	if newRegistration == nil {
+		t.Fatal("replacement registration is nil")
+	}
+	defer hub.Unregister(newRegistration)
+	lock.unlock()
+
+	if err := <-done; err != nil {
+		t.Fatalf("SendSessionSnapshotFromLoader: %v", err)
+	}
+	select {
+	case <-loaderCalled:
+		t.Fatal("stale queued snapshot called the loader")
+	default:
+	}
+}
+
+func TestQueuedMarkerSnapshotStopsWhenContextIsCanceled(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
+	hub := NewRealtimeHub()
+	registration := hub.Register(session.ID, &dispatchTestConn{})
+	defer hub.Unregister(registration)
+	notifier := NewMarkerUpdateNotifier(sessions, hub)
+
+	lock := notifier.fileLock(100)
+	lock.lock()
+	defer lock.unlock()
+	observed := make(chan struct{})
+	loaderCalled := make(chan struct{})
+	baseCtx, cancel := context.WithCancel(context.Background())
+	ctx := &observedDoneContext{Context: baseCtx, observed: observed}
+	done := make(chan error, 1)
+	go func() {
+		done <- notifier.SendSessionSnapshotFromLoader(
+			ctx,
+			registration,
+			100,
+			observedMarkerSnapshotLoader{called: loaderCalled},
+		)
+	}()
+	<-observed
+	cancel()
+
+	if err := <-done; err != context.Canceled {
+		t.Fatalf("SendSessionSnapshotFromLoader error = %v, want context.Canceled", err)
+	}
+	select {
+	case <-loaderCalled:
+		t.Fatal("canceled queued snapshot called the loader")
+	default:
 	}
 }

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -17,15 +17,10 @@ type blockingMarkerSnapshotLoader struct {
 	release chan struct{}
 }
 
-type observedDoneContext struct {
-	context.Context
-	observed chan struct{}
-	once     sync.Once
-}
-
-func (c *observedDoneContext) Done() <-chan struct{} {
-	c.once.Do(func() { close(c.observed) })
-	return c.Context.Done()
+func (l blockingMarkerSnapshotLoader) GetByID(context.Context, int) (*models.MediaFile, error) {
+	close(l.entered)
+	<-l.release
+	return l.file, nil
 }
 
 type observedMarkerSnapshotLoader struct {
@@ -37,10 +32,47 @@ func (l observedMarkerSnapshotLoader) GetByID(context.Context, int) (*models.Med
 	return &models.MediaFile{ID: 100}, nil
 }
 
-func (l blockingMarkerSnapshotLoader) GetByID(context.Context, int) (*models.MediaFile, error) {
-	close(l.entered)
-	<-l.release
-	return l.file, nil
+type blockingMarkerWriteConn struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (c *blockingMarkerWriteConn) WriteJSON(any) error {
+	c.once.Do(func() { close(c.entered) })
+	<-c.release
+	return nil
+}
+
+func waitForDispatchMessages(t *testing.T, conn *dispatchTestConn, want int) []any {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		messages := conn.sent()
+		if len(messages) >= want {
+			return messages
+		}
+		time.Sleep(time.Millisecond)
+	}
+	messages := conn.sent()
+	t.Fatalf("messages = %d, want at least %d", len(messages), want)
+	return nil
+}
+
+func markerStartFromMessage(t *testing.T, message any) float64 {
+	t.Helper()
+	event, ok := message.(EventEnvelope)
+	if !ok {
+		t.Fatalf("message type = %T, want EventEnvelope", message)
+	}
+	var payload MarkersUpdatedPayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(payload): %v", err)
+	}
+	if payload.Intro == nil {
+		t.Fatal("intro payload is nil")
+	}
+	return payload.Intro.Start
 }
 
 func TestMarkerUpdateNotifierTargetsMatchingSessions(t *testing.T) {
@@ -49,7 +81,6 @@ func TestMarkerUpdateNotifierTargetsMatchingSessions(t *testing.T) {
 	matchB, _ := sessions.StartSession(2, "profile-b", 100, PlayDirect, false)
 	matchRequested, _ := sessions.StartSessionWithFiles(4, "profile-d", 200, 100, PlayDirect, false)
 	other, _ := sessions.StartSession(3, "profile-c", 101, PlayDirect, false)
-
 	_ = sessions.SetRealtimeConnection(matchA.ID, true)
 	_ = sessions.SetRealtimeConnection(matchB.ID, true)
 	_ = sessions.SetRealtimeConnection(matchRequested.ID, true)
@@ -69,40 +100,25 @@ func TestMarkerUpdateNotifierTargetsMatchingSessions(t *testing.T) {
 	defer hub.Unregister(regRequested)
 	defer hub.Unregister(regOther)
 
-	introStart := 12.0
-	introEnd := 75.0
-	creditsStart := 3600.0
-	creditsEnd := 3660.0
+	introStart, introEnd := 12.0, 75.0
+	creditsStart, creditsEnd := 3600.0, 3660.0
 	notifier := NewMarkerUpdateNotifier(sessions, hub)
 	notifier.MarkersUpdated(context.Background(), &models.MediaFile{
-		ID:           100,
-		IntroStart:   &introStart,
-		IntroEnd:     &introEnd,
-		CreditsStart: &creditsStart,
-		CreditsEnd:   &creditsEnd,
+		ID: 100, IntroStart: &introStart, IntroEnd: &introEnd,
+		CreditsStart: &creditsStart, CreditsEnd: &creditsEnd,
 	})
 
-	if len(connA.messages) != 1 {
-		t.Fatalf("matching session A messages = %d, want 1", len(connA.messages))
-	}
-	if len(connB.messages) != 1 {
-		t.Fatalf("matching session B messages = %d, want 1", len(connB.messages))
-	}
-	if len(connRequested.messages) != 1 {
-		t.Fatalf("requested-file session messages = %d, want 1", len(connRequested.messages))
-	}
-	if len(connOther.messages) != 0 {
-		t.Fatalf("non-matching session messages = %d, want 0", len(connOther.messages))
+	messagesA := waitForDispatchMessages(t, connA, 1)
+	waitForDispatchMessages(t, connB, 1)
+	waitForDispatchMessages(t, connRequested, 1)
+	if got := len(connOther.sent()); got != 0 {
+		t.Fatalf("non-matching session messages = %d, want 0", got)
 	}
 
-	event, ok := connA.messages[0].(EventEnvelope)
+	event, ok := messagesA[0].(EventEnvelope)
 	if !ok {
-		t.Fatalf("message type = %T, want EventEnvelope", connA.messages[0])
+		t.Fatalf("message type = %T, want EventEnvelope", messagesA[0])
 	}
-	if event.Type != RealtimeMessageTypeEvent || event.Name != RealtimeEventMarkersUpdated {
-		t.Fatalf("event = %#v, want markers updated event", event)
-	}
-
 	var payload MarkersUpdatedPayload
 	if err := json.Unmarshal(event.Payload, &payload); err != nil {
 		t.Fatalf("json.Unmarshal(payload): %v", err)
@@ -122,7 +138,6 @@ func TestMarkerUpdateNotifierSendsAllClearedMarkers(t *testing.T) {
 	sessions := NewSessionManager(0, 0)
 	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
 	_ = sessions.SetRealtimeConnection(session.ID, true)
-
 	hub := NewRealtimeHub()
 	conn := &dispatchTestConn{}
 	reg := hub.Register(session.ID, conn)
@@ -130,14 +145,8 @@ func TestMarkerUpdateNotifierSendsAllClearedMarkers(t *testing.T) {
 
 	notifier := NewMarkerUpdateNotifier(sessions, hub)
 	notifier.MarkersUpdated(context.Background(), &models.MediaFile{ID: 100})
-
-	if len(conn.messages) != 1 {
-		t.Fatalf("messages = %d, want 1 all-cleared marker update", len(conn.messages))
-	}
-	event, ok := conn.messages[0].(EventEnvelope)
-	if !ok {
-		t.Fatalf("message type = %T, want EventEnvelope", conn.messages[0])
-	}
+	messages := waitForDispatchMessages(t, conn, 1)
+	event := messages[0].(EventEnvelope)
 	var payload MarkersUpdatedPayload
 	if err := json.Unmarshal(event.Payload, &payload); err != nil {
 		t.Fatalf("json.Unmarshal(payload): %v", err)
@@ -147,37 +156,35 @@ func TestMarkerUpdateNotifierSendsAllClearedMarkers(t *testing.T) {
 	}
 }
 
-func TestMarkerUpdateNotifierSendsSnapshotToOnlyRequestedSession(t *testing.T) {
+func TestMarkerUpdateNotifierDoesNotBlockCallerOnWebSocketWrite(t *testing.T) {
 	sessions := NewSessionManager(0, 0)
-	sessionA, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
-	sessionB, _ := sessions.StartSession(2, "profile-b", 100, PlayDirect, false)
-
+	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
+	_ = sessions.SetRealtimeConnection(session.ID, true)
 	hub := NewRealtimeHub()
-	connA := &dispatchTestConn{}
-	connB := &dispatchTestConn{}
-	regA := hub.Register(sessionA.ID, connA)
-	regB := hub.Register(sessionB.ID, connB)
-	defer hub.Unregister(regA)
-	defer hub.Unregister(regB)
-
-	introStart := 3.0
-	introEnd := 64.0
+	conn := &blockingMarkerWriteConn{entered: make(chan struct{}), release: make(chan struct{})}
+	reg := hub.Register(session.ID, conn)
+	defer hub.Unregister(reg)
 	notifier := NewMarkerUpdateNotifier(sessions, hub)
-	notifier.SendSessionSnapshot(context.Background(), sessionA.ID, &models.MediaFile{
-		ID:         100,
-		IntroStart: &introStart,
-		IntroEnd:   &introEnd,
-	})
 
-	if len(connA.messages) != 1 {
-		t.Fatalf("requested session messages = %d, want 1", len(connA.messages))
+	returned := make(chan struct{})
+	go func() {
+		notifier.MarkersUpdated(context.Background(), &models.MediaFile{ID: 100})
+		close(returned)
+	}()
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("MarkersUpdated blocked on websocket delivery")
 	}
-	if len(connB.messages) != 0 {
-		t.Fatalf("other session messages = %d, want 0", len(connB.messages))
+	select {
+	case <-conn.entered:
+	case <-time.After(time.Second):
+		t.Fatal("background websocket delivery did not start")
 	}
+	close(conn.release)
 }
 
-func TestMarkerUpdateNotifierOrdersPersistedSnapshotBeforeConcurrentUpdate(t *testing.T) {
+func TestMarkerUpdateNotifierNeverDeliversStaleSnapshotAfterNewerUpdate(t *testing.T) {
 	sessions := NewSessionManager(0, 0)
 	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
 	_ = sessions.SetRealtimeConnection(session.ID, true)
@@ -187,60 +194,57 @@ func TestMarkerUpdateNotifierOrdersPersistedSnapshotBeforeConcurrentUpdate(t *te
 	defer hub.Unregister(registration)
 	notifier := NewMarkerUpdateNotifier(sessions, hub)
 
-	oldIntroStart, oldIntroEnd := 1.0, 50.0
-	newIntroStart, newIntroEnd := 2.0, 60.0
+	oldStart, oldEnd := 1.0, 50.0
+	newStart, newEnd := 2.0, 60.0
 	entered := make(chan struct{})
 	release := make(chan struct{})
-	snapshotDone := make(chan struct{})
+	snapshotDone := make(chan struct {
+		sent bool
+		err  error
+	}, 1)
 	go func() {
-		defer close(snapshotDone)
-		_ = notifier.SendSessionSnapshotFromLoader(context.Background(), registration, 100, blockingMarkerSnapshotLoader{
-			file: &models.MediaFile{
-				ID:         100,
-				IntroStart: &oldIntroStart,
-				IntroEnd:   &oldIntroEnd,
-			},
-			entered: entered,
-			release: release,
+		sent, err := notifier.SendSessionSnapshotFromLoader(context.Background(), registration, 100, blockingMarkerSnapshotLoader{
+			file:    &models.MediaFile{ID: 100, IntroStart: &oldStart, IntroEnd: &oldEnd},
+			entered: entered, release: release,
 		})
+		snapshotDone <- struct {
+			sent bool
+			err  error
+		}{sent: sent, err: err}
 	}()
 	<-entered
 
-	updateDone := make(chan struct{})
+	updateReturned := make(chan struct{})
 	go func() {
-		defer close(updateDone)
-		notifier.MarkersUpdated(context.Background(), &models.MediaFile{
-			ID:         100,
-			IntroStart: &newIntroStart,
-			IntroEnd:   &newIntroEnd,
-		})
+		notifier.MarkersUpdated(context.Background(), &models.MediaFile{ID: 100, IntroStart: &newStart, IntroEnd: &newEnd})
+		close(updateReturned)
 	}()
 	close(release)
-	<-snapshotDone
-	<-updateDone
-
-	if len(conn.messages) != 2 {
-		t.Fatalf("messages = %d, want snapshot then update", len(conn.messages))
+	result := <-snapshotDone
+	if result.err != nil {
+		t.Fatalf("SendSessionSnapshotFromLoader: %v", result.err)
 	}
-	markerStart := func(message any) float64 {
-		event, ok := message.(EventEnvelope)
-		if !ok {
-			t.Fatalf("message type = %T, want EventEnvelope", message)
+	<-updateReturned
+	messages := waitForDispatchMessages(t, conn, 1)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		current := conn.sent()
+		if len(current) > 0 {
+			messages = current
+			if markerStartFromMessage(t, current[len(current)-1]) == newStart {
+				break
+			}
 		}
-		var payload MarkersUpdatedPayload
-		if err := json.Unmarshal(event.Payload, &payload); err != nil {
-			t.Fatalf("json.Unmarshal(payload): %v", err)
-		}
-		if payload.Intro == nil {
-			t.Fatal("intro payload is nil")
-		}
-		return payload.Intro.Start
+		time.Sleep(time.Millisecond)
 	}
-	if got := markerStart(conn.messages[0]); got != oldIntroStart {
-		t.Fatalf("first marker start = %v, want old snapshot %v", got, oldIntroStart)
+	if len(messages) > 2 {
+		t.Fatalf("messages = %d, want at most snapshot and update", len(messages))
 	}
-	if got := markerStart(conn.messages[1]); got != newIntroStart {
-		t.Fatalf("second marker start = %v, want new update %v", got, newIntroStart)
+	if got := markerStartFromMessage(t, messages[len(messages)-1]); got != newStart {
+		t.Fatalf("last marker start = %v, want newest update %v", got, newStart)
+	}
+	if len(messages) == 2 && markerStartFromMessage(t, messages[0]) != oldStart {
+		t.Fatalf("first marker was not the old snapshot: %#v", messages[0])
 	}
 }
 
@@ -257,20 +261,11 @@ func TestMarkerSnapshotFromReplacedConnectionDoesNotReachReplacement(t *testing.
 	release := make(chan struct{})
 	snapshotDone := make(chan error, 1)
 	go func() {
-		snapshotDone <- notifier.SendSessionSnapshotFromLoader(
-			context.Background(),
-			oldRegistration,
-			100,
-			blockingMarkerSnapshotLoader{
-				file: &models.MediaFile{
-					ID:         100,
-					IntroStart: &introStart,
-					IntroEnd:   &introEnd,
-				},
-				entered: entered,
-				release: release,
-			},
-		)
+		_, err := notifier.SendSessionSnapshotFromLoader(context.Background(), oldRegistration, 100, blockingMarkerSnapshotLoader{
+			file:    &models.MediaFile{ID: 100, IntroStart: &introStart, IntroEnd: &introEnd},
+			entered: entered, release: release,
+		})
+		snapshotDone <- err
 	}()
 	<-entered
 
@@ -279,100 +274,52 @@ func TestMarkerSnapshotFromReplacedConnectionDoesNotReachReplacement(t *testing.
 	}
 	newConn := &dispatchTestConn{}
 	newRegistration := hub.Register(session.ID, newConn)
-	if newRegistration == nil {
-		t.Fatal("replacement registration is nil")
-	}
 	defer hub.Unregister(newRegistration)
 	close(release)
 	if err := <-snapshotDone; err != nil {
 		t.Fatalf("SendSessionSnapshotFromLoader: %v", err)
 	}
-
-	if len(oldConn.messages) != 0 {
-		t.Fatalf("old connection messages = %d, want 0", len(oldConn.messages))
-	}
-	if len(newConn.messages) != 0 {
-		t.Fatalf("replacement connection messages = %d, want 0", len(newConn.messages))
+	if len(oldConn.sent()) != 0 || len(newConn.sent()) != 0 {
+		t.Fatal("stale snapshot reached an old or replacement connection")
 	}
 }
 
-func TestQueuedStaleMarkerSnapshotDoesNotLoadFile(t *testing.T) {
+func TestMarkerSnapshotSkipsEmptyRows(t *testing.T) {
 	sessions := NewSessionManager(0, 0)
 	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
 	hub := NewRealtimeHub()
-	oldRegistration := hub.Register(session.ID, &dispatchTestConn{})
+	conn := &dispatchTestConn{}
+	registration := hub.Register(session.ID, conn)
+	defer hub.Unregister(registration)
 	notifier := NewMarkerUpdateNotifier(sessions, hub)
 
-	lock := notifier.fileLock(100)
-	lock.lock()
-	defer lock.unlock()
-	observed := make(chan struct{})
-	loaderCalled := make(chan struct{})
-	done := make(chan error, 1)
-	go func() {
-		done <- notifier.SendSessionSnapshotFromLoader(
-			&observedDoneContext{Context: context.Background(), observed: observed},
-			oldRegistration,
-			100,
-			observedMarkerSnapshotLoader{called: loaderCalled},
-		)
-	}()
-	<-observed
-
-	newRegistration := hub.Register(session.ID, &dispatchTestConn{})
-	if newRegistration == nil {
-		t.Fatal("replacement registration is nil")
+	sent, err := notifier.SendSessionSnapshotFromLoader(context.Background(), registration, 100, observedMarkerSnapshotLoader{called: make(chan struct{})})
+	if err != nil {
+		t.Fatalf("SendSessionSnapshotFromLoader: %v", err)
 	}
-	defer hub.Unregister(newRegistration)
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("SendSessionSnapshotFromLoader: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("stale queued snapshot did not stop after replacement")
-	}
-	select {
-	case <-loaderCalled:
-		t.Fatal("stale queued snapshot called the loader")
-	default:
+	if sent || len(conn.sent()) != 0 {
+		t.Fatal("empty persisted markers emitted a clearing snapshot")
 	}
 }
 
-func TestQueuedMarkerSnapshotStopsWhenContextIsCanceled(t *testing.T) {
+func TestMarkerSnapshotStopsWhenContextIsCanceled(t *testing.T) {
 	sessions := NewSessionManager(0, 0)
 	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
 	hub := NewRealtimeHub()
 	registration := hub.Register(session.ID, &dispatchTestConn{})
 	defer hub.Unregister(registration)
 	notifier := NewMarkerUpdateNotifier(sessions, hub)
-
-	lock := notifier.fileLock(100)
-	lock.lock()
-	defer lock.unlock()
-	observed := make(chan struct{})
 	loaderCalled := make(chan struct{})
-	baseCtx, cancel := context.WithCancel(context.Background())
-	ctx := &observedDoneContext{Context: baseCtx, observed: observed}
-	done := make(chan error, 1)
-	go func() {
-		done <- notifier.SendSessionSnapshotFromLoader(
-			ctx,
-			registration,
-			100,
-			observedMarkerSnapshotLoader{called: loaderCalled},
-		)
-	}()
-	<-observed
+	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if err := <-done; !errors.Is(err, context.Canceled) {
+	_, err := notifier.SendSessionSnapshotFromLoader(ctx, registration, 100, observedMarkerSnapshotLoader{called: loaderCalled})
+	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("SendSessionSnapshotFromLoader error = %v, want context.Canceled", err)
 	}
 	select {
 	case <-loaderCalled:
-		t.Fatal("canceled queued snapshot called the loader")
+		t.Fatal("canceled snapshot called the loader")
 	default:
 	}
 }

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -3,6 +3,7 @@ package playback
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -366,7 +367,7 @@ func TestQueuedMarkerSnapshotStopsWhenContextIsCanceled(t *testing.T) {
 	<-observed
 	cancel()
 
-	if err := <-done; err != context.Canceled {
+	if err := <-done; !errors.Is(err, context.Canceled) {
 		t.Fatalf("SendSessionSnapshotFromLoader error = %v, want context.Canceled", err)
 	}
 	select {

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -284,6 +284,73 @@ func TestMarkerSnapshotFromReplacedConnectionDoesNotReachReplacement(t *testing.
 	}
 }
 
+func TestQueuedMarkerSnapshotStopsBeforeLoadWhenConnectionIsReplaced(t *testing.T) {
+	sessions := NewSessionManager(0, 0)
+	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)
+	hub := NewRealtimeHub()
+	oldRegistration := hub.Register(session.ID, &dispatchTestConn{})
+	notifier := NewMarkerUpdateNotifier(sessions, hub)
+
+	introStart, introEnd := 1.0, 50.0
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := notifier.SendSessionSnapshotFromLoader(context.Background(), oldRegistration, 100, blockingMarkerSnapshotLoader{
+			file:    &models.MediaFile{ID: 100, IntroStart: &introStart, IntroEnd: &introEnd},
+			entered: entered, release: release,
+		})
+		firstDone <- err
+	}()
+	<-entered
+
+	queuedLoaderCalled := make(chan struct{})
+	queuedDone := make(chan error, 1)
+	go func() {
+		_, err := notifier.SendSessionSnapshotFromLoader(
+			context.Background(), oldRegistration, 100, observedMarkerSnapshotLoader{called: queuedLoaderCalled},
+		)
+		queuedDone <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		notifier.stateMu.Lock()
+		refs := notifier.states[100].refs
+		notifier.stateMu.Unlock()
+		if refs == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second snapshot did not queue behind the file state")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	newRegistration := hub.Register(session.ID, &dispatchTestConn{})
+	if newRegistration == nil {
+		t.Fatal("replacement connection did not register")
+	}
+	defer hub.Unregister(newRegistration)
+	select {
+	case err := <-queuedDone:
+		if err != nil {
+			t.Fatalf("queued snapshot: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued snapshot did not stop after its registration was replaced")
+	}
+	select {
+	case <-queuedLoaderCalled:
+		t.Fatal("queued stale snapshot called the loader")
+	default:
+	}
+
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first snapshot: %v", err)
+	}
+}
+
 func TestMarkerSnapshotSkipsEmptyRows(t *testing.T) {
 	sessions := NewSessionManager(0, 0)
 	session, _ := sessions.StartSession(1, "profile-a", 100, PlayDirect, false)

--- a/internal/playback/marker_update_notifier_test.go
+++ b/internal/playback/marker_update_notifier_test.go
@@ -251,6 +251,9 @@ func TestMarkerSnapshotFromReplacedConnectionDoesNotReachReplacement(t *testing.
 	}()
 	<-entered
 
+	if !hub.Unregister(oldRegistration) {
+		t.Fatal("old connection did not unregister")
+	}
 	newConn := &dispatchTestConn{}
 	newRegistration := hub.Register(session.ID, newConn)
 	if newRegistration == nil {

--- a/internal/playback/realtime_hub.go
+++ b/internal/playback/realtime_hub.go
@@ -30,6 +30,14 @@ type RealtimeRegistration struct {
 	generation uint64
 }
 
+// SessionID returns the playback session owned by this registration.
+func (r *RealtimeRegistration) SessionID() string {
+	if r == nil {
+		return ""
+	}
+	return r.sessionID
+}
+
 // RealtimeHub stores one active realtime connection per playback session.
 type RealtimeHub struct {
 	mu                   sync.RWMutex
@@ -135,6 +143,31 @@ func (h *RealtimeHub) Send(sessionID string, message any) error {
 
 	lane.mu.Lock()
 	if lane.closed || lane.conn == nil {
+		lane.mu.Unlock()
+		return ErrRealtimeConnectionNotFound
+	}
+	err := lane.conn.WriteJSON(message)
+	lane.mu.Unlock()
+	return err
+}
+
+// SendRegistered writes only when reg still owns the active connection. It is
+// used for connection-specific work that must not spill into a replacement
+// websocket after a reconnect.
+func (h *RealtimeHub) SendRegistered(reg *RealtimeRegistration, message any) error {
+	if h == nil || reg == nil || reg.sessionID == "" || reg.lane == nil {
+		return ErrRealtimeConnectionNotFound
+	}
+
+	h.mu.RLock()
+	lane, ok := h.connections[reg.sessionID]
+	h.mu.RUnlock()
+	if !ok || lane == nil || lane != reg.lane {
+		return ErrRealtimeConnectionNotFound
+	}
+
+	lane.mu.Lock()
+	if lane.closed || lane.conn == nil || lane.generation != reg.generation {
 		lane.mu.Unlock()
 		return ErrRealtimeConnectionNotFound
 	}

--- a/internal/playback/realtime_hub.go
+++ b/internal/playback/realtime_hub.go
@@ -17,10 +17,11 @@ type RealtimeConnection interface {
 }
 
 type sessionLane struct {
-	conn       RealtimeConnection
-	mu         sync.Mutex
-	closed     bool
-	generation uint64
+	conn             RealtimeConnection
+	mu               sync.Mutex
+	closed           bool
+	generation       uint64
+	registrationDone chan struct{}
 }
 
 // RealtimeRegistration is an opaque ownership token for a realtime connection.
@@ -28,6 +29,7 @@ type RealtimeRegistration struct {
 	sessionID  string
 	lane       *sessionLane
 	generation uint64
+	done       <-chan struct{}
 }
 
 // SessionID returns the playback session owned by this registration.
@@ -36,6 +38,14 @@ func (r *RealtimeRegistration) SessionID() string {
 		return ""
 	}
 	return r.sessionID
+}
+
+// Done closes when this registration stops owning the active connection.
+func (r *RealtimeRegistration) Done() <-chan struct{} {
+	if r == nil {
+		return nil
+	}
+	return r.done
 }
 
 // RealtimeHub stores one active realtime connection per playback session.
@@ -63,13 +73,14 @@ func (h *RealtimeHub) Register(sessionID string, conn RealtimeConnection) *Realt
 	h.mu.Lock()
 	lane := h.connections[sessionID]
 	if lane == nil {
-		lane = &sessionLane{conn: conn, generation: 1}
+		done := make(chan struct{})
+		lane = &sessionLane{conn: conn, generation: 1, registrationDone: done}
 		h.connections[sessionID] = lane
 		h.mu.Unlock()
 		if h.onInitialRegister != nil {
 			h.onInitialRegister()
 		}
-		return &RealtimeRegistration{sessionID: sessionID, lane: lane, generation: 1}
+		return &RealtimeRegistration{sessionID: sessionID, lane: lane, generation: 1, done: done}
 	}
 	h.mu.Unlock()
 
@@ -81,13 +92,19 @@ func (h *RealtimeHub) Register(sessionID string, conn RealtimeConnection) *Realt
 		lane.mu.Unlock()
 		return nil
 	}
+	if lane.registrationDone != nil {
+		close(lane.registrationDone)
+	}
+	done := make(chan struct{})
 	lane.conn = conn
 	lane.closed = false
 	lane.generation++
+	lane.registrationDone = done
 	reg := &RealtimeRegistration{
 		sessionID:  sessionID,
 		lane:       lane,
 		generation: lane.generation,
+		done:       done,
 	}
 	lane.mu.Unlock()
 
@@ -112,6 +129,10 @@ func (h *RealtimeHub) Unregister(reg *RealtimeRegistration) bool {
 	if lane.generation != reg.generation || lane.closed {
 		lane.mu.Unlock()
 		return false
+	}
+	if lane.registrationDone != nil {
+		close(lane.registrationDone)
+		lane.registrationDone = nil
 	}
 	lane.closed = true
 	lane.conn = nil

--- a/internal/playback/realtime_hub.go
+++ b/internal/playback/realtime_hub.go
@@ -155,17 +155,11 @@ func (h *RealtimeHub) Send(sessionID string, message any) error {
 // used for connection-specific work that must not spill into a replacement
 // websocket after a reconnect.
 func (h *RealtimeHub) SendRegistered(reg *RealtimeRegistration, message any) error {
-	if h == nil || reg == nil || reg.sessionID == "" || reg.lane == nil {
+	if !h.HasRegistration(reg) {
 		return ErrRealtimeConnectionNotFound
 	}
 
-	h.mu.RLock()
-	lane, ok := h.connections[reg.sessionID]
-	h.mu.RUnlock()
-	if !ok || lane == nil || lane != reg.lane {
-		return ErrRealtimeConnectionNotFound
-	}
-
+	lane := reg.lane
 	lane.mu.Lock()
 	if lane.closed || lane.conn == nil || lane.generation != reg.generation {
 		lane.mu.Unlock()
@@ -174,4 +168,23 @@ func (h *RealtimeHub) SendRegistered(reg *RealtimeRegistration, message any) err
 	err := lane.conn.WriteJSON(message)
 	lane.mu.Unlock()
 	return err
+}
+
+// HasRegistration reports whether reg still owns the active connection.
+func (h *RealtimeHub) HasRegistration(reg *RealtimeRegistration) bool {
+	if h == nil || reg == nil || reg.sessionID == "" || reg.lane == nil {
+		return false
+	}
+
+	h.mu.RLock()
+	lane, ok := h.connections[reg.sessionID]
+	h.mu.RUnlock()
+	if !ok || lane == nil || lane != reg.lane {
+		return false
+	}
+
+	lane.mu.Lock()
+	active := !lane.closed && lane.conn != nil && lane.generation == reg.generation
+	lane.mu.Unlock()
+	return active
 }

--- a/internal/playback/realtime_hub.go
+++ b/internal/playback/realtime_hub.go
@@ -150,45 +150,71 @@ func (h *RealtimeHub) Unregister(reg *RealtimeRegistration) bool {
 
 // Send writes a message to the active connection for the given session.
 func (h *RealtimeHub) Send(sessionID string, message any) error {
+	_, err := h.sendIf(sessionID, message, nil)
+	return err
+}
+
+func (h *RealtimeHub) sendIf(sessionID string, message any, predicate func() bool) (bool, error) {
 	if h == nil || sessionID == "" {
-		return ErrRealtimeConnectionNotFound
+		return false, ErrRealtimeConnectionNotFound
 	}
 
 	h.mu.RLock()
 	lane, ok := h.connections[sessionID]
 	if !ok || lane == nil {
 		h.mu.RUnlock()
-		return ErrRealtimeConnectionNotFound
+		return false, ErrRealtimeConnectionNotFound
 	}
 	h.mu.RUnlock()
 
 	lane.mu.Lock()
 	if lane.closed || lane.conn == nil {
 		lane.mu.Unlock()
-		return ErrRealtimeConnectionNotFound
+		return false, ErrRealtimeConnectionNotFound
+	}
+	if predicate != nil && !predicate() {
+		lane.mu.Unlock()
+		return false, nil
 	}
 	err := lane.conn.WriteJSON(message)
 	lane.mu.Unlock()
-	return err
+	return true, err
 }
 
-// SendRegistered writes only when reg still owns the active connection. It is
-// used for connection-specific work that must not spill into a replacement
-// websocket after a reconnect.
-func (h *RealtimeHub) SendRegistered(reg *RealtimeRegistration, message any) error {
-	if !h.HasRegistration(reg) {
-		return ErrRealtimeConnectionNotFound
+func (h *RealtimeHub) sendRegisteredIf(reg *RealtimeRegistration, message any, predicate func() bool) (bool, error) {
+	if h == nil || reg == nil || reg.sessionID == "" || reg.lane == nil {
+		return false, ErrRealtimeConnectionNotFound
 	}
-
 	lane := reg.lane
 	lane.mu.Lock()
 	if lane.closed || lane.conn == nil || lane.generation != reg.generation {
 		lane.mu.Unlock()
-		return ErrRealtimeConnectionNotFound
+		return false, ErrRealtimeConnectionNotFound
+	}
+	if predicate != nil && !predicate() {
+		lane.mu.Unlock()
+		return false, nil
 	}
 	err := lane.conn.WriteJSON(message)
 	lane.mu.Unlock()
-	return err
+	return true, err
+}
+
+// HasConnection reports whether a session currently has a registered socket.
+func (h *RealtimeHub) HasConnection(sessionID string) bool {
+	if h == nil || sessionID == "" {
+		return false
+	}
+	h.mu.RLock()
+	lane := h.connections[sessionID]
+	h.mu.RUnlock()
+	if lane == nil {
+		return false
+	}
+	lane.mu.Lock()
+	active := !lane.closed && lane.conn != nil
+	lane.mu.Unlock()
+	return active
 }
 
 // HasRegistration reports whether reg still owns the active connection.

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -72,6 +72,73 @@ const overlayFileColumns = `content_id, episode_id, media_folder_id, file_path,
 	codec_video, codec_audio, resolution, audio_channels, hdr, container,
 	video_tracks, audio_tracks, subtitle_tracks, external_subtitles, edition_key`
 
+type markerInvalidationColumn struct {
+	name         string
+	sourceColumn string
+}
+
+var markerInvalidationColumns = []markerInvalidationColumn{
+	{name: "intro_start", sourceColumn: "intro_markers_source"},
+	{name: "intro_end", sourceColumn: "intro_markers_source"},
+	{name: "credits_start", sourceColumn: "credits_markers_source"},
+	{name: "credits_end", sourceColumn: "credits_markers_source"},
+	{name: "recap_start", sourceColumn: "recap_markers_source"},
+	{name: "recap_end", sourceColumn: "recap_markers_source"},
+	{name: "preview_start", sourceColumn: "preview_markers_source"},
+	{name: "preview_end", sourceColumn: "preview_markers_source"},
+	{name: "markers_source", sourceColumn: "markers_source"},
+	{name: "markers_confidence", sourceColumn: "markers_source"},
+	{name: "intro_markers_source", sourceColumn: "intro_markers_source"},
+	{name: "intro_markers_provider", sourceColumn: "intro_markers_source"},
+	{name: "intro_markers_confidence", sourceColumn: "intro_markers_source"},
+	{name: "intro_markers_algorithm", sourceColumn: "intro_markers_source"},
+	{name: "intro_markers_detected_at", sourceColumn: "intro_markers_source"},
+	{name: "credits_markers_source", sourceColumn: "credits_markers_source"},
+	{name: "credits_markers_provider", sourceColumn: "credits_markers_source"},
+	{name: "credits_markers_confidence", sourceColumn: "credits_markers_source"},
+	{name: "credits_markers_algorithm", sourceColumn: "credits_markers_source"},
+	{name: "credits_markers_detected_at", sourceColumn: "credits_markers_source"},
+	{name: "recap_markers_source", sourceColumn: "recap_markers_source"},
+	{name: "recap_markers_provider", sourceColumn: "recap_markers_source"},
+	{name: "recap_markers_confidence", sourceColumn: "recap_markers_source"},
+	{name: "recap_markers_algorithm", sourceColumn: "recap_markers_source"},
+	{name: "recap_markers_detected_at", sourceColumn: "recap_markers_source"},
+	{name: "preview_markers_source", sourceColumn: "preview_markers_source"},
+	{name: "preview_markers_provider", sourceColumn: "preview_markers_source"},
+	{name: "preview_markers_confidence", sourceColumn: "preview_markers_source"},
+	{name: "preview_markers_algorithm", sourceColumn: "preview_markers_source"},
+	{name: "preview_markers_detected_at", sourceColumn: "preview_markers_source"},
+}
+
+const markerInvalidationPredicate = `media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash`
+
+// markerInvalidationAssignments builds the conflict-update fragment in one
+// place so every range and provenance column follows the same file-generation
+// rule. Manual segments survive a remux or replacement because there is no
+// external source from which their admin-entered ranges can be restored.
+func markerInvalidationAssignments() string {
+	var b strings.Builder
+	for i, column := range markerInvalidationColumns {
+		if i > 0 {
+			b.WriteString(",\n\t\t")
+		}
+		sourceExpr := "COALESCE(media_files." + column.sourceColumn + ", '')"
+		if column.sourceColumn != "markers_source" {
+			sourceExpr = "COALESCE(media_files." + column.sourceColumn + ", media_files.markers_source, '')"
+		}
+		fmt.Fprintf(
+			&b,
+			"%s = CASE WHEN %s AND %s <> '%s' THEN NULL ELSE media_files.%s END",
+			column.name,
+			markerInvalidationPredicate,
+			sourceExpr,
+			models.MarkerSourceManual,
+			column.name,
+		)
+	}
+	return b.String()
+}
+
 // mfFileColumns qualifies every column with the "mf" alias for use in JOIN queries
 // where unqualified "id" would be ambiguous.
 const mfFileColumns = `mf.id, mf.content_id, mf.episode_id, mf.extra_id, mf.season_number, mf.episode_number,
@@ -835,12 +902,6 @@ func (r *FileRepository) Upsert(ctx context.Context, mf models.MediaFile) (*mode
 		return nil, fmt.Errorf("marshaling chapters: %w", err)
 	}
 
-	// Marker ranges describe one exact generation of a file. When a scan sees
-	// different non-empty content hashes at the same path, clear every range and
-	// its provenance in the upsert below; the new generation can then take its
-	// own hash-keyed S3 markers or be repopulated lazily at playback. A missing
-	// hash on either side is not enough evidence to discard existing markers.
-
 	// Convert empty strings to nil for nullable text columns.
 	var contentID *string
 	if mf.ContentID != "" {
@@ -920,36 +981,7 @@ func (r *FileRepository) Upsert(ctx context.Context, mf models.MediaFile) (*mode
 		file_size = EXCLUDED.file_size,
 		file_modified_at = EXCLUDED.file_modified_at,
 		file_hash = EXCLUDED.file_hash,
-		intro_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_start END,
-		intro_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_end END,
-		credits_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_start END,
-		credits_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_end END,
-		recap_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_start END,
-		recap_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_end END,
-		preview_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_start END,
-		preview_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_end END,
-		markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.markers_source END,
-		markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.markers_confidence END,
-		intro_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_source END,
-		intro_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_provider END,
-		intro_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_confidence END,
-		intro_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_algorithm END,
-		intro_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_detected_at END,
-		credits_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_source END,
-		credits_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_provider END,
-		credits_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_confidence END,
-		credits_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_algorithm END,
-		credits_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_detected_at END,
-		recap_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_source END,
-		recap_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_provider END,
-		recap_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_confidence END,
-		recap_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_algorithm END,
-		recap_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_detected_at END,
-		preview_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_source END,
-		preview_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_provider END,
-		preview_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_confidence END,
-		preview_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_algorithm END,
-		preview_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_detected_at END,
+		` + markerInvalidationAssignments() + `,
 		codec_video = EXCLUDED.codec_video,
 		codec_audio = EXCLUDED.codec_audio,
 		resolution = EXCLUDED.resolution,

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -77,37 +77,45 @@ type markerInvalidationColumn struct {
 	sourceColumn string
 }
 
+const (
+	markerSourceColumnShared  = "markers_source"
+	markerSourceColumnIntro   = "intro_markers_source"
+	markerSourceColumnCredits = "credits_markers_source"
+	markerSourceColumnRecap   = "recap_markers_source"
+	markerSourceColumnPreview = "preview_markers_source"
+)
+
 var markerInvalidationColumns = []markerInvalidationColumn{
-	{name: "intro_start", sourceColumn: "intro_markers_source"},
-	{name: "intro_end", sourceColumn: "intro_markers_source"},
-	{name: "credits_start", sourceColumn: "credits_markers_source"},
-	{name: "credits_end", sourceColumn: "credits_markers_source"},
-	{name: "recap_start", sourceColumn: "recap_markers_source"},
-	{name: "recap_end", sourceColumn: "recap_markers_source"},
-	{name: "preview_start", sourceColumn: "preview_markers_source"},
-	{name: "preview_end", sourceColumn: "preview_markers_source"},
-	{name: "markers_source", sourceColumn: "markers_source"},
-	{name: "markers_confidence", sourceColumn: "markers_source"},
-	{name: "intro_markers_source", sourceColumn: "intro_markers_source"},
-	{name: "intro_markers_provider", sourceColumn: "intro_markers_source"},
-	{name: "intro_markers_confidence", sourceColumn: "intro_markers_source"},
-	{name: "intro_markers_algorithm", sourceColumn: "intro_markers_source"},
-	{name: "intro_markers_detected_at", sourceColumn: "intro_markers_source"},
-	{name: "credits_markers_source", sourceColumn: "credits_markers_source"},
-	{name: "credits_markers_provider", sourceColumn: "credits_markers_source"},
-	{name: "credits_markers_confidence", sourceColumn: "credits_markers_source"},
-	{name: "credits_markers_algorithm", sourceColumn: "credits_markers_source"},
-	{name: "credits_markers_detected_at", sourceColumn: "credits_markers_source"},
-	{name: "recap_markers_source", sourceColumn: "recap_markers_source"},
-	{name: "recap_markers_provider", sourceColumn: "recap_markers_source"},
-	{name: "recap_markers_confidence", sourceColumn: "recap_markers_source"},
-	{name: "recap_markers_algorithm", sourceColumn: "recap_markers_source"},
-	{name: "recap_markers_detected_at", sourceColumn: "recap_markers_source"},
-	{name: "preview_markers_source", sourceColumn: "preview_markers_source"},
-	{name: "preview_markers_provider", sourceColumn: "preview_markers_source"},
-	{name: "preview_markers_confidence", sourceColumn: "preview_markers_source"},
-	{name: "preview_markers_algorithm", sourceColumn: "preview_markers_source"},
-	{name: "preview_markers_detected_at", sourceColumn: "preview_markers_source"},
+	{name: "intro_start", sourceColumn: markerSourceColumnIntro},
+	{name: "intro_end", sourceColumn: markerSourceColumnIntro},
+	{name: "credits_start", sourceColumn: markerSourceColumnCredits},
+	{name: "credits_end", sourceColumn: markerSourceColumnCredits},
+	{name: "recap_start", sourceColumn: markerSourceColumnRecap},
+	{name: "recap_end", sourceColumn: markerSourceColumnRecap},
+	{name: "preview_start", sourceColumn: markerSourceColumnPreview},
+	{name: "preview_end", sourceColumn: markerSourceColumnPreview},
+	{name: markerSourceColumnShared, sourceColumn: markerSourceColumnShared},
+	{name: "markers_confidence", sourceColumn: markerSourceColumnShared},
+	{name: markerSourceColumnIntro, sourceColumn: markerSourceColumnIntro},
+	{name: "intro_markers_provider", sourceColumn: markerSourceColumnIntro},
+	{name: "intro_markers_confidence", sourceColumn: markerSourceColumnIntro},
+	{name: "intro_markers_algorithm", sourceColumn: markerSourceColumnIntro},
+	{name: "intro_markers_detected_at", sourceColumn: markerSourceColumnIntro},
+	{name: markerSourceColumnCredits, sourceColumn: markerSourceColumnCredits},
+	{name: "credits_markers_provider", sourceColumn: markerSourceColumnCredits},
+	{name: "credits_markers_confidence", sourceColumn: markerSourceColumnCredits},
+	{name: "credits_markers_algorithm", sourceColumn: markerSourceColumnCredits},
+	{name: "credits_markers_detected_at", sourceColumn: markerSourceColumnCredits},
+	{name: markerSourceColumnRecap, sourceColumn: markerSourceColumnRecap},
+	{name: "recap_markers_provider", sourceColumn: markerSourceColumnRecap},
+	{name: "recap_markers_confidence", sourceColumn: markerSourceColumnRecap},
+	{name: "recap_markers_algorithm", sourceColumn: markerSourceColumnRecap},
+	{name: "recap_markers_detected_at", sourceColumn: markerSourceColumnRecap},
+	{name: markerSourceColumnPreview, sourceColumn: markerSourceColumnPreview},
+	{name: "preview_markers_provider", sourceColumn: markerSourceColumnPreview},
+	{name: "preview_markers_confidence", sourceColumn: markerSourceColumnPreview},
+	{name: "preview_markers_algorithm", sourceColumn: markerSourceColumnPreview},
+	{name: "preview_markers_detected_at", sourceColumn: markerSourceColumnPreview},
 }
 
 const markerInvalidationPredicate = `media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash`
@@ -123,7 +131,7 @@ func markerInvalidationAssignments() string {
 			b.WriteString(",\n\t\t")
 		}
 		sourceExpr := "COALESCE(media_files." + column.sourceColumn + ", '')"
-		if column.sourceColumn != "markers_source" {
+		if column.sourceColumn != markerSourceColumnShared {
 			sourceExpr = "COALESCE(media_files." + column.sourceColumn + ", media_files.markers_source, '')"
 		}
 		fmt.Fprintf(

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -835,6 +835,12 @@ func (r *FileRepository) Upsert(ctx context.Context, mf models.MediaFile) (*mode
 		return nil, fmt.Errorf("marshaling chapters: %w", err)
 	}
 
+	// Marker ranges describe one exact generation of a file. When a scan sees
+	// different non-empty content hashes at the same path, clear every range and
+	// its provenance in the upsert below; the new generation can then take its
+	// own hash-keyed S3 markers or be repopulated lazily at playback. A missing
+	// hash on either side is not enough evidence to discard existing markers.
+
 	// Convert empty strings to nil for nullable text columns.
 	var contentID *string
 	if mf.ContentID != "" {
@@ -914,6 +920,36 @@ func (r *FileRepository) Upsert(ctx context.Context, mf models.MediaFile) (*mode
 		file_size = EXCLUDED.file_size,
 		file_modified_at = EXCLUDED.file_modified_at,
 		file_hash = EXCLUDED.file_hash,
+		intro_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_start END,
+		intro_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_end END,
+		credits_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_start END,
+		credits_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_end END,
+		recap_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_start END,
+		recap_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_end END,
+		preview_start = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_start END,
+		preview_end = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_end END,
+		markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.markers_source END,
+		markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.markers_confidence END,
+		intro_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_source END,
+		intro_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_provider END,
+		intro_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_confidence END,
+		intro_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_algorithm END,
+		intro_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.intro_markers_detected_at END,
+		credits_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_source END,
+		credits_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_provider END,
+		credits_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_confidence END,
+		credits_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_algorithm END,
+		credits_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.credits_markers_detected_at END,
+		recap_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_source END,
+		recap_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_provider END,
+		recap_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_confidence END,
+		recap_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_algorithm END,
+		recap_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.recap_markers_detected_at END,
+		preview_markers_source = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_source END,
+		preview_markers_provider = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_provider END,
+		preview_markers_confidence = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_confidence END,
+		preview_markers_algorithm = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_algorithm END,
+		preview_markers_detected_at = CASE WHEN media_files.file_hash IS NOT NULL AND EXCLUDED.file_hash IS NOT NULL AND media_files.file_hash IS DISTINCT FROM EXCLUDED.file_hash THEN NULL ELSE media_files.preview_markers_detected_at END,
 		codec_video = EXCLUDED.codec_video,
 		codec_audio = EXCLUDED.codec_audio,
 		resolution = EXCLUDED.resolution,

--- a/internal/scanner/file_repo_marker_replacement_db_test.go
+++ b/internal/scanner/file_repo_marker_replacement_db_test.go
@@ -1,0 +1,139 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestUpsertInvalidatesMarkersOnlyForKnownFileReplacement(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled)
+		VALUES ('tv', $1, true)
+		RETURNING id
+	`, fmt.Sprintf("Marker replacement test %d", suffix)).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_files WHERE media_folder_id = $1`, folderID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	repo := NewFileRepository(pool)
+	seed := func(t *testing.T, name, hash string) models.MediaFile {
+		t.Helper()
+		file := models.MediaFile{
+			MediaFolderID: folderID,
+			FilePath:      fmt.Sprintf("/tmp/marker-replacement-%d/%s.mkv", suffix, name),
+			FileSize:      1024,
+			FileHash:      hash,
+			Duration:      3600,
+		}
+		stored, err := repo.Upsert(ctx, file)
+		if err != nil {
+			t.Fatalf("seed file: %v", err)
+		}
+		provider := "plugin:marker-test"
+		confidence := 0.9
+		algorithm := "marker-test:v1"
+		startIntro, endIntro := 30.0, 90.0
+		startCredits, endCredits := 3500.0, 3600.0
+		startRecap, endRecap := 0.0, 25.0
+		startPreview, endPreview := 3570.0, 3590.0
+		if wrote, err := repo.UpsertMarkers(ctx, stored.ID, MarkerUpdate{
+			IntroStart:        &startIntro,
+			IntroEnd:          &endIntro,
+			CreditsStart:      &startCredits,
+			CreditsEnd:        &endCredits,
+			RecapStart:        &startRecap,
+			RecapEnd:          &endRecap,
+			PreviewStart:      &startPreview,
+			PreviewEnd:        &endPreview,
+			MarkersSource:     models.MarkerSourcePlugin,
+			MarkersProvider:   &provider,
+			MarkersConfidence: &confidence,
+			MarkersAlgorithm:  algorithm,
+		}); err != nil || !wrote {
+			t.Fatalf("seed markers = (%v, %v), want write", wrote, err)
+		}
+		return file
+	}
+
+	markersPresent := func(file *models.MediaFile) bool {
+		return file.IntroStart != nil && file.IntroEnd != nil &&
+			file.CreditsStart != nil && file.CreditsEnd != nil &&
+			file.RecapStart != nil && file.RecapEnd != nil &&
+			file.PreviewStart != nil && file.PreviewEnd != nil &&
+			file.MarkersSource != nil && file.MarkersConfidence != nil &&
+			file.IntroMarkersSource != nil && file.IntroMarkersProvider != nil && file.IntroMarkersConfidence != nil && file.IntroMarkersAlgorithm != nil && file.IntroMarkersDetectedAt != nil &&
+			file.CreditsMarkersSource != nil && file.CreditsMarkersProvider != nil && file.CreditsMarkersConfidence != nil && file.CreditsMarkersAlgorithm != nil && file.CreditsMarkersDetectedAt != nil &&
+			file.RecapMarkersSource != nil && file.RecapMarkersProvider != nil && file.RecapMarkersConfidence != nil && file.RecapMarkersAlgorithm != nil && file.RecapMarkersDetectedAt != nil &&
+			file.PreviewMarkersSource != nil && file.PreviewMarkersProvider != nil && file.PreviewMarkersConfidence != nil && file.PreviewMarkersAlgorithm != nil && file.PreviewMarkersDetectedAt != nil
+	}
+	markersCleared := func(file *models.MediaFile) bool {
+		return file.IntroStart == nil && file.IntroEnd == nil &&
+			file.CreditsStart == nil && file.CreditsEnd == nil &&
+			file.RecapStart == nil && file.RecapEnd == nil &&
+			file.PreviewStart == nil && file.PreviewEnd == nil &&
+			file.MarkersSource == nil && file.MarkersConfidence == nil &&
+			file.IntroMarkersSource == nil && file.IntroMarkersProvider == nil && file.IntroMarkersConfidence == nil && file.IntroMarkersAlgorithm == nil && file.IntroMarkersDetectedAt == nil &&
+			file.CreditsMarkersSource == nil && file.CreditsMarkersProvider == nil && file.CreditsMarkersConfidence == nil && file.CreditsMarkersAlgorithm == nil && file.CreditsMarkersDetectedAt == nil &&
+			file.RecapMarkersSource == nil && file.RecapMarkersProvider == nil && file.RecapMarkersConfidence == nil && file.RecapMarkersAlgorithm == nil && file.RecapMarkersDetectedAt == nil &&
+			file.PreviewMarkersSource == nil && file.PreviewMarkersProvider == nil && file.PreviewMarkersConfidence == nil && file.PreviewMarkersAlgorithm == nil && file.PreviewMarkersDetectedAt == nil
+	}
+
+	t.Run("same hash preserves markers", func(t *testing.T) {
+		file := seed(t, "same", "hash-same")
+		updated, err := repo.Upsert(ctx, file)
+		if err != nil {
+			t.Fatalf("rescan same generation: %v", err)
+		}
+		if !markersPresent(updated) {
+			t.Fatalf("same-generation rescan cleared markers: %+v", updated)
+		}
+	})
+
+	t.Run("hash backfill preserves markers", func(t *testing.T) {
+		file := seed(t, "backfill", "")
+		file.FileHash = "hash-backfilled"
+		updated, err := repo.Upsert(ctx, file)
+		if err != nil {
+			t.Fatalf("backfill hash: %v", err)
+		}
+		if !markersPresent(updated) {
+			t.Fatalf("hash backfill cleared markers: %+v", updated)
+		}
+	})
+
+	t.Run("different hashes clear markers", func(t *testing.T) {
+		file := seed(t, "replaced", "hash-before")
+		file.FileHash = "hash-after"
+		file.FileSize = 2048
+		updated, err := repo.Upsert(ctx, file)
+		if err != nil {
+			t.Fatalf("replace file generation: %v", err)
+		}
+		if !markersCleared(updated) {
+			t.Fatalf("replacement retained stale markers: %+v", updated)
+		}
+	})
+}

--- a/internal/scanner/file_repo_test.go
+++ b/internal/scanner/file_repo_test.go
@@ -1,11 +1,51 @@
 package scanner
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
+
+func TestMarkerInvalidationAssignmentsCoverEveryColumnAndPreserveManualSegments(t *testing.T) {
+	assignments := markerInvalidationAssignments()
+	seen := make(map[string]struct{}, len(markerInvalidationColumns))
+	assignmentParts := strings.Split(assignments, ",\n\t\t")
+	if len(assignmentParts) != len(markerInvalidationColumns) {
+		t.Fatalf("assignment count = %d, want %d", len(assignmentParts), len(markerInvalidationColumns))
+	}
+	for i, column := range markerInvalidationColumns {
+		if _, exists := seen[column.name]; exists {
+			t.Fatalf("duplicate marker invalidation column %q", column.name)
+		}
+		seen[column.name] = struct{}{}
+		if !strings.HasPrefix(assignmentParts[i], column.name+" = CASE WHEN ") {
+			t.Fatalf("assignment %d = %q, want column %s", i, assignmentParts[i], column.name)
+		}
+		if !strings.Contains(assignmentParts[i], "media_files."+column.sourceColumn) {
+			t.Fatalf("assignment for %s does not use source column %s", column.name, column.sourceColumn)
+		}
+	}
+
+	markerBlock := strings.Split(strings.Split(fileColumns, "intro_start, ")[1], ",\n\tedition_raw")[0]
+	for _, column := range strings.Split("intro_start, "+markerBlock, ",") {
+		name := strings.TrimSpace(column)
+		if _, ok := seen[name]; !ok {
+			t.Fatalf("fileColumns marker column %q has no invalidation rule", name)
+		}
+	}
+
+	if got, want := strings.Count(assignments, markerInvalidationPredicate), len(markerInvalidationColumns); got != want {
+		t.Fatalf("shared invalidation predicate count = %d, want %d", got, want)
+	}
+	if !strings.Contains(assignments, "COALESCE(media_files.intro_markers_source, media_files.markers_source, '') <> 'manual'") {
+		t.Fatal("intro assignments do not preserve manual segment provenance")
+	}
+	if !strings.Contains(assignments, "COALESCE(media_files.markers_source, '') <> 'manual'") {
+		t.Fatal("shared assignments do not preserve manual provenance")
+	}
+}
 
 func TestRecomputeSharedMarkerAttributionPreservesHigherPrioritySegment(t *testing.T) {
 	manual := models.MarkerSourceManual


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Skip Intro could appear only intermittently, and Skip Credits could stay missing even when an online provider had useful data. The server stopped refreshing online markers too early when only one skip segment was complete. A provider result could also arrive before the player's realtime connection was ready, leaving the active session with stale ranges.

This also needed to support public read-only marker providers without exposing contribution controls or sending submission jobs to them.

## Approach

Playback-time refresh remains eligible until both intro and credits are complete from online, plugin, or manual sources. Scanner and S3 ranges remain eligible for an online upgrade. A bounded 30-minute server-side retry cache prevents partial or missing provider data from triggering a new lookup on every play.

After the first validated realtime hello on each connection, the server loads the current persisted markers and sends them only to that exact WebSocket registration. Empty rows do not emit an all-null clearing event. Per-file epochs order snapshots with concurrent marker updates, while WebSocket writes happen outside the state lock and outside the request path. Marker ranges are built once per update rather than once per session.

Replacement connections become control-ready only after their own hello. Registration, readiness, and teardown are serialized so an old connection cannot leave a replacement marked ready or clear a replacement that has already completed its hello.

Marker ranges remain tied to a file generation, but hash changes now preserve manually entered segments. The invalidation SQL is generated from one column table and one predicate, with a database-free test proving that every marker range and provenance column is covered.

Marker plugins can declare `supports_contribution=false`. Existing plugins retain contribution support by default, while fetch-only providers expose only the provider interface.

## Client coordination

- Apple follow-up: https://github.com/Silo-Server/silo-apple/pull/203
- Android phone and TV already decode the existing `markers_updated` event and apply intro, credits, recap, and preview ranges. This PR does not change that event's schema, and empty reconnect snapshots are now suppressed, so no Android change is required.
- jellycompat already serves persisted ranges through `/MediaSegments/{id}`. The native WebSocket reconciliation does not change that surface, so no jellycompat change is required.

## Performance

Playback does not wait for provider lookups. Online refresh remains background work, duplicate work is collapsed per file, and recent partial or empty online results are negatively cached in a bounded in-memory map.

Realtime reconciliation adds at most one bounded media-row read after the first hello on a connection. Admin marker saves and provider updates no longer wait for WebSocket I/O, and unrelated files no longer share one of 64 lock buckets.

## Related changes

- TheIntroDB alternate-ID fallback, caching, and Cloudflare backoff: https://github.com/Silo-Server/silo-plugin-markers-theintrodb/pull/5
- New independent IntroDB.app provider: https://github.com/blurbery/silo-plugin-markers-introdb-app
- Tested IntroDB.app v0.1.0 release: https://github.com/blurbery/silo-plugin-markers-introdb-app/releases/tag/v0.1.0
- IntroDB.app catalog entry: https://github.com/Silo-Server/silo-plugins/pull/7
- Apple prompt and reconciliation fix: https://github.com/Silo-Server/silo-apple/pull/203

## Validation

Passed on the focused PR branch:

- Targeted race suite for scanner invalidation, marker refresh/cooldown, realtime ordering, reconnect ownership, snapshot delivery, and provider registry behavior across `internal/scanner`, `internal/playback`, `internal/api/handlers`, and `internal/markers`
- `GOWORK=off go vet ./internal/scanner ./internal/playback ./internal/api/handlers ./internal/markers`
- `make verify-local-paths`
- `git diff --check`

A full non-race run of the four relevant packages passed for scanner, API handlers, and markers. The playback package reached only the repository's macOS/NVIDIA GPU-probe failures; the changed marker and realtime tests passed separately under the race detector. `GOWORK=off go build ./internal/... ./cmd/...` was not completed locally because this clean worktree does not contain the generated `web/dist` embed target. The complete Go and Web build remains covered by GitHub Actions.

The earlier implementation was also live-tested on a Silo server: playback started immediately, online markers completed in the background, and persisted intro and credit ranges were reused by later sessions. The review-fix commit itself has not been deployed.

## Risks

The online retry cache is node-local, so a multi-node deployment can make one provider attempt per node during the retry window. It is bounded to entries attempted in the last 30 minutes and requires no migration or shared cache dependency.

Live marker invalidation events may still intentionally carry null ranges when the server has removed a previously persisted marker. Only the initial reconnect snapshot suppresses an entirely empty row.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: I reviewed the complete review-fix diff against the reported data-loss and concurrency sequences, traced every changed call site, and ran the targeted race suite. That pass caught an initially unbounded negative-cache map, which was replaced with expiry pruning. I also checked manual-marker retention, source priority, stale snapshot ordering, connection replacement, all-null payload behavior, Android handling, and jellycompat parity. The optional companion-review runtime was not installed locally, so no companion model result is claimed.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request contains only the focused marker refresh and realtime reconciliation work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket clients receive persisted playback marker snapshots when connecting.
  * Marker updates are delivered in the correct order, improving playback state consistency.
  * Plugins that don’t support marker contributions are restricted to read-only access.

* **Bug Fixes**
  * Online marker lookups now retry when only partial skip markers are available, with a cooldown to prevent repeated attempts.
  * Marker snapshots are sent only once per connection and not to replaced connections.
  * Markers are cleared when a file is replaced, while manual markers are preserved.
  * Improved error details in marker provider logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->