### PR TITLE
fix(auth): serialize initial administrator setup

### DIFF
--- a/internal/auth/account_provisioner.go
+++ b/internal/auth/account_provisioner.go
@@ -14,6 +14,10 @@ type AccountUserRepository interface {
 	Delete(ctx context.Context, id int) error
 }
 
+type initialAccountUserRepository interface {
+	CreateInitial(ctx context.Context, input models.CreateUserInput) (*models.User, error)
+}
+
 type DefaultProfileOptions struct {
 	Enabled bool
 	Name    string
@@ -43,7 +47,28 @@ func (p *AccountProvisioner) CreateAccount(
 	ctx context.Context,
 	input CreateAccountInput,
 ) (*models.User, error) {
-	user, err := p.users.Create(ctx, input.User)
+	return p.createAccount(ctx, input, p.users.Create)
+}
+
+// CreateInitialAccount provisions the first account through the repository's
+// database-enforced empty-table claim, then applies the normal profile flow.
+func (p *AccountProvisioner) CreateInitialAccount(
+	ctx context.Context,
+	input CreateAccountInput,
+) (*models.User, error) {
+	initialUsers, ok := p.users.(initialAccountUserRepository)
+	if !ok {
+		return nil, fmt.Errorf("initial account creation unavailable")
+	}
+	return p.createAccount(ctx, input, initialUsers.CreateInitial)
+}
+
+func (p *AccountProvisioner) createAccount(
+	ctx context.Context,
+	input CreateAccountInput,
+	createUser func(context.Context, models.CreateUserInput) (*models.User, error),
+) (*models.User, error) {
+	user, err := createUser(ctx, input.User)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/auth/account_provisioner_test.go
+++ b/internal/auth/account_provisioner_test.go
@@ -10,11 +10,19 @@ import (
 )
 
 type stubAccountUsers struct {
-	createFn func(context.Context, models.CreateUserInput) (*models.User, error)
-	deleteFn func(context.Context, int) error
+	createFn        func(context.Context, models.CreateUserInput) (*models.User, error)
+	createInitialFn func(context.Context, models.CreateUserInput) (*models.User, error)
+	deleteFn        func(context.Context, int) error
 }
 
 func (s stubAccountUsers) Create(ctx context.Context, input models.CreateUserInput) (*models.User, error) {
+	return s.createFn(ctx, input)
+}
+
+func (s stubAccountUsers) CreateInitial(ctx context.Context, input models.CreateUserInput) (*models.User, error) {
+	if s.createInitialFn != nil {
+		return s.createInitialFn(ctx, input)
+	}
 	return s.createFn(ctx, input)
 }
 

--- a/internal/auth/repository.go
+++ b/internal/auth/repository.go
@@ -43,6 +43,10 @@ type UserRepository struct {
 	pool *pgxpool.Pool
 }
 
+type userRowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
 // NewUserRepository creates a new UserRepository backed by the given pool.
 func NewUserRepository(pool *pgxpool.Pool) *UserRepository {
 	return &UserRepository{pool: pool}
@@ -133,6 +137,48 @@ func scanUsers(rows pgx.Rows) ([]*models.User, error) {
 
 // Create inserts a new user with a bcrypt-hashed password and returns the created user.
 func (r *UserRepository) Create(ctx context.Context, input models.CreateUserInput) (*models.User, error) {
+	return r.createWithQuerier(ctx, r.pool, input)
+}
+
+// CreateInitial inserts the first user only while the users table is still
+// empty. The table lock, emptiness check, and insert share one transaction so
+// setup is linearizable across Silo nodes and competing account-creation paths.
+func (r *UserRepository) CreateInitial(ctx context.Context, input models.CreateUserInput) (*models.User, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning initial user creation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// SHARE ROW EXCLUSIVE conflicts with the ROW EXCLUSIVE lock taken by every
+	// INSERT, while still allowing setup-status reads during the short claim.
+	if _, err := tx.Exec(ctx, "LOCK TABLE users IN SHARE ROW EXCLUSIVE MODE"); err != nil {
+		return nil, fmt.Errorf("locking users for initial creation: %w", err)
+	}
+
+	var usersExist bool
+	if err := tx.QueryRow(ctx, "SELECT EXISTS (SELECT 1 FROM users)").Scan(&usersExist); err != nil {
+		return nil, fmt.Errorf("checking for existing users: %w", err)
+	}
+	if usersExist {
+		return nil, ErrSetupAlreadyComplete
+	}
+
+	user, err := r.createWithQuerier(ctx, tx, input)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("committing initial user creation: %w", err)
+	}
+	return user, nil
+}
+
+func (r *UserRepository) createWithQuerier(
+	ctx context.Context,
+	db userRowQuerier,
+	input models.CreateUserInput,
+) (*models.User, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(input.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, fmt.Errorf("hashing password: %w", err)
@@ -212,7 +258,7 @@ func (r *UserRepository) Create(ctx context.Context, input models.CreateUserInpu
 		allColumns,
 	)
 
-	row := r.pool.QueryRow(ctx, query, args...)
+	row := db.QueryRow(ctx, query, args...)
 
 	user, err := scanUser(row)
 	if err != nil {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -306,7 +306,7 @@ func (s *Service) SetupInitialUser(
 		return nil, nil, ErrSetupAlreadyComplete
 	}
 
-	if _, err := s.accounts.CreateAccount(ctx, CreateAccountInput{
+	if _, err := s.accounts.CreateInitialAccount(ctx, CreateAccountInput{
 		User: models.CreateUserInput{
 			Username: username,
 			Email:    email,

--- a/internal/auth/service_setup_test.go
+++ b/internal/auth/service_setup_test.go
@@ -1,0 +1,201 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type setupCountTraceKey struct{}
+
+// setupCountBarrier holds both setup attempts after PostgreSQL has answered
+// their initial zero-user query. Releasing them together deterministically
+// exercises the check-to-create interleaving that the setup lock must close.
+type setupCountBarrier struct {
+	mu      sync.Mutex
+	reached int
+	release chan struct{}
+}
+
+func newSetupCountBarrier() *setupCountBarrier {
+	return &setupCountBarrier{release: make(chan struct{})}
+}
+
+func (b *setupCountBarrier) TraceQueryStart(
+	ctx context.Context,
+	_ *pgx.Conn,
+	data pgx.TraceQueryStartData,
+) context.Context {
+	if strings.Contains(data.SQL, "SELECT COUNT(*) FROM users") {
+		return context.WithValue(ctx, setupCountTraceKey{}, true)
+	}
+	return ctx
+}
+
+func (b *setupCountBarrier) TraceQueryEnd(
+	ctx context.Context,
+	_ *pgx.Conn,
+	_ pgx.TraceQueryEndData,
+) {
+	if traced, _ := ctx.Value(setupCountTraceKey{}).(bool); !traced {
+		return
+	}
+
+	b.mu.Lock()
+	b.reached++
+	if b.reached == 2 {
+		close(b.release)
+	}
+	release := b.release
+	b.mu.Unlock()
+
+	select {
+	case <-release:
+	case <-ctx.Done():
+	}
+}
+
+func TestSetupInitialUserConcurrentAcrossPoolsDB(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := t.Context()
+
+	controlPool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect control pool: %v", err)
+	}
+	t.Cleanup(controlPool.Close)
+
+	var existingUsers int
+	if err := controlPool.QueryRow(ctx, "SELECT COUNT(*) FROM users").Scan(&existingUsers); err != nil {
+		t.Fatalf("count existing users: %v", err)
+	}
+	if existingUsers != 0 {
+		t.Skipf("setup concurrency test requires an empty dedicated database; found %d users", existingUsers)
+	}
+
+	prefix := fmt.Sprintf("setup-race-test-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = controlPool.Exec(cleanupCtx, "DELETE FROM users WHERE username LIKE $1", prefix+"%")
+	})
+
+	barrier := newSetupCountBarrier()
+	newTracedPool := func() *pgxpool.Pool {
+		config, err := pgxpool.ParseConfig(dsn)
+		if err != nil {
+			t.Fatalf("parse test database URL: %v", err)
+		}
+		config.ConnConfig.Tracer = barrier
+		config.MaxConns = 1
+		pool, err := pgxpool.NewWithConfig(ctx, config)
+		if err != nil {
+			t.Fatalf("connect traced pool: %v", err)
+		}
+		t.Cleanup(pool.Close)
+		return pool
+	}
+
+	newSetupService := func(pool *pgxpool.Pool) *Service {
+		users := NewUserRepository(pool)
+		sessions := NewSessionRepository(pool)
+		provider := NewLocalProvider(users, sessions)
+		jwt := NewJWTService("setup-race-test-secret", time.Minute, time.Hour)
+		return NewService(provider, jwt, sessions, users, nil, nil, nil)
+	}
+
+	type setupAttempt struct {
+		service  *Service
+		username string
+		email    string
+	}
+	type setupResult struct {
+		pair *TokenPair
+		err  error
+	}
+
+	attempts := []setupAttempt{
+		{service: newSetupService(newTracedPool()), username: prefix + "-a", email: prefix + "-a@example.invalid"},
+		{service: newSetupService(newTracedPool()), username: prefix + "-b", email: prefix + "-b@example.invalid"},
+	}
+	results := make([]setupResult, len(attempts))
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range attempts {
+		wg.Go(func() {
+			<-start
+			attempt := attempts[i]
+			pair, _, err := attempt.service.SetupInitialUser(
+				ctx,
+				attempt.username,
+				attempt.email,
+				"synthetic-test-password",
+				false,
+				"",
+				"setup-race-test",
+				"127.0.0.1",
+			)
+			results[i] = setupResult{pair: pair, err: err}
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	var successes, setupComplete int
+	for _, result := range results {
+		switch {
+		case result.err == nil && result.pair != nil:
+			successes++
+		case errors.Is(result.err, ErrSetupAlreadyComplete) && result.pair == nil:
+			setupComplete++
+		default:
+			t.Fatalf("unexpected setup result: pair nil = %v, error = %v", result.pair == nil, result.err)
+		}
+	}
+	if successes != 1 || setupComplete != 1 {
+		t.Fatalf("setup results: successes=%d setup_complete=%d, want 1 and 1", successes, setupComplete)
+	}
+
+	var users, admins, sessions int
+	if err := controlPool.QueryRow(ctx, `
+		SELECT count(*), count(*) FILTER (WHERE role = 'admin')
+		FROM users
+		WHERE username LIKE $1`, prefix+"%").Scan(&users, &admins); err != nil {
+		t.Fatalf("count setup users: %v", err)
+	}
+	if err := controlPool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM auth_sessions AS sessions
+		JOIN users ON users.id = sessions.user_id
+		WHERE users.username LIKE $1`, prefix+"%").Scan(&sessions); err != nil {
+		t.Fatalf("count setup sessions: %v", err)
+	}
+	if users != 1 || admins != 1 || sessions != 1 {
+		t.Fatalf("persisted setup state: users=%d admins=%d sessions=%d, want 1 each", users, admins, sessions)
+	}
+
+	pair, user, err := attempts[0].service.SetupInitialUser(
+		ctx,
+		prefix+"-later",
+		prefix+"-later@example.invalid",
+		"synthetic-test-password",
+		false,
+		"",
+		"setup-race-test",
+		"127.0.0.1",
+	)
+	if !errors.Is(err, ErrSetupAlreadyComplete) || pair != nil || user != nil {
+		t.Fatalf("later setup = (%v, %v, %v), want setup already complete", pair, user, err)
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: N/A — audit-validated security fix

`POST /api/v1/auth/setup` checked whether any users existed and created the first administrator in separate autocommit operations. Two requests could both observe an empty `users` table, then create different administrator accounts and login sessions.

The finding was reproduced on fresh `origin/main` at `8164fd594b9fdd8c1944bb0b6251f2d00e4a24ca`: two synchronized setup requests both returned `201`, leaving two administrators and two sessions.

## Approach

Add a repository operation dedicated to first-user creation. It opens a PostgreSQL transaction, takes a `SHARE ROW EXCLUSIVE` lock on `users`, rechecks that the table is empty, inserts through the same transaction, and commits. Competing setup requests and ordinary user writers therefore serialize on the database connection that owns the transaction. If the connection is lost, PostgreSQL rolls the transaction back and releases the lock.

The normal account-provisioning path is unchanged. Initial setup reuses its profile creation and cleanup flow but selects the database-enforced first-user operation. No migration or API shape change is required.

The regression test uses two independent one-connection pools. A query tracer holds both setup attempts after their initial zero-user checks and releases them together. It asserts one token-pair success, one `ErrSetupAlreadyComplete`, and exactly one user, administrator, and session.

## Validation

Focused and database-backed checks:

- `go test ./internal/auth ./internal/database/pglock` — pass
- `go test -race ./internal/auth ./internal/database/pglock` — pass
- `go vet ./internal/auth ./internal/database/pglock` — pass
- `go test ./internal/api/handlers -run '^TestAuthProviders' -count=1` — pass
- `SILO_TEST_DATABASE_URL=<isolated-empty-database> go test ./internal/auth -run '^TestSetupInitialUserConcurrentAcrossPoolsDB$' -count=20` — pass
- `SILO_TEST_DATABASE_URL=<isolated-empty-database> go test -race ./internal/auth -run '^TestSetupInitialUserConcurrentAcrossPoolsDB$' -count=5` — pass

Full repository gate:

- `make embed-stub` — pass
- `go build ./...` — pass
- `gofmt -l .` — pass, no output
- `go vet ./...` — pass
- `golangci-lint run --new-from-merge-base="origin/main" ./...` — pass, 0 issues; it printed one warning about an unrelated stale worktree path
- `make test-go` on macOS — not passing because of repeatable failures in untouched packages: `internal/httpstream/TestReadFromRollsDeadlineUnderProductionStep` and `internal/jellycompat/TestBeginWebOperationRecoversDeadProcessLock` / `TestBeginWebOperationRejectsLiveProcessLock`
- `go test ./...` against the exact candidate source on the Linux dev-builder — pass, including `internal/httpstream` and `internal/jellycompat`
- `pnpm install --frozen-lockfile` — pass
- `pnpm run lint` — pass with 167 inherited warnings and 0 errors
- `pnpm run format:check` — pass
- `pnpm run build` — pass with existing asset/chunk-size warnings
- `make test-web` — pass: 294 files, 2,184 tests
- `make verify-settings-bindings-all` — pass
- `make verify-playback-fixtures` — pass
- `make verify-local-paths` — pass

Isolated dev-builder validation in `audit-bootstrap-admin`:

- controller orientation and `doctor` passed before and after validation
- a normal first setup returned `201` and produced one administrator, one user, and one session
- after resetting only the synthetic test identity, synchronized competing setup requests returned `201` and `401 setup_complete`
- the competing run produced one administrator, one user, and one session

## Risks

The table lock briefly blocks writes to `users` while first-user creation hashes the password and inserts the row. This happens only while the database has no users. Setup-status reads remain available. There is no migration, stored-data rewrite, client contract change, or Jellyfin compatibility change.

Rollback is a revert of this commit; no schema or data rollback is needed.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): n/a (the tool did not report a model identifier)
- Involvement: AI-assisted
- Adversarial review: A fresh read-only investigator independently reproduced the count-then-create race. A separate bypass reviewer rejected an earlier advisory-lock design because a one-connection pool could deadlock and lock-session loss could release the fence before side effects completed; it also found an over-broad test interface. The implementation was replaced with a same-transaction PostgreSQL table lock and emptiness check, and the interface was narrowed. The reviewer then rechecked the replacement for concurrent setup, ordinary user writers, connection loss, pool exhaustion, and API regressions and found no remaining concrete bypass or regression.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
