### PR TITLE
fix(scanqueue): fence stale scan workers

### DIFF
--- a/internal/claimcontext/context.go
+++ b/internal/claimcontext/context.go
@@ -1,0 +1,78 @@
+package claimcontext
+
+import (
+	"context"
+	"sync"
+)
+
+type ownershipGuardKey struct{}
+
+type guardedCancelContext struct {
+	context.Context
+	guard    func() error
+	cancel   context.CancelFunc
+	done     chan struct{}
+	doneOnce sync.Once
+}
+
+// WithOwnershipGuard installs a synchronous ownership check for claimed work.
+func WithOwnershipGuard(ctx context.Context, guard func() error) context.Context {
+	if guard == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ownershipGuardKey{}, guard)
+}
+
+// WithGuardedCancel derives a cancelable context without losing an installed
+// ownership guard.
+func WithGuardedCancel(ctx context.Context) (context.Context, context.CancelFunc) {
+	base, cancel := context.WithCancel(ctx)
+	guard, _ := ctx.Value(ownershipGuardKey{}).(func() error)
+	if guard == nil {
+		return base, cancel
+	}
+	guarded := &guardedCancelContext{
+		Context: base,
+		guard:   guard,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	context.AfterFunc(base, guarded.closeDone)
+	return guarded, func() {
+		cancel()
+		guarded.closeDone()
+	}
+}
+
+func (c *guardedCancelContext) Done() <-chan struct{} {
+	c.check()
+	return c.done
+}
+
+func (c *guardedCancelContext) Err() error {
+	c.check()
+	if err := c.Context.Err(); err != nil {
+		return err
+	}
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (c *guardedCancelContext) check() {
+	if c.guard() != nil {
+		c.cancel()
+		c.closeDone()
+		return
+	}
+	if c.Context.Err() != nil {
+		c.closeDone()
+	}
+}
+
+func (c *guardedCancelContext) closeDone() {
+	c.doneOnce.Do(func() { close(c.done) })
+}

--- a/internal/libraryingest/executor.go
+++ b/internal/libraryingest/executor.go
@@ -58,6 +58,39 @@ type Result struct {
 	Skipped                bool
 }
 
+type afterCommitRegistrarKey struct{}
+
+// WithLeaseGuard installs a synchronous ownership check that survives the
+// executor's derived scan context and its descendants.
+func WithLeaseGuard(ctx context.Context, guard func() error) context.Context {
+	return scanner.WithOwnershipGuard(ctx, guard)
+}
+
+func withIngestCancel(ctx context.Context) (context.Context, context.CancelFunc) {
+	return scanner.WithGuardedCancel(ctx)
+}
+
+// WithAfterCommitRegistrar lets a queue owner defer best-effort side effects
+// until it has durably committed the ingest result. Direct callers retain the
+// executor's existing immediate behavior.
+func WithAfterCommitRegistrar(ctx context.Context, register func(func(context.Context))) context.Context {
+	if register == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, afterCommitRegistrarKey{}, register)
+}
+
+// DeferUntilCommitted registers callback with a queue owner when one is
+// present. It returns false when the caller should run callback immediately.
+func DeferUntilCommitted(ctx context.Context, callback func(context.Context)) bool {
+	register, ok := ctx.Value(afterCommitRegistrarKey{}).(func(func(context.Context)))
+	if !ok || register == nil {
+		return false
+	}
+	register(callback)
+	return true
+}
+
 type scopeMode string
 
 const (
@@ -152,7 +185,7 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 	}
 
 	// Wrap the caller's context so we can cancel from CancelLibrary.
-	scanCtx, cancel := context.WithCancel(ctx)
+	scanCtx, cancel := withIngestCancel(ctx)
 	defer cancel()
 
 	claim := scopeClaim{
@@ -364,10 +397,9 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 	}
 
 	// Content availability runs after matching/reconcile so releases are tied
-	// to resolved items. It runs detached: the detector is best-effort with
-	// its own deadline (it detaches from scanCtx internally, surviving its
-	// cancellation), and a slow pass must not delay scan completion or the
-	// serialized scan queue.
+	// to resolved items. Queue-owned ingests defer it until the queue has
+	// durably accepted the fenced completion. Other callers retain the existing
+	// detached, best-effort behavior.
 	if e.availability != nil {
 		lk := librarykind.Of(folder.Type)
 		// Audiobook/ebook are dedicated library types, never part of "mixed"
@@ -379,7 +411,12 @@ func (e *Executor) ingest(ctx context.Context, folder *models.MediaFolder, mode 
 			Ebooks:     lk.Ebook,
 		}
 		if kinds.Any() {
-			go e.availability.HandleIngestCompleted(scanCtx, folder.ID, mode == scopeModeLibrary, matchScopes, kinds)
+			callback := func(afterCommitCtx context.Context) {
+				e.availability.HandleIngestCompleted(afterCommitCtx, folder.ID, mode == scopeModeLibrary, matchScopes, kinds)
+			}
+			if !DeferUntilCommitted(scanCtx, callback) {
+				go callback(context.Background())
+			}
 		}
 	}
 

--- a/internal/metadata/worker.go
+++ b/internal/metadata/worker.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/claimcontext"
 	"github.com/Silo-Server/silo-server/internal/librarykind"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/naming"
@@ -1038,7 +1039,7 @@ func (w *MatchWorker) processSeriesRoots(ctx context.Context, jobs []models.Seri
 	}
 	defer w.releaseSeriesLeases(jobs)
 
-	runCtx, cancel := context.WithCancel(ctx)
+	runCtx, cancel := claimcontext.WithGuardedCancel(ctx)
 	defer cancel()
 
 	jobChan := make(chan models.SeriesRootMatchJob, len(jobs))

--- a/internal/metadata/worker_test.go
+++ b/internal/metadata/worker_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/claimcontext"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
@@ -296,6 +298,37 @@ func TestProcessSeriesRoots_ReleasesUnfinishedBatchOnCancellation(t *testing.T) 
 	}
 	if processed != 0 {
 		t.Fatalf("processed = %d, want 0", processed)
+	}
+	if got := repo.releasedLeases; len(got) != 1 || got[0] != leaseToken {
+		t.Fatalf("released leases = %v, want [%s]", got, leaseToken)
+	}
+}
+
+func TestProcessSeriesRootsPreservesOwnershipGuard(t *testing.T) {
+	const leaseToken = "series-ownership-guard"
+	repo := newFakeSeriesQueueRepo()
+	worker := NewMatchWorker(nil, nil, 2, 10, 0)
+	worker.seriesClaimer = repo
+	var claimLost atomic.Bool
+	ctx := claimcontext.WithOwnershipGuard(t.Context(), func() error {
+		if claimLost.Load() {
+			return errors.New("scan claim lost")
+		}
+		return nil
+	})
+	claimLost.Store(true)
+
+	processed, err := worker.processSeriesRoots(ctx, []models.SeriesRootMatchJob{
+		{MediaFolderID: 1, ObservedRootPath: "/shows/One", LeaseToken: leaseToken},
+	})
+	if err != nil {
+		t.Fatalf("process series roots: %v", err)
+	}
+	if processed != 0 {
+		t.Fatalf("processed = %d, want 0", processed)
+	}
+	if len(repo.deleted) != 0 || len(repo.errors) != 0 {
+		t.Fatalf("lost claim mutated series queue: deleted=%v errors=%v", repo.deleted, repo.errors)
 	}
 	if got := repo.releasedLeases; len(got) != 1 || got[0] != leaseToken {
 		t.Fatalf("released leases = %v, want [%s]", got, leaseToken)

--- a/internal/models/scan_run.go
+++ b/internal/models/scan_run.go
@@ -16,6 +16,7 @@ type ScanRun struct {
 	ResultPayload   json.RawMessage
 	ErrorMessage    string
 	AutoscanEventID *int64
+	ClaimToken      string
 	RequestedAt     time.Time
 	StartedAt       *time.Time
 	CompletedAt     *time.Time

--- a/internal/scanner/guard_context.go
+++ b/internal/scanner/guard_context.go
@@ -1,0 +1,19 @@
+package scanner
+
+import (
+	"context"
+
+	"github.com/Silo-Server/silo-server/internal/claimcontext"
+)
+
+// WithOwnershipGuard installs a synchronous ownership check for scan work.
+func WithOwnershipGuard(ctx context.Context, guard func() error) context.Context {
+	return claimcontext.WithOwnershipGuard(ctx, guard)
+}
+
+// WithGuardedCancel derives a cancelable context without losing an installed
+// ownership guard. Scanner code must use it instead of context.WithCancel when
+// deriving a context that can perform ingest mutations.
+func WithGuardedCancel(ctx context.Context) (context.Context, context.CancelFunc) {
+	return claimcontext.WithGuardedCancel(ctx)
+}

--- a/internal/scanner/guard_context_test.go
+++ b/internal/scanner/guard_context_test.go
@@ -1,0 +1,30 @@
+package scanner
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+)
+
+func TestOwnershipGuardSurvivesScannerContextDerivation(t *testing.T) {
+	var expired atomic.Bool
+	ctx := WithOwnershipGuard(t.Context(), func() error {
+		if expired.Load() {
+			return errors.New("claim expired")
+		}
+		return nil
+	})
+	ingestCtx, cancelIngest := WithGuardedCancel(ctx)
+	defer cancelIngest()
+	watchCtx, cancelWatch := WithGuardedCancel(ingestCtx)
+	defer cancelWatch()
+
+	if err := watchCtx.Err(); err != nil {
+		t.Fatalf("watch context before expiry = %v, want nil", err)
+	}
+	expired.Store(true)
+	if err := watchCtx.Err(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("watch context after expiry = %v, want %v", err, context.Canceled)
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2626,7 +2626,7 @@ func (s *Scanner) watchFolderContext(ctx context.Context, folderID int) (context
 		return ctx, cancel
 	}
 
-	watchCtx, cancel := context.WithCancel(ctx)
+	watchCtx, cancel := WithGuardedCancel(ctx)
 	enabled, err := s.folderEnabledState(watchCtx, folderID)
 	if err != nil {
 		slog.WarnContext(ctx, "scanner: failed to load folder state", "component", "scanner", "folder_id", folderID, "error", err)

--- a/internal/scanqueue/claim_fencing_db_test.go
+++ b/internal/scanqueue/claim_fencing_db_test.go
@@ -1,0 +1,719 @@
+package scanqueue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	evt "github.com/Silo-Server/silo-server/internal/events"
+	"github.com/Silo-Server/silo-server/internal/libraryingest"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestStaleScanClaimCannotMutateSuccessor(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+
+	tests := []struct {
+		name   string
+		mutate func(context.Context, *Repository, *models.ScanRun) error
+	}{
+		{
+			name: "heartbeat",
+			mutate: func(ctx context.Context, repo *Repository, claim *models.ScanRun) error {
+				return repo.TouchHeartbeat(ctx, claim.ID, claim.ClaimToken)
+			},
+		},
+		{
+			name: "progress",
+			mutate: func(ctx context.Context, repo *Repository, claim *models.ScanRun) error {
+				_, err := repo.UpdateProgress(ctx, claim.ID, claim.ClaimToken, &evt.ScanRunResult{FilesProcessed: 1})
+				return err
+			},
+		},
+		{
+			name: "success",
+			mutate: func(ctx context.Context, repo *Repository, claim *models.ScanRun) error {
+				_, err := repo.Complete(ctx, claim.ID, claim.ClaimToken, &evt.ScanRunResult{FilesProcessed: 1})
+				return err
+			},
+		},
+		{
+			name: "failure",
+			mutate: func(ctx context.Context, repo *Repository, claim *models.ScanRun) error {
+				_, err := repo.Fail(ctx, claim.ID, claim.ClaimToken, "stale worker")
+				return err
+			},
+		},
+		{
+			name: "cancellation",
+			mutate: func(ctx context.Context, repo *Repository, claim *models.ScanRun) error {
+				_, err := repo.CancelClaim(ctx, claim.ID, claim.ClaimToken)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			first := createAndClaimScanRun(t, pool, repo)
+			successor := expireRequeueAndReclaim(t, pool, repo, first)
+
+			if err := tt.mutate(ctx, repo, first); !errors.Is(err, ErrScanRunClaimLost) {
+				t.Fatalf("stale %s error = %v, want %v", tt.name, err, ErrScanRunClaimLost)
+			}
+
+			current, err := repo.GetByID(ctx, successor.ID)
+			if err != nil {
+				t.Fatalf("load successor after stale %s: %v", tt.name, err)
+			}
+			if current.Status != StatusRunning || current.ClaimToken != successor.ClaimToken {
+				t.Fatalf("successor after stale %s = status:%q token:%q, want running token %q", tt.name, current.Status, current.ClaimToken, successor.ClaimToken)
+			}
+
+			completed, err := repo.Complete(ctx, successor.ID, successor.ClaimToken, &evt.ScanRunResult{FilesProcessed: 2})
+			if err != nil {
+				t.Fatalf("complete legitimate successor after stale %s: %v", tt.name, err)
+			}
+			if completed.Status != StatusCompleted {
+				t.Fatalf("legitimate successor status = %q, want %q", completed.Status, StatusCompleted)
+			}
+		})
+	}
+}
+
+func TestScanServiceCancelsIngestionWhenClaimIsLost(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	first := createAndClaimScanRun(t, pool, repo)
+	ingester := &blockingScanIngester{
+		started:   make(chan struct{}),
+		canceled:  make(chan struct{}),
+		committed: make(chan struct{}),
+	}
+	service := NewService(
+		repo,
+		fixedFolderLoader{folder: &models.MediaFolder{ID: first.MediaFolderID, Enabled: true}},
+		ingester,
+		nil,
+		t.Context(),
+		1,
+		1,
+	)
+	service.heartbeatInterval = 20 * time.Millisecond
+	service.staleAfter = 10 * time.Second
+
+	processed := make(chan struct{})
+	go func() {
+		service.process(first)
+		close(processed)
+	}()
+	waitForScanSignal(t, ingester.started, "ingestion to start")
+
+	successor := expireRequeueAndReclaim(t, pool, repo, first)
+	waitForScanSignal(t, ingester.canceled, "stale ingestion to observe claim loss")
+	waitForScanSignal(t, processed, "stale scan process to stop")
+	select {
+	case <-ingester.committed:
+		t.Fatal("stale ingestion ran a post-commit callback")
+	default:
+	}
+
+	current, err := repo.GetByID(t.Context(), successor.ID)
+	if err != nil {
+		t.Fatalf("load successor after stale ingestion stopped: %v", err)
+	}
+	if current.Status != StatusRunning || current.ClaimToken != successor.ClaimToken {
+		t.Fatalf("successor after stale ingestion stopped = status:%q token:%q, want running token %q", current.Status, current.ClaimToken, successor.ClaimToken)
+	}
+
+	successorCommitted := make(chan struct{})
+	successorService := NewService(
+		repo,
+		fixedFolderLoader{folder: &models.MediaFolder{ID: successor.MediaFolderID, Enabled: true}},
+		successfulCommitIngester{committed: successorCommitted},
+		nil,
+		t.Context(),
+		1,
+		1,
+	)
+	successorService.heartbeatInterval = 20 * time.Millisecond
+	successorService.staleAfter = 10 * time.Second
+	successorService.process(successor)
+	waitForScanSignal(t, successorCommitted, "successor post-commit callback")
+	completed, err := repo.GetByID(t.Context(), successor.ID)
+	if err != nil {
+		t.Fatalf("load completed successor: %v", err)
+	}
+	if completed.Status != StatusCompleted {
+		t.Fatalf("successor status = %q, want %q", completed.Status, StatusCompleted)
+	}
+}
+
+func TestScanServiceLocalLeaseExpiryCancelsIngestion(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	claim := createAndClaimScanRun(t, pool, repo)
+	ingester := &blockingScanIngester{
+		started:   make(chan struct{}),
+		canceled:  make(chan struct{}),
+		committed: make(chan struct{}),
+	}
+	service := NewService(
+		repo,
+		fixedFolderLoader{folder: &models.MediaFolder{ID: claim.MediaFolderID, Enabled: true}},
+		ingester,
+		nil,
+		t.Context(),
+		1,
+		1,
+	)
+	service.heartbeatInterval = time.Hour
+	service.staleAfter = 50 * time.Millisecond
+
+	processed := make(chan struct{})
+	go func() {
+		service.process(claim)
+		close(processed)
+	}()
+	waitForScanSignal(t, ingester.started, "ingestion to start")
+	waitForScanSignal(t, ingester.canceled, "local lease expiry to cancel ingestion")
+	waitForScanSignal(t, processed, "lease-expired scan process to stop")
+
+	select {
+	case <-ingester.committed:
+		t.Fatal("lease-expired ingestion ran a post-commit callback")
+	default:
+	}
+}
+
+func TestScanServiceRejectsReclaimedClaimBeforeIngestionStarts(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	first := createAndClaimScanRun(t, pool, repo)
+	successor := expireRequeueAndReclaim(t, pool, repo, first)
+	ingester := &recordingScanIngester{}
+	service := NewService(
+		repo,
+		fixedFolderLoader{folder: &models.MediaFolder{ID: first.MediaFolderID, Enabled: true}},
+		ingester,
+		nil,
+		t.Context(),
+		1,
+		1,
+	)
+
+	service.process(first)
+	if calls := ingester.calls.Load(); calls != 0 {
+		t.Fatalf("stale claim started ingestion %d times, want 0", calls)
+	}
+	current, err := repo.GetByID(t.Context(), successor.ID)
+	if err != nil {
+		t.Fatalf("load successor after stale process resumed: %v", err)
+	}
+	if current.Status != StatusRunning || current.ClaimToken != successor.ClaimToken {
+		t.Fatalf("successor after stale process resumed = status:%q token:%q", current.Status, current.ClaimToken)
+	}
+}
+
+func TestScanServiceRegistersCancellationBeforeInitialHeartbeat(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	claim := createAndClaimScanRun(t, pool, repo)
+	ingester := &recordingScanIngester{}
+	service := NewService(
+		repo,
+		fixedFolderLoader{folder: &models.MediaFolder{ID: claim.MediaFolderID, Enabled: true}},
+		ingester,
+		nil,
+		t.Context(),
+		1,
+		1,
+	)
+
+	tx, err := pool.Begin(t.Context())
+	if err != nil {
+		t.Fatalf("begin heartbeat blocker: %v", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+	var lockedID string
+	if err := tx.QueryRow(t.Context(), `SELECT id FROM scan_runs WHERE id = $1 FOR UPDATE`, claim.ID).Scan(&lockedID); err != nil {
+		t.Fatalf("lock claimed row: %v", err)
+	}
+
+	processed := make(chan struct{})
+	go func() {
+		service.process(claim)
+		close(processed)
+	}()
+	cancel := waitForTrackedScanCancel(t, service, claim)
+	cancel()
+	waitForScanSignal(t, processed, "startup heartbeat to stop after local cancellation")
+	if err := tx.Rollback(t.Context()); err != nil {
+		t.Fatalf("release heartbeat blocker: %v", err)
+	}
+	if calls := ingester.calls.Load(); calls != 0 {
+		t.Fatalf("canceled startup began ingestion %d times, want 0", calls)
+	}
+
+	canceled, err := repo.CancelActiveByLibrary(t.Context(), claim.MediaFolderID)
+	if err != nil {
+		t.Fatalf("durably cancel startup claim: %v", err)
+	}
+	if len(canceled) != 1 || canceled[0].Status != StatusCancelled {
+		t.Fatalf("durably canceled runs = %#v, want one canceled run", canceled)
+	}
+}
+
+func TestScanServiceLeaseExpiryAtCompletionBoundaryLeavesRunForRetry(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	claim := createAndClaimScanRun(t, pool, repo)
+	service := NewService(repo, nil, nil, nil, t.Context(), 1, 1)
+	parent, cancel := context.WithCancelCause(t.Context())
+	ctx, lease := newClaimLeaseContext(parent, cancel, time.Minute, time.Now())
+	lease.deadline.Store(time.Now().Add(-time.Second).UnixNano())
+
+	if service.finishRun(ctx, lease, claim, &libraryingest.Result{}, nil) {
+		t.Fatal("expired claim completed successfully")
+	}
+	current, err := repo.GetByID(t.Context(), claim.ID)
+	if err != nil {
+		t.Fatalf("load expired claim after completion boundary: %v", err)
+	}
+	if current.Status != StatusRunning || current.ClaimToken != claim.ClaimToken {
+		t.Fatalf("expired claim = status:%q token:%q, want running for stale requeue", current.Status, current.ClaimToken)
+	}
+}
+
+func TestLegacyStaleWorkerCannotMutateDistinctSuccessor(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	first := createAndClaimScanRun(t, pool, repo)
+	successor := expireRequeueAndReclaim(t, pool, repo, first)
+
+	legacyWrites := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "heartbeat",
+			sql:  `UPDATE scan_runs SET heartbeat_at = NOW(), updated_at = NOW() WHERE id = $1 AND status = 'running'`,
+		},
+		{
+			name: "progress",
+			sql:  `UPDATE scan_runs SET result_payload = '{}'::jsonb, updated_at = NOW() WHERE id = $1 AND status = 'running'`,
+		},
+		{
+			name: "success",
+			sql:  `UPDATE scan_runs SET status = 'completed', completed_at = NOW(), updated_at = NOW() WHERE id = $1 AND status = 'running'`,
+		},
+		{
+			name: "failure",
+			sql:  `UPDATE scan_runs SET status = 'failed', completed_at = NOW(), updated_at = NOW() WHERE id = $1 AND status = 'running'`,
+		},
+	}
+	for _, write := range legacyWrites {
+		t.Run(write.name, func(t *testing.T) {
+			tag, err := pool.Exec(t.Context(), write.sql, first.ID)
+			if err != nil {
+				t.Fatalf("legacy stale %s: %v", write.name, err)
+			}
+			if tag.RowsAffected() != 0 {
+				t.Fatalf("legacy stale %s affected %d rows, want 0", write.name, tag.RowsAffected())
+			}
+		})
+	}
+
+	current, err := repo.GetByID(t.Context(), successor.ID)
+	if err != nil {
+		t.Fatalf("load successor after legacy writes: %v", err)
+	}
+	if current.Status != StatusRunning || current.ClaimToken != successor.ClaimToken {
+		t.Fatalf("successor after legacy writes = status:%q token:%q, want running token %q", current.Status, current.ClaimToken, successor.ClaimToken)
+	}
+}
+
+func TestLegacyTokenlessClaimIsNotAutomaticallyRequeued(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	claim := createAndClaimScanRun(t, pool, repo)
+	if _, err := pool.Exec(t.Context(), `
+		UPDATE scan_runs
+		SET claim_token = NULL, heartbeat_at = '1900-01-01'
+		WHERE id = $1`, claim.ID); err != nil {
+		t.Fatalf("convert claim to legacy tokenless row: %v", err)
+	}
+
+	requeued, err := repo.RequeueStaleRunning(t.Context(), time.Now())
+	if err != nil {
+		t.Fatalf("requeue stale claims: %v", err)
+	}
+	if len(requeued) != 0 {
+		t.Fatalf("requeued %d legacy tokenless claims, want 0", len(requeued))
+	}
+	current, err := repo.GetByID(t.Context(), claim.ID)
+	if err != nil {
+		t.Fatalf("load legacy claim: %v", err)
+	}
+	if current.Status != StatusRunning || current.ClaimToken != "" {
+		t.Fatalf("legacy claim = status:%q token:%q, want tokenless running", current.Status, current.ClaimToken)
+	}
+}
+
+func TestDatabaseRejectsLegacyClaimAndInPlaceRequeue(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	claim := createAndClaimScanRun(t, pool, repo)
+
+	if _, err := pool.Exec(t.Context(), `
+		UPDATE scan_runs
+		SET status = 'accepted', started_at = NULL, heartbeat_at = NULL,
+			completed_at = NULL, error_message = '', updated_at = NOW()
+		WHERE id = $1 AND status = 'running'`, claim.ID); err == nil {
+		t.Fatal("legacy in-place requeue succeeded, want database trigger rejection")
+	}
+	current, err := repo.GetByID(t.Context(), claim.ID)
+	if err != nil {
+		t.Fatalf("load claim after rejected legacy requeue: %v", err)
+	}
+	if current.Status != StatusRunning || current.ClaimToken != claim.ClaimToken {
+		t.Fatalf("claim after rejected legacy requeue = status:%q token:%q", current.Status, current.ClaimToken)
+	}
+	if _, err := repo.Complete(t.Context(), claim.ID, claim.ClaimToken, &evt.ScanRunResult{}); err != nil {
+		t.Fatalf("complete token-bearing claim: %v", err)
+	}
+
+	accepted, inserted, err := repo.Create(t.Context(), CreateInput{
+		LibraryID: claim.MediaFolderID,
+		Mode:      claim.Mode,
+		Path:      claim.Path,
+		Trigger:   claim.Trigger,
+	})
+	if err != nil || !inserted {
+		t.Fatalf("create accepted run: inserted=%v err=%v", inserted, err)
+	}
+	if _, err := pool.Exec(t.Context(), `
+		UPDATE scan_runs
+		SET status = 'running', started_at = NOW(), heartbeat_at = NOW(), updated_at = NOW()
+		WHERE id = $1 AND status = 'accepted'`, accepted.ID); err == nil {
+		t.Fatal("legacy tokenless claim succeeded, want database trigger rejection")
+	}
+	current, err = repo.GetByID(t.Context(), accepted.ID)
+	if err != nil {
+		t.Fatalf("load accepted run after rejected legacy claim: %v", err)
+	}
+	if current.Status != StatusAccepted || current.ClaimToken != "" {
+		t.Fatalf("accepted run after rejected legacy claim = status:%q token:%q", current.Status, current.ClaimToken)
+	}
+}
+
+func TestCancelByLibrarySerializesWithStaleRequeue(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	claim := createAndClaimScanRun(t, pool, repo)
+	if _, err := pool.Exec(t.Context(), `UPDATE scan_runs SET heartbeat_at = '1900-01-01' WHERE id = $1`, claim.ID); err != nil {
+		t.Fatalf("expire claim: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		<-start
+		_, err := repo.RequeueStaleRunning(t.Context(), time.Now())
+		errs <- err
+	})
+	wg.Go(func() {
+		<-start
+		_, err := repo.CancelActiveByLibrary(t.Context(), claim.MediaFolderID)
+		errs <- err
+	})
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent cancellation/requeue: %v", err)
+		}
+	}
+
+	active, err := repo.ListActive(t.Context())
+	if err != nil {
+		t.Fatalf("list active claims: %v", err)
+	}
+	for _, run := range active {
+		if run.MediaFolderID == claim.MediaFolderID {
+			t.Fatalf("active claim survived cancellation/requeue race: %#v", run)
+		}
+	}
+}
+
+func TestRequeuePublishesRetiredAndSuccessorLifecycleEvents(t *testing.T) {
+	pool := newScanQueueTestPool(t)
+	repo := NewRepository(pool)
+	claim := createAndClaimScanRun(t, pool, repo)
+	if _, err := pool.Exec(t.Context(), `UPDATE scan_runs SET heartbeat_at = '1900-01-01' WHERE id = $1`, claim.ID); err != nil {
+		t.Fatalf("expire claim: %v", err)
+	}
+
+	hub := evt.NewHub("scan-claim-test", nil)
+	events, unsubscribe := hub.Subscribe()
+	defer unsubscribe()
+	service := NewService(repo, nil, nil, hub, t.Context(), 1, 1)
+	service.requeueStale()
+
+	failed := waitForScanEvent(t, events, "scan.failed")
+	accepted := waitForScanEvent(t, events, "scan.accepted")
+	if failed == accepted {
+		t.Fatalf("retired and successor event IDs both %q, want distinct runs", failed)
+	}
+}
+
+func TestClaimLeaseRejectsLateRenewalAndExpiresSynchronously(t *testing.T) {
+	parent, cancel := context.WithCancelCause(t.Context())
+	ctx, lease := newClaimLeaseContext(parent, cancel, time.Minute, time.Now())
+	deadline := time.Now().Add(-time.Second)
+	lease.deadline.Store(deadline.UnixNano())
+
+	if lease.renew(deadline.Add(time.Second)) {
+		t.Fatal("late heartbeat renewed an expired lease")
+	}
+	if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("lease context error = %v, want %v", err, context.Canceled)
+	}
+	if cause := context.Cause(ctx); !errors.Is(cause, ErrScanRunClaimLost) {
+		t.Fatalf("lease context cause = %v, want %v", cause, ErrScanRunClaimLost)
+	}
+}
+
+func newScanQueueTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(t.Context(), dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func createAndClaimScanRun(t *testing.T, pool *pgxpool.Pool, repo *Repository) *models.ScanRun {
+	t.Helper()
+	ctx := t.Context()
+	fixture := fmt.Sprintf("scan-claim-fence-%d", time.Now().UnixNano())
+
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name, enabled)
+		VALUES ('movies', $1, TRUE)
+		RETURNING id
+	`, fixture).Scan(&folderID); err != nil {
+		t.Fatalf("seed media folder: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM scan_runs WHERE media_folder_id = $1`, folderID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	created, inserted, err := repo.Create(ctx, CreateInput{
+		LibraryID: folderID,
+		Mode:      ModeFile,
+		Path:      "/synthetic/claim-fence.mkv",
+		Trigger:   "claim-fencing-test",
+	})
+	if err != nil || !inserted {
+		t.Fatalf("create scan run: inserted=%v err=%v", inserted, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE scan_runs SET requested_at = '1900-01-01' WHERE id = $1`, created.ID); err != nil {
+		t.Fatalf("age accepted scan run: %v", err)
+	}
+
+	claim, err := repo.ClaimNextAccepted(ctx, 1_000_000, 1_000_000)
+	if err != nil {
+		t.Fatalf("claim first worker: %v", err)
+	}
+	if claim == nil || claim.ID != created.ID || claim.ClaimToken == "" {
+		t.Fatalf("first claim = %#v, want token-bearing run %q", claim, created.ID)
+	}
+	return claim
+}
+
+func expireRequeueAndReclaim(t *testing.T, pool *pgxpool.Pool, repo *Repository, first *models.ScanRun) *models.ScanRun {
+	t.Helper()
+	ctx := t.Context()
+	if _, err := pool.Exec(ctx, `UPDATE scan_runs SET heartbeat_at = '1900-01-01' WHERE id = $1`, first.ID); err != nil {
+		t.Fatalf("expire first claim: %v", err)
+	}
+	requeued, err := repo.RequeueStaleRunning(ctx, time.Now())
+	if err != nil || len(requeued) != 1 {
+		t.Fatalf("requeue first claim: count=%d err=%v", len(requeued), err)
+	}
+
+	successor, err := repo.ClaimNextAccepted(ctx, 1_000_000, 1_000_000)
+	if err != nil {
+		t.Fatalf("claim successor worker: %v", err)
+	}
+	if successor == nil || successor.ID == first.ID || successor.ClaimToken == "" || successor.ClaimToken == first.ClaimToken {
+		t.Fatalf("successor claim = %#v, want a distinct run with a fresh token", successor)
+	}
+	retired, err := repo.GetByID(ctx, first.ID)
+	if err != nil {
+		t.Fatalf("load retired claim: %v", err)
+	}
+	if retired.Status != StatusFailed || retired.ClaimToken != "" {
+		t.Fatalf("retired claim = status:%q token:%q, want failed without token", retired.Status, retired.ClaimToken)
+	}
+	if requeued[0].Retired.ID != retired.ID || requeued[0].Successor.ID != successor.ID {
+		t.Fatalf("requeue result = %#v, want retired %q successor %q", requeued[0], retired.ID, successor.ID)
+	}
+	if successor.MediaFolderID != first.MediaFolderID || successor.Mode != first.Mode || successor.Path != first.Path || successor.Trigger != first.Trigger || !successor.RequestedAt.Equal(first.RequestedAt) {
+		t.Fatalf("successor did not preserve claim scope: first=%#v successor=%#v", first, successor)
+	}
+	return successor
+}
+
+func waitForScanSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitForTrackedScanCancel(t *testing.T, service *Service, run *models.ScanRun) context.CancelFunc {
+	t.Helper()
+	deadline := time.NewTimer(10 * time.Second)
+	defer deadline.Stop()
+	poll := time.NewTicker(time.Millisecond)
+	defer poll.Stop()
+	key := scanClaimKey{runID: run.ID, claimToken: run.ClaimToken}
+	for {
+		service.runningMu.Lock()
+		tracked, ok := service.runningCancels[key]
+		service.runningMu.Unlock()
+		if ok {
+			return tracked.cancel
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("timed out waiting for startup claim cancellation registration")
+			return nil
+		case <-poll.C:
+		}
+	}
+}
+
+func waitForScanEvent(t *testing.T, events <-chan evt.Envelope, eventName string) string {
+	t.Helper()
+	select {
+	case event := <-events:
+		if event.Event != eventName {
+			t.Fatalf("event = %q, want %q", event.Event, eventName)
+		}
+		var run evt.ScanRun
+		if err := json.Unmarshal(event.Data, &run); err != nil {
+			t.Fatalf("decode %s event: %v", eventName, err)
+		}
+		return run.ID
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for %s", eventName)
+		return ""
+	}
+}
+
+type fixedFolderLoader struct {
+	folder *models.MediaFolder
+}
+
+func (l fixedFolderLoader) GetByID(context.Context, int) (*models.MediaFolder, error) {
+	return l.folder, nil
+}
+
+type blockingScanIngester struct {
+	started   chan struct{}
+	canceled  chan struct{}
+	committed chan struct{}
+}
+
+func (i *blockingScanIngester) IngestFolder(ctx context.Context, _ *models.MediaFolder) (*libraryingest.Result, error) {
+	return i.ingest(ctx)
+}
+
+func (i *blockingScanIngester) IngestSubtree(ctx context.Context, _ *models.MediaFolder, _ string) (*libraryingest.Result, error) {
+	return i.ingest(ctx)
+}
+
+func (i *blockingScanIngester) IngestFile(ctx context.Context, _ *models.MediaFolder, _ string) (*libraryingest.Result, error) {
+	return i.ingest(ctx)
+}
+
+func (i *blockingScanIngester) ingest(ctx context.Context) (*libraryingest.Result, error) {
+	close(i.started)
+	if !libraryingest.DeferUntilCommitted(ctx, func(context.Context) { close(i.committed) }) {
+		return nil, errors.New("scan queue did not install an after-commit registrar")
+	}
+	<-ctx.Done()
+	close(i.canceled)
+	return nil, ctx.Err()
+}
+
+type successfulCommitIngester struct {
+	committed chan struct{}
+}
+
+type recordingScanIngester struct {
+	calls atomic.Int32
+}
+
+func (i *recordingScanIngester) IngestFolder(context.Context, *models.MediaFolder) (*libraryingest.Result, error) {
+	i.calls.Add(1)
+	return &libraryingest.Result{}, nil
+}
+
+func (i *recordingScanIngester) IngestSubtree(context.Context, *models.MediaFolder, string) (*libraryingest.Result, error) {
+	i.calls.Add(1)
+	return &libraryingest.Result{}, nil
+}
+
+func (i *recordingScanIngester) IngestFile(context.Context, *models.MediaFolder, string) (*libraryingest.Result, error) {
+	i.calls.Add(1)
+	return &libraryingest.Result{}, nil
+}
+
+func (i successfulCommitIngester) IngestFolder(ctx context.Context, _ *models.MediaFolder) (*libraryingest.Result, error) {
+	return i.ingest(ctx)
+}
+
+func (i successfulCommitIngester) IngestSubtree(ctx context.Context, _ *models.MediaFolder, _ string) (*libraryingest.Result, error) {
+	return i.ingest(ctx)
+}
+
+func (i successfulCommitIngester) IngestFile(ctx context.Context, _ *models.MediaFolder, _ string) (*libraryingest.Result, error) {
+	return i.ingest(ctx)
+}
+
+func (i successfulCommitIngester) ingest(ctx context.Context) (*libraryingest.Result, error) {
+	if !libraryingest.DeferUntilCommitted(ctx, func(afterCommitCtx context.Context) {
+		if afterCommitCtx.Err() != nil {
+			return
+		}
+		close(i.committed)
+	}) {
+		return nil, errors.New("scan queue did not install an after-commit registrar")
+	}
+	return &libraryingest.Result{}, nil
+}

--- a/internal/scanqueue/repository.go
+++ b/internal/scanqueue/repository.go
@@ -30,7 +30,10 @@ const (
 	libraryClaimAdvisoryLockID int64 = 8_500_001
 )
 
-var ErrScanRunNotFound = errors.New("scan run not found")
+var (
+	ErrScanRunNotFound  = errors.New("scan run not found")
+	ErrScanRunClaimLost = errors.New("scan run claim lost")
+)
 
 type CreateInput struct {
 	LibraryID       int
@@ -44,12 +47,18 @@ type Repository struct {
 	pool *pgxpool.Pool
 }
 
+type RequeuedRun struct {
+	Retired   *models.ScanRun
+	Successor *models.ScanRun
+}
+
 func NewRepository(pool *pgxpool.Pool) *Repository {
 	return &Repository{pool: pool}
 }
 
 const scanRunColumns = `id, media_folder_id, mode, path, trigger, status, result_payload,
-	error_message, autoscan_event_id, requested_at, started_at, completed_at, heartbeat_at, updated_at`
+	error_message, autoscan_event_id, COALESCE(claim_token, ''), requested_at, started_at,
+	completed_at, heartbeat_at, updated_at`
 
 func scanRunRow(row pgx.Row) (*models.ScanRun, error) {
 	var run models.ScanRun
@@ -63,6 +72,7 @@ func scanRunRow(row pgx.Row) (*models.ScanRun, error) {
 		&run.ResultPayload,
 		&run.ErrorMessage,
 		&run.AutoscanEventID,
+		&run.ClaimToken,
 		&run.RequestedAt,
 		&run.StartedAt,
 		&run.CompletedAt,
@@ -75,6 +85,14 @@ func scanRunRow(row pgx.Row) (*models.ScanRun, error) {
 		return nil, fmt.Errorf("scan scan run row: %w", err)
 	}
 	return &run, nil
+}
+
+func scanRunClaimRow(row pgx.Row) (*models.ScanRun, error) {
+	run, err := scanRunRow(row)
+	if errors.Is(err, ErrScanRunNotFound) {
+		return nil, ErrScanRunClaimLost
+	}
+	return run, err
 }
 
 func scanRunRows(rows pgx.Rows) ([]*models.ScanRun, error) {
@@ -306,16 +324,21 @@ func (r *Repository) ClaimNextAccepted(ctx context.Context, maxRunningLibraries,
 		return nil, fmt.Errorf("claim scan run: %w", err)
 	}
 
+	claimToken := ulid.Make().String()
 	run, err := scanRunRow(tx.QueryRow(ctx, `
 		UPDATE scan_runs
 		SET status = $2,
+			claim_token = $3,
 			started_at = NOW(),
 			heartbeat_at = NOW(),
 			updated_at = NOW()
 		WHERE id = $1
+		  AND status = $4
 		RETURNING `+scanRunColumns,
 		id,
 		StatusRunning,
+		claimToken,
+		StatusAccepted,
 	))
 	if err != nil {
 		return nil, fmt.Errorf("mark scan run running: %w", err)
@@ -326,81 +349,91 @@ func (r *Repository) ClaimNextAccepted(ctx context.Context, maxRunningLibraries,
 	return run, nil
 }
 
-func (r *Repository) TouchHeartbeat(ctx context.Context, id string) error {
+func (r *Repository) TouchHeartbeat(ctx context.Context, id, claimToken string) error {
 	tag, err := r.pool.Exec(ctx, `
 		UPDATE scan_runs
 		SET heartbeat_at = NOW(),
 			updated_at = NOW()
 		WHERE id = $1
-		  AND status = $2`,
+		  AND status = $2
+		  AND claim_token = $3`,
 		id,
 		StatusRunning,
+		claimToken,
 	)
 	if err != nil {
 		return fmt.Errorf("touch scan heartbeat: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return ErrScanRunNotFound
+		return ErrScanRunClaimLost
 	}
 	return nil
 }
 
-func (r *Repository) UpdateProgress(ctx context.Context, id string, result *evt.ScanRunResult) (*models.ScanRun, error) {
+func (r *Repository) UpdateProgress(ctx context.Context, id, claimToken string, result *evt.ScanRunResult) (*models.ScanRun, error) {
 	payload, err := json.Marshal(result)
 	if err != nil {
 		return nil, fmt.Errorf("marshal scan progress: %w", err)
 	}
-	return scanRunRow(r.pool.QueryRow(ctx, `
+	return scanRunClaimRow(r.pool.QueryRow(ctx, `
 		UPDATE scan_runs
 		SET result_payload = $2,
 			updated_at = NOW()
 		WHERE id = $1
 		  AND status = $3
+		  AND claim_token = $4
 		RETURNING `+scanRunColumns,
 		id,
 		payload,
 		StatusRunning,
+		claimToken,
 	))
 }
 
-func (r *Repository) Complete(ctx context.Context, id string, result *evt.ScanRunResult) (*models.ScanRun, error) {
+func (r *Repository) Complete(ctx context.Context, id, claimToken string, result *evt.ScanRunResult) (*models.ScanRun, error) {
 	payload, err := json.Marshal(result)
 	if err != nil {
 		return nil, fmt.Errorf("marshal scan result: %w", err)
 	}
-	return scanRunRow(r.pool.QueryRow(ctx, `
+	return scanRunClaimRow(r.pool.QueryRow(ctx, `
 		UPDATE scan_runs
 		SET status = $2,
 			result_payload = $3,
 			error_message = '',
+			claim_token = NULL,
 			completed_at = NOW(),
 			heartbeat_at = NOW(),
 			updated_at = NOW()
 		WHERE id = $1
 		  AND status = $4
+		  AND claim_token = $5
 		RETURNING `+scanRunColumns,
 		id,
 		StatusCompleted,
 		payload,
 		StatusRunning,
+		claimToken,
 	))
 }
 
-func (r *Repository) Fail(ctx context.Context, id string, errorMessage string) (*models.ScanRun, error) {
-	return scanRunRow(r.pool.QueryRow(ctx, `
+func (r *Repository) Fail(ctx context.Context, id, claimToken, errorMessage string) (*models.ScanRun, error) {
+	return scanRunClaimRow(r.pool.QueryRow(ctx, `
 		UPDATE scan_runs
 		SET status = $2,
 			error_message = $3,
+			claim_token = NULL,
 			completed_at = NOW(),
 			heartbeat_at = NOW(),
 			updated_at = NOW()
 		WHERE id = $1
 		  AND status = $4
+		  AND claim_token = $5
 		RETURNING `+scanRunColumns,
 		id,
 		StatusFailed,
 		errorMessage,
 		StatusRunning,
+		claimToken,
 	))
 }
 
@@ -423,31 +456,61 @@ func (r *Repository) CancelAcceptedByLibrary(ctx context.Context, libraryID int)
 	return scanRunRows(rows)
 }
 
-func (r *Repository) MarkCancelled(ctx context.Context, id string) (*models.ScanRun, bool, error) {
-	run, err := scanRunRow(r.pool.QueryRow(ctx, `
+func (r *Repository) CancelActiveByLibrary(ctx context.Context, libraryID int) ([]*models.ScanRun, error) {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin active scan cancellation: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, libraryClaimAdvisoryLockID); err != nil {
+		return nil, fmt.Errorf("lock active scan cancellation: %w", err)
+	}
+	rows, err := tx.Query(ctx, `
 		UPDATE scan_runs
 		SET status = $2,
+			claim_token = NULL,
+			completed_at = NOW(),
+			heartbeat_at = CASE WHEN status = $3 THEN NOW() ELSE heartbeat_at END,
+			updated_at = NOW()
+		WHERE media_folder_id = $1
+		  AND status = ANY($4)
+		RETURNING `+scanRunColumns,
+		libraryID,
+		StatusCancelled,
+		StatusRunning,
+		[]string{StatusAccepted, StatusRunning},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cancel active scan runs: %w", err)
+	}
+	runs, err := scanRunRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit active scan cancellation: %w", err)
+	}
+	return runs, nil
+}
+
+func (r *Repository) CancelClaim(ctx context.Context, id, claimToken string) (*models.ScanRun, error) {
+	return scanRunClaimRow(r.pool.QueryRow(ctx, `
+		UPDATE scan_runs
+		SET status = $2,
+			claim_token = NULL,
 			completed_at = NOW(),
 			heartbeat_at = NOW(),
 			updated_at = NOW()
 		WHERE id = $1
-		  AND status = ANY($3)
+		  AND status = $3
+		  AND claim_token = $4
 		RETURNING `+scanRunColumns,
 		id,
 		StatusCancelled,
-		[]string{StatusAccepted, StatusRunning},
+		StatusRunning,
+		claimToken,
 	))
-	if err == nil {
-		return run, true, nil
-	}
-	if !errors.Is(err, ErrScanRunNotFound) {
-		return nil, false, err
-	}
-	run, err = r.GetByID(ctx, id)
-	if err != nil {
-		return nil, false, err
-	}
-	return run, false, nil
 }
 
 func (r *Repository) GetByID(ctx context.Context, id string) (*models.ScanRun, error) {
@@ -459,23 +522,74 @@ func (r *Repository) GetByID(ctx context.Context, id string) (*models.ScanRun, e
 	))
 }
 
-func (r *Repository) RequeueStaleRunning(ctx context.Context, before time.Time) (int, error) {
-	tag, err := r.pool.Exec(ctx, `
+func (r *Repository) RequeueStaleRunning(ctx context.Context, before time.Time) ([]RequeuedRun, error) {
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("begin stale scan requeue: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1)`, libraryClaimAdvisoryLockID); err != nil {
+		return nil, fmt.Errorf("lock stale scan requeue: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, `
 		UPDATE scan_runs
 		SET status = $2,
-			started_at = NULL,
-			heartbeat_at = NULL,
-			completed_at = NULL,
-			error_message = '',
+			claim_token = NULL,
+			completed_at = NOW(),
+			error_message = 'scan worker lease expired; retry queued',
 			updated_at = NOW()
 		WHERE status = $1
-		  AND COALESCE(heartbeat_at, started_at, requested_at) < $3`,
+		  AND claim_token IS NOT NULL
+		  AND COALESCE(heartbeat_at, started_at, requested_at) < $3
+		RETURNING `+scanRunColumns,
 		StatusRunning,
-		StatusAccepted,
+		StatusFailed,
 		before,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("requeue stale scan runs: %w", err)
+		return nil, fmt.Errorf("requeue stale scan runs: %w", err)
 	}
-	return int(tag.RowsAffected()), nil
+	retired := make([]*models.ScanRun, 0)
+	for rows.Next() {
+		run, err := scanRunRow(rows)
+		if err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan stale scan run for retry: %w", err)
+		}
+		retired = append(retired, run)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate stale scan runs for retry: %w", err)
+	}
+	rows.Close()
+
+	requeued := make([]RequeuedRun, 0, len(retired))
+	for _, run := range retired {
+		successor, err := scanRunRow(tx.QueryRow(ctx, `
+			INSERT INTO scan_runs (
+				id, media_folder_id, mode, path, trigger, status,
+				autoscan_event_id, requested_at
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			RETURNING `+scanRunColumns,
+			ulid.Make().String(),
+			run.MediaFolderID,
+			run.Mode,
+			run.Path,
+			run.Trigger,
+			StatusAccepted,
+			run.AutoscanEventID,
+			run.RequestedAt,
+		))
+		if err != nil {
+			return nil, fmt.Errorf("create successor for stale scan run: %w", err)
+		}
+		requeued = append(requeued, RequeuedRun{Retired: run, Successor: successor})
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit stale scan requeue: %w", err)
+	}
+	return requeued, nil
 }

--- a/internal/scanqueue/service.go
+++ b/internal/scanqueue/service.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -46,12 +48,114 @@ type Service struct {
 	stop                   chan struct{}
 	stopOnce               sync.Once
 	runningMu              sync.Mutex
-	runningCancels         map[string]runningCancel
+	runningCancels         map[scanClaimKey]runningCancel
 }
 
 type runningCancel struct {
 	libraryID int
 	cancel    context.CancelFunc
+}
+
+type scanClaimKey struct {
+	runID      string
+	claimToken string
+}
+
+type claimLease struct {
+	cancel     context.CancelCauseFunc
+	staleAfter time.Duration
+	deadline   atomic.Int64
+	renewed    chan struct{}
+	done       chan struct{}
+	doneOnce   sync.Once
+}
+
+type claimLeaseContext struct {
+	context.Context
+	lease *claimLease
+}
+
+func newClaimLeaseContext(
+	parent context.Context,
+	cancel context.CancelCauseFunc,
+	staleAfter time.Duration,
+	renewedAt time.Time,
+) (context.Context, *claimLease) {
+	lease := &claimLease{
+		cancel:     cancel,
+		staleAfter: staleAfter,
+		renewed:    make(chan struct{}, 1),
+		done:       make(chan struct{}),
+	}
+	lease.deadline.Store(renewedAt.Add(staleAfter).UnixNano())
+	context.AfterFunc(parent, lease.closeDone)
+	return &claimLeaseContext{Context: parent, lease: lease}, lease
+}
+
+func (c *claimLeaseContext) Done() <-chan struct{} {
+	c.lease.expireIfDue(time.Now())
+	if c.Context.Err() != nil {
+		c.lease.closeDone()
+	}
+	return c.lease.done
+}
+
+func (c *claimLeaseContext) Err() error {
+	c.lease.expireIfDue(time.Now())
+	if err := c.Context.Err(); err != nil {
+		c.lease.closeDone()
+		return err
+	}
+	select {
+	case <-c.lease.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (l *claimLease) closeDone() {
+	l.doneOnce.Do(func() { close(l.done) })
+}
+
+func (l *claimLease) expireIfDue(now time.Time) bool {
+	for {
+		deadline := l.deadline.Load()
+		if deadline <= 0 {
+			return true
+		}
+		if now.UnixNano() < deadline {
+			return false
+		}
+		if l.deadline.CompareAndSwap(deadline, 0) {
+			l.closeDone()
+			l.cancel(ErrScanRunClaimLost)
+			return true
+		}
+	}
+}
+
+func (l *claimLease) renew(succeededAt time.Time) bool {
+	for {
+		deadline := l.deadline.Load()
+		if deadline <= 0 || succeededAt.UnixNano() >= deadline {
+			l.expireIfDue(time.Now())
+			return false
+		}
+		newDeadline := succeededAt.Add(l.staleAfter).UnixNano()
+		if time.Now().UnixNano() >= newDeadline {
+			l.expireIfDue(time.Now())
+			return false
+		}
+		if !l.deadline.CompareAndSwap(deadline, newDeadline) {
+			continue
+		}
+		select {
+		case l.renewed <- struct{}{}:
+		default:
+		}
+		return true
+	}
 }
 
 func NewService(
@@ -84,7 +188,7 @@ func NewService(
 		heartbeatInterval:      defaultHeartbeatInterval,
 		staleAfter:             defaultStaleAfter,
 		stop:                   make(chan struct{}),
-		runningCancels:         make(map[string]runningCancel),
+		runningCancels:         make(map[scanClaimKey]runningCancel),
 	}
 }
 
@@ -194,11 +298,6 @@ func (s *Service) CancelByLibrary(ctx context.Context, libraryID int) (int, erro
 		return 0, nil
 	}
 
-	cancelled, err := s.CancelAcceptedByLibrary(ctx, libraryID)
-	if err != nil {
-		return 0, err
-	}
-
 	s.runningMu.Lock()
 	for _, running := range s.runningCancels {
 		if running.libraryID != libraryID || running.cancel == nil {
@@ -208,26 +307,14 @@ func (s *Service) CancelByLibrary(ctx context.Context, libraryID int) (int, erro
 	}
 	s.runningMu.Unlock()
 
-	activeRuns, err := s.repo.ListActive(ctx)
+	activeRuns, err := s.repo.CancelActiveByLibrary(ctx, libraryID)
 	if err != nil {
-		return cancelled, err
+		return 0, err
 	}
 	for _, run := range activeRuns {
-		if run == nil || run.MediaFolderID != libraryID {
-			continue
-		}
-		_, changed, err := s.repo.MarkCancelled(ctx, run.ID)
-		if err != nil {
-			return cancelled, err
-		}
-		if changed {
-			cancelled++
-			if cancelledRun, err := s.repo.GetByID(ctx, run.ID); err == nil {
-				s.publish(ctx, "scan.cancelled", cancelledRun)
-			}
-		}
+		s.publish(ctx, "scan.cancelled", run)
 	}
-	return cancelled, nil
+	return len(activeRuns), nil
 }
 
 func (s *Service) ListActive(ctx context.Context) ([]evt.ScanRun, error) {
@@ -288,8 +375,12 @@ func (s *Service) requeueStale() {
 		slog.Warn("scan queue: failed to requeue stale runs", "error", err)
 		return
 	}
-	if requeued > 0 {
-		slog.Info("scan queue: requeued stale runs", "count", requeued)
+	for _, retry := range requeued {
+		s.publish(ctx, "scan.failed", retry.Retired)
+		s.publish(ctx, "scan.accepted", retry.Successor)
+	}
+	if len(requeued) > 0 {
+		slog.Info("scan queue: requeued stale runs", "count", len(requeued))
 	}
 }
 
@@ -316,7 +407,6 @@ func (s *Service) workerLoop() {
 			continue
 		}
 
-		s.publish(context.Background(), "scan.started", run)
 		s.process(run)
 	}
 }
@@ -337,27 +427,64 @@ func (s *Service) process(run *models.ScanRun) {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(s.appCtx)
+	ctx, cancelCause := context.WithCancelCause(s.appCtx)
+	heartbeatStartedAt := time.Now()
+	ctx, lease := newClaimLeaseContext(ctx, cancelCause, s.staleAfter, heartbeatStartedAt)
+	cancel := func() {
+		cancelCause(context.Canceled)
+		lease.closeDone()
+	}
 	defer cancel()
-	s.trackRunning(run.ID, run.MediaFolderID, cancel)
-	defer s.untrackRunning(run.ID)
-	progressReporter := newScanProgressReporter(s, run)
+	s.trackRunning(run, cancel)
+	defer s.untrackRunning(run)
+
+	touchCtx, touchCancel := context.WithTimeout(ctx, 15*time.Second)
+	err := s.repo.TouchHeartbeat(touchCtx, run.ID, run.ClaimToken)
+	touchCancel()
+	if errors.Is(err, ErrScanRunClaimLost) {
+		return
+	}
+	if err != nil {
+		slog.WarnContext(ctx, "scan queue: failed to establish claim lease", "component", "scanqueue", "scan_id", run.ID, "error", err)
+		return
+	}
+	if lease.expireIfDue(time.Now()) || ctx.Err() != nil {
+		return
+	}
+	ctx = libraryingest.WithLeaseGuard(ctx, func() error {
+		if lease.expireIfDue(time.Now()) {
+			return ErrScanRunClaimLost
+		}
+		return nil
+	})
+	var afterCommitMu sync.Mutex
+	afterCommit := make([]func(context.Context), 0, 1)
+	ctx = libraryingest.WithAfterCommitRegistrar(ctx, func(callback func(context.Context)) {
+		afterCommitMu.Lock()
+		defer afterCommitMu.Unlock()
+		afterCommit = append(afterCommit, callback)
+	})
+	progressReporter := newScanProgressReporter(s, run, ctx, cancelCause)
 	ctx = libraryingest.WithProgressReporter(ctx, progressReporter.Report)
+	s.publish(context.Background(), "scan.started", run)
 
 	heartbeatStop := make(chan struct{})
-	go s.heartbeatLoop(ctx, run.ID, heartbeatStop)
+	go s.claimLeaseWatchdog(ctx, run, lease)
+	go s.heartbeatLoop(ctx, run, cancelCause, heartbeatStop, lease)
 	defer close(heartbeatStop)
 
 	folder, err := s.folders.GetByID(ctx, run.MediaFolderID)
 	switch {
+	case errors.Is(context.Cause(ctx), ErrScanRunClaimLost):
+		return
 	case errors.Is(err, catalog.ErrFolderNotFound):
-		s.cancelRun(run.ID)
+		s.cancelRun(run)
 		return
 	case err != nil:
-		s.failRun(run.ID, fmt.Errorf("load library for scan: %w", err))
+		s.failRun(run, fmt.Errorf("load library for scan: %w", err))
 		return
 	case folder == nil || !folder.Enabled:
-		s.cancelRun(run.ID)
+		s.cancelRun(run)
 		return
 	}
 
@@ -372,32 +499,61 @@ func (s *Service) process(run *models.ScanRun) {
 	default:
 		err = fmt.Errorf("unsupported scan mode %q", run.Mode)
 	}
+	if s.finishRun(ctx, lease, run, result, err) {
+		afterCommitMu.Lock()
+		callbacks := slices.Clone(afterCommit)
+		afterCommitMu.Unlock()
+		for _, callback := range callbacks {
+			go callback(context.Background())
+		}
+	}
+}
+
+func (s *Service) finishRun(
+	ctx context.Context,
+	lease *claimLease,
+	run *models.ScanRun,
+	result *libraryingest.Result,
+	runErr error,
+) bool {
+	lease.expireIfDue(time.Now())
 	switch {
-	case errors.Is(err, context.Canceled):
-		s.cancelRun(run.ID)
-	case err != nil:
-		s.failRun(run.ID, err)
+	case errors.Is(context.Cause(ctx), ErrScanRunClaimLost):
+		return false
+	case errors.Is(runErr, context.Canceled), errors.Is(ctx.Err(), context.Canceled):
+		s.cancelRun(run)
+		return false
+	case runErr != nil:
+		s.failRun(run, runErr)
+		return false
 	default:
-		s.completeRun(run.ID, result)
+		return s.completeRun(run, result)
 	}
 }
 
 type scanProgressReporter struct {
 	service *Service
 	run     *models.ScanRun
+	ctx     context.Context
+	cancel  context.CancelCauseFunc
 	mu      sync.Mutex
 	last    evt.ScanRunResult
 }
 
-func newScanProgressReporter(service *Service, run *models.ScanRun) *scanProgressReporter {
+func newScanProgressReporter(service *Service, run *models.ScanRun, ctx context.Context, cancel context.CancelCauseFunc) *scanProgressReporter {
 	return &scanProgressReporter{
 		service: service,
 		run:     run,
+		ctx:     ctx,
+		cancel:  cancel,
 	}
 }
 
 func (r *scanProgressReporter) Report(update libraryingest.ProgressUpdate) {
 	if r == nil || r.service == nil || r.service.repo == nil || r.run == nil {
+		return
+	}
+	if context.Cause(r.ctx) != nil {
 		return
 	}
 
@@ -418,9 +574,13 @@ func (r *scanProgressReporter) Report(update libraryingest.ProgressUpdate) {
 	r.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	run, err := r.service.repo.UpdateProgress(ctx, r.run.ID, &current)
+	run, err := r.service.repo.UpdateProgress(ctx, r.run.ID, r.run.ClaimToken, &current)
 	cancel()
-	if err != nil && !errors.Is(err, ErrScanRunNotFound) {
+	if errors.Is(err, ErrScanRunClaimLost) {
+		r.cancel(ErrScanRunClaimLost)
+		return
+	}
+	if err != nil {
 		slog.Warn("scan queue: failed to persist scan progress", "scan_id", r.run.ID, "error", err)
 		return
 	}
@@ -439,28 +599,64 @@ func (r *scanProgressReporter) Report(update libraryingest.ProgressUpdate) {
 	}
 }
 
-func (s *Service) trackRunning(runID string, libraryID int, cancel context.CancelFunc) {
-	if s == nil || cancel == nil {
+func (s *Service) trackRunning(run *models.ScanRun, cancel context.CancelFunc) {
+	if s == nil || run == nil || cancel == nil {
 		return
 	}
 	s.runningMu.Lock()
 	defer s.runningMu.Unlock()
-	s.runningCancels[runID] = runningCancel{
-		libraryID: libraryID,
+	s.runningCancels[scanClaimKey{runID: run.ID, claimToken: run.ClaimToken}] = runningCancel{
+		libraryID: run.MediaFolderID,
 		cancel:    cancel,
 	}
 }
 
-func (s *Service) untrackRunning(runID string) {
-	if s == nil {
+func (s *Service) untrackRunning(run *models.ScanRun) {
+	if s == nil || run == nil {
 		return
 	}
 	s.runningMu.Lock()
 	defer s.runningMu.Unlock()
-	delete(s.runningCancels, runID)
+	delete(s.runningCancels, scanClaimKey{runID: run.ID, claimToken: run.ClaimToken})
 }
 
-func (s *Service) heartbeatLoop(ctx context.Context, runID string, stop <-chan struct{}) {
+func (s *Service) claimLeaseWatchdog(
+	ctx context.Context,
+	run *models.ScanRun,
+	lease *claimLease,
+) {
+	timer := time.NewTimer(time.Until(time.Unix(0, lease.deadline.Load())))
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-lease.renewed:
+		case <-timer.C:
+		}
+
+		if lease.expireIfDue(time.Now()) {
+			slog.InfoContext(ctx, "scan queue: local claim lease expired; canceling ingestion", "component", "scanqueue", "scan_id", run.ID)
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(time.Until(time.Unix(0, lease.deadline.Load())))
+	}
+}
+
+func (s *Service) heartbeatLoop(
+	ctx context.Context,
+	run *models.ScanRun,
+	cancelClaim context.CancelCauseFunc,
+	stop <-chan struct{},
+	lease *claimLease,
+) {
 	ticker := time.NewTicker(s.heartbeatInterval)
 	defer ticker.Stop()
 
@@ -471,52 +667,72 @@ func (s *Service) heartbeatLoop(ctx context.Context, runID string, stop <-chan s
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			heartbeatStartedAt := time.Now()
 			touchCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-			err := s.repo.TouchHeartbeat(touchCtx, runID)
+			err := s.repo.TouchHeartbeat(touchCtx, run.ID, run.ClaimToken)
 			cancel()
-			if err != nil && !errors.Is(err, ErrScanRunNotFound) {
-				slog.WarnContext(ctx, "scan queue: failed to touch heartbeat", "component", "scanqueue", "scan_id", runID, "error", err)
+			if errors.Is(err, ErrScanRunClaimLost) {
+				slog.InfoContext(ctx, "scan queue: claim lost; canceling ingestion", "component", "scanqueue", "scan_id", run.ID)
+				cancelClaim(ErrScanRunClaimLost)
+				return
+			}
+			if err != nil {
+				slog.WarnContext(ctx, "scan queue: failed to touch heartbeat", "component", "scanqueue", "scan_id", run.ID, "error", err)
+				continue
+			}
+			if !lease.renew(heartbeatStartedAt) {
+				slog.InfoContext(ctx, "scan queue: heartbeat arrived after local claim lease expiry", "component", "scanqueue", "scan_id", run.ID)
+				cancelClaim(ErrScanRunClaimLost)
+				return
 			}
 		}
 	}
 }
 
-func (s *Service) cancelRun(runID string) {
+func (s *Service) cancelRun(claim *models.ScanRun) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	run, changed, err := s.repo.MarkCancelled(ctx, runID)
-	if err != nil {
-		slog.Warn("scan queue: failed to mark cancelled", "scan_id", runID, "error", err)
+	run, err := s.repo.CancelClaim(ctx, claim.ID, claim.ClaimToken)
+	if errors.Is(err, ErrScanRunClaimLost) {
 		return
 	}
-	if changed {
-		s.publish(context.Background(), "scan.cancelled", run)
+	if err != nil {
+		slog.Warn("scan queue: failed to mark canceled", "scan_id", claim.ID, "error", err)
+		return
 	}
+	s.publish(context.Background(), "scan.cancelled", run)
 }
 
-func (s *Service) failRun(runID string, runErr error) {
+func (s *Service) failRun(claim *models.ScanRun, runErr error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	run, err := s.repo.Fail(ctx, runID, errString(runErr))
+	run, err := s.repo.Fail(ctx, claim.ID, claim.ClaimToken, errString(runErr))
+	if errors.Is(err, ErrScanRunClaimLost) {
+		return
+	}
 	if err != nil {
-		slog.Warn("scan queue: failed to mark failed", "scan_id", runID, "error", err)
+		slog.Warn("scan queue: failed to mark failed", "scan_id", claim.ID, "error", err)
 		return
 	}
 	s.publish(context.Background(), "scan.failed", run)
 }
 
-func (s *Service) completeRun(runID string, result *libraryingest.Result) {
+func (s *Service) completeRun(claim *models.ScanRun, result *libraryingest.Result) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	run, err := s.repo.Complete(ctx, runID, scanResultFromIngest(result))
+	run, err := s.repo.Complete(ctx, claim.ID, claim.ClaimToken, scanResultFromIngest(result))
+	if errors.Is(err, ErrScanRunClaimLost) {
+		return false
+	}
 	if err != nil {
-		slog.Warn("scan queue: failed to mark completed", "scan_id", runID, "error", err)
-		return
+		slog.Warn("scan queue: failed to mark completed", "scan_id", claim.ID, "error", err)
+		return false
 	}
 	s.publish(context.Background(), "scan.completed", run)
+	return true
 }
 
 func (s *Service) publish(ctx context.Context, eventName string, run *models.ScanRun) {

--- a/migrations/sql/20260827201717_add_scan_run_claim_token.sql
+++ b/migrations/sql/20260827201717_add_scan_run_claim_token.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE scan_runs
+    ADD COLUMN claim_token TEXT NULL;
+
+-- The first upgraded node takes this lock before checking for running work.
+-- That makes the rollout fail closed: operators must let existing scans drain
+-- before any upgraded worker can issue token-bearing claims.
+LOCK TABLE scan_runs IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM scan_runs WHERE status = 'running') THEN
+        RAISE EXCEPTION 'scan claim fencing migration requires all running scans to drain first';
+    END IF;
+END
+$$;
+
+COMMENT ON COLUMN scan_runs.claim_token IS
+    'Opaque ownership token for fenced scan workers; NULL on legacy or unclaimed rows';
+
+CREATE FUNCTION enforce_scan_run_claim_fencing()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.status = 'running' AND NEW.status = 'accepted' THEN
+        RAISE EXCEPTION 'in-place scan requeue is disabled';
+    END IF;
+    IF OLD.status = 'accepted' AND NEW.status = 'running'
+       AND (NEW.claim_token IS NULL OR NEW.claim_token IS NOT DISTINCT FROM OLD.claim_token) THEN
+        RAISE EXCEPTION 'scan claims require a fresh ownership token';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER scan_runs_claim_fencing
+    BEFORE UPDATE OF status, claim_token ON scan_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION enforce_scan_run_claim_fencing();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS scan_runs_claim_fencing ON scan_runs;
+DROP FUNCTION IF EXISTS enforce_scan_run_claim_fencing();
+
+ALTER TABLE scan_runs
+    DROP COLUMN IF EXISTS claim_token;
+-- +goose StatementEnd


### PR DESCRIPTION
## Problem

Related issue: N/A — audit-validated distributed correctness fix

Scan workers owned a run only by its row ID and `running` status. Stale-run maintenance reused that same row when requeueing, so worker A could lose its heartbeat, worker B could claim the requeued run, and A could later resume and write progress or a terminal status into B's work.

The finding was independently reproduced against fresh `origin/main` at `8164fd594b9fdd8c1944bb0b6251f2d00e4a24ca`. No existing issue or PR matched the defect.

## Approach

- Add an opaque claim token to each accepted-to-running transition. Heartbeat, progress, completion, failure, and worker cancellation now require both the run ID and current token.
- Retire an expired run as failed and create a distinct accepted successor instead of reusing the old row. The successor preserves scope, trigger, autoscan event, and original request time.
- Establish a fenced heartbeat before publishing `scan.started` or beginning ingestion. Local cancellation is registered first, and local lease loss cancels guarded scanner and metadata contexts synchronously.
- Run post-ingest availability work only after the queue commits a fenced completion.
- Serialize library cancellation with claim/requeue maintenance using the existing scan advisory-lock boundary.
- Add a migration guard for mixed-version rollout. The migration refuses to run while any scan is `running`, rejects tokenless legacy claims, and rejects legacy in-place requeues.

The protocol invariant is: a worker may mutate a run or perform scan-owned ingestion only while `(run_id, claim_token)` is the current durable claim. Losing that ownership cancels local work; retry creates a new run ID.

## Validation

Repository gate:

```text
make embed-stub                                      PASS
go build ./...                                       PASS
gofmt -l .                                           PASS (no output)
go vet ./...                                         PASS
golangci-lint run --new-from-merge-base=origin/main  PASS (0 issues)
make test-go                                         PASS on dev-builder
pnpm install --frozen-lockfile                       PASS
pnpm run lint                                        PASS (0 errors; 167 existing warnings)
pnpm run format:check                                PASS
pnpm run build                                       PASS
make test-web                                        PASS (294 files, 2184 tests)
make verify-settings-bindings-all                    PASS
make verify-playback-fixtures                        PASS
make verify-local-paths                              PASS
make migrate-validate                                PASS
```

Focused and race checks on isolated dev-builder sandbox `audit-scan-lease`:

```text
SILO_TEST_DATABASE_URL=<redacted> go test -v ./internal/scanqueue -run <claim-fencing cases>
PASS: stale heartbeat, progress, success, failure, and cancellation
PASS: claim loss during ingestion and local lease expiry
PASS: A paused before process, B requeued/claimed, A resumed without starting ingestion
PASS: cancel registration before the initial heartbeat
PASS: completion-boundary lease expiry leaves the run eligible for retry
PASS: legitimate distinct-row requeue and successor completion
PASS: old tokenless claim/in-place requeue rejection and cancel/requeue serialization

go test -race ./internal/metadata -run TestProcessSeriesRootsPreservesOwnershipGuard
PASS

SILO_TEST_DATABASE_URL=<redacted> go test -race ./internal/scanqueue ./internal/scanner
PASS
```

Migration lifecycle against pre-existing accepted, running, and completed rows:

```text
upgrade_with_running_row=rejected
transaction_rollback_column_present=false
upgrade_after_drain=true,trigger=true
rollback_column_present=false
final_version=20260827201717
```

The exact candidate was built and deployed in `audit-scan-lease`. Controller `doctor` reported the application and Redis containers healthy, the database query successful, `/api/v1/health` status `ok`, and both API and frontend reachable. The synthetic A/B lifecycle passed against the sandbox Postgres; scan claims do not store ownership state in Redis.

Two exploratory configurations were not used as gates: exporting one `SILO_TEST_DATABASE_URL` to every package in `make test-go` caused unrelated parallel database suites to mutate the same schema, and running the entire metadata package under `-race` exposed a pre-existing test-fake race plus unrelated schema interference. The supported full suite passed without that global opt-in; the changed Postgres packages and the new metadata guard test passed separately under `-race` as shown above.

No screenshots: this changes backend orchestration and schema only.

## Risks

- Upgrade is intentionally fail-closed if a scan is running. Operators must drain active scans and retry the migration.
- Rollback requires all upgraded binaries to be stopped and active scans drained before dropping `claim_token`; upgraded code reads that column.
- A stale retry now appears as a failed attempt plus a distinct accepted successor. This is intentional and preserves an auditable ownership boundary.
- No native v1 API shape changed. Apple, Android, and Jellyfin-compatible clients require no changes.

Independent read-only review covered stale-worker bypasses, mixed-version migration safety, requeue/retry behavior, cancellation races, derived contexts, completion boundaries, and after-commit side effects. It found and drove fixes for the rollout barrier, old-maintenance bypass, cancel/requeue race, durable startup fencing, derived-context guard propagation, completion-boundary classification, and startup cancellation registration. The final review reported no actionable findings.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): gpt-5.6-sol
- Involvement: Fully AI-generated; human verification pending
- Adversarial review: An independent read-only Codex agent reviewed the complete patch in six passes for stale-worker bypasses, migration safety, retry semantics, cancellation races, derived-context propagation, completion boundaries, side-effect ordering, and regressions. All actionable findings were confirmed, fixed, and re-tested; the final pass reported no blockers.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
