### PR TITLE
fix(web): scope and throttle realtime media-surface invalidations

### DIFF
--- a/web/src/components/RealtimeEventsProvider.test.tsx
+++ b/web/src/components/RealtimeEventsProvider.test.tsx
@@ -1,7 +1,17 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { adminKeys, catalogKeys, libraryKeys, sectionKeys } from "@/hooks/queries/keys";
+import {
+  adminKeys,
+  catalogKeys,
+  favoriteKeys,
+  historyKeys,
+  itemKeys,
+  libraryKeys,
+  progressKeys,
+  sectionKeys,
+  watchlistKeys,
+} from "@/hooks/queries/keys";
 import { invalidateCatalogState } from "./realtimeCatalogInvalidation";
 import { buildEventsUrl, RealtimeEventsProvider } from "./RealtimeEventsProvider";
 
@@ -165,6 +175,22 @@ describe("invalidateCatalogState", () => {
   });
 });
 
+function renderProvider(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RealtimeEventsProvider>
+        <div />
+      </RealtimeEventsProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function emitSocketMessage(socket: FakeWebSocket | undefined, message: object) {
+  act(() => {
+    socket?.onmessage?.({ data: JSON.stringify(message) } as MessageEvent);
+  });
+}
+
 describe("RealtimeEventsProvider", () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
@@ -239,5 +265,115 @@ describe("RealtimeEventsProvider", () => {
     });
 
     expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("invalidates only the changed item's queries for per-item catalog events", () => {
+    const queryClient = new QueryClient();
+    renderProvider(queryClient);
+    const socket = FakeWebSocket.instances[0];
+
+    // The first event spends the throttle's leading edge on a broad pass.
+    emitSocketMessage(socket, {
+      type: "event",
+      channel: "catalog",
+      event: "catalog.item.changed",
+      data: { content_id: "prime", library_id: 3 },
+    });
+
+    queryClient.setQueryData(catalogKeys.itemDetail("target"), { content_id: "target" });
+    queryClient.setQueryData(itemKeys.watchDetail("target"), { content_id: "target" });
+    queryClient.setQueryData(favoriteKeys.check("target"), { is_favorite: false });
+    queryClient.setQueryData(watchlistKeys.check("target"), { in_watchlist: false });
+    queryClient.setQueryData(catalogKeys.itemDetail("other"), { content_id: "other" });
+    queryClient.setQueryData(catalogKeys.seriesSeasons("other"), { seasons: [] });
+
+    emitSocketMessage(socket, {
+      type: "event",
+      channel: "catalog",
+      event: "catalog.item.changed",
+      data: { content_id: "target", library_id: 3 },
+    });
+
+    expect(queryClient.getQueryState(catalogKeys.itemDetail("target"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(itemKeys.watchDetail("target"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(favoriteKeys.check("target"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(watchlistKeys.check("target"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(catalogKeys.itemDetail("other"))?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(catalogKeys.seriesSeasons("other"))?.isInvalidated).toBe(
+      false,
+    );
+
+    // The trailing broad pass still refreshes everything once per window.
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(queryClient.getQueryState(catalogKeys.itemDetail("other"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(catalogKeys.seriesSeasons("other"))?.isInvalidated).toBe(true);
+  });
+
+  it("keeps catalog surfaces untouched for user_state progress events", () => {
+    const queryClient = new QueryClient();
+    renderProvider(queryClient);
+    const socket = FakeWebSocket.instances[0];
+
+    const browseKey = itemKeys.browse({
+      q: "",
+      type: "all",
+      sort: "created_at",
+      order: "desc",
+      offset: 0,
+      limit: 20,
+    });
+    const catalogListKey = catalogKeys.list({ source: "query", q: "star", limit: 20, offset: 0 });
+    queryClient.setQueryData(browseKey, { items: [] });
+    queryClient.setQueryData(catalogListKey, { items: [] });
+    queryClient.setQueryData(progressKeys.list(), { progress: [] });
+    queryClient.setQueryData(historyKeys.list(), { items: [] });
+    queryClient.setQueryData(sectionKeys.homeItems("continue"), { section: null });
+    queryClient.setQueryData(favoriteKeys.list(), { items: [] });
+    queryClient.setQueryData(catalogKeys.itemDetail("target"), { content_id: "target" });
+    queryClient.setQueryData(catalogKeys.seriesSeasons("show"), { seasons: [] });
+    queryClient.setQueryData(catalogKeys.seasonEpisodes("show", 1), { episodes: [] });
+    queryClient.setQueryData(catalogKeys.itemEpisodes("show"), { episodes: [] });
+    queryClient.setQueryData(catalogKeys.seriesSeasons("other-show"), { seasons: [] });
+
+    emitSocketMessage(socket, {
+      type: "event",
+      channel: "user_state",
+      event: "user_state.changed",
+      data: {
+        profile_id: "profile-1",
+        content_id: "target",
+        series_id: "show",
+        change: "progress",
+      },
+    });
+
+    expect(queryClient.getQueryState(progressKeys.list())?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(historyKeys.list())?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(sectionKeys.homeItems("continue"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(catalogKeys.itemDetail("target"))?.isInvalidated).toBe(true);
+    // The episode's series refreshes immediately so an open series page's
+    // watched ticks and season counters track playback on another device.
+    expect(queryClient.getQueryState(catalogKeys.seriesSeasons("show"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(catalogKeys.seasonEpisodes("show", 1))?.isInvalidated).toBe(
+      true,
+    );
+    expect(queryClient.getQueryState(catalogKeys.itemEpisodes("show"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(catalogKeys.seriesSeasons("other-show"))?.isInvalidated).toBe(
+      false,
+    );
+    expect(queryClient.getQueryState(browseKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(catalogListKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(favoriteKeys.list())?.isInvalidated).toBe(false);
+
+    // The remaining watch-state surfaces (browse grids, catalog lists) catch
+    // up through the trailing-only broad throttle instead of staying stale
+    // forever — threshold completion emits only change:"progress".
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(queryClient.getQueryState(browseKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(catalogListKey)?.isInvalidated).toBe(true);
   });
 });

--- a/web/src/components/RealtimeEventsProvider.throttle.test.tsx
+++ b/web/src/components/RealtimeEventsProvider.throttle.test.tsx
@@ -1,0 +1,223 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invalidateCatalogState } from "./realtimeCatalogInvalidation";
+import { RealtimeEventsProvider } from "./RealtimeEventsProvider";
+
+vi.mock("./realtimeCatalogInvalidation", () => ({
+  invalidateCatalogState: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAuth", () => {
+  const useAuth = () => ({
+    user: {
+      id: 1,
+      username: "admin",
+      email: "admin@example.com",
+      role: "admin",
+      permissions: [],
+      download_allowed: true,
+    },
+    profile: null,
+  });
+  return { useAuth, useOptionalAuth: useAuth };
+});
+
+const mockPageActivity = vi.hoisted(() => ({
+  isVisible: true,
+  isFocused: true,
+  isFrozen: false,
+  canPollDashboard: true,
+  canApplyRealtimeUpdates: true,
+}));
+
+vi.mock("@/hooks/usePageActivity", () => ({
+  usePageActivity: () => ({ ...mockPageActivity }),
+}));
+
+vi.mock("react-router", () => ({
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  readyState = FakeWebSocket.CONNECTING;
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send() {}
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+}
+
+function renderProvider() {
+  const queryClient = new QueryClient();
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <RealtimeEventsProvider>
+        <div />
+      </RealtimeEventsProvider>
+    </QueryClientProvider>,
+  );
+  const rerender = () =>
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <RealtimeEventsProvider>
+          <div />
+        </RealtimeEventsProvider>
+      </QueryClientProvider>,
+    );
+  return { view, rerender, socket: FakeWebSocket.instances[0] };
+}
+
+function emitCatalogEvent(socket: FakeWebSocket | undefined, event: string, data: object) {
+  act(() => {
+    socket?.onmessage?.({
+      data: JSON.stringify({ type: "event", channel: "catalog", event, data }),
+    } as MessageEvent);
+  });
+}
+
+describe("RealtimeEventsProvider broad catalog throttle", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.useFakeTimers();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    vi.mocked(invalidateCatalogState).mockClear();
+    mockPageActivity.canApplyRealtimeUpdates = true;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("coalesces a catalog event burst into one leading and one trailing pass", () => {
+    const { socket } = renderProvider();
+
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "a", library_id: 3 });
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "b", library_id: 3 });
+    emitCatalogEvent(socket, "catalog.library.changed", { library_id: 5 });
+
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(invalidateCatalogState).mock.calls[0]?.[1]).toMatchObject({
+      libraryId: 3,
+      includeLibraryLists: false,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(2);
+    const trailing = vi.mocked(invalidateCatalogState).mock.calls[1]?.[1];
+    // Coalesced options: differing library ids collapse to all libraries and
+    // includeLibraryLists ORs to true.
+    expect(trailing?.libraryId).toBeUndefined();
+    expect(trailing?.includeLibraryLists).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires a fresh leading pass once the window after the trailing pass closes", () => {
+    const { socket } = renderProvider();
+
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "a", library_id: 3 });
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "b", library_id: 3 });
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(2);
+
+    // A wedged throttle (timer never cleared, lastRunAt never reset) would
+    // swallow every later broad pass; a fresh event after the window must
+    // fire the leading edge again.
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    emitCatalogEvent(socket, "catalog.library.changed", { library_id: 5 });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips the trailing pass while realtime updates are suppressed", () => {
+    const { rerender, socket } = renderProvider();
+
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "a", library_id: 3 });
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "b", library_id: 3 });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(1);
+
+    // Hide the tab before the trailing timer fires: the pass is dropped like
+    // any other realtime update (the catch-up-on-focus refetch covers it).
+    act(() => {
+      mockPageActivity.canApplyRealtimeUpdates = false;
+      rerender();
+    });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the throttle when a job-terminal pass runs", () => {
+    const { socket } = renderProvider();
+
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "a", library_id: 3 });
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "b", library_id: 3 });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(1);
+
+    // catalog_import completion sweeps everything immediately and must
+    // swallow the pending trailing pass instead of running a second full
+    // sweep moments later.
+    act(() => {
+      socket?.onmessage?.({
+        data: JSON.stringify({
+          type: "event",
+          channel: "jobs",
+          event: "job.completed",
+          data: {
+            id: "job-1",
+            job_type: "catalog_import",
+            status: "completed",
+            requested_at: "2026-08-27T00:00:00Z",
+          },
+        }),
+      } as MessageEvent);
+    });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops the pending trailing pass on unmount", () => {
+    const { view, socket } = renderProvider();
+
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "a", library_id: 3 });
+    emitCatalogEvent(socket, "catalog.item.changed", { content_id: "b", library_id: 3 });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(invalidateCatalogState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/RealtimeEventsProvider.tsx
+++ b/web/src/components/RealtimeEventsProvider.tsx
@@ -33,9 +33,18 @@ import { invalidateCatalogState } from "@/components/realtimeCatalogInvalidation
 import { useAuth } from "@/hooks/useAuth";
 import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
 import { usePageActivity } from "@/hooks/usePageActivity";
-import { adminKeys, historyImportKeys, libraryKeys } from "@/hooks/queries/keys";
 import {
+  adminKeys,
+  historyImportKeys,
+  historyKeys,
+  libraryKeys,
+  progressKeys,
+  sectionKeys,
+} from "@/hooks/queries/keys";
+import {
+  invalidateItemScopedQueries,
   invalidateMediaSurfaceQueries,
+  invalidateSeriesScopedQueries,
   updateCatalogItemDetail,
 } from "@/hooks/queries/mediaSurfaceRefresh";
 import { bumpHomeRefreshSignal } from "@/pages/homeSurfaceRefresh";
@@ -64,7 +73,35 @@ const CATALOG_ITEM_CHANGED_EVENTS = new Set([
   "library.item_added",
   "metadata.updated",
 ]);
-const SCOPED_CATALOG_LIBRARY_EVENTS = new Set(["catalog.library.changed", "library.changed"]);
+// Broad catalog invalidations refetch every active media surface. Metadata
+// enrichment and scans publish per-item events in bursts, so realtime-driven
+// broad passes are throttled to one leading + one trailing run per window;
+// only per-item invalidations fire immediately (#796).
+const CATALOG_BROAD_INVALIDATE_THROTTLE_MS = 15_000;
+
+interface BroadCatalogInvalidateOptions {
+  libraryId?: number;
+  allowDashboardRefetch: boolean;
+  includeLibraryLists: boolean;
+}
+
+function mergeBroadCatalogOptions(
+  current: BroadCatalogInvalidateOptions | null,
+  next: BroadCatalogInvalidateOptions,
+): BroadCatalogInvalidateOptions {
+  if (!current) {
+    return next;
+  }
+  return {
+    // Differing libraries collapse to undefined (all libraries): tracking a
+    // set of ids across the throttle window isn't worth the complexity for
+    // one coalesced refresh.
+    libraryId: current.libraryId === next.libraryId ? current.libraryId : undefined,
+    allowDashboardRefetch: current.allowDashboardRefetch || next.allowDashboardRefetch,
+    includeLibraryLists: current.includeLibraryLists || next.includeLibraryLists,
+  };
+}
+
 const DASHBOARD_QUERY_KEYS = [
   adminKeys.stats(),
   adminKeys.sessions(),
@@ -281,6 +318,7 @@ function handleJobSideEffects(
   job: AdminJob,
   eventName: string,
   allowDashboardRefetch: boolean,
+  runBroadCatalogInvalidation: (options: { allowDashboardRefetch: boolean }) => void,
 ) {
   if (job.job_type === "delete_library") {
     void queryClient.invalidateQueries({
@@ -290,12 +328,14 @@ function handleJobSideEffects(
     void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
   }
 
-  if (eventName === "job.completed" && job.job_type === "catalog_import") {
-    invalidateCatalogState(queryClient, { allowDashboardRefetch });
-  }
-
-  if (eventName === "job.completed" && job.job_type === "delete_library") {
-    invalidateCatalogState(queryClient, { allowDashboardRefetch });
+  if (
+    eventName === "job.completed" &&
+    (job.job_type === "catalog_import" || job.job_type === "delete_library")
+  ) {
+    // Job-terminal passes run immediately (one-shot events, not bursts) but
+    // reset the broad-catalog throttle so a pending trailing pass from the
+    // same import's event burst doesn't repeat the full sweep moments later.
+    runBroadCatalogInvalidation({ allowDashboardRefetch });
   }
 }
 
@@ -403,6 +443,7 @@ function handleUserStateEvent(
   payload: UserStatePayload,
   activeProfileID: string | null | undefined,
   allowDashboardRefetch: boolean,
+  scheduleBroadCatalogRefresh: (options: BroadCatalogInvalidateOptions) => void,
 ) {
   if (payload.profile_id && activeProfileID && payload.profile_id !== activeProfileID) {
     return;
@@ -419,12 +460,41 @@ function handleUserStateEvent(
     }));
   }
 
-  void invalidateMediaSurfaceQueries(
-    queryClient,
-    payload.content_id ? { itemId: payload.content_id } : {},
-  ).then(() => {
-    bumpHomeRefreshSignal(queryClient);
-  });
+  if (payload.change === "progress") {
+    // Progress events arrive continuously while any device is playing; a
+    // broad media-surface invalidation here refetches the open player's
+    // metadata queries and competes with segment downloads (#796). Touch only
+    // the progress-driven surfaces, the item, and its series immediately —
+    // the remaining watch-state surfaces (browse grids, catalog lists,
+    // watched-filtered collections) catch up through the trailing-only broad
+    // throttle instead of going permanently stale: threshold-based completion
+    // emits only change:"progress", never "watched".
+    const invalidations: Array<Promise<void>> = [
+      queryClient.invalidateQueries({ queryKey: progressKeys.all }),
+      queryClient.invalidateQueries({ queryKey: historyKeys.all }),
+      queryClient.invalidateQueries({ queryKey: sectionKeys.all }),
+    ];
+    if (payload.content_id) {
+      invalidations.push(invalidateItemScopedQueries(queryClient, payload.content_id));
+    }
+    if (payload.series_id) {
+      invalidations.push(invalidateSeriesScopedQueries(queryClient, payload.series_id));
+    }
+    void Promise.all(invalidations).then(() => {
+      bumpHomeRefreshSignal(queryClient);
+    });
+    scheduleBroadCatalogRefresh({
+      allowDashboardRefetch,
+      includeLibraryLists: false,
+    });
+  } else {
+    void invalidateMediaSurfaceQueries(
+      queryClient,
+      payload.content_id ? { itemId: payload.content_id } : {},
+    ).then(() => {
+      bumpHomeRefreshSignal(queryClient);
+    });
+  }
   void queryClient.invalidateQueries({
     queryKey: adminKeys.stats(),
     refetchType: allowDashboardRefetch ? "active" : "none",
@@ -455,6 +525,11 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
   const canApplyRealtimeUpdatesRef = useRef(pageActivity.canApplyRealtimeUpdates);
   const allowDashboardRealtimeUpdatesRef = useRef(allowDashboardRealtimeUpdates);
   const shouldCatchUpOnFocusRef = useRef(!pageActivity.canApplyRealtimeUpdates);
+  const broadCatalogThrottleRef = useRef<{
+    lastRunAt: number;
+    timerId: number | undefined;
+    pending: BroadCatalogInvalidateOptions | null;
+  }>({ lastRunAt: 0, timerId: undefined, pending: null });
 
   activeProfileIDRef.current = profile?.id;
   canApplyRealtimeUpdatesRef.current = pageActivity.canApplyRealtimeUpdates;
@@ -536,6 +611,75 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
     },
     [sendSubscribe],
   );
+
+  // Leading edge fires immediately; events arriving during the window merge
+  // into a single trailing pass with the coalesced options. `trailingOnly`
+  // (progress-driven catch-up) never spends the leading edge: the broad pass
+  // always lands a full window after the event, so continuous playback costs
+  // at most one broad refresh per window and none immediately.
+  function scheduleBroadCatalogInvalidation(
+    options: BroadCatalogInvalidateOptions,
+    { trailingOnly = false }: { trailingOnly?: boolean } = {},
+  ) {
+    const throttle = broadCatalogThrottleRef.current;
+    const now = Date.now();
+    const remainder = Math.max(
+      0,
+      CATALOG_BROAD_INVALIDATE_THROTTLE_MS - (now - throttle.lastRunAt),
+    );
+    if (!trailingOnly && throttle.timerId === undefined && remainder === 0) {
+      throttle.lastRunAt = now;
+      invalidateCatalogState(queryClient, options);
+      return;
+    }
+    throttle.pending = mergeBroadCatalogOptions(throttle.pending, options);
+    if (throttle.timerId === undefined) {
+      throttle.timerId = window.setTimeout(
+        () => {
+          throttle.timerId = undefined;
+          const pending = throttle.pending;
+          throttle.pending = null;
+          if (!canApplyRealtimeUpdatesRef.current) {
+            // A hidden/frozen tab drops the pass the same way onmessage drops
+            // events; the catch-up-on-focus refetch covers it on return.
+            // lastRunAt stays untouched so the next event after refocus gets
+            // an immediate leading pass.
+            return;
+          }
+          throttle.lastRunAt = Date.now();
+          if (pending) {
+            invalidateCatalogState(queryClient, pending);
+          }
+        },
+        remainder > 0 ? remainder : CATALOG_BROAD_INVALIDATE_THROTTLE_MS,
+      );
+    }
+  }
+
+  // Immediate broad pass for one-shot triggers (job completion). Resets the
+  // throttle window and swallows any pending trailing pass — this full
+  // unscoped sweep is a superset of every coalesced option set.
+  function runBroadCatalogInvalidationNow(options: { allowDashboardRefetch: boolean }) {
+    const throttle = broadCatalogThrottleRef.current;
+    if (throttle.timerId !== undefined) {
+      window.clearTimeout(throttle.timerId);
+      throttle.timerId = undefined;
+    }
+    throttle.pending = null;
+    throttle.lastRunAt = Date.now();
+    invalidateCatalogState(queryClient, options);
+  }
+
+  useEffect(() => {
+    const throttle = broadCatalogThrottleRef.current;
+    return () => {
+      if (throttle.timerId !== undefined) {
+        window.clearTimeout(throttle.timerId);
+        throttle.timerId = undefined;
+        throttle.pending = null;
+      }
+    };
+  }, []);
 
   function dispatchChannelMessage(
     channel: EventChannel,
@@ -641,24 +785,26 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
         {
           const eventLibraryID = catalogEventLibraryID(message.data);
           if (CATALOG_ITEM_CHANGED_EVENTS.has(message.event)) {
-            invalidateCatalogState(queryClient, {
-              itemId:
-                typeof message.data === "object" && message.data && "content_id" in message.data
-                  ? (message.data as { content_id?: string }).content_id
-                  : undefined,
+            const contentID =
+              typeof message.data === "object" && message.data && "content_id" in message.data
+                ? (message.data as { content_id?: string }).content_id
+                : undefined;
+            // Refresh the changed item right away; the broad surface refresh
+            // (lists, sections, home) rides the throttle so per-item bursts
+            // don't starve an open player of bandwidth.
+            if (contentID) {
+              void invalidateItemScopedQueries(queryClient, contentID);
+            }
+            scheduleBroadCatalogInvalidation({
               libraryId: eventLibraryID,
               allowDashboardRefetch: allowDashboardRealtimeUpdatesRef.current,
               includeLibraryLists: false,
             });
-          } else if (SCOPED_CATALOG_LIBRARY_EVENTS.has(message.event) && eventLibraryID) {
-            invalidateCatalogState(queryClient, {
-              libraryId: eventLibraryID,
-              allowDashboardRefetch: allowDashboardRealtimeUpdatesRef.current,
-            });
           } else {
-            invalidateCatalogState(queryClient, {
+            scheduleBroadCatalogInvalidation({
               libraryId: eventLibraryID,
               allowDashboardRefetch: allowDashboardRealtimeUpdatesRef.current,
+              includeLibraryLists: true,
             });
           }
         }
@@ -670,6 +816,7 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
           message.data as AdminJob,
           message.event,
           allowDashboardRealtimeUpdatesRef.current,
+          runBroadCatalogInvalidationNow,
         );
         settleWaiterRef.current(message.data as AdminJob);
         break;
@@ -707,6 +854,7 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
           message.data as UserStatePayload,
           activeProfileIDRef.current,
           allowDashboardRealtimeUpdatesRef.current,
+          (options) => scheduleBroadCatalogInvalidation(options, { trailingOnly: true }),
         );
         break;
       case "notifications":

--- a/web/src/hooks/queries/mediaSurfaceRefresh.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.ts
@@ -98,6 +98,36 @@ export function isItemDetailQueryKey(queryKey: unknown, itemId: string) {
   );
 }
 
+/** Invalidates only the queries scoped to a single item: both item-detail key
+ * shapes, the watch detail, and the favorite/watchlist membership checks. */
+export function invalidateItemScopedQueries(
+  queryClient: QueryClient,
+  itemId: string,
+): Promise<void> {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["catalog", "items", itemId, "detail"] }),
+    queryClient.invalidateQueries({ queryKey: ["items", "detail", itemId] }),
+    queryClient.invalidateQueries({ queryKey: ["items", "watchDetail", itemId] }),
+    queryClient.invalidateQueries({ queryKey: favoriteKeys.check(itemId) }),
+    queryClient.invalidateQueries({ queryKey: watchlistKeys.check(itemId) }),
+  ]).then(() => undefined);
+}
+
+/** Invalidates the series-level surfaces that render per-episode watch state
+ * (season/episode lists and the series' own item queries), so a progress
+ * change on one episode refreshes an open series page without a broad
+ * media-surface pass. */
+export function invalidateSeriesScopedQueries(
+  queryClient: QueryClient,
+  seriesId: string,
+): Promise<void> {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["catalog", "series", seriesId] }),
+    queryClient.invalidateQueries({ queryKey: ["catalog", "items", seriesId] }),
+    invalidateItemScopedQueries(queryClient, seriesId),
+  ]).then(() => undefined);
+}
+
 export async function invalidateMediaSurfaceQueries(
   queryClient: QueryClient,
   options: InvalidateMediaSurfaceOptions = {},
@@ -132,13 +162,7 @@ export async function invalidateMediaSurfaceQueries(
   ];
 
   if (options.itemId) {
-    invalidations.push(
-      queryClient.invalidateQueries({ queryKey: ["catalog", "items", options.itemId, "detail"] }),
-      queryClient.invalidateQueries({ queryKey: ["items", "detail", options.itemId] }),
-      queryClient.invalidateQueries({ queryKey: ["items", "watchDetail", options.itemId] }),
-      queryClient.invalidateQueries({ queryKey: favoriteKeys.check(options.itemId) }),
-      queryClient.invalidateQueries({ queryKey: watchlistKeys.check(options.itemId) }),
-    );
+    invalidations.push(invalidateItemScopedQueries(queryClient, options.itemId));
   }
 
   for (const key of options.watchedKeys ?? []) {


### PR DESCRIPTION
## Problem

During web playback, the network log fills with repeated identical batches of metadata requests (watch detail, `seasons`, two `episodes` fetches) and the video buffers. Root cause: `RealtimeEventsProvider` responded to **every** realtime `catalog` and `user_state` websocket event by calling `invalidateMediaSurfaceQueries`, which invalidates `itemKeys.all`, `catalogKeys.all`, sections, progress, history, favorites, watchlist, recs, and persons — unscoped. React Query immediately refetches invalidated active queries, so any background catalog churn (metadata worker publishing `catalog.item.changed` per enriched item, scans, another device's progress sync) turned into per-event refetch bursts on the watch page that compete with HLS segment downloads. The queries' 5-minute `staleTime` was defeated entirely.

## Approach

Web frontend only; no API or server change.

- **Per-item catalog events** (`catalog.item.changed`, `metadata.updated`, `library.item_added`) invalidate only the changed item's queries immediately (new `invalidateItemScopedQueries`, extracted from the existing per-item block so key literals aren't duplicated).
- **Broad surface refreshes** (lists, sections, home) ride a per-provider throttle: at most one leading + one trailing `invalidateCatalogState` pass per 15s window, with coalesced options (differing library ids collapse to all-libraries; boolean flags OR together). The trailing timer is dropped while the tab is hidden (the catch-up-on-focus refetch covers it) and cleared on unmount.
- **`user_state` progress events** — continuous while any device plays — now touch only progress/history/section surfaces, the item, and its series (`invalidateSeriesScopedQueries`, so an open series page's episode ticks still refresh), plus a trailing-only throttled broad pass so browse grids and watched-filtered collections catch up within 15s instead of going permanently stale. Threshold-based completion emits only `change:"progress"`, so the trailing pass is what keeps those surfaces converging. Other `user_state` kinds (favorite/watchlist/watched) keep immediate behavior.
- **Job-terminal passes** (`catalog_import`/`delete_library` completion) still run immediately but reset the throttle and swallow any pending trailing pass, avoiding a redundant back-to-back full sweep.
- Direct user mutations (favorites, watchlist, history, dismissals, taste seed) are untouched and keep immediate unthrottled invalidation.

Net effect during playback with catalog churn: one 4-request metadata batch per 15s worst case, instead of one per event.

## Evidence

Focused tests (3 files, 19 tests, includes new coverage for per-item scoping, throttle leading/trailing/recovery, hidden-tab suppression, job-terminal reset, and progress-event narrowing):

```
Test Files  3 passed (3)
     Tests  19 passed (19)
```

`npx tsc -b` clean; `npx prettier --check` clean on all touched files; ESLint on touched files: 0 errors, 7 pre-existing warnings untouched by this change. No entries added to `WEBTEST_KNOWN_FAILURES`.

Not run: full `make test-go` (no Go changes) and manual playback-under-scan reproduction on a live deployment — the fix is validated by unit tests asserting invalidation behavior.

## Risks / follow-ups

- Server publish sites currently pass an empty `series_id` in `publishUserStateEvent` (e.g. `internal/api/handlers/progress.go`), so the series-scoped immediate invalidation is inert until the server populates it; the trailing throttled pass covers the gap today. Populating `series_id` is a small server-side follow-up.
- Progress events for the *same series* from another device invalidate series-scoped keys per event (unthrottled) — bounded to one series' queries, kept immediate so open series pages update promptly.
- Surfaces refreshed by broad passes now update up to 15s later during event bursts; per-item and progress surfaces still update immediately.
- Worth checking whether `silo-apple`/`silo-android` have an equivalent invalidate-everything pattern in their realtime handling; this PR is web-only.

Related issue: #796

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-fable-5[1m]
- Involvement: Fully AI-generated, human verified
- Adversarial review: three independent review passes over the full diff (freshness-regression lens tracing every surface that previously updated instantly; timing/lifecycle lens on the throttle state machine; test-adequacy lens). 5 findings, all resolved: permanent staleness of series/browse watch-state on progress-driven completion (fixed via series-scoped invalidation + trailing-only catch-up), trailing timer escaping the page-activity gate (fixed), ignored `series_id` (fixed), job-terminal pass doubling with a pending trailing pass (fixed), and a missing throttle-recovery test (added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)