### PR TITLE
test(httpstream): stabilize rolling deadline pacing

### DIFF
--- a/internal/httpstream/readfrom_deadline_test.go
+++ b/internal/httpstream/readfrom_deadline_test.go
@@ -8,21 +8,22 @@ import (
 	"time"
 )
 
-// pacedReader delivers src in fixed-size pieces with a pause between each, so a
-// transfer takes a predictable wall-clock time regardless of socket buffering.
-// It models a slow disk or a rate-limited upstream, which is what makes a single
+// pacedReader delivers src at a fixed byte rate, so a transfer takes a
+// predictable wall-clock time regardless of the caller's read-buffer size. It
+// models a slow disk or a rate-limited upstream, which is what makes a single
 // zero-copy slice long-lived.
 type pacedReader struct {
 	remaining int64
 	piece     int64
 	pause     time.Duration
+	started   time.Time
+	delivered int64
 }
 
 func (r *pacedReader) Read(p []byte) (int, error) {
 	if r.remaining <= 0 {
 		return 0, io.EOF
 	}
-	time.Sleep(r.pause)
 	n := r.piece
 	if n > int64(len(p)) {
 		n = int64(len(p))
@@ -30,6 +31,15 @@ func (r *pacedReader) Read(p []byte) (int, error) {
 	if n > r.remaining {
 		n = r.remaining
 	}
+	// ReaderFrom implementations choose their own buffer size. Scale the pause
+	// to the bytes actually returned instead of assuming every call accepts a
+	// full piece; otherwise a smaller platform buffer silently slows the reader
+	// and consumes the deadline margin this test is meant to control.
+	if r.started.IsZero() {
+		r.started = time.Now()
+	}
+	r.delivered += n
+	time.Sleep(time.Until(r.started.Add(time.Duration(r.delivered) * r.pause / time.Duration(r.piece))))
 	r.remaining -= n
 	return int(n), nil
 }
@@ -55,10 +65,11 @@ func sliceDuration() time.Duration {
 // despite making continuous progress.
 func TestReadFromRollsDeadlineBetweenSlices(t *testing.T) {
 	slice := sliceDuration()
-	// Window comfortably exceeds one slice but is far shorter than the whole
-	// transfer, so only per-slice bumping can carry it to completion.
-	window := slice * 3
-	total := readFromChunk * 3
+	// Leave enough headroom for scheduler jitter while keeping the whole
+	// transfer longer than the window, so only per-slice bumping can carry it to
+	// completion.
+	window := slice * 6
+	total := readFromChunk * 8
 
 	done := make(chan error, 1)
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -96,8 +107,8 @@ func TestReadFromRollsDeadlineBetweenSlices(t *testing.T) {
 // stay reproducible so nobody restores a large slice without noticing.
 func TestOversizedReadFromSliceIsReaped(t *testing.T) {
 	slice := sliceDuration()
-	window := slice * 3
-	oversized := readFromChunk * 8 // one slice ≈ 8x slice duration >> window
+	window := slice * 6
+	oversized := readFromChunk * 12 // one slice ≈ 12x slice duration >> window
 
 	done := make(chan error, 1)
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -159,8 +170,8 @@ func TestReadFromChunkAllowsSlowClients(t *testing.T) {
 // sustaining the documented floor rate was reaped despite never stalling.
 func TestReadFromRollsDeadlineUnderProductionStep(t *testing.T) {
 	slice := sliceDuration()
-	window := slice * 3
-	total := readFromChunk * 3
+	window := slice * 6
+	total := readFromChunk * 8
 
 	done := make(chan error, 1)
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -197,7 +208,7 @@ func TestReadFromRollsDeadlineUnderProductionStep(t *testing.T) {
 // spend that wait against the window set at construction.
 func TestReadFromBumpsBeforeTheFirstSlice(t *testing.T) {
 	slice := sliceDuration()
-	window := slice * 3
+	window := slice * 6
 	total := readFromChunk
 
 	done := make(chan error, 1)


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow CI fix; follow-up to #808

The macOS workflow failed on `main` before reaching the artifact and VideoToolbox checks. Two `internal/httpstream` rolling-deadline tests reported `unexpected EOF` on a healthy paced stream.

The failure was in the test model, not the rolling-deadline implementation. `pacedReader` slept once per `Read`, while `sliceDuration` assumed every call accepted the configured 64 KiB piece. Go's HTTP writer can use a smaller read buffer, so the reader delivered fewer bytes per sleep and consumed more of the deadline than the test calculated. Scheduler jitter on the hosted Mac was then enough to expire a slice.

## Approach

Pace the reader from cumulative bytes delivered and elapsed time. This makes its rate independent of the `ReaderFrom` implementation's buffer size and carries fractional per-read delays instead of rounding them away.

The healthy-stream tests now give one slice a six-times timing margin and transfer eight slices, so the full transfer still outlives the deadline and still depends on a bump between slices. The negative test drives twelve slices through one oversized copy, preserving its assertion that a deadline expires within an unbounded slice.

Production code is unchanged.

## Validation

Focused and adversarial stress tests:

```text
GOWORK=off go test ./internal/httpstream -count=10
# pass; 80.586s

GOWORK=off go test -race ./internal/httpstream -count=3
# pass; 25.596s

GOWORK=off go test ./...
# pass; internal/httpstream 8.167s
```

Hosted validation:

```text
Native macOS Server / Build Darwin arm64
# pass; 8m36s
# Darwin Go suite, native archive, VideoToolbox smoke encode, checksum, and upload all passed

Artifact: silo-darwin-arm64-80ccc86c3eaff2a265f8e9abbf5960f90bf2c6c8
# 350,449,161 bytes; retained through 2026-09-11
```

[Hosted macOS run](https://github.com/Silo-Server/silo-server/actions/runs/33187542026)

Repository gate:

```text
make embed-stub
GOWORK=off go build ./...
gofmt -l .
GOWORK=off go vet ./...
golangci-lint run --new-from-merge-base=origin/main ./...
# pass; 0 changed-line issues

pnpm install --frozen-lockfile
pnpm run lint
# pass with existing warnings
pnpm run format:check
# pass
pnpm run build
# pass
make test-web
# 327 files passed; 2562 tests passed

make verify-settings-bindings-all
# settings bindings are current
make verify-playback-fixtures
# playback fixtures are current
make verify-local-paths
# pass
```

## Risks

- Only test code changes; streaming behavior and production deadline values are untouched.
- The tests still use real loopback sockets and wall-clock deadlines, but a six-times per-slice margin removes the platform-buffer error and leaves substantial scheduler headroom without weakening the cross-slice requirement.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): GPT-5 (the client did not expose a more specific serving identifier)
- Involvement: Fully AI-generated; maintainer review pending
- Adversarial review: Traced the failed byte counts through `net/http`'s `ReaderFrom` path, compared calculated and observed slice durations, and checked that the proposed timing ratios still require cross-slice deadline bumps. The review rejected a simple timeout increase and then caught a fractional-delay rounding problem in the first byte-scaled implementation; cumulative pacing replaced it. Ten repeated package runs, three race-detector runs, the full Go suite, and the repository gate found no remaining issue.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
