### PR TITLE
fix(scanner): fence stale scan reconciliation

### DIFF
--- a/internal/scanner/audiobook_scan.go
+++ b/internal/scanner/audiobook_scan.go
@@ -311,6 +311,11 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 		return fmt.Errorf("ScanAudiobookFolder: nil scanner or folder")
 	}
 
+	reconcileSnapshot, err := s.snapshotScanStateForRoots(ctx, folder.ID, folder.Paths)
+	if err != nil {
+		return err
+	}
+
 	// Phase 1: walk the tree to collect candidate book folders. This is
 	// I/O-light (no ffprobe), and avoids holding the worker pool open
 	// for the duration of a 240k-folder scan.
@@ -329,7 +334,7 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 		// library converges — but only when a root was readable, and the
 		// empty-walk guard requires operator confirmation before deleting.
 		if len(reconcileRoots) > 0 {
-			if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, fullScan); err != nil {
+			if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, reconcileSnapshot, fullScan); err != nil {
 				slog.WarnContext(ctx, "audiobook scan: missing-file reconcile failed", "component", "scanner", "folder_id", folder.ID, "error", err)
 			}
 		} else if len(scans) > 0 {
@@ -432,7 +437,7 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 
 	// Reconcile files that vanished from disk now that the full walk's
 	// seenPaths is known and the scan completed without cancellation.
-	if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, fullScan); err != nil {
+	if err := s.reconcileAudiobookMissingFiles(ctx, folder, reconcileRoots, seenPaths, reconcileSnapshot, fullScan); err != nil {
 		slog.WarnContext(ctx, "audiobook scan: missing-file reconcile failed", "component", "scanner", "folder_id", folder.ID, "error", err)
 	}
 	return nil
@@ -445,7 +450,7 @@ func (s *Scanner) ScanAudiobookFolder(ctx context.Context, folder *models.MediaF
 // the newly indexed path instead of leaving a stale duplicate). A scan that saw
 // zero files while the DB still has rows only reconciles when the operator has
 // confirmed cleanup, so an unmounted source can't wipe the catalog.
-func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, fullScan bool) error {
+func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, existingFiles []*scanStateFile, fullScan bool) error {
 	if s.fileRepo == nil || s.libraryRepo == nil || len(roots) == 0 {
 		return nil
 	}
@@ -459,27 +464,28 @@ func (s *Scanner) reconcileAudiobookMissingFiles(ctx context.Context, folder *mo
 	if blockAll {
 		return nil
 	}
+	if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, presentScanPaths(seenPaths)); err != nil {
+		return fmt.Errorf("refreshing present audiobook paths: %w", err)
+	}
 
 	now := time.Now().UTC()
 	missing := 0
-	for _, root := range roots {
-		existing, err := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
-		if err != nil {
-			return fmt.Errorf("listing existing audiobook files for %q: %w", root, err)
+	for _, mf := range existingFiles {
+		if mf == nil || seenPaths[mf.FilePath] || !pathWithinAnyRoot(mf.FilePath, roots) {
+			continue
 		}
-		for _, mf := range existing {
-			if mf == nil || seenPaths[mf.FilePath] {
+		if mf.MissingSince == nil {
+			marked, err := s.fileRepo.MarkMissingIfUnchanged(ctx, mf.ID, mf.ScanGeneration, now)
+			if err != nil {
+				slog.ErrorContext(ctx, "audiobook scan: failed to mark file missing", "component", "scanner",
+					"folder_id", folder.ID, "path", mf.FilePath, "error", err)
 				continue
 			}
-			if mf.MissingSince == nil {
-				if err := s.fileRepo.MarkMissing(ctx, mf.ID, now); err != nil {
-					slog.ErrorContext(ctx, "audiobook scan: failed to mark file missing", "component", "scanner",
-						"folder_id", folder.ID, "path", mf.FilePath, "error", err)
-					continue
-				}
+			if !marked {
+				continue
 			}
-			missing++
 		}
+		missing++
 	}
 
 	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder, confirmedCleanup)

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -135,6 +135,10 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 	if s == nil || folder == nil {
 		return fmt.Errorf("scanEbookPaths: nil scanner or folder")
 	}
+	reconcileSnapshot, err := s.snapshotScanStateForRoots(ctx, folder.ID, roots)
+	if err != nil {
+		return err
+	}
 	scans, err := collectEbookRootScans(ctx, folder.ID, roots)
 	if err != nil {
 		return err
@@ -148,7 +152,7 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 	}
 
 	if len(candidates) == 0 {
-		return s.reconcileEbookScan(ctx, folder, scans, nil, fullScan)
+		return s.reconcileEbookScan(ctx, folder, scans, nil, reconcileSnapshot, fullScan)
 	}
 
 	workers := ebookScanWorkers()
@@ -251,7 +255,10 @@ func (s *Scanner) scanEbookPaths(ctx context.Context, folder *models.MediaFolder
 	for _, p := range candidates {
 		seenPaths[p] = true
 	}
-	return s.reconcileEbookScan(ctx, folder, scans, seenPaths, fullScan)
+	if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, presentScanPaths(seenPaths)); err != nil {
+		return fmt.Errorf("refreshing present ebook paths: %w", err)
+	}
+	return s.reconcileEbookScan(ctx, folder, scans, seenPaths, reconcileSnapshot, fullScan)
 }
 
 // ebookCleanupGuardRepo is the slice of catalog.FolderRepository the
@@ -367,7 +374,7 @@ func (s *Scanner) emptyCleanupDecision(
 
 // reconcileEbookScan applies the post-walk safety policy and then performs
 // missing-file reconciliation for the roots that walked cleanly.
-func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFolder, scans []ebookRootScan, seenPaths map[string]bool, fullScan bool) error {
+func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFolder, scans []ebookRootScan, seenPaths map[string]bool, existingFiles []*scanStateFile, fullScan bool) error {
 	if folder != nil {
 		defer s.reconcileMissingEbookEnrichment(ctx, folder.ID)
 	}
@@ -400,8 +407,7 @@ func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFo
 	if blockAll {
 		return nil
 	}
-
-	if err := s.reconcileMissingEbookFiles(ctx, folder, reconcileRoots, seenPaths, confirmedCleanup); err != nil {
+	if err := s.reconcileMissingEbookFiles(ctx, folder, reconcileRoots, seenPaths, existingFiles, confirmedCleanup); err != nil {
 		return err
 	}
 	if fullScan && s.folderRepo != nil {
@@ -419,34 +425,32 @@ func (s *Scanner) reconcileEbookScan(ctx context.Context, folder *models.MediaFo
 // folder trash is optionally emptied, and library memberships are reconciled
 // so items with no remaining files are removed (renames therefore converge on
 // the newly indexed path instead of leaving a stale duplicate item).
-func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, confirmedCleanup bool) error {
+func (s *Scanner) reconcileMissingEbookFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, existingFiles []*scanStateFile, confirmedCleanup bool) error {
 	if s.fileRepo == nil || s.libraryRepo == nil || len(roots) == 0 {
 		return nil
 	}
 
 	now := time.Now().UTC()
 	missing := 0
-	for _, root := range roots {
-		existing, err := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
-		if err != nil {
-			return fmt.Errorf("listing existing ebook files for %q: %w", root, err)
+	for _, mf := range existingFiles {
+		if mf == nil || seenPaths[mf.FilePath] || !pathWithinAnyRoot(mf.FilePath, roots) {
+			continue
 		}
-		for _, mf := range existing {
-			if mf == nil || seenPaths[mf.FilePath] {
+		if mf.MissingSince == nil {
+			marked, err := s.fileRepo.MarkMissingIfUnchanged(ctx, mf.ID, mf.ScanGeneration, now)
+			if err != nil {
+				slog.ErrorContext(ctx, "ebook scan: failed to mark file missing", "component", "scanner",
+					"folder_id", folder.ID,
+					"path", mf.FilePath,
+					"error", err,
+				)
 				continue
 			}
-			if mf.MissingSince == nil {
-				if err := s.fileRepo.MarkMissing(ctx, mf.ID, now); err != nil {
-					slog.ErrorContext(ctx, "ebook scan: failed to mark file missing", "component", "scanner",
-						"folder_id", folder.ID,
-						"path", mf.FilePath,
-						"error", err,
-					)
-					continue
-				}
+			if !marked {
+				continue
 			}
-			missing++
 		}
+		missing++
 	}
 
 	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder, confirmedCleanup)

--- a/internal/scanner/ebook_test.go
+++ b/internal/scanner/ebook_test.go
@@ -75,6 +75,7 @@ func TestScannerEbookEnrichmentReconciliationIsBoundedAndNonFatal(t *testing.T) 
 		&models.MediaFolder{ID: 17},
 		nil,
 		nil,
+		nil,
 		true,
 	); err != nil {
 		t.Fatalf("reconcileEbookScan() error = %v", err)

--- a/internal/scanner/file_repo.go
+++ b/internal/scanner/file_repo.go
@@ -33,6 +33,13 @@ type FileRepository struct {
 	pool *pgxpool.Pool
 }
 
+type fileScanFence struct {
+	ID             int
+	ScanGeneration int64
+}
+
+const scanReconcileBatchSize = 1000
+
 type RawMatchBacklogMode string
 
 const (
@@ -2760,6 +2767,77 @@ func (r *FileRepository) MarkMissing(ctx context.Context, id int, since time.Tim
 	return nil
 }
 
+// MarkMissingIfUnchanged marks a file missing only when it is still the scan
+// generation observed by the caller. A false result means another scan
+// refreshed, removed, or already marked the row after that snapshot.
+func (r *FileRepository) MarkMissingIfUnchanged(ctx context.Context, id int, scanGeneration int64, since time.Time) (bool, error) {
+	tag, err := r.pool.Exec(ctx, `
+		WITH locked AS (
+			SELECT id
+			FROM media_files
+			WHERE id = $2 AND missing_since IS NULL
+			FOR UPDATE
+		), claimed AS (
+			UPDATE media_file_scan_generations AS generation
+			SET scan_generation = generation.scan_generation + 1
+			FROM locked
+			WHERE generation.media_file_id = locked.id
+			  AND generation.scan_generation = $3
+			RETURNING generation.media_file_id
+		)
+		UPDATE media_files AS mf
+		SET missing_since = $1, updated_at = NOW()
+		FROM claimed
+		WHERE mf.id = claimed.media_file_id
+	`, since, id, scanGeneration)
+	if err != nil {
+		return false, fmt.Errorf("conditionally marking file missing: %w", err)
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+// RefreshPresentPaths records that a completed scan observed paths on disk.
+// Advancing the generation even for otherwise-unchanged files prevents an
+// older overlapping scan from marking or deleting those rows from its stale
+// snapshot. Batching keeps parameter and lock footprints bounded for large
+// libraries while the folder/path uniqueness constraint keeps each update
+// indexable.
+func (r *FileRepository) RefreshPresentPaths(ctx context.Context, folderID int, paths []string) (int, error) {
+	refreshed := 0
+	for start := 0; start < len(paths); start += scanReconcileBatchSize {
+		end := min(start+scanReconcileBatchSize, len(paths))
+		var batchRefreshed int
+		err := r.pool.QueryRow(ctx, `
+			WITH present AS MATERIALIZED (
+				SELECT id
+				FROM media_files
+				WHERE media_folder_id = $1
+				  AND file_path = ANY($2::text[])
+				FOR UPDATE
+			), bumped AS (
+				UPDATE media_file_scan_generations AS generation
+				SET scan_generation = generation.scan_generation + 1
+				FROM present
+				WHERE generation.media_file_id = present.id
+				RETURNING generation.media_file_id
+			), cleared AS (
+				UPDATE media_files AS mf
+				SET missing_since = NULL, updated_at = NOW()
+				FROM bumped
+				WHERE mf.id = bumped.media_file_id
+				  AND mf.missing_since IS NOT NULL
+				RETURNING mf.id
+			)
+			SELECT count(*) FROM bumped
+		`, folderID, paths[start:end]).Scan(&batchRefreshed)
+		if err != nil {
+			return refreshed, fmt.Errorf("refreshing present file paths for folder %d: %w", folderID, err)
+		}
+		refreshed += batchRefreshed
+	}
+	return refreshed, nil
+}
+
 // DeleteMissingByFolder deletes media files in the given folder that have been
 // marked missing for longer than the grace period. Missing files are already
 // hidden from clients; the grace only delays deleting the row so a file that
@@ -2888,44 +2966,77 @@ func (r *FileRepository) ListRootsWithOnlyMissingFiles(ctx context.Context, fold
 	return suspect, nil
 }
 
-// DeleteByIDs removes specific media file rows by primary key.
-func (r *FileRepository) DeleteByIDs(ctx context.Context, ids []int) (int, error) {
-	if len(ids) == 0 {
+// DeleteIfUnchanged removes snapshot rows only while their scan generation is
+// current. A newer presence observation or upsert advances the generation and
+// makes a stale reconciliation harmless.
+func (r *FileRepository) DeleteIfUnchanged(ctx context.Context, fences []fileScanFence) (int, error) {
+	if len(fences) == 0 {
 		return 0, nil
 	}
 
-	tag, err := r.pool.Exec(ctx,
-		"DELETE FROM media_files WHERE id = ANY($1)",
-		ids,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("deleting media files by id: %w", err)
+	deleted := 0
+	for start := 0; start < len(fences); start += scanReconcileBatchSize {
+		end := min(start+scanReconcileBatchSize, len(fences))
+		ids := make([]int, 0, end-start)
+		generations := make([]int64, 0, end-start)
+		for _, fence := range fences[start:end] {
+			ids = append(ids, fence.ID)
+			generations = append(generations, fence.ScanGeneration)
+		}
+		tag, err := r.pool.Exec(ctx, `
+			WITH snapshot AS MATERIALIZED (
+				SELECT mf.id, expected.scan_generation
+				FROM media_files AS mf
+				JOIN unnest($1::int[], $2::bigint[]) AS expected(id, scan_generation)
+				  ON expected.id = mf.id
+				FOR UPDATE OF mf
+			), claimed AS (
+				UPDATE media_file_scan_generations AS generation
+				SET scan_generation = generation.scan_generation + 1
+				FROM snapshot
+				WHERE generation.media_file_id = snapshot.id
+				  AND generation.scan_generation = snapshot.scan_generation
+				RETURNING generation.media_file_id
+			)
+			DELETE FROM media_files AS mf
+			USING claimed
+			WHERE mf.id = claimed.media_file_id
+		`, ids, generations)
+		if err != nil {
+			return deleted, fmt.Errorf("conditionally deleting media files: %w", err)
+		}
+		deleted += int(tag.RowsAffected())
 	}
-	return int(tag.RowsAffected()), nil
+	return deleted, nil
 }
 
-// ListIDsOutsideRoots returns file row ids for a folder whose paths are no
-// longer covered by any configured root.
-func (r *FileRepository) ListIDsOutsideRoots(ctx context.Context, folderID int, roots []string) ([]int, error) {
+// ListFencesOutsideRoots returns the deletion fences for rows whose paths are
+// no longer covered by any configured root.
+func (r *FileRepository) ListFencesOutsideRoots(ctx context.Context, folderID int, roots []string) ([]fileScanFence, error) {
 	if len(roots) == 0 {
-		rows, err := r.pool.Query(ctx, `SELECT id FROM media_files WHERE media_folder_id = $1`, folderID)
+		rows, err := r.pool.Query(ctx, `
+			SELECT mf.id, generation.scan_generation
+			FROM media_files AS mf
+			JOIN media_file_scan_generations AS generation ON generation.media_file_id = mf.id
+			WHERE mf.media_folder_id = $1
+		`, folderID)
 		if err != nil {
-			return nil, fmt.Errorf("querying file ids outside roots: %w", err)
+			return nil, fmt.Errorf("querying file fences outside roots: %w", err)
 		}
 		defer rows.Close()
 
-		ids := make([]int, 0)
+		fences := make([]fileScanFence, 0)
 		for rows.Next() {
-			var id int
-			if err := rows.Scan(&id); err != nil {
-				return nil, fmt.Errorf("scanning file id outside roots: %w", err)
+			var fence fileScanFence
+			if err := rows.Scan(&fence.ID, &fence.ScanGeneration); err != nil {
+				return nil, fmt.Errorf("scanning file fence outside roots: %w", err)
 			}
-			ids = append(ids, id)
+			fences = append(fences, fence)
 		}
 		if err := rows.Err(); err != nil {
-			return nil, fmt.Errorf("iterating file ids outside roots: %w", err)
+			return nil, fmt.Errorf("iterating file fences outside roots: %w", err)
 		}
-		return ids, nil
+		return fences, nil
 	}
 
 	args := make([]any, 0, 1+len(roots)*2)
@@ -2933,25 +3044,29 @@ func (r *FileRepository) ListIDsOutsideRoots(ctx context.Context, folderID int, 
 	coveredClauses, coveredArgs := rootCoverageClauses(roots, 2)
 	args = append(args, coveredArgs...)
 
-	query := `SELECT id FROM media_files WHERE media_folder_id = $1 AND NOT (` + strings.Join(coveredClauses, " OR ") + `)`
+	query := `
+		SELECT mf.id, generation.scan_generation
+		FROM media_files AS mf
+		JOIN media_file_scan_generations AS generation ON generation.media_file_id = mf.id
+		WHERE mf.media_folder_id = $1 AND NOT (` + strings.Join(coveredClauses, " OR ") + `)`
 	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("querying file ids outside roots: %w", err)
+		return nil, fmt.Errorf("querying file fences outside roots: %w", err)
 	}
 	defer rows.Close()
 
-	ids := make([]int, 0)
+	fences := make([]fileScanFence, 0)
 	for rows.Next() {
-		var id int
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scanning file id outside roots: %w", err)
+		var fence fileScanFence
+		if err := rows.Scan(&fence.ID, &fence.ScanGeneration); err != nil {
+			return nil, fmt.Errorf("scanning file fence outside roots: %w", err)
 		}
-		ids = append(ids, id)
+		fences = append(fences, fence)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating file ids outside roots: %w", err)
+		return nil, fmt.Errorf("iterating file fences outside roots: %w", err)
 	}
-	return ids, nil
+	return fences, nil
 }
 
 // GetByFolder returns all media files belonging to the specified folder.

--- a/internal/scanner/manga_scan.go
+++ b/internal/scanner/manga_scan.go
@@ -36,6 +36,10 @@ func (s *Scanner) scanMangaPaths(ctx context.Context, folder *models.MediaFolder
 	if s == nil || folder == nil {
 		return fmt.Errorf("scanMangaPaths: nil scanner or folder")
 	}
+	reconcileSnapshot, err := s.snapshotScanStateForRoots(ctx, folder.ID, roots)
+	if err != nil {
+		return err
+	}
 	scans, err := collectEbookRootScans(ctx, folder.ID, roots)
 	if err != nil {
 		return err
@@ -49,7 +53,7 @@ func (s *Scanner) scanMangaPaths(ctx context.Context, folder *models.MediaFolder
 	}
 
 	if len(candidates) == 0 {
-		return s.reconcileMangaScan(ctx, folder, scans, nil, fullScan)
+		return s.reconcileMangaScan(ctx, folder, scans, nil, reconcileSnapshot, fullScan)
 	}
 
 	workers := ebookScanWorkers()
@@ -152,15 +156,18 @@ func (s *Scanner) scanMangaPaths(ctx context.Context, folder *models.MediaFolder
 	for _, p := range candidates {
 		seenPaths[p] = true
 	}
-	return s.reconcileMangaScan(ctx, folder, scans, seenPaths, fullScan)
+	if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, presentScanPaths(seenPaths)); err != nil {
+		return fmt.Errorf("refreshing present manga paths: %w", err)
+	}
+	return s.reconcileMangaScan(ctx, folder, scans, seenPaths, reconcileSnapshot, fullScan)
 }
 
 // reconcileMangaScan runs the shared ebook missing-file reconciliation (which
 // removes vanished chapters) and then deletes any type='manga' series left with
 // no chapters. Series items are file-less parents reconciled by chapter count,
 // not file presence — catalog.ReconcileFolderMembership deliberately skips them.
-func (s *Scanner) reconcileMangaScan(ctx context.Context, folder *models.MediaFolder, scans []ebookRootScan, seenPaths map[string]bool, fullScan bool) error {
-	if err := s.reconcileEbookScan(ctx, folder, scans, seenPaths, fullScan); err != nil {
+func (s *Scanner) reconcileMangaScan(ctx context.Context, folder *models.MediaFolder, scans []ebookRootScan, seenPaths map[string]bool, existingFiles []*scanStateFile, fullScan bool) error {
+	if err := s.reconcileEbookScan(ctx, folder, scans, seenPaths, existingFiles, fullScan); err != nil {
 		return err
 	}
 	return s.deleteOrphanedMangaSeries(ctx, folder.ID)

--- a/internal/scanner/podcast_scan.go
+++ b/internal/scanner/podcast_scan.go
@@ -30,6 +30,11 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 		return fmt.Errorf("ScanPodcastFolder: nil scanner or folder")
 	}
 
+	reconcileSnapshot, err := s.snapshotScanStateForRoots(ctx, folder.ID, folder.Paths)
+	if err != nil {
+		return err
+	}
+
 	var attempted int
 	var succeeded int
 	var failures scanFailures
@@ -84,7 +89,7 @@ func (s *Scanner) ScanPodcastFolder(ctx context.Context, folder *models.MediaFol
 	if attempted > 0 && succeeded == 0 && failures.len() > 0 {
 		return fmt.Errorf("podcast scan failed for every attempted folder_id=%d: %w", folder.ID, failures.join())
 	}
-	if err := s.reconcilePodcastMissingFiles(ctx, folder, reconcileRoots, seenPaths); err != nil {
+	if err := s.reconcilePodcastMissingFiles(ctx, folder, reconcileRoots, seenPaths, reconcileSnapshot); err != nil {
 		slog.WarnContext(ctx, "podcast scan: missing-file reconcile failed", "component", "scanner", "folder_id", folder.ID, "error", err)
 	}
 	return nil
@@ -217,7 +222,7 @@ func applyPodcastShowMetadata(item *models.MediaItem, show *parsedPodcastShow) b
 	return changed
 }
 
-func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool) error {
+func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *models.MediaFolder, roots []string, seenPaths map[string]bool, existingFiles []*scanStateFile) error {
 	if s.fileRepo == nil || s.libraryRepo == nil || len(roots) == 0 {
 		return nil
 	}
@@ -231,27 +236,28 @@ func (s *Scanner) reconcilePodcastMissingFiles(ctx context.Context, folder *mode
 	if blockAll {
 		return nil
 	}
+	if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, presentScanPaths(seenPaths)); err != nil {
+		return fmt.Errorf("refreshing present podcast paths: %w", err)
+	}
 
 	now := time.Now().UTC()
 	missing := 0
-	for _, root := range roots {
-		existing, err := s.fileRepo.GetByFolderAndPathPrefix(ctx, folder.ID, root)
-		if err != nil {
-			return fmt.Errorf("listing existing podcast files for %q: %w", root, err)
+	for _, mf := range existingFiles {
+		if mf == nil || seenPaths[mf.FilePath] || !pathWithinAnyRoot(mf.FilePath, roots) {
+			continue
 		}
-		for _, mf := range existing {
-			if mf == nil || seenPaths[mf.FilePath] {
+		if mf.MissingSince == nil {
+			marked, err := s.fileRepo.MarkMissingIfUnchanged(ctx, mf.ID, mf.ScanGeneration, now)
+			if err != nil {
+				slog.ErrorContext(ctx, "podcast scan: failed to mark file missing", "component", "scanner",
+					"folder_id", folder.ID, "path", mf.FilePath, "error", err)
 				continue
 			}
-			if mf.MissingSince == nil {
-				if err := s.fileRepo.MarkMissing(ctx, mf.ID, now); err != nil {
-					slog.ErrorContext(ctx, "podcast scan: failed to mark file missing", "component", "scanner",
-						"folder_id", folder.ID, "path", mf.FilePath, "error", err)
-					continue
-				}
+			if !marked {
+				continue
 			}
-			missing++
 		}
+		missing++
 	}
 
 	trashed, removedMemberships, deletedItems, err := s.sweepMissingAndReconcile(ctx, folder, confirmedCleanup)

--- a/internal/scanner/scan_reconcile_fence_test.go
+++ b/internal/scanner/scan_reconcile_fence_test.go
@@ -1,0 +1,560 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestStaleReconciliationPreservesConcurrentUpsert(t *testing.T) {
+	ctx := t.Context()
+	pool := newDeadRootTestPool(t)
+	repo := NewFileRepository(pool)
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "reconcile-fence")
+
+	root := t.TempDir()
+	filePath := filepath.Join(root, "subtree", "movie.mkv")
+	if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		t.Fatalf("create media directory: %v", err)
+	}
+	if err := os.WriteFile(filePath, []byte("old"), 0o644); err != nil {
+		t.Fatalf("create initial media file: %v", err)
+	}
+
+	initial, err := repo.Upsert(ctx, models.MediaFile{
+		MediaFolderID: folderID,
+		FilePath:      filePath,
+		FileSize:      3,
+	})
+	if err != nil {
+		t.Fatalf("seed media file: %v", err)
+	}
+
+	// Full scan A snapshots the row, then observes the path as absent.
+	snapshot, err := repo.GetScanStateByFolder(ctx, folderID)
+	if err != nil {
+		t.Fatalf("snapshot scan state: %v", err)
+	}
+	if len(snapshot) != 1 {
+		t.Fatalf("snapshot rows = %d, want 1", len(snapshot))
+	}
+	if err := os.Remove(filePath); err != nil {
+		t.Fatalf("remove media file for stale walk: %v", err)
+	}
+
+	// Scoped scan B sees the path return and refreshes the same row.
+	if err := os.WriteFile(filePath, []byte("fresh"), 0o644); err != nil {
+		t.Fatalf("restore media file: %v", err)
+	}
+	refreshed, err := repo.Upsert(ctx, models.MediaFile{
+		MediaFolderID: folderID,
+		FilePath:      filePath,
+		FileSize:      5,
+	})
+	if err != nil {
+		t.Fatalf("refresh media file: %v", err)
+	}
+	if refreshed.ID != initial.ID {
+		t.Fatalf("refreshed row id = %d, want stable id %d", refreshed.ID, initial.ID)
+	}
+
+	// Full scan A reconciles from its stale snapshot after B committed.
+	result := &ScanResult{}
+	scanner := &Scanner{fileRepo: repo}
+	scanner.markMissingExcludingProtected(ctx, folderID, snapshot, map[string]bool{}, nil, result)
+	if result.Missing != 0 {
+		t.Fatalf("stale reconciliation missing count = %d, want 0", result.Missing)
+	}
+
+	got, err := repo.GetByPath(ctx, filePath)
+	if err != nil {
+		t.Fatalf("reload media file: %v", err)
+	}
+	if got.MissingSince != nil {
+		t.Fatalf("refreshed media file was marked missing at %v", got.MissingSince)
+	}
+	deleted, err := repo.DeleteMissingByFolder(ctx, folderID, 0, nil)
+	if err != nil {
+		t.Fatalf("sweep missing files: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted files = %d, want refreshed row retained", deleted)
+	}
+}
+
+func TestReconciliationMarksAndSweepsGenuinelyMissingFile(t *testing.T) {
+	ctx := t.Context()
+	pool := newDeadRootTestPool(t)
+	repo := NewFileRepository(pool)
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "reconcile-normal-missing")
+	filePath := filepath.Join(t.TempDir(), "deleted.mkv")
+
+	if _, err := repo.Upsert(ctx, models.MediaFile{
+		MediaFolderID: folderID,
+		FilePath:      filePath,
+		FileSize:      7,
+	}); err != nil {
+		t.Fatalf("seed media file: %v", err)
+	}
+	snapshot, err := repo.GetScanStateByFolder(ctx, folderID)
+	if err != nil {
+		t.Fatalf("snapshot scan state: %v", err)
+	}
+
+	result := &ScanResult{}
+	scanner := &Scanner{fileRepo: repo}
+	scanner.markMissingExcludingProtected(ctx, folderID, snapshot, map[string]bool{}, nil, result)
+	if result.Missing != 1 {
+		t.Fatalf("missing count = %d, want 1", result.Missing)
+	}
+
+	deleted, err := repo.DeleteMissingByFolder(ctx, folderID, time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sweep recent missing files: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("recently missing files deleted = %d, want 0 during grace", deleted)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE media_files SET missing_since = $1 WHERE media_folder_id = $2 AND file_path = $3`,
+		time.Now().UTC().Add(-2*time.Hour), folderID, filePath,
+	); err != nil {
+		t.Fatalf("age missing file beyond grace: %v", err)
+	}
+
+	deleted, err = repo.DeleteMissingByFolder(ctx, folderID, time.Hour, nil)
+	if err != nil {
+		t.Fatalf("sweep expired missing files: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted files = %d, want 1", deleted)
+	}
+	if _, err := repo.GetByPath(ctx, filePath); !errors.Is(err, ErrFileNotFound) {
+		t.Fatalf("reload deleted file error = %v, want ErrFileNotFound", err)
+	}
+}
+
+func TestCompletedPresenceObservationFencesStaleConfirmedCleanup(t *testing.T) {
+	ctx := t.Context()
+	pool := newDeadRootTestPool(t)
+	repo := NewFileRepository(pool)
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "reconcile-confirmed-empty")
+	root := t.TempDir()
+	filePath := filepath.Join(root, "movie.mkv")
+
+	if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: filePath, FileSize: 1}); err != nil {
+		t.Fatalf("seed media file: %v", err)
+	}
+	snapshot, err := repo.GetScanStateByFolder(ctx, folderID)
+	if err != nil {
+		t.Fatalf("snapshot stale full scan: %v", err)
+	}
+
+	// Scoped scan B completes an unchanged-file observation. No upsert is
+	// required for this fast path, so the explicit presence refresh must carry
+	// the freshness fence.
+	refreshed, err := repo.RefreshPresentPaths(ctx, folderID, []string{filePath})
+	if err != nil {
+		t.Fatalf("refresh unchanged present path: %v", err)
+	}
+	if refreshed != 1 {
+		t.Fatalf("refreshed rows = %d, want 1", refreshed)
+	}
+
+	// Full scan A resumes from its empty snapshot and takes the production
+	// confirmed-cleanup path. Both its missing mark and hard delete must lose
+	// to B's completed presence observation.
+	scanner := &Scanner{fileRepo: repo}
+	scope := &scopedScan{
+		walkRoots:      []string{root},
+		reconcileRoots: []string{root},
+		existingFiles:  snapshot,
+		seenPaths:      map[string]bool{},
+		result:         &ScanResult{},
+	}
+	if err := scanner.applyScopedScan(ctx, &models.MediaFolder{ID: folderID}, scope, true, nil); err != nil {
+		t.Fatalf("apply stale confirmed cleanup: %v", err)
+	}
+	if scope.result.Missing != 0 || scope.result.FilesDeleted != 0 {
+		t.Fatalf("stale cleanup result = missing %d deleted %d, want both 0", scope.result.Missing, scope.result.FilesDeleted)
+	}
+
+	got, err := repo.GetByPath(ctx, filePath)
+	if err != nil {
+		t.Fatalf("reload refreshed file: %v", err)
+	}
+	if got.MissingSince != nil {
+		t.Fatalf("refreshed file marked missing at %v", got.MissingSince)
+	}
+}
+
+func TestStaleRemovedPathCleanupPreservesConcurrentRefresh(t *testing.T) {
+	ctx := t.Context()
+	pool := newDeadRootTestPool(t)
+	repo := NewFileRepository(pool)
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "reconcile-removed-root")
+	oldRoot := t.TempDir()
+	newRoot := t.TempDir()
+	filePath := filepath.Join(oldRoot, "movie.mkv")
+
+	if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: filePath, FileSize: 1}); err != nil {
+		t.Fatalf("seed media file: %v", err)
+	}
+	fences, err := repo.ListFencesOutsideRoots(ctx, folderID, []string{newRoot})
+	if err != nil {
+		t.Fatalf("snapshot production outside-root fences: %v", err)
+	}
+	if _, err := repo.RefreshPresentPaths(ctx, folderID, []string{filePath}); err != nil {
+		t.Fatalf("refresh file in overlapping scan: %v", err)
+	}
+
+	deleted, err := repo.DeleteIfUnchanged(ctx, fences)
+	if err != nil {
+		t.Fatalf("apply stale removed-root cleanup: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("stale removed-root cleanup deleted %d rows, want 0", deleted)
+	}
+	if _, err := repo.GetByPath(ctx, filePath); err != nil {
+		t.Fatalf("refreshed file did not survive removed-root cleanup: %v", err)
+	}
+}
+
+func TestStaleReconciliationRechecksGenerationAfterRefreshLock(t *testing.T) {
+	tests := []struct {
+		name        string
+		waitPattern string
+		reconcile   func(context.Context, *FileRepository, *scanStateFile) (int, error)
+	}{
+		{
+			name:        "mark missing",
+			waitPattern: "%WHERE id = $2 AND missing_since IS NULL%",
+			reconcile: func(ctx context.Context, repo *FileRepository, snapshot *scanStateFile) (int, error) {
+				marked, err := repo.MarkMissingIfUnchanged(ctx, snapshot.ID, snapshot.ScanGeneration, time.Now().UTC())
+				if marked {
+					return 1, err
+				}
+				return 0, err
+			},
+		},
+		{
+			name:        "delete",
+			waitPattern: "%JOIN unnest($1::int[], $2::bigint[])%",
+			reconcile: func(ctx context.Context, repo *FileRepository, snapshot *scanStateFile) (int, error) {
+				return repo.DeleteIfUnchanged(ctx, []fileScanFence{{
+					ID:             snapshot.ID,
+					ScanGeneration: snapshot.ScanGeneration,
+				}})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			pool := newDeadRootTestPool(t)
+			repo := NewFileRepository(pool)
+			folderID := seedDeadRootTestFolder(t, pool, "movies", "reconcile-lock-recheck-"+tt.name)
+			filePath := filepath.Join(t.TempDir(), "movie.mkv")
+
+			if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: filePath, FileSize: 1}); err != nil {
+				t.Fatalf("seed media file: %v", err)
+			}
+			snapshot, err := repo.GetScanStateByFolderAndPath(ctx, folderID, filePath)
+			if err != nil {
+				t.Fatalf("take stale snapshot: %v", err)
+			}
+
+			refreshTx, err := pool.Begin(ctx)
+			if err != nil {
+				t.Fatalf("begin refresh transaction: %v", err)
+			}
+			refreshCommitted := false
+			defer func() {
+				if !refreshCommitted {
+					_ = refreshTx.Rollback(ctx)
+				}
+			}()
+
+			// Execute the locking and generation-bump portion of
+			// RefreshPresentPaths, but hold the transaction open. This puts stale
+			// reconciliation A behind an uncommitted presence observation B.
+			var refreshed int
+			if err := refreshTx.QueryRow(ctx, `
+				WITH present AS MATERIALIZED (
+					SELECT id
+					FROM media_files
+					WHERE media_folder_id = $1 AND file_path = $2
+					FOR UPDATE
+				), bumped AS (
+					UPDATE media_file_scan_generations AS generation
+					SET scan_generation = generation.scan_generation + 1
+					FROM present
+					WHERE generation.media_file_id = present.id
+					RETURNING generation.media_file_id
+				)
+				SELECT count(*) FROM bumped
+			`, folderID, filePath).Scan(&refreshed); err != nil {
+				t.Fatalf("run uncommitted refresh: %v", err)
+			}
+			if refreshed != 1 {
+				t.Fatalf("uncommitted refresh count = %d, want 1", refreshed)
+			}
+
+			type reconcileResult struct {
+				count int
+				err   error
+			}
+			done := make(chan reconcileResult, 1)
+			go func() {
+				count, err := tt.reconcile(ctx, repo, snapshot)
+				done <- reconcileResult{count: count, err: err}
+			}()
+
+			waitDeadline := time.Now().Add(10 * time.Second)
+			for {
+				var waiting int
+				if err := pool.QueryRow(ctx, `
+					SELECT count(*)
+					FROM pg_stat_activity
+					WHERE datname = current_database()
+					  AND wait_event_type = 'Lock'
+					  AND query LIKE $1
+				`, tt.waitPattern).Scan(&waiting); err != nil {
+					t.Fatalf("poll stale reconciliation lock: %v", err)
+				}
+				if waiting > 0 {
+					break
+				}
+				if time.Now().After(waitDeadline) {
+					t.Fatal("stale reconciliation never blocked behind refresh")
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+
+			if err := refreshTx.Commit(ctx); err != nil {
+				t.Fatalf("commit refresh transaction: %v", err)
+			}
+			refreshCommitted = true
+
+			select {
+			case result := <-done:
+				if result.err != nil {
+					t.Fatalf("stale reconciliation after refresh commit: %v", result.err)
+				}
+				if result.count != 0 {
+					t.Fatalf("stale reconciliation changed %d rows, want 0", result.count)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("stale reconciliation remained blocked after refresh commit")
+			}
+
+			got, err := repo.GetByPath(ctx, filePath)
+			if err != nil {
+				t.Fatalf("reload refreshed file: %v", err)
+			}
+			if got.MissingSince != nil {
+				t.Fatalf("refreshed file marked missing at %v", got.MissingSince)
+			}
+		})
+	}
+}
+
+func TestLiteraryAndPodcastReconciliationUsesPreWalkFence(t *testing.T) {
+	tests := []struct {
+		name      string
+		mediaType string
+		reconcile func(context.Context, *Scanner, *models.MediaFolder, string, map[string]bool, []*scanStateFile) error
+	}{
+		{
+			name:      "audiobook",
+			mediaType: "audiobooks",
+			reconcile: func(ctx context.Context, scanner *Scanner, folder *models.MediaFolder, root string, seenPaths map[string]bool, snapshot []*scanStateFile) error {
+				return scanner.reconcileAudiobookMissingFiles(ctx, folder, []string{root}, seenPaths, snapshot, false)
+			},
+		},
+		{
+			name:      "ebook",
+			mediaType: "ebooks",
+			reconcile: func(ctx context.Context, scanner *Scanner, folder *models.MediaFolder, root string, seenPaths map[string]bool, snapshot []*scanStateFile) error {
+				return scanner.reconcileEbookScan(ctx, folder, []ebookRootScan{{root: root}}, seenPaths, snapshot, false)
+			},
+		},
+		{
+			name:      "manga",
+			mediaType: "manga",
+			reconcile: func(ctx context.Context, scanner *Scanner, folder *models.MediaFolder, root string, seenPaths map[string]bool, snapshot []*scanStateFile) error {
+				return scanner.reconcileMangaScan(ctx, folder, []ebookRootScan{{root: root}}, seenPaths, snapshot, false)
+			},
+		},
+		{
+			name:      "podcast",
+			mediaType: "podcasts",
+			reconcile: func(ctx context.Context, scanner *Scanner, folder *models.MediaFolder, root string, seenPaths map[string]bool, snapshot []*scanStateFile) error {
+				return scanner.reconcilePodcastMissingFiles(ctx, folder, []string{root}, seenPaths, snapshot)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			pool := newDeadRootTestPool(t)
+			repo := NewFileRepository(pool)
+			folderID := seedDeadRootTestFolder(t, pool, tt.mediaType, "reconcile-"+tt.name)
+			root := t.TempDir()
+			stalePath := filepath.Join(root, "stale.dat")
+			seenPath := filepath.Join(root, "seen.dat")
+			if err := os.WriteFile(seenPath, []byte("present"), 0o644); err != nil {
+				t.Fatalf("create seen control file: %v", err)
+			}
+
+			for _, path := range []string{stalePath, seenPath} {
+				if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: path, FileSize: 1}); err != nil {
+					t.Fatalf("seed %s: %v", path, err)
+				}
+			}
+			snapshot, err := repo.GetScanStateByFolderAndPathPrefix(ctx, folderID, root)
+			if err != nil {
+				t.Fatalf("take pre-walk snapshot: %v", err)
+			}
+
+			// Overlapping scan B observes the path that A's filesystem walk
+			// missed, without needing to change any media metadata.
+			if _, err := repo.RefreshPresentPaths(ctx, folderID, []string{stalePath}); err != nil {
+				t.Fatalf("refresh stale candidate concurrently: %v", err)
+			}
+
+			scanner := NewScanner(repo, "", nil, 1, false, time.Hour)
+			folder := &models.MediaFolder{ID: folderID, Type: tt.mediaType, Paths: []string{root}}
+			if err := tt.reconcile(ctx, scanner, folder, root, map[string]bool{seenPath: true}, snapshot); err != nil {
+				t.Fatalf("run stale %s reconciliation: %v", tt.name, err)
+			}
+
+			got, err := repo.GetByPath(ctx, stalePath)
+			if err != nil {
+				t.Fatalf("reload concurrently refreshed path: %v", err)
+			}
+			if got.MissingSince != nil {
+				t.Fatalf("concurrently refreshed path marked missing at %v", got.MissingSince)
+			}
+		})
+	}
+}
+
+func TestRepeatedUpsertAdvancesReconciliationGeneration(t *testing.T) {
+	ctx := t.Context()
+	pool := newDeadRootTestPool(t)
+	repo := NewFileRepository(pool)
+	folderID := seedDeadRootTestFolder(t, pool, "movies", "reconcile-repeated-upsert")
+	filePath := filepath.Join(t.TempDir(), "movie.mkv")
+
+	if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: filePath, FileSize: 1}); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	initial, err := repo.GetScanStateByFolderAndPath(ctx, folderID, filePath)
+	if err != nil {
+		t.Fatalf("load initial generation: %v", err)
+	}
+	for size := int64(2); size <= 3; size++ {
+		if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: filePath, FileSize: size}); err != nil {
+			t.Fatalf("repeat upsert size %d: %v", size, err)
+		}
+	}
+	current, err := repo.GetScanStateByFolderAndPath(ctx, folderID, filePath)
+	if err != nil {
+		t.Fatalf("load current generation: %v", err)
+	}
+	if current.ScanGeneration != initial.ScanGeneration+2 {
+		t.Fatalf("scan generation = %d, want %d", current.ScanGeneration, initial.ScanGeneration+2)
+	}
+
+	for _, staleGeneration := range []int64{initial.ScanGeneration, initial.ScanGeneration + 1} {
+		marked, err := repo.MarkMissingIfUnchanged(ctx, current.ID, staleGeneration, time.Now().UTC())
+		if err != nil {
+			t.Fatalf("mark with generation %d: %v", staleGeneration, err)
+		}
+		if marked {
+			t.Fatalf("stale generation %d marked current row missing", staleGeneration)
+		}
+	}
+	marked, err := repo.MarkMissingIfUnchanged(ctx, current.ID, current.ScanGeneration, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("mark current generation: %v", err)
+	}
+	if !marked {
+		t.Fatal("current generation was not marked missing")
+	}
+}
+
+func TestReconciliationFenceCoversFolderSubtreeAndFileSnapshots(t *testing.T) {
+	tests := []struct {
+		name     string
+		snapshot func(*FileRepository, int, string, string) (*scanStateFile, error)
+	}{
+		{
+			name: "folder",
+			snapshot: func(repo *FileRepository, folderID int, _, _ string) (*scanStateFile, error) {
+				files, err := repo.GetScanStateByFolder(t.Context(), folderID)
+				if err != nil || len(files) != 1 {
+					return nil, err
+				}
+				return files[0], nil
+			},
+		},
+		{
+			name: "subtree",
+			snapshot: func(repo *FileRepository, folderID int, root, _ string) (*scanStateFile, error) {
+				files, err := repo.GetScanStateByFolderAndPathPrefix(t.Context(), folderID, filepath.Join(root, "subtree"))
+				if err != nil || len(files) != 1 {
+					return nil, err
+				}
+				return files[0], nil
+			},
+		},
+		{
+			name: "file",
+			snapshot: func(repo *FileRepository, folderID int, _, filePath string) (*scanStateFile, error) {
+				return repo.GetScanStateByFolderAndPath(t.Context(), folderID, filePath)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			pool := newDeadRootTestPool(t)
+			repo := NewFileRepository(pool)
+			folderID := seedDeadRootTestFolder(t, pool, "movies", "reconcile-overlap-"+tt.name)
+			root := t.TempDir()
+			filePath := filepath.Join(root, "subtree", "movie.mkv")
+
+			if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: filePath, FileSize: 1}); err != nil {
+				t.Fatalf("initial upsert: %v", err)
+			}
+			snapshot, err := tt.snapshot(repo, folderID, root, filePath)
+			if err != nil {
+				t.Fatalf("take %s snapshot: %v", tt.name, err)
+			}
+			if snapshot == nil {
+				t.Fatalf("take %s snapshot: no row", tt.name)
+			}
+			if _, err := repo.Upsert(ctx, models.MediaFile{MediaFolderID: folderID, FilePath: filePath, FileSize: 2}); err != nil {
+				t.Fatalf("overlapping refresh: %v", err)
+			}
+
+			marked, err := repo.MarkMissingIfUnchanged(ctx, snapshot.ID, snapshot.ScanGeneration, time.Now().UTC())
+			if err != nil {
+				t.Fatalf("stale %s reconciliation: %v", tt.name, err)
+			}
+			if marked {
+				t.Fatalf("stale %s reconciliation marked refreshed row", tt.name)
+			}
+		})
+	}
+}

--- a/internal/scanner/scan_state.go
+++ b/internal/scanner/scan_state.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -46,6 +47,7 @@ type scanStateFile struct {
 	ProbeSource            string
 	ProbeUpdatedAt         *time.Time
 	MissingSince           *time.Time
+	ScanGeneration         int64
 	HasVideoTracks         bool
 	HasNonImageVideoTracks bool
 	HasAudioTracks         bool
@@ -63,6 +65,11 @@ const scanStateColumns = `id, content_id, extra_id,
 	presentation_kind, presentation_group_key, presentation_part_index,
 	multi_episode_start, multi_episode_end,
 	probe_source, probe_updated_at, missing_since,
+	COALESCE((
+		SELECT generation.scan_generation
+		FROM media_file_scan_generations AS generation
+		WHERE generation.media_file_id = media_files.id
+	), 1) AS scan_generation,
 	COALESCE(jsonb_typeof(video_tracks) = 'array' AND jsonb_array_length(video_tracks) > 0, FALSE) AS has_video_tracks,
 	COALESCE((
 		SELECT bool_or(lower(btrim(COALESCE(track->>'codec', ''))) NOT IN ('mjpeg', 'jpeg', 'png', 'webp', 'gif', 'bmp'))
@@ -138,6 +145,7 @@ func scanScanStateRow(row pgx.Row) (*scanStateFile, error) {
 		&probeSource,
 		&state.ProbeUpdatedAt,
 		&state.MissingSince,
+		&state.ScanGeneration,
 		&state.HasVideoTracks,
 		&state.HasNonImageVideoTracks,
 		&state.HasAudioTracks,
@@ -276,6 +284,21 @@ func (r *FileRepository) GetScanStateByFolderAndPathPrefix(ctx context.Context, 
 		return nil, fmt.Errorf("querying scan state by folder and path prefix: %w", err)
 	}
 	return scanScanStateRows(rows)
+}
+
+// GetScanStateByFolderAndPath returns the lightweight scan-state row for an
+// exact path in a folder.
+func (r *FileRepository) GetScanStateByFolderAndPath(ctx context.Context, folderID int, path string) (*scanStateFile, error) {
+	query := `SELECT ` + scanStateColumns + ` FROM media_files
+		WHERE media_folder_id = $1 AND file_path = $2`
+	file, err := scanScanStateRow(r.pool.QueryRow(ctx, query, folderID, path))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrFileNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying scan state by folder and path: %w", err)
+	}
+	return file, nil
 }
 
 func scanStateFromMediaFile(file *models.MediaFile) *scanStateFile {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -929,6 +931,9 @@ func (s *Scanner) scanPaths(
 	result.Updated += extraStats.Updated
 	result.Unchanged += extraStats.Unchanged
 	result.Errors += extraStats.Errors
+	if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, presentScanPaths(seenPaths)); err != nil {
+		return nil, err
+	}
 
 	if err := s.syncPresentLibraryState(ctx, folder.ID); err != nil {
 		return nil, fmt.Errorf("syncing present library state for folder %d: %w", folder.ID, err)
@@ -964,14 +969,14 @@ func (s *Scanner) scanPaths(
 		result.FilesDeleted += trashed
 	}
 
-	staleFileIDs := collectStaleRemovedPathFileIDs(existingFiles, seenPaths, reconcileRoots)
+	staleFiles := collectStaleRemovedPathFiles(existingFiles, seenPaths, reconcileRoots)
 	if len(filePaths) == 0 && allowEmptyCleanup {
-		staleFileIDs = make([]int, 0, len(existingFiles))
+		staleFiles = make([]fileScanFence, 0, len(existingFiles))
 		for _, existing := range existingFiles {
-			staleFileIDs = append(staleFileIDs, existing.ID)
+			staleFiles = append(staleFiles, fileScanFence{ID: existing.ID, ScanGeneration: existing.ScanGeneration})
 		}
 	}
-	deletedFiles, err := s.fileRepo.DeleteByIDs(ctx, staleFileIDs)
+	deletedFiles, err := s.fileRepo.DeleteIfUnchanged(ctx, staleFiles)
 	if err != nil {
 		return nil, fmt.Errorf("deleting stale files for folder %d: %w", folder.ID, err)
 	}
@@ -1066,6 +1071,10 @@ func (s *Scanner) scanFolderByRoots(
 		configuredRoots = cleanScanRoots(walkRoots)
 	}
 	roots := compactScanRoots(configuredRoots)
+	outsideRootFences, err := s.fileRepo.ListFencesOutsideRoots(ctx, folder.ID, roots)
+	if err != nil {
+		return nil, fmt.Errorf("snapshotting stale files outside configured roots for folder %d: %w", folder.ID, err)
+	}
 
 	// An unreachable root (dead drive, lost mount) is temporarily offline, not
 	// removed from the library: its files are left untouched below — not
@@ -1377,11 +1386,7 @@ func (s *Scanner) scanFolderByRoots(
 		result.FilesDeleted += trashed
 	}
 
-	staleOutsideRoots, err := s.fileRepo.ListIDsOutsideRoots(ctx, folder.ID, roots)
-	if err != nil {
-		return nil, fmt.Errorf("listing stale files outside configured roots for folder %d: %w", folder.ID, err)
-	}
-	deletedOutsideRoots, err := s.fileRepo.DeleteByIDs(ctx, staleOutsideRoots)
+	deletedOutsideRoots, err := s.fileRepo.DeleteIfUnchanged(ctx, outsideRootFences)
 	if err != nil {
 		return nil, fmt.Errorf("deleting stale files outside configured roots for folder %d: %w", folder.ID, err)
 	}
@@ -1758,6 +1763,9 @@ func (s *Scanner) scanScope(
 		result.Updated += extraStats.Updated
 		result.Unchanged += extraStats.Unchanged
 		result.Errors += extraStats.Errors
+		if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, presentScanPaths(seenPaths)); err != nil {
+			return nil, err
+		}
 	}
 
 	return &scopedScan{
@@ -1833,17 +1841,17 @@ func (s *Scanner) applyScopedScan(
 	}
 	s.markMissingExcludingProtected(ctx, folder.ID, scope.existingFiles, scope.seenPaths, protectedRoots, scope.result)
 
-	staleFileIDs := collectStaleRemovedPathFileIDs(scope.existingFiles, scope.seenPaths, scope.reconcileRoots)
+	staleFiles := collectStaleRemovedPathFiles(scope.existingFiles, scope.seenPaths, scope.reconcileRoots)
 	if forceDeleteAll && len(scope.filePaths) == 0 {
-		staleFileIDs = make([]int, 0, len(scope.existingFiles))
+		staleFiles = make([]fileScanFence, 0, len(scope.existingFiles))
 		for _, existing := range scope.existingFiles {
 			if pathWithinAnyRoot(existing.FilePath, protectedRoots) {
 				continue
 			}
-			staleFileIDs = append(staleFileIDs, existing.ID)
+			staleFiles = append(staleFiles, fileScanFence{ID: existing.ID, ScanGeneration: existing.ScanGeneration})
 		}
 	}
-	deletedFiles, err := s.fileRepo.DeleteByIDs(ctx, staleFileIDs)
+	deletedFiles, err := s.fileRepo.DeleteIfUnchanged(ctx, staleFiles)
 	if err != nil {
 		return fmt.Errorf("deleting stale files for scope %q: %w", scope.reconcileRoots[0], err)
 	}
@@ -1894,12 +1902,16 @@ func (s *Scanner) markMissingExcludingProtected(
 		}
 		// Only mark as missing if not already marked.
 		if existing.MissingSince == nil {
-			if err := s.fileRepo.MarkMissing(ctx, existing.ID, now); err != nil {
+			marked, err := s.fileRepo.MarkMissingIfUnchanged(ctx, existing.ID, existing.ScanGeneration, now)
+			if err != nil {
 				slog.ErrorContext(ctx, "scanner: failed to mark file missing", "component", "scanner",
 					"path", existing.FilePath,
 					"error", err,
 				)
 				result.Errors++
+				continue
+			}
+			if !marked {
 				continue
 			}
 		}
@@ -2345,8 +2357,8 @@ func (s *Scanner) sweepMissingAndReconcile(ctx context.Context, folder *models.M
 	return trashed, removedMemberships, deletedItems, nil
 }
 
-func collectStaleRemovedPathFileIDs(existingFiles []*scanStateFile, seenPaths map[string]bool, roots []string) []int {
-	ids := make([]int, 0)
+func collectStaleRemovedPathFiles(existingFiles []*scanStateFile, seenPaths map[string]bool, roots []string) []fileScanFence {
+	fences := make([]fileScanFence, 0)
 	for _, existing := range existingFiles {
 		if seenPaths[existing.FilePath] {
 			continue
@@ -2354,9 +2366,43 @@ func collectStaleRemovedPathFileIDs(existingFiles []*scanStateFile, seenPaths ma
 		if pathWithinAnyRoot(existing.FilePath, roots) {
 			continue
 		}
-		ids = append(ids, existing.ID)
+		fences = append(fences, fileScanFence{ID: existing.ID, ScanGeneration: existing.ScanGeneration})
 	}
-	return ids
+	return fences
+}
+
+func presentScanPaths(seenPaths map[string]bool) []string {
+	return slices.Collect(maps.Keys(seenPaths))
+}
+
+// snapshotScanStateForRoots captures the row generations before a filesystem
+// walk starts. Reconciliation must use this snapshot rather than re-reading
+// after the walk, otherwise a concurrent scan that finishes during the walk
+// can look old to the late snapshot and be overwritten.
+func (s *Scanner) snapshotScanStateForRoots(ctx context.Context, folderID int, roots []string) ([]*scanStateFile, error) {
+	if s == nil || s.fileRepo == nil {
+		return nil, nil
+	}
+
+	files := make([]*scanStateFile, 0)
+	seenIDs := make(map[int]struct{})
+	for _, root := range cleanScanRoots(roots) {
+		rootFiles, err := s.fileRepo.GetScanStateByFolderAndPathPrefix(ctx, folderID, root)
+		if err != nil {
+			return nil, fmt.Errorf("snapshotting scan state for folder %d root %q: %w", folderID, root, err)
+		}
+		for _, file := range rootFiles {
+			if file == nil {
+				continue
+			}
+			if _, exists := seenIDs[file.ID]; exists {
+				continue
+			}
+			seenIDs[file.ID] = struct{}{}
+			files = append(files, file)
+		}
+	}
+	return files, nil
 }
 
 func collectScanStateContentIDs(files []*scanStateFile) []string {
@@ -2474,6 +2520,9 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		if stats.Errors > 0 {
 			return fmt.Errorf("processing extra file %s failed", cleanFile)
 		}
+		if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, []string{cleanFile}); err != nil {
+			return err
+		}
 		// The Upsert above already nulled this row's content/episode links as
 		// part of converting it into an extra. What still needs repair is the
 		// library membership: if this was the last primary file behind an
@@ -2530,6 +2579,9 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 	if err != nil {
 		return err
 	}
+	if _, err := s.fileRepo.RefreshPresentPaths(ctx, folder.ID, []string{cleanFile}); err != nil {
+		return err
+	}
 	if err := s.reconcileScannedRoots(
 		ctx,
 		folder.ID,
@@ -2577,18 +2629,15 @@ func (s *Scanner) reconcileVanishedFileIfNeeded(ctx context.Context, folder *mod
 		return true, fmt.Errorf("reconcile vanished file: scanner repositories not configured")
 	}
 
-	file, err := s.fileRepo.GetByPath(ctx, filePath)
+	file, err := s.fileRepo.GetScanStateByFolderAndPath(ctx, folder.ID, filePath)
 	if errors.Is(err, ErrFileNotFound) {
 		return true, nil
 	}
 	if err != nil {
 		return true, fmt.Errorf("loading vanished media file %s: %w", filePath, err)
 	}
-	if file.MediaFolderID != folder.ID {
-		return true, fmt.Errorf("vanished media file %s belongs to library %d, not %d", filePath, file.MediaFolderID, folder.ID)
-	}
 	if file.MissingSince == nil {
-		if err := s.fileRepo.MarkMissing(ctx, file.ID, time.Now().UTC()); err != nil {
+		if _, err := s.fileRepo.MarkMissingIfUnchanged(ctx, file.ID, file.ScanGeneration, time.Now().UTC()); err != nil {
 			return true, fmt.Errorf("marking vanished media file %s missing: %w", filePath, err)
 		}
 	}

--- a/migrations/sql/20260827201436_add_media_file_scan_generation.sql
+++ b/migrations/sql/20260827201436_add_media_file_scan_generation.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+CREATE TABLE media_file_scan_generations (
+    media_file_id integer PRIMARY KEY REFERENCES media_files(id) ON DELETE CASCADE,
+    scan_generation bigint NOT NULL DEFAULT 1
+);
+
+-- +goose StatementBegin
+CREATE FUNCTION maintain_media_file_scan_generation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        INSERT INTO media_file_scan_generations (media_file_id)
+        VALUES (NEW.id)
+        ON CONFLICT (media_file_id) DO NOTHING;
+    ELSE
+        INSERT INTO media_file_scan_generations (media_file_id, scan_generation)
+        VALUES (NEW.id, 2)
+        ON CONFLICT (media_file_id) DO UPDATE
+        SET scan_generation = media_file_scan_generations.scan_generation + 1;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER media_files_scan_generation
+AFTER INSERT OR UPDATE ON media_files
+FOR EACH ROW
+EXECUTE FUNCTION maintain_media_file_scan_generation();
+
+INSERT INTO media_file_scan_generations (media_file_id)
+SELECT id FROM media_files
+ON CONFLICT (media_file_id) DO NOTHING;
+
+-- +goose Down
+DROP TRIGGER media_files_scan_generation ON media_files;
+DROP FUNCTION maintain_media_file_scan_generation();
+DROP TABLE media_file_scan_generations;


### PR DESCRIPTION
## Problem

Related issue: N/A — audit-validated catalog correctness fix

A full scan could snapshot a `media_files` row, miss its path during the walk, and later mark that row missing even after an overlapping scoped scan had re-upserted it. The stale mark hid present media and made it eligible for deletion after the missing-file grace period.

The invariant this PR adds is: reconciliation may mark or delete a snapshot row only while its scan generation still matches the snapshot. Any committed upsert or completed presence observation advances the generation first.

## Approach

- Add a narrow `media_file_scan_generations` table keyed by `media_files.id`. An `AFTER INSERT OR UPDATE` trigger creates or advances the generation for every media-row write, including identity-only upserts.
- Capture the generation with pre-walk scan state for full, subtree, exact-file, audiobook, ebook, manga, podcast, and removed-root reconciliation.
- Refresh generations for paths a completed scan observed, including unchanged-file fast paths.
- Lock `media_files` first, then atomically claim the expected generation before marking or deleting. If a refresh committed first, PostgreSQL rechecks the predicate after the lock wait and the stale operation changes zero rows.
- Keep missing grace cleanup unchanged. Genuine missing rows are still marked and swept after the configured grace period.

The side table avoids rewriting wide `media_files` rows just to record presence. Refreshes use the existing folder/path lookup and primary keys in batches of 1,000. A synthetic 100,000-path run completed 100 batches in 3.081 seconds and generated 27,890,056 WAL bytes. The rejected wide-row prototype took 10.277 seconds and generated 192,749,136 WAL bytes on the same harness.

## Validation

Passed:

- `make embed-stub`
- `go build ./...`
- `gofmt -l .` (no output)
- `go vet ./...`
- `golangci-lint run --new-from-merge-base=origin/main ./...` (`0 issues`)
- `make test-go` on dev-builder. The first run hit an unrelated transient `ETXTBSY` in `TestProbeFileKeepsMetadataWhenPacketFallbackFails`; the full retry passed.
- Database-backed `go test ./internal/scanner -count=1`
- Database-backed race run covering stale mark/delete, grace, caller snapshots, repeated upserts, and overlap cases
- Database-backed `go test ./internal/libraryingest -count=1`
- `make migrate-validate`
- `pnpm install --frozen-lockfile`
- `pnpm run lint` (0 errors; 167 existing warnings)
- `pnpm run format:check`
- `pnpm run build`
- `make test-web` (294 files, 2,184 tests)
- `make verify-settings-bindings-all`
- `make verify-playback-fixtures`
- `make verify-local-paths`
- Isolated dev-builder `doctor`: container, database, API, and frontend healthy
- Independent read-only review of the final patch and deterministic PostgreSQL lock-barrier test

The database-backed catalog package still has its pre-existing `TestEpisodeSearchPostgresAndDocumentSource` failure because the document contains `silo_recommendations: nil`. The ordinary catalog suite passes under `make test-go`; this change does not touch catalog document construction.

The deterministic sandbox matrix proves both sides of the behavior: a refreshed synthetic file remains present and visible after stale reconciliation, while a genuinely absent file is marked missing, survives a nonzero grace period, and becomes eligible for cleanup afterward. A separate barrier test holds the refresh transaction uncommitted, observes stale mark and delete blocked on its row lock, commits the refresh, and verifies both stale operations return zero.

No private fixtures were used. All sandbox media and paths were synthetic.

## Risks

The migration creates and backfills one narrow row per existing media file, so apply time and WAL scale linearly with `media_files`. The trigger is installed before the conflict-safe repair backfill so concurrent inserts and updates cannot miss initialization.

Unrelated metadata updates conservatively invalidate the current scan snapshot and can delay missing detection until the next scan. Pathological overlapping multi-row batches can receive PostgreSQL's normal retryable deadlock error. Both cases fail without applying a stale mark or delete.

Rollback order is application first, migration second: deploy the pre-change binary, then run the migration down step to drop the trigger, function, and side table. The new binary requires the side table.

This is internal catalog-state behavior. It does not change the v1 API, capability surface, auth, playback contract, or client models, so no Apple or Android changes are needed. Jellyfin-compatible clients benefit from the same preserved catalog visibility without a jellycompat contract change.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): gpt-5.6-sol (ultra)
- Involvement: Fully AI-generated, human verified
- Adversarial review: A separate read-only agent reviewed row identity, snapshot timing, MVCC predicate rechecks, lock ordering, migration installation races, clock assumptions, grace behavior, caller coverage, index use, WAL, and false-negative missing detection. It found gaps in confirmed-empty deletion, unchanged-path refreshes, literary scan timing, removed-root timing, the original wide-row design, migration ordering, non-atomic generation checks, and lock-barrier coverage. Each finding was resolved and the relevant tests and performance probe were rerun. The final review found no actionable issues.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
