### PR TITLE
fix(api): bound inbound control request bodies

### DIFF
--- a/internal/api/handlers/webhook_sync.go
+++ b/internal/api/handlers/webhook_sync.go
@@ -1,8 +1,11 @@
 package handlers
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -13,11 +16,24 @@ import (
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"github.com/Silo-Server/silo-server/internal/requestbody"
 	"github.com/Silo-Server/silo-server/internal/webhooksync"
 )
 
+// Webhook-sync JSON payloads are normally a few KiB. Plex may attach a small
+// thumbnail file, so this aggregate cap leaves upload headroom while ensuring
+// multipart parsers cannot spill an unbounded request to temporary disk.
+const maxWebhookSyncBodyBytes = 4 << 20
+
+type webhookDeliveryService interface {
+	ResolveWebhook(ctx context.Context, secret string) (*webhooksync.Connection, error)
+	ProcessWebhook(ctx context.Context, conn *webhooksync.Connection, r *http.Request) (*webhooksync.ProcessWebhookResult, error)
+	CreateEventLog(ctx context.Context, entry webhooksync.WebhookEventLog) (*webhooksync.WebhookEventLog, error)
+}
+
 type WebhookSyncHandler struct {
-	service *webhooksync.Service
+	service  *webhooksync.Service
+	delivery webhookDeliveryService
 }
 
 type legacyPlexSyncConnection struct {
@@ -89,7 +105,7 @@ type legacyUpdatePlexSyncActorsRequest struct {
 }
 
 func NewWebhookSyncHandler(service *webhooksync.Service) *WebhookSyncHandler {
-	return &WebhookSyncHandler{service: service}
+	return &WebhookSyncHandler{service: service, delivery: service}
 }
 
 func (h *WebhookSyncHandler) HandleListConnections(w http.ResponseWriter, r *http.Request) {
@@ -357,10 +373,25 @@ func (h *WebhookSyncHandler) HandleWebhook(w http.ResponseWriter, r *http.Reques
 		http.NotFound(w, r)
 		return
 	}
+	conn, err := h.delivery.ResolveWebhook(r.Context(), secret)
+	if err != nil {
+		h.writeError(w, err)
+		return
+	}
+	body, err := requestbody.Read(w, r, maxWebhookSyncBodyBytes)
+	if err != nil {
+		if requestbody.IsTooLarge(err) {
+			writeError(w, http.StatusRequestEntityTooLarge, "payload_too_large", "Request body exceeds the webhook payload cap")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "bad_request", "Could not read request body")
+		return
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
 	capture := webhooksync.NewBodyCaptureReadCloser(r.Body, webhooksync.WebhookBodyCaptureLimit)
 	r.Body = capture
 
-	result, err := h.service.ProcessWebhook(r.Context(), secret, r)
+	result, err := h.delivery.ProcessWebhook(r.Context(), conn, r)
 	logContext := webhooksync.BuildWebhookRequestLogContext(
 		r,
 		webhooksync.SanitizeWebhookBodyExcerpt(r.Header.Get("Content-Type"), capture.Captured()),
@@ -371,7 +402,7 @@ func (h *WebhookSyncHandler) HandleWebhook(w http.ResponseWriter, r *http.Reques
 	}
 
 	if result != nil {
-		if _, logErr := h.service.CreateEventLog(r.Context(), webhooksync.WebhookEventLog{
+		if _, logErr := h.delivery.CreateEventLog(r.Context(), webhooksync.WebhookEventLog{
 			ConnectionID: result.ConnectionID,
 			RequestID:    logContext.RequestID,
 			HTTPStatus:   statusCode,

--- a/internal/api/handlers/webhook_sync_test.go
+++ b/internal/api/handlers/webhook_sync_test.go
@@ -1,11 +1,57 @@
 package handlers
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/Silo-Server/silo-server/internal/webhooksync"
 )
+
+type fakeWebhookDeliveryService struct {
+	resolveErr   error
+	resolveCalls int
+	processCalls int
+	logCalls     int
+	body         []byte
+}
+
+func (s *fakeWebhookDeliveryService) ResolveWebhook(context.Context, string) (*webhooksync.Connection, error) {
+	s.resolveCalls++
+	if s.resolveErr != nil {
+		return nil, s.resolveErr
+	}
+	return &webhooksync.Connection{}, nil
+}
+
+func (s *fakeWebhookDeliveryService) ProcessWebhook(_ context.Context, _ *webhooksync.Connection, r *http.Request) (*webhooksync.ProcessWebhookResult, error) {
+	s.processCalls++
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	s.body = body
+	return nil, nil
+}
+
+func (s *fakeWebhookDeliveryService) CreateEventLog(context.Context, webhooksync.WebhookEventLog) (*webhooksync.WebhookEventLog, error) {
+	s.logCalls++
+	return nil, nil
+}
+
+type webhookFailingReadCloser struct{ err error }
+
+func (r *webhookFailingReadCloser) Read([]byte) (int, error) { return 0, r.err }
+func (*webhookFailingReadCloser) Close() error               { return nil }
 
 func TestRequestWebhookURLWithPrefix(t *testing.T) {
 	t.Parallel()
@@ -51,4 +97,146 @@ func TestToLegacyPlexActorsResponse(t *testing.T) {
 	if len(resp.DiscoveredActors) != 2 || resp.DiscoveredActors[1].PlexAccountID != 77 {
 		t.Fatalf("unexpected legacy discovered actors: %#v", resp.DiscoveredActors)
 	}
+}
+
+func TestWebhookSyncEndpointAcceptsExactLimit(t *testing.T) {
+	delivery := &fakeWebhookDeliveryService{}
+	handler := &WebhookSyncHandler{delivery: delivery}
+	router := webhookSyncBodyTestRouter(handler)
+	body := strings.Repeat("x", maxWebhookSyncBodyBytes)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhook-sync/webhooks/secret", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	if delivery.processCalls != 1 || len(delivery.body) != len(body) {
+		t.Fatalf("process calls = %d, body length = %d", delivery.processCalls, len(delivery.body))
+	}
+}
+
+func TestWebhookSyncEndpointPreservesUnknownSecretPrecedence(t *testing.T) {
+	delivery := &fakeWebhookDeliveryService{resolveErr: webhooksync.ErrConnectionNotFound}
+	handler := &WebhookSyncHandler{delivery: delivery}
+	router := webhookSyncBodyTestRouter(handler)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhook-sync/webhooks/unknown", strings.NewReader(strings.Repeat("x", maxWebhookSyncBodyBytes+1)))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+	if delivery.resolveCalls != 1 || delivery.processCalls != 0 || delivery.logCalls != 0 {
+		t.Fatalf("unknown secret reached delivery: resolve=%d process=%d logs=%d", delivery.resolveCalls, delivery.processCalls, delivery.logCalls)
+	}
+}
+
+func TestWebhookSyncEndpointRejectsProviderBodiesOverAggregateLimit(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		contentType string
+		body        func(t *testing.T) []byte
+	}{
+		{
+			name: "plex multipart ignored file",
+			path: "/api/v1/plex-sync/webhooks/secret",
+			body: func(t *testing.T) []byte {
+				t.Helper()
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				payload, err := writer.CreateFormField("payload")
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, _ = payload.Write([]byte(`{"event":"media.stop"}`))
+				file, err := writer.CreateFormFile("thumb", "thumb.jpg")
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, _ = file.Write(bytes.Repeat([]byte("x"), maxWebhookSyncBodyBytes))
+				if err := writer.Close(); err != nil {
+					t.Fatal(err)
+				}
+				return body.Bytes()
+			},
+		},
+		{
+			name: "plex multipart payload part",
+			path: "/api/v1/plex-sync/webhooks/secret",
+			body: func(t *testing.T) []byte {
+				t.Helper()
+				var body bytes.Buffer
+				writer := multipart.NewWriter(&body)
+				payload, err := writer.CreateFormField("payload")
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, _ = payload.Write(bytes.Repeat([]byte("x"), maxWebhookSyncBodyBytes))
+				if err := writer.Close(); err != nil {
+					t.Fatal(err)
+				}
+				return body.Bytes()
+			},
+		},
+		{
+			name:        "emby encoded JSON",
+			path:        "/api/v1/webhook-sync/webhooks/secret",
+			contentType: "application/x-www-form-urlencoded",
+			body:        func(*testing.T) []byte { return bytes.Repeat([]byte("x"), maxWebhookSyncBodyBytes+1) },
+		},
+		{
+			name:        "jellyfin JSON",
+			path:        "/api/v1/webhook-sync/webhooks/secret",
+			contentType: "application/json",
+			body:        func(*testing.T) []byte { return bytes.Repeat([]byte("x"), maxWebhookSyncBodyBytes+1) },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			delivery := &fakeWebhookDeliveryService{}
+			handler := &WebhookSyncHandler{delivery: delivery}
+			router := webhookSyncBodyTestRouter(handler)
+			req := httptest.NewRequest(http.MethodPost, tc.path, bytes.NewReader(tc.body(t)))
+			req.ContentLength = -1
+			if tc.contentType != "" {
+				req.Header.Set("Content-Type", tc.contentType)
+			}
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+			}
+			if delivery.processCalls != 0 || delivery.logCalls != 0 {
+				t.Fatalf("oversized delivery mutated state: process=%d logs=%d", delivery.processCalls, delivery.logCalls)
+			}
+		})
+	}
+}
+
+func TestWebhookSyncEndpointRejectsUnreadableBody(t *testing.T) {
+	delivery := &fakeWebhookDeliveryService{}
+	handler := &WebhookSyncHandler{delivery: delivery}
+	router := webhookSyncBodyTestRouter(handler)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhook-sync/webhooks/secret", nil)
+	req.Body = &webhookFailingReadCloser{err: errors.New("read failed")}
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if delivery.processCalls != 0 || delivery.logCalls != 0 {
+		t.Fatalf("unreadable delivery mutated state: process=%d logs=%d", delivery.processCalls, delivery.logCalls)
+	}
+}
+
+func webhookSyncBodyTestRouter(handler *WebhookSyncHandler) http.Handler {
+	router := chi.NewRouter()
+	router.Post("/api/v1/plex-sync/webhooks/{secret}", handler.HandleWebhook)
+	router.Post("/api/v1/webhook-sync/webhooks/{secret}", handler.HandleWebhook)
+	return router
 }

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -1,6 +1,7 @@
 package jellycompat
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
@@ -28,6 +29,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
 	"github.com/Silo-Server/silo-server/internal/playback"
+	"github.com/Silo-Server/silo-server/internal/requestbody"
 	"github.com/Silo-Server/silo-server/internal/streamtoken"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
 	"github.com/Silo-Server/silo-server/internal/tonemap"
@@ -43,6 +45,10 @@ var compatRemoteTranscodeStartTimeout time.Duration
 const (
 	compatRemoteNodeProbeFallbackTimeout = 2 * time.Minute
 	compatToneMapNegotiationTimeout      = 5 * time.Second
+	// Jellyfin PlaybackInfo and Capabilities carry control JSON and generated
+	// device profiles, never media. Real profiles are tens of KiB; 256 KiB
+	// preserves substantial headroom without retaining attacker-sized slices.
+	maxCompatProfileRequestBodyBytes = 256 << 10
 )
 
 type playbackInfoRequest struct {
@@ -1539,7 +1545,12 @@ func (h *PlaybackHandler) HandleCapabilitiesFull(w http.ResponseWriter, r *http.
 		return
 	}
 
-	profile, err := decodeDeviceProfile(r.Body)
+	body, err := requestbody.Read(w, r, maxCompatProfileRequestBodyBytes)
+	if err != nil {
+		writeCompatControlBodyError(w, err, "Invalid capabilities payload")
+		return
+	}
+	profile, err := decodeDeviceProfile(bytes.NewReader(body))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "BadRequest", "Invalid capabilities payload")
 		return
@@ -1577,9 +1588,9 @@ func (h *PlaybackHandler) HandlePlaybackInfo(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	req, profile, err := h.parsePlaybackRequest(r, session.Token)
+	req, profile, err := h.parsePlaybackRequest(w, r, session.Token)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "BadRequest", "Invalid playback request")
+		writeCompatControlBodyError(w, err, "Invalid playback request")
 		return
 	}
 	// PlaybackInfo is authorized by the token-derived session. Some clients
@@ -1758,9 +1769,9 @@ func stripCompatNUL(value string) string {
 	return strings.ReplaceAll(value, "\x00", "")
 }
 
-func (h *PlaybackHandler) parsePlaybackRequest(r *http.Request, compatToken string) (playbackInfoRequest, DeviceProfile, error) {
+func (h *PlaybackHandler) parsePlaybackRequest(w http.ResponseWriter, r *http.Request, compatToken string) (playbackInfoRequest, DeviceProfile, error) {
 	var req playbackInfoRequest
-	body, err := io.ReadAll(r.Body)
+	body, err := requestbody.Read(w, r, maxCompatProfileRequestBodyBytes)
 	if err != nil {
 		return req, DeviceProfile{}, err
 	}
@@ -1789,6 +1800,14 @@ func (h *PlaybackHandler) parsePlaybackRequest(r *http.Request, compatToken stri
 	}
 
 	return req, profile, nil
+}
+
+func writeCompatControlBodyError(w http.ResponseWriter, err error, invalidMessage string) {
+	if requestbody.IsTooLarge(err) {
+		writeError(w, http.StatusRequestEntityTooLarge, "PayloadTooLarge", "Request body is too large")
+		return
+	}
+	writeError(w, http.StatusBadRequest, "BadRequest", invalidMessage)
 }
 
 func (h *PlaybackHandler) buildPlaybackSource(

--- a/internal/jellycompat/logging.go
+++ b/internal/jellycompat/logging.go
@@ -25,6 +25,23 @@ type loggingResponseWriter struct {
 	status int
 }
 
+type debugRequestBody struct {
+	body io.ReadCloser
+	buf  bytes.Buffer
+}
+
+func (b *debugRequestBody) Read(p []byte) (int, error) {
+	n, err := b.body.Read(p)
+	if remaining := debugMaxBodyCapture - b.buf.Len(); n > 0 && remaining > 0 {
+		_, _ = b.buf.Write(p[:min(n, remaining)])
+	}
+	return n, err
+}
+
+func (b *debugRequestBody) Close() error {
+	return b.body.Close()
+}
+
 func (w *loggingResponseWriter) WriteHeader(status int) {
 	w.status = status
 	w.ResponseWriter.WriteHeader(status)
@@ -205,10 +222,10 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 			}
 
 			// Capture request body for POST/PUT/PATCH.
-			var reqBody []byte
+			var capturedBody *debugRequestBody
 			if r.Body != nil && (r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch) {
-				reqBody, _ = io.ReadAll(io.LimitReader(r.Body, debugMaxBodyCapture))
-				r.Body = io.NopCloser(bytes.NewReader(reqBody))
+				capturedBody = &debugRequestBody{body: r.Body}
+				r.Body = capturedBody
 			}
 
 			start := time.Now()
@@ -218,6 +235,10 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 
 			reqID := middleware.GetReqID(r.Context())
 			status := statusOrDefault(dw.status)
+			var reqBody []byte
+			if capturedBody != nil {
+				reqBody = capturedBody.buf.Bytes()
+			}
 
 			mu.Lock()
 			defer mu.Unlock()

--- a/internal/jellycompat/playback_negotiation_dedup_test.go
+++ b/internal/jellycompat/playback_negotiation_dedup_test.go
@@ -3,6 +3,7 @@ package jellycompat
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -136,6 +137,126 @@ func TestHandlePlaybackInfoIgnoresStaleRequestUserID(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
+}
+
+func TestHandlePlaybackInfoBodyBudgetAcrossEquivalentRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, path string
+	}{
+		{name: "item get", method: http.MethodGet, path: "/Items/%s/PlaybackInfo"},
+		{name: "item post", method: http.MethodPost, path: "/Items/%s/PlaybackInfo"},
+		{name: "user item get", method: http.MethodGet, path: "/Users/user/Items/%s/PlaybackInfo"},
+		{name: "user item post", method: http.MethodPost, path: "/Users/user/Items/%s/PlaybackInfo"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, routeID := newSubtitleSelectionHandler(t)
+			req := playbackInfoBodyTestRequest(tc.method, strings.Replace(tc.path, "%s", routeID, 1), routeID, strings.NewReader(strings.Repeat("x", maxCompatProfileRequestBodyBytes+1)))
+			req.ContentLength = -1
+			rec := httptest.NewRecorder()
+			handler.HandlePlaybackInfo(rec, req)
+
+			if rec.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+			}
+			if _, ok := handler.deviceProfiles.Get("token-1"); ok {
+				t.Fatal("oversized PlaybackInfo stored a device profile")
+			}
+			store := handler.playbackStore.(*PlaybackSessionStore)
+			if len(store.sessions) != 0 {
+				t.Fatalf("oversized PlaybackInfo stored %d playback sessions", len(store.sessions))
+			}
+		})
+	}
+}
+
+func TestHandlePlaybackInfoAcceptsExactLimit(t *testing.T) {
+	handler, routeID := newSubtitleSelectionHandler(t)
+	body := paddedJSONBody(maxCompatProfileRequestBodyBytes, `{ "padding": "`, `" }`)
+	req := playbackInfoBodyTestRequest(http.MethodPost, "/Items/"+routeID+"/PlaybackInfo", routeID, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.HandlePlaybackInfo(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
+func TestHandlePlaybackInfoRejectsMalformedAndUnreadableBodies(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body io.ReadCloser
+	}{
+		{name: "malformed JSON", body: io.NopCloser(strings.NewReader("{"))},
+		{name: "transport read error", body: &playbackFailingReadCloser{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, routeID := newSubtitleSelectionHandler(t)
+			req := playbackInfoBodyTestRequest(http.MethodPost, "/Items/"+routeID+"/PlaybackInfo", routeID, nil)
+			req.Body = tc.body
+			rec := httptest.NewRecorder()
+			handler.HandlePlaybackInfo(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			if _, ok := handler.deviceProfiles.Get("token-1"); ok {
+				t.Fatal("invalid PlaybackInfo stored a device profile")
+			}
+			if len(handler.playbackStore.(*PlaybackSessionStore).sessions) != 0 {
+				t.Fatal("invalid PlaybackInfo stored a playback session")
+			}
+		})
+	}
+}
+
+type playbackFailingReadCloser struct{}
+
+func (*playbackFailingReadCloser) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+func (*playbackFailingReadCloser) Close() error             { return nil }
+
+func TestHandleCapabilitiesFullBodyBudget(t *testing.T) {
+	handler, _ := newSubtitleSelectionHandler(t)
+	for _, path := range []string{"/Sessions/Capabilities", "/Sessions/Capabilities/Full"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(strings.Repeat("x", maxCompatProfileRequestBodyBytes+1)))
+			req.ContentLength = -1
+			req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, &Session{Token: "token-cap"}))
+			rec := httptest.NewRecorder()
+			handler.HandleCapabilitiesFull(rec, req)
+			if rec.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+			}
+			if _, ok := handler.deviceProfiles.Get("token-cap"); ok {
+				t.Fatal("oversized capabilities request stored a device profile")
+			}
+		})
+	}
+
+	body := paddedJSONBody(
+		maxCompatProfileRequestBodyBytes,
+		`{"DeviceProfile":{"DirectPlayProfiles":[{"Type":"Video","Container":"mp4"}]},"padding":"`,
+		`"}`,
+	)
+	req := httptest.NewRequest(http.MethodPost, "/Sessions/Capabilities/Full", strings.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, &Session{Token: "token-exact"}))
+	rec := httptest.NewRecorder()
+	handler.HandleCapabilitiesFull(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("exact-limit status = %d, want %d: %s", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	if _, ok := handler.deviceProfiles.Get("token-exact"); !ok {
+		t.Fatal("exact-limit capabilities profile was not stored")
+	}
+}
+
+func playbackInfoBodyTestRequest(method, path, routeID string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, path, body)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", routeID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	return req.WithContext(context.WithValue(req.Context(), compatSessionKey, &Session{Token: "token-1"}))
+}
+
+func paddedJSONBody(size int, prefix, suffix string) string {
+	return prefix + strings.Repeat("x", size-len(prefix)-len(suffix)) + suffix
 }
 
 func TestHandlePlaybackInfoFallsBackFromStaleMediaSourceID(t *testing.T) {

--- a/internal/jellycompat/readfrom_test.go
+++ b/internal/jellycompat/readfrom_test.go
@@ -81,3 +81,17 @@ func TestDebugLogMiddlewareReadFromLogsTextAndMedia(t *testing.T) {
 		})
 	}
 }
+
+func TestDebugLogMiddlewareDoesNotTruncateRequestBody(t *testing.T) {
+	body := strings.Repeat("x", debugMaxBodyCapture+1)
+	var got []byte
+	var log bytes.Buffer
+	handler := newDebugLogMiddleware(&log, "")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
+	if string(got) != body {
+		t.Fatalf("downstream body length = %d, want %d", len(got), len(body))
+	}
+}

--- a/internal/plugins/http_proxy.go
+++ b/internal/plugins/http_proxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -15,7 +14,12 @@ import (
 
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
 	"github.com/Silo-Server/silo-server/internal/pluginhost"
+	"github.com/Silo-Server/silo-server/internal/requestbody"
 )
+
+// Keep opaque plugin request bodies below the default 4 MiB gRPC receive
+// envelope, leaving headroom for protobuf fields and forwarded metadata.
+const maxPluginRouteBodyBytes = 3 << 20
 
 type httpRouteClient interface {
 	Handle(ctx context.Context, req *pluginv1.HandleHTTPRequest) (*pluginv1.HandleHTTPResponse, error)
@@ -111,6 +115,15 @@ func (p *HTTPProxy) ServeRoute(w http.ResponseWriter, r *http.Request, installat
 		p.serveResolvedAsset(w, r, installationID, strings.TrimPrefix(routePath, "/"))
 		return
 	}
+	body, err := requestbody.Read(w, r, maxPluginRouteBodyBytes)
+	if err != nil {
+		if requestbody.IsTooLarge(err) {
+			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		http.Error(w, "could not read request body", http.StatusBadRequest)
+		return
+	}
 
 	capabilityID, err := p.resolveHTTPRoutesCapability(r.Context(), installationID)
 	if err != nil {
@@ -125,7 +138,6 @@ func (p *HTTPProxy) ServeRoute(w http.ResponseWriter, r *http.Request, installat
 		return
 	}
 
-	body, _ := io.ReadAll(r.Body)
 	headers := forwardedRequestHeaders(r.Header)
 	if _, _, userID, contextProfileID := pluginAccessUserFromContext(r.Context()); userID > 0 {
 		headers["X-Silo-User-Id"] = strconv.Itoa(userID)

--- a/internal/plugins/http_proxy_profile_test.go
+++ b/internal/plugins/http_proxy_profile_test.go
@@ -2,8 +2,11 @@ package plugins
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
@@ -22,11 +25,16 @@ func (c *profileTestRouteClient) Handle(
 
 type profileTestProxyService struct {
 	client *profileTestRouteClient
+	access string
 }
 
 func (s profileTestProxyService) RouteDescriptors(context.Context, int) ([]*pluginv1.HttpRouteDescriptor, error) {
+	access := s.access
+	if access == "" {
+		access = "authenticated"
+	}
 	return []*pluginv1.HttpRouteDescriptor{{
-		Method: http.MethodGet, Path: "/page", Access: "authenticated",
+		Method: http.MethodGet, Path: "/page", Access: access,
 	}}, nil
 }
 
@@ -88,3 +96,75 @@ func TestHTTPProxyUsesLaunchProfileWithoutRequestHeader(t *testing.T) {
 		t.Fatalf("forwarded request = %#v", client.request)
 	}
 }
+
+func TestHTTPProxyRejectsOversizedPublicBodyBeforePlugin(t *testing.T) {
+	client := &profileTestRouteClient{}
+	proxy := NewHTTPProxy(
+		profileTestProxyService{client: client, access: "public"}, profileTestInstallationStore{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/plugins/1/page", strings.NewReader(strings.Repeat("x", 3<<20+1)))
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	proxy.ServeRoute(rec, req, 1, false, false)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+	if client.request != nil {
+		t.Fatal("plugin was invoked for an oversized public request")
+	}
+}
+
+func TestHTTPProxyAcceptsExactLimitForPublicAndAuthenticatedRoutes(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		access        string
+		authenticated bool
+	}{
+		{name: "public", access: "public"},
+		{name: "authenticated", access: "authenticated", authenticated: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &profileTestRouteClient{}
+			proxy := NewHTTPProxy(
+				profileTestProxyService{client: client, access: tc.access}, profileTestInstallationStore{},
+			)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/plugins/1/page", strings.NewReader(strings.Repeat("x", maxPluginRouteBodyBytes)))
+			rec := httptest.NewRecorder()
+			proxy.ServeRoute(rec, req, 1, tc.authenticated, false)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+			}
+			if client.request == nil || len(client.request.GetBody()) != maxPluginRouteBodyBytes {
+				t.Fatalf("forwarded body length = %d", len(client.request.GetBody()))
+			}
+		})
+	}
+}
+
+func TestHTTPProxyRejectsUnreadableBodyBeforePlugin(t *testing.T) {
+	client := &profileTestRouteClient{}
+	proxy := NewHTTPProxy(
+		profileTestProxyService{client: client, access: "public"}, profileTestInstallationStore{},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/plugins/1/page", nil)
+	req.Body = &proxyFailingReadCloser{err: errors.New("read failed")}
+	rec := httptest.NewRecorder()
+	proxy.ServeRoute(rec, req, 1, false, false)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+	if client.request != nil {
+		t.Fatal("plugin was invoked with a partial unreadable body")
+	}
+}
+
+type proxyFailingReadCloser struct{ err error }
+
+func (r *proxyFailingReadCloser) Read([]byte) (int, error) { return 0, r.err }
+func (*proxyFailingReadCloser) Close() error               { return nil }
+
+var _ io.ReadCloser = (*proxyFailingReadCloser)(nil)

--- a/internal/requestbody/requestbody.go
+++ b/internal/requestbody/requestbody.go
@@ -1,0 +1,34 @@
+// Package requestbody provides byte-counted reads for bounded HTTP control payloads.
+package requestbody
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ErrUnreadable identifies transport-level request body read or close failures.
+var ErrUnreadable = errors.New("request body is unreadable")
+
+// Read consumes and closes r.Body while enforcing maxBytes on bytes actually
+// received. It does not trust Content-Length, so the same budget applies to
+// chunked and HTTP/2 request bodies.
+func Read(w http.ResponseWriter, r *http.Request, maxBytes int64) ([]byte, error) {
+	limited := http.MaxBytesReader(w, r.Body, maxBytes)
+	body, readErr := io.ReadAll(limited)
+	closeErr := limited.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUnreadable, readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("%w: %w", ErrUnreadable, closeErr)
+	}
+	return body, nil
+}
+
+// IsTooLarge reports whether err came from exceeding a Read byte budget.
+func IsTooLarge(err error) bool {
+	_, ok := errors.AsType[*http.MaxBytesError](err)
+	return ok
+}

--- a/internal/requestbody/requestbody_test.go
+++ b/internal/requestbody/requestbody_test.go
@@ -1,0 +1,68 @@
+package requestbody
+
+import (
+	"errors"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type failingReadCloser struct {
+	err    error
+	closed bool
+}
+
+func (r *failingReadCloser) Read([]byte) (int, error) { return 0, r.err }
+func (r *failingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestReadAcceptsExactLimitAndClosesBody(t *testing.T) {
+	req := httptest.NewRequest("POST", "/", strings.NewReader("1234"))
+	body, err := Read(httptest.NewRecorder(), req, 4)
+	if err != nil || string(body) != "1234" {
+		t.Fatalf("Read() = %q, %v", body, err)
+	}
+}
+
+func TestReadRejectsOverLimitWithoutContentLength(t *testing.T) {
+	req := httptest.NewRequest("POST", "/", strings.NewReader("12345"))
+	req.ContentLength = -1
+	_, err := Read(httptest.NewRecorder(), req, 4)
+	if !IsTooLarge(err) || !errors.Is(err, ErrUnreadable) {
+		t.Fatalf("Read() error = %v, want unreadable MaxBytesError", err)
+	}
+}
+
+func TestReadRejectsTransportErrorAndClosesBody(t *testing.T) {
+	wantErr := errors.New("read failed")
+	reader := &failingReadCloser{err: wantErr}
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Body = reader
+	_, err := Read(httptest.NewRecorder(), req, 4)
+	if !errors.Is(err, ErrUnreadable) || !errors.Is(err, wantErr) || IsTooLarge(err) {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !reader.closed {
+		t.Fatal("request body was not closed")
+	}
+}
+
+func TestReadRejectsCloseError(t *testing.T) {
+	wantErr := errors.New("close failed")
+	req := httptest.NewRequest("POST", "/", nil)
+	req.Body = struct {
+		io.Reader
+		io.Closer
+	}{Reader: strings.NewReader("ok"), Closer: closeFunc(func() error { return wantErr })}
+	_, err := Read(httptest.NewRecorder(), req, 4)
+	if !errors.Is(err, ErrUnreadable) || !errors.Is(err, wantErr) {
+		t.Fatalf("Read() error = %v", err)
+	}
+}
+
+type closeFunc func() error
+
+func (f closeFunc) Close() error { return f() }

--- a/internal/webhooksync/providers_test.go
+++ b/internal/webhooksync/providers_test.go
@@ -56,6 +56,31 @@ func TestEmbyProviderParseWebhook(t *testing.T) {
 	}
 }
 
+func TestPlexProviderParseWebhookIgnoresUnsupportedEvent(t *testing.T) {
+	provider := NewPlexProvider(nil)
+	var body strings.Builder
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormField("payload")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write([]byte(`{"event":"media.play","Account":{"id":1,"title":"Alice"},"Metadata":{"ratingKey":"item-1","type":"movie"}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("POST", "/webhook", strings.NewReader(body.String()))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	event, err := provider.ParseWebhook(t.Context(), &Connection{}, req)
+	if err != nil {
+		t.Fatalf("ParseWebhook() error = %v", err)
+	}
+	if event == nil || event.Apply {
+		t.Fatalf("expected ignored Plex event, got %#v", event)
+	}
+}
+
 func TestEmbyProviderParseWebhookMultipart(t *testing.T) {
 	t.Parallel()
 
@@ -257,6 +282,33 @@ func TestJellyfinProviderParseWebhookIgnoresNonStop(t *testing.T) {
 	}
 	if event == nil || event.Apply {
 		t.Fatalf("expected ignored event, got %#v", event)
+	}
+}
+
+func TestWebhookProvidersRejectMalformedBodies(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    Provider
+		contentType string
+		body        string
+	}{
+		{name: "plex multipart", provider: NewPlexProvider(nil), contentType: "multipart/form-data; boundary=missing", body: "not multipart"},
+		{name: "emby JSON", provider: NewEmbyProvider(), contentType: "application/json", body: "{"},
+		{name: "jellyfin JSON", provider: NewJellyfinProvider(), contentType: "application/json", body: "{"},
+		{name: "compressed bytes are not decompressed", provider: NewJellyfinProvider(), contentType: "application/json", body: "\x1f\x8bnot-json"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/webhook", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", tc.contentType)
+			if tc.name == "compressed bytes are not decompressed" {
+				req.Header.Set("Content-Encoding", "gzip")
+			}
+			if _, err := tc.provider.ParseWebhook(t.Context(), &Connection{}, req); err == nil {
+				t.Fatal("ParseWebhook() accepted malformed body")
+			}
+		})
 	}
 }
 

--- a/internal/webhooksync/service.go
+++ b/internal/webhooksync/service.go
@@ -214,11 +214,11 @@ func (s *Service) CreateEventLog(ctx context.Context, entry WebhookEventLog) (*W
 	return s.repo.CreateEventLog(ctx, entry)
 }
 
-func (s *Service) ProcessWebhook(ctx context.Context, secret string, r *http.Request) (*ProcessWebhookResult, error) {
-	conn, err := s.repo.GetConnectionBySecret(ctx, secret)
-	if err != nil {
-		return nil, err
-	}
+func (s *Service) ResolveWebhook(ctx context.Context, secret string) (*Connection, error) {
+	return s.repo.GetConnectionBySecret(ctx, secret)
+}
+
+func (s *Service) ProcessWebhook(ctx context.Context, conn *Connection, r *http.Request) (*ProcessWebhookResult, error) {
 	result := &ProcessWebhookResult{
 		ConnectionID: conn.ID,
 		Provider:     conn.Provider,


### PR DESCRIPTION
## Problem

Related issue: N/A — audit-validated security fix

Plugin HTTP routes, webhook-sync deliveries, and Jellyfin control requests could buffer or parse request bodies without a byte ceiling. A public plugin route made the strongest case unauthenticated; authenticated plugin routes, signed webhooks, PlaybackInfo, and Capabilities shared the same missing boundary. Chunked bodies bypassed `Content-Length`-based screening, and Plex multipart parsing could spill an unbounded aggregate body to temporary disk.

Fresh verification against `origin/main` at `8164fd594b9fdd8c1944bb0b6251f2d00e4a24ca` reproduced a 3 MiB + 1 byte chunked public-plugin request reaching the plugin and returning 200 before this patch.

## Approach

Add `internal/requestbody` as the shared byte-counted read boundary. It uses `http.MaxBytesReader`, reads through the enforced limit, closes the transport body, and distinguishes overflow from other read failures. Bodies are rejected rather than truncated.

The limits reflect each control surface:

- Plugin routes: 3 MiB. The body is opaque, and this leaves room inside the plugin runtime's default 4 MiB gRPC receive envelope for protobuf fields and forwarded metadata.
- Webhook sync: 4 MiB aggregate. Provider JSON/form payloads are normally a few KiB, while Plex may include a small thumbnail. The cap is below Plex's 10 MiB multipart memory threshold, so an oversized delivery cannot spill to temporary disk.
- Jellyfin PlaybackInfo and Capabilities: 256 KiB. These requests contain control JSON and device profiles, which are normally tens of KiB and never media.

Plugin descriptor and access checks still run before the body read. A valid webhook secret is resolved before reading, preserving unknown-secret 404 behavior, but overflow is rejected before provider parsing, event logging, or watch-state mutation. All four PlaybackInfo routes and both Capabilities aliases share the Jellyfin limit. Jellyfin debug logging now captures a prefix while forwarding the complete body instead of truncating what the handler receives.

No native client contract changed, and no Apple or Android follow-up is needed. Jellyfin compatibility is handled directly. Upload and media-stream endpoints were reviewed and left unchanged because their large-body semantics are intentional or already have dedicated budgets. There is no published API document for these oversized control-body errors to update.

## Validation

Focused and adversarial checks:

```text
go test ./internal/requestbody ./internal/plugins ./internal/api/handlers ./internal/webhooksync ./internal/jellycompat -run '<body-budget tests>' -count=1
PASS

go test -race ./internal/requestbody ./internal/plugins ./internal/api/handlers ./internal/webhooksync ./internal/jellycompat -run '<body-budget tests>' -count=1
PASS

go vet ./internal/requestbody ./internal/plugins ./internal/api/handlers ./internal/webhooksync ./internal/jellycompat
PASS

golangci-lint run --new-from-merge-base="origin/main" ./...
0 issues
```

The complete Linux Go suite passed against the exact candidate mirror on dev-builder:

```text
make test-go
PASS (including internal/jellycompat)
```

The local macOS `make test-go` run reached two pre-existing process-lock failures in `internal/jellycompat`: `TestBeginWebOperationRecoversDeadProcessLock` and `TestBeginWebOperationRejectsLiveProcessLock`. The same failures reproduce on untouched `origin/main`; the exact Linux candidate run passed them.

The remaining repository gate passed:

```text
make embed-stub
go build ./...
gofmt -l .
go vet ./...
pnpm install --frozen-lockfile
pnpm run lint                 # 0 errors; inherited warnings only
pnpm run format:check
pnpm run build
make test-web                 # 294 files, 2,184 tests passed
make verify-settings-bindings-all
make verify-playback-fixtures
make verify-local-paths
```

Live validation used the isolated `audit-body-budget` dev-builder sandbox with the exact candidate. `doctor` passed before testing. A registered synthetic plugin and API-created webhook connections produced:

```text
plugin public normal/exact-limit: 200/200
plugin public/authenticated over-limit, chunked: 413/413
Emby, Jellyfin, Plex normal webhook controls: 204/204/204
Emby, Jellyfin, Plex, and legacy webhook alias over-limit, chunked: 413
Jellyfin Capabilities normal/over-limit: 204/413
Jellyfin PlaybackInfo over-limit, chunked: 413
24 concurrent oversized requests: health 200, process running/healthy
memory before/after: 215.7 MiB / 106 MiB
```

The sandbox was torn down after validation. Tokens, webhook secrets, private hostnames, and media details were not printed.

## Risks

Clients or plugins sending unusually large control documents will now receive 413. The limits have substantial headroom over observed legitimate payloads, but a legitimate integration above a cap would need a narrowly justified limit adjustment. Rollback is the single commit in this PR; there is no migration or persisted-format change.

## AI Disclosure

- Tool(s): Codex; Modern Go Guidelines CLI; Codex Security fix-finding workflow; Silo dev-builder workflow
- Model(s): `gpt-5.6-sol`
- Involvement: Fully AI-generated; human verification pending
- Adversarial review: A fresh read-only investigator traced every body source through plugin gRPC buffering, Plex/Emby/Jellyfin webhook parsing, Jellyfin profile persistence, alternate encodings, multipart behavior, compression behavior, and auth modes before editing. A separate fresh read-only reviewer then challenged the final diff for bypasses and compatibility regressions. It found no source-backed bypasses or regressions. One additional contract hardening was made after review: valid webhook secrets are resolved before reading so unknown-secret 404 precedence remains unchanged. Focused, race, full Linux, and live concurrent validation passed afterward.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
