### PR TITLE
fix(web): cap the season episode grid at four scrolling rows

### DIFF
--- a/web/src/hooks/useGridRowCap.test.tsx
+++ b/web/src/hooks/useGridRowCap.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGridRowCap } from "./useGridRowCap";
+
+const observedNodes: Element[] = [];
+
+/**
+ * jsdom performs no layout, so every offsetTop is 0. Each test supplies the row
+ * offsets it wants the grid to appear to have; the hook's contract is entirely
+ * about how it reads those offsets, not about producing them.
+ */
+function Harness({
+  visibleRows,
+  tops,
+  rendered = true,
+}: {
+  visibleRows: number;
+  tops: number[];
+  rendered?: boolean;
+}) {
+  const setGrid = useGridRowCap<HTMLDivElement>(visibleRows, rendered ? tops.length : 0);
+
+  // Mirrors the real caller, which renders a skeleton until episodes arrive.
+  if (!rendered) return <div>loading</div>;
+
+  return (
+    <div
+      data-testid="grid"
+      ref={(element) => {
+        if (element) {
+          Array.from(element.children).forEach((child, index) => {
+            Object.defineProperty(child, "offsetTop", {
+              configurable: true,
+              get: () => tops[index] ?? 0,
+            });
+          });
+        }
+        setGrid(element);
+      }}
+      style={{ rowGap: "16px", paddingTop: "4px", paddingBottom: "0px" }}
+    >
+      {tops.map((_, index) => (
+        <div key={index}>item {index}</div>
+      ))}
+    </div>
+  );
+}
+
+/** `rows` rows of `columns` items, each row 100px below the last. */
+function grid(rows: number, columns: number): number[] {
+  return Array.from({ length: rows * columns }, (_, i) => 4 + Math.floor(i / columns) * 100);
+}
+
+describe("useGridRowCap", () => {
+  beforeEach(() => {
+    observedNodes.length = 0;
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe(node: Element) {
+          observedNodes.push(node);
+        }
+        disconnect() {}
+      },
+    );
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("leaves a grid shorter than the cap uncapped", () => {
+    // Four rows of three, capped at four rows: nothing is hidden, so the
+    // section keeps its natural height instead of gaining an inert scrollport.
+    render(<Harness visibleRows={4} tops={grid(4, 3)} />);
+    expect(screen.getByTestId("grid").style.maxHeight).toBe("");
+  });
+
+  it("caps at the last visible row, excluding the gap before the hidden one", () => {
+    // A fifth row starts at 404. Showing exactly four rows means stopping at
+    // the bottom of row four — 404 minus the 16px gap — plus the 4px of top
+    // padding that keeps the hover lift from being clipped.
+    render(<Harness visibleRows={4} tops={grid(5, 3)} />);
+    expect(screen.getByTestId("grid").style.maxHeight).toBe("388px");
+  });
+
+  it("caps by row rather than by item count, whatever the column count", () => {
+    // The same cap in a two-column layout still lands on the fourth row, so a
+    // breakpoint change re-measures to a new height rather than a new row.
+    const wide = render(<Harness visibleRows={4} tops={grid(6, 5)} />);
+    expect(wide.getByTestId("grid").style.maxHeight).toBe("388px");
+    wide.unmount();
+
+    const narrow = render(<Harness visibleRows={4} tops={grid(6, 2)} />);
+    expect(narrow.getByTestId("grid").style.maxHeight).toBe("388px");
+  });
+
+  it("observes a grid that only mounts after loading finishes", () => {
+    // Regression: binding the observer in an effect attached it to a null ref
+    // while the skeleton was showing and never retried, so the cap froze at
+    // whatever the first layout produced and ignored every later resize.
+    const { rerender } = render(<Harness visibleRows={4} tops={grid(5, 3)} rendered={false} />);
+    expect(observedNodes).toHaveLength(0);
+
+    rerender(<Harness visibleRows={4} tops={grid(5, 3)} rendered />);
+    expect(observedNodes).toContain(screen.getByTestId("grid"));
+  });
+});

--- a/web/src/hooks/useGridRowCap.ts
+++ b/web/src/hooks/useGridRowCap.ts
@@ -1,0 +1,101 @@
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+/**
+ * Caps a CSS grid at a measured number of rows and scrolls the remainder.
+ *
+ * The cap is measured, not derived. Cards that pair a fixed-ratio image with a
+ * variable block of text have no row height a stylesheet can name, and the
+ * column count changes at every breakpoint, so a `calc()` would have to encode
+ * both and would drift the moment either changed. Reading the offset of the
+ * first item on the row after the cap stays correct for any combination.
+ *
+ * The measurement is written straight to the element rather than held in state:
+ * it is a layout value applied to the node it was read from, so a render round
+ * trip would buy nothing and would make every resize frame cascade.
+ *
+ * Returns a callback ref. Callers typically render the grid only after loading
+ * finishes, so binding the observer to the node as it mounts is the only way to
+ * be sure it is attached — an effect would run once against a null ref and,
+ * with nothing in its dependencies changing afterwards, never retry.
+ */
+export function useGridRowCap<T extends HTMLElement>(visibleRows: number, itemCount: number) {
+  const gridRef = useRef<T | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const applyCap = useCallback(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+
+    // A subtree skipped by `content-visibility: auto` reports every child at
+    // the same offset. That reads as "short enough, no cap needed" and would
+    // drop the cap moments before the rows scroll into view, so leave whatever
+    // is already applied and wait for the observer to report a laid-out box.
+    if (
+      typeof grid.checkVisibility === "function" &&
+      !grid.checkVisibility({ contentVisibilityAuto: true })
+    ) {
+      return;
+    }
+
+    // A capped grid still lays its children out at their natural offsets — the
+    // scrollport clips rather than compresses — so this stays correct without
+    // clearing the previous cap and forcing an extra reflow first.
+    let firstRowTop: number | null = null;
+    let currentRowTop: number | null = null;
+    let clippedRowTop: number | null = null;
+    let rowCount = 0;
+
+    for (const child of grid.children) {
+      const top = (child as HTMLElement).offsetTop;
+      // Children come in DOM order, so each new offset starts a row.
+      if (top === currentRowTop) continue;
+      currentRowTop = top;
+      rowCount += 1;
+      if (firstRowTop === null) firstRowTop = top;
+      if (rowCount > visibleRows) {
+        clippedRowTop = top;
+        break;
+      }
+    }
+
+    // Short enough to need no cap: drop any left over from a narrower layout so
+    // the section never shows an inert scrollport.
+    if (firstRowTop === null || clippedRowTop === null) {
+      if (grid.style.maxHeight) grid.style.maxHeight = "";
+      return;
+    }
+
+    const style = getComputedStyle(grid);
+    const rowGap = parseFloat(style.rowGap) || 0;
+    const padding = (parseFloat(style.paddingTop) || 0) + (parseFloat(style.paddingBottom) || 0);
+    // `clippedRowTop` is the top of the first hidden row, so drop the gap that
+    // precedes it to land flush with the last visible row. Padding is added
+    // back because `max-height` is measured against the border box.
+    const next = `${Math.round(clippedRowTop - firstRowTop - rowGap + padding)}px`;
+
+    // Writing an unchanged value would keep the observer below ping-ponging.
+    if (grid.style.maxHeight !== next) grid.style.maxHeight = next;
+  }, [visibleRows]);
+
+  const setGrid = useCallback(
+    (node: T | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      gridRef.current = node;
+      if (!node || typeof ResizeObserver === "undefined") return;
+
+      // Width changes move the breakpoint, which changes both the column count
+      // and the row height. Observing the grid covers both.
+      const observer = new ResizeObserver(applyCap);
+      observer.observe(node);
+      observerRef.current = observer;
+    },
+    [applyCap],
+  );
+
+  // Content can change without the box changing — swapping to a season with a
+  // different episode count while the grid stays capped at the same height.
+  useLayoutEffect(applyCap, [applyCap, itemCount]);
+
+  return setGrid;
+}

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -141,7 +141,7 @@ export default function DetailHero({
             ? // min-height (not fixed height) below lg: bottom-justified content
               // taller than the hero would otherwise overflow out the top, under
               // the floating back button.
-              "min-h-[max(35vh,300px)] pt-20 lg:h-[42vh]"
+              "min-h-[max(35vh,300px)] pt-20 lg:min-h-[42vh]"
             : "min-h-[60dvh] pt-28 lg:min-h-[72dvh]"
         }`}
       >

--- a/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.test.tsx
+++ b/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.test.tsx
@@ -118,4 +118,50 @@ describe("SeasonEpisodeGrid", () => {
     expect(screen.getByText("Episode 2").parentElement).not.toContainElement(watchedIndicator);
     expect(screen.getAllByLabelText("Watched")).toHaveLength(1);
   });
+  it("caps the grid at four rows and scrolls the rest", () => {
+    render(
+      <MemoryRouter>
+        <SeasonEpisodeGrid
+          isLoading={false}
+          episodes={[
+            {
+              content_id: "ep-1",
+              season_number: 1,
+              episode_number: 1,
+              title: "Pilot",
+              overview: "An episode.",
+              air_date: null,
+              runtime: 42,
+              still_url: "",
+              still_thumbhash: "",
+              files: [],
+            },
+            {
+              content_id: "ep-2",
+              season_number: 1,
+              episode_number: 2,
+              title: "Second",
+              overview: "An episode.",
+              air_date: null,
+              runtime: 42,
+              still_url: "",
+              still_thumbhash: "",
+              files: [],
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    const grid = screen.getByText("Pilot").closest(".grid");
+    expect(grid).not.toBeNull();
+    // Two columns is the narrowest layout. A single column made the capped
+    // section over two viewports tall on a phone, so it scrolled inside a
+    // region the reader could not see the extent of.
+    expect(grid).toHaveClass("grid-cols-2", "sm:grid-cols-3", "lg:grid-cols-5");
+    expect(grid).toHaveClass("overflow-y-auto");
+    // Two episodes is under the cap, so nothing is clipped and the section
+    // keeps its natural height rather than showing an inert scrollport.
+    expect((grid as HTMLElement).style.maxHeight).toBe("");
+  });
 });

--- a/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
+++ b/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
@@ -8,10 +8,22 @@ import MediaItemMenu from "@/components/MediaItemMenu";
 import CardOverlays from "@/components/overlays/CardOverlays";
 import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
 import { usePrefetchCatalogItemDetail } from "@/hooks/queries/catalogRead";
+import { useGridRowCap } from "@/hooks/useGridRowCap";
 import type { CardQuickActionMode } from "@/lib/cardQuickActions";
 import { overlayDataFromEpisodeListItem, type CardOverlayPrefs } from "@/lib/overlays";
 import { EpisodeGridSkeleton } from "./SectionSkeletons";
 import type { EpisodeNavigationState } from "../itemDetailLayout";
+
+/**
+ * How much of a season stays visible before the section scrolls, so a long one
+ * cannot push the cast and crew off the page.
+ *
+ * Flat across breakpoints rather than scaled by column count: the cap is
+ * really a height budget, and four rows is already about one screen tall on a
+ * phone. Trading rows for columns there would only produce a nested scroll
+ * region taller than the viewport it sits in.
+ */
+const VISIBLE_EPISODE_ROWS = 4;
 
 interface SeasonEpisodeGridProps {
   episodes: EpisodeListItem[];
@@ -26,6 +38,7 @@ export default function SeasonEpisodeGrid({
 }: SeasonEpisodeGridProps) {
   const { prefs: overlayPrefs, quickActionMode } = useOverlayPrefs();
   const prefetchEpisodeDetail = usePrefetchCatalogItemDetail();
+  const setGridRef = useGridRowCap<HTMLDivElement>(VISIBLE_EPISODE_ROWS, episodes.length);
 
   if (isLoading) {
     return <EpisodeGridSkeleton />;
@@ -40,7 +53,12 @@ export default function SeasonEpisodeGrid({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 min-[460px]:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+    <div
+      ref={setGridRef}
+      // `pt-1 -mt-1` gives the top row's 4px hover lift somewhere to go: the
+      // scrollport clips both axes, and the cap adds this padding back.
+      className="overlay-scroll -mt-1 grid grid-cols-2 gap-4 overflow-y-auto pt-1 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+    >
       {episodes.map((episode) => (
         <SeasonEpisodeCard
           key={episode.content_id}

--- a/web/src/pages/ItemDetail/components/SectionSkeletons.tsx
+++ b/web/src/pages/ItemDetail/components/SectionSkeletons.tsx
@@ -87,7 +87,7 @@ export function RecommendationGridSkeleton({ count = 6 }: { count?: number }) {
 /** Skeleton for the episode grid on a season page (landscape cards + text) */
 export function EpisodeGridSkeleton({ count = 10 }: { count?: number }) {
   return (
-    <div className="grid grid-cols-1 gap-4 min-[460px]:grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
       {Array.from({ length: count }, (_, i) => (
         <div key={i}>
           <Skeleton className="aspect-video w-full rounded-lg" />


### PR DESCRIPTION
## Problem

Related issue: #804

A full season pushed the cast, crew and everything below it off the page. The grid
rendered every episode, so a 194-episode season (One Piece: Wano Country, the worst
case in my library) was a 9,575px wall of cards before anything else on the page.

The compact hero had the matching problem in the other direction: `lg:h-[42vh]` is a
fixed height, so a long season summary overflowed above its own clipped backdrop and
took the breadcrumb and title with it.

## Approach

The grid shows four rows and scrolls the rest; the compact hero grows downward
instead of overflowing.

**Why the cap is measured rather than calculated.** These cards pair a fixed-ratio
still with a variable block of text, so there is no row height a stylesheet can name,
and the column count changes at every breakpoint — a `calc()` would have to encode
both and would drift the moment either changed. `useGridRowCap` reads the offset of
the first item on the row after the cap. That is correct for any combination of
column count, card content and breakpoint, and it needs no constant kept in sync with
the CSS.

The measurement is written straight to the element rather than held in state: it is a
layout value applied to the node it was read from, so a render round trip would buy
nothing and would make every resize frame cascade.

**Two columns is now the narrowest layout**, replacing the single-column base. At one
column the capped region measured **2.33 viewports** on a 375px screen — a nested
scroll region taller than the screen containing it, which is worse than the problem
being fixed. Two columns brings that to 1.06 while doubling the episodes on screen.

## Validation

Measured live against the 194-episode season at every breakpoint. The cap lands flush
with the last visible row in each case (`row5.offsetTop − row1.offsetTop − rowGap`),
and the section stops scrolling entirely when a season is shorter than the cap:

| Viewport | Columns | Rows | Episodes visible | Cap | vs viewport |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1308px | 5 | 4 | 20 | 971px | 0.76 |
| 900px | 4 | 4 | 16 | 1160px | — |
| 375px | 2 | 4 | 8 | 859px | 1.06 |

Also confirmed a short season (8 episodes, 2 rows) gets no `max-height` and no
scrollport at all, and that a live resize re-measures rather than keeping a stale cap.

- `pnpm run build` — passed
- `pnpm exec vitest run` — 2613 passed
- `pnpm run lint` — 0 errors (165 pre-existing warnings, unchanged baseline)
- `pnpm run format:check` — passed

> [!NOTE]
> Screenshots to follow — I verified this against a live deployment but cannot attach
> images from the CLI. The measurements above are the substantive evidence.

## Risks

The episode section is now a nested scroll region, which is a pattern worth being
deliberate about. It stays under ~1.06 viewports at every breakpoint so the whole
region and its scrollbar are visible at once — that bound is why the single-column
layout was dropped. A `ResizeObserver` re-measures on breakpoint changes; the
regression test covers the case where the grid mounts after a loading skeleton, which
is where an earlier revision of this hook silently froze the cap at first layout.

## Provenance

Ports the season-layout half of #805 by @blurbery, rebuilt against the data router now
on `main`. That branch moved episodes into a horizontal carousel; this keeps the grid,
which is what @Quick104 preferred on review. The navigation and app-wide presentation
changes from that branch are deliberately not included.

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: Fully AI-generated, human verified — @Quick104 set the direction, chose
  the grid over the carousel, chose the row cap and the two-column mobile base, and
  reviewed the result against a live deployment.
- Adversarial review: this began as a defect-first review of #805 and the layout was
  then rebuilt from scratch against `main`. Two bugs were found and fixed during live
  verification rather than by reading the diff: the `ResizeObserver` bound to a null
  ref while the loading skeleton was showing and never retried (the cap froze at first
  layout and ignored every resize), and `tsc -b` caught an unchecked index access that
  `tsc --noEmit` passed. Both are covered by tests.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
