### PR TITLE
ci(macos): build native arm64 server artifact

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,133 @@
+name: Native macOS Server
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GOPROXY: https://proxy.golang.org,direct
+  GOPRIVATE: github.com/Silo-Server/*
+  GONOSUMDB: github.com/Silo-Server/*
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Darwin arm64
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install native dependencies
+        run: brew install vips ffmpeg
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend assets
+        working-directory: web
+        run: pnpm run build
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Reject committed local SDK replaces
+        run: |
+          if grep -Eq '^replace github.com/Silo-Server/silo-plugin-sdk => /' go.mod; then
+            echo "go.mod contains a machine-local silo-plugin-sdk replace."
+            exit 1
+          fi
+
+      - name: Validate SDK resolves from the module graph
+        env:
+          GOWORK: off
+        run: |
+          sdk_module_json="$(mktemp)"
+          go list -m -json github.com/Silo-Server/silo-plugin-sdk > "$sdk_module_json"
+          if grep -q '"Main": true' "$sdk_module_json"; then
+            echo "silo-plugin-sdk resolved from the local workspace instead of go.mod."
+            cat "$sdk_module_json"
+            exit 1
+          fi
+
+      - name: Test Go on macOS
+        run: go test ./...
+
+      - name: Build native server archive
+        id: build
+        env:
+          BUILDINFO_PKG: github.com/Silo-Server/silo-server/internal/buildinfo
+        run: |
+          built_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          archive="silo-darwin-arm64-${GITHUB_SHA::8}.tar.gz"
+          package_dir="dist/silo-darwin-arm64"
+          mkdir -p "$package_dir"
+
+          go build -trimpath \
+            -ldflags "-X ${BUILDINFO_PKG}.revisionOverride=${GITHUB_SHA} -X ${BUILDINFO_PKG}.dirtyOverride=false -X ${BUILDINFO_PKG}.builtAtOverride=${built_at}" \
+            -o "$package_dir/silo" ./cmd/silo/
+
+          cp LICENSE "$package_dir/LICENSE"
+          go version -m "$package_dir/silo" > "$package_dir/build-info.txt"
+          otool -L "$package_dir/silo" > "$package_dir/linked-libraries.txt"
+          tar -czf "dist/$archive" -C dist silo-darwin-arm64
+          (cd dist && shasum -a 256 "$archive" > "$archive.sha256")
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Verify native runtime and VideoToolbox
+        env:
+          ARCHIVE: ${{ steps.build.outputs.archive }}
+        run: |
+          file dist/silo-darwin-arm64/silo | grep -q 'Mach-O 64-bit executable arm64'
+          dist/silo-darwin-arm64/silo -h >/dev/null
+          grep -aFq "$GITHUB_SHA" dist/silo-darwin-arm64/silo
+
+          ffmpeg -hide_banner -hwaccels > "$RUNNER_TEMP/ffmpeg-hwaccels.txt" 2>/dev/null
+          grep -Fxq 'videotoolbox' "$RUNNER_TEMP/ffmpeg-hwaccels.txt"
+          ffmpeg -hide_banner -encoders > "$RUNNER_TEMP/ffmpeg-encoders.txt" 2>/dev/null
+          grep -q 'h264_videotoolbox' "$RUNNER_TEMP/ffmpeg-encoders.txt"
+          ffmpeg -hide_banner -loglevel error \
+            -f lavfi -i color=c=black:s=128x72:r=24 \
+            -frames:v 12 -c:v h264_videotoolbox -f null -
+
+          (cd dist && shasum -a 256 -c "$ARCHIVE.sha256")
+
+      - name: Upload native server
+        uses: actions/upload-artifact@v4
+        with:
+          name: silo-darwin-arm64-${{ github.sha }}
+          path: |
+            dist/${{ steps.build.outputs.archive }}
+            dist/${{ steps.build.outputs.archive }}.sha256
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,7 @@ env:
   GOPROXY: https://proxy.golang.org,direct
   GOPRIVATE: github.com/Silo-Server/*
   GONOSUMDB: github.com/Silo-Server/*
+  GOWORK: off
 
 permissions:
   contents: read
@@ -61,19 +62,15 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Reject committed local SDK replaces
-        run: |
-          if grep -Eq '^replace github.com/Silo-Server/silo-plugin-sdk => /' go.mod; then
-            echo "go.mod contains a machine-local silo-plugin-sdk replace."
-            exit 1
-          fi
-
       - name: Validate SDK resolves from the module graph
-        env:
-          GOWORK: off
         run: |
           sdk_module_json="$(mktemp)"
           go list -m -json github.com/Silo-Server/silo-plugin-sdk > "$sdk_module_json"
+          if grep -q '"Replace":' "$sdk_module_json"; then
+            echo "silo-plugin-sdk resolved through a module replacement."
+            cat "$sdk_module_json"
+            exit 1
+          fi
           if grep -q '"Main": true' "$sdk_module_json"; then
             echo "silo-plugin-sdk resolved from the local workspace instead of go.mod."
             cat "$sdk_module_json"

--- a/internal/jellycompat/process_token_darwin.go
+++ b/internal/jellycompat/process_token_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package jellycompat
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func processToken(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	process, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || process.Proc.P_pid != int32(pid) {
+		return ""
+	}
+	startedAt := process.Proc.P_starttime
+	return fmt.Sprintf("%d:%d", startedAt.Sec, startedAt.Usec)
+}

--- a/internal/jellycompat/process_token_linux.go
+++ b/internal/jellycompat/process_token_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package jellycompat
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func processToken(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return ""
+	}
+	stat := string(data)
+	commEnd := strings.LastIndex(stat, ") ")
+	if commEnd == -1 || commEnd+2 >= len(stat) {
+		return ""
+	}
+	fields := strings.Fields(stat[commEnd+2:])
+	if len(fields) < 20 {
+		return ""
+	}
+	return fields[19]
+}

--- a/internal/jellycompat/web_component.go
+++ b/internal/jellycompat/web_component.go
@@ -1103,26 +1103,6 @@ func currentProcessToken() string {
 	return processToken(os.Getpid())
 }
 
-func processToken(pid int) string {
-	if pid <= 0 {
-		return ""
-	}
-	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
-	if err != nil {
-		return ""
-	}
-	stat := string(data)
-	commEnd := strings.LastIndex(stat, ") ")
-	if commEnd == -1 || commEnd+2 >= len(stat) {
-		return ""
-	}
-	fields := strings.Fields(stat[commEnd+2:])
-	if len(fields) < 20 {
-		return ""
-	}
-	return fields[19]
-}
-
 func finishWebOperation(root, id string, err error) *WebComponentOperationStatus {
 	now := time.Now().UTC().Format(time.RFC3339)
 


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow CI fix

Silo publishes Linux container images, but CI does not build a native macOS server. The Linux image cannot use macOS VideoToolbox, so there is no downloadable build for validating the Mac hardware path added in #439.

The first hosted macOS run also exposed that Jellyfin-web operation locks derived their process identity only from Linux `/proc`. On Darwin, that made live and stale locks indistinguishable.

## Approach

Add a read-only GitHub Actions workflow that runs on the Apple Silicon `macos-15` runner for pull requests, pushes to `main`, and manual dispatches. It:

- installs the native `vips` and `ffmpeg` dependencies;
- builds the real embedded frontend and runs the full Go suite on Darwin;
- builds a revision-stamped `darwin/arm64` server archive;
- records Go module and dynamic-library metadata in the archive;
- verifies the Mach-O architecture, binary startup, embedded revision, checksum, advertised VideoToolbox support, and a real H.264 VideoToolbox smoke encode; and
- uploads the archive and SHA-256 file for 14 days.

The lock implementation now keeps the existing Linux `/proc` start token behind a Linux build tag and uses Darwin's kernel process start time through `unix.SysctlKinfoProc`. Both identify a PID incarnation, so PID reuse does not make a stale lock look live.

This deliberately produces an architecture-specific archive instead of a universal binary. The server uses CGO/libvips, so each architecture must be built against matching native libraries. Intel packaging and code signing/notarization remain separate follow-up work.

## Validation

Workflow and artifact checks:

```text
actionlint .github/workflows/macos.yml
# no findings (actionlint 1.7.12; ShellCheck 0.11.0)

pnpm exec prettier --check ../.github/workflows/macos.yml
# All matched files use Prettier code style!

file dist/silo-darwin-arm64/silo
# Mach-O 64-bit executable arm64

shasum -a 256 -c silo-darwin-arm64-<revision>.tar.gz.sha256
# silo-darwin-arm64-<revision>.tar.gz: OK

ffmpeg ... -c:v h264_videotoolbox -f null -
# exit 0
```

Repository gate:

```text
make embed-stub
GOWORK=off go build ./...
gofmt -l .
GOWORK=off go vet ./...
golangci-lint run --new-from-merge-base=origin/main ./...
# 0 issues

GOWORK=off go test ./...
# pass

GOWORK=off go test ./internal/jellycompat/... -count=1
# pass; includes both lock tests that failed on the first hosted macOS run

pnpm run lint
# 0 errors, 167 existing warnings
pnpm run format:check
# pass
pnpm run build
# pass
make test-web
# 300 files passed; 2244 tests passed

make verify-settings-bindings-all
# settings bindings are current
make verify-playback-fixtures
# playback fixtures are current
make verify-local-paths
# pass
```

Local native runtime validation on Apple Silicon macOS:

```text
GET http://127.0.0.1:18180/api/v1/health
# 200: {"status":"ok",...}

GET http://127.0.0.1:18196/System/Info/Public
# 200; StartupWizardCompleted=true

# Startup probe, observed twice:
hw_accel=auto: macOS detected, using VideoToolbox
```

The temporary native instance used alternate ports and was shut down cleanly after the checks. The existing OrbStack deployment was not replaced.

## Risks

- The artifact is arm64-only, unsigned, and not notarized.
- The binary links against Homebrew `vips`; the target Mac also needs compatible `vips`, `ffmpeg`, and `ffprobe` installations.
- The hardware smoke test makes loss of VideoToolbox support a CI failure instead of silently publishing a software-only artifact.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): GPT-5 (the client did not expose a more specific serving identifier)
- Involvement: Fully AI-generated; maintainer review pending
- Adversarial review: Reviewed runner architecture, least-privilege permissions, fork behavior, shell failure semantics, artifact identity, runtime linkage, checksum portability, module provenance, and the hosted failure. The review fixed an invalid assumption that `go version -m` would always expose `vcs.revision`, a checksum that included a `dist/` prefix and would fail after download, Linux-only process identity in Jellyfin-web operation locks, and incomplete isolation from Go module/workspace replacements. Actionlint and ShellCheck found no remaining workflow issues.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
