### PR TITLE
perf(web): scope detail-page render cost during viewport changes

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -113,6 +113,12 @@
   /* ── Hero Backdrop Defaults ─────────────────────────────────── */
   --hero-backdrop-brightness: 0.75;
   --hero-backdrop-saturate: 0.9;
+  /* Detail heroes tint their artwork with a flat `--background` wash instead
+     of a `filter`, so a viewport resize does not re-rasterize a filtered
+     layer every frame. This is the detail-page equivalent of
+     `--hero-backdrop-brightness`: 25% over a dark background lands close to
+     brightness(0.75). Themes tune it here rather than losing the knob. */
+  --hero-backdrop-scrim: 25%;
   --hero-text-shadow: 0 18px 50px rgb(0 0 0 / 45%);
 }
 
@@ -459,6 +465,9 @@
     /* Hero: light-mode overrides */
     --hero-backdrop-brightness: 1.15;
     --hero-backdrop-saturate: 0.6;
+    /* A heavier wash of the near-white background both lifts and desaturates,
+       matching what brightness(1.15)/saturate(0.6) did for this theme. */
+    --hero-backdrop-scrim: 35%;
     --hero-text-shadow: 0 1px 3px rgb(255 255 255 / 60%);
   }
 
@@ -867,6 +876,84 @@
     transition:
       background var(--duration-cinematic) var(--ease-gentle),
       opacity var(--duration-cinematic) var(--ease-gentle);
+  }
+
+  /* Keep the detail hero as one contained layout/paint boundary. Browser UI
+     that animates the content viewport can then resize this surface without
+     invalidating every supporting rail below it. */
+  .item-detail-hero {
+    contain: layout paint style;
+  }
+
+  /* Keep the text and controls on a stable compositor surface while the
+     browser changes the viewport (for example, Brave's hover sidebar). The
+     hero copy itself does not move at desktop widths, so repainting it for
+     every intermediate viewport size only stalls the browser UI animation. */
+  .detail-hero-copy {
+    transform: translateZ(0);
+    backface-visibility: hidden;
+  }
+
+  /* Item artwork stays on the browser's inexpensive image/composite path. */
+  .hero-backdrop-artwork {
+    contain: strict;
+  }
+
+  /* Detail pages previously stacked a tint, two separate bottom fades, two
+     separate side fades, and a vignette as five full-hero elements. Group the
+     static treatment into two contained surfaces around the ambient glow so
+     resize does less paint work without changing the artwork's layer order. */
+  .detail-hero-scrim {
+    position: absolute;
+    inset: 0;
+    contain: paint;
+    pointer-events: none;
+  }
+
+  /* These layers sat below the ambient artwork glow in the original hero. */
+  .detail-hero-scrim-under {
+    background:
+      linear-gradient(
+        to right,
+        var(--background) 0%,
+        color-mix(in srgb, var(--background) 80%, transparent) 20%,
+        color-mix(in srgb, var(--background) 40%, transparent) 40%,
+        transparent 60%
+      ),
+      linear-gradient(
+        color-mix(in srgb, var(--background) var(--hero-backdrop-scrim, 25%), transparent),
+        color-mix(in srgb, var(--background) var(--hero-backdrop-scrim, 25%), transparent)
+      );
+  }
+
+  /* These layers sat above the ambient artwork glow in the original hero. */
+  .detail-hero-scrim-over {
+    background:
+      linear-gradient(
+        90deg,
+        color-mix(in srgb, var(--background) 92%, transparent) 0%,
+        color-mix(in srgb, var(--background) 64%, transparent) 28%,
+        transparent 58%
+      ),
+      linear-gradient(
+        to top,
+        var(--background) 0%,
+        color-mix(in srgb, var(--background) 75%, transparent) 28%,
+        transparent 62%
+      ),
+      linear-gradient(
+        to top,
+        var(--background) 0%,
+        color-mix(in srgb, var(--background) 92%, transparent) 20%,
+        color-mix(in srgb, var(--background) 55%, transparent) 50%,
+        color-mix(in srgb, var(--background) 20%, transparent) 75%,
+        transparent 100%
+      );
+  }
+
+  .detail-hero-ambient {
+    contain: paint;
+    transition: none;
   }
 
   /* ── Sidebar Immersion ─────────────────────────────────────── */
@@ -1349,6 +1436,23 @@
     contain-intrinsic-size: auto var(--carousel-intrinsic-h, 23rem);
   }
 
+  /* Detail pages can contain several image-heavy rails below the fold. Match
+     the home carousel strategy so a viewport resize only lays out and paints
+     the supporting sections near the user. The remembered intrinsic size
+     prevents already-visited sections from shifting the scroll position. */
+  .detail-supporting-content > * {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 24rem;
+  }
+
+  /* A detail page may mount several Embla rails close enough to the viewport
+     that the browser keeps all of them render-relevant. Isolate each clipped
+     viewport so a browser-chrome resize or vertical page scroll cannot make
+     an episode/cast rail invalidate neighbouring detail sections. */
+  .detail-supporting-content .embla__viewport {
+    contain: layout paint style;
+  }
+
   /* Card actions stay hidden at rest so touch devices get clean artwork; a
      long press opens the action sheet instead. Keyboard focus and an open
      menu reveal them on every device so keyboard and assistive-tech users
@@ -1375,9 +1479,18 @@
      action always covers the badges in that corner. Badges anchor flush in the
      corners and never reserve room for the actions; the overlay layer is
      pointer-events-none, so covered badges cannot steal an action's clicks. */
+  .media-card-hover-dim {
+    background: rgb(0 0 0 / 0.3);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-fast) var(--ease-default);
+  }
+  .group\/media:focus-within .media-card-hover-dim {
+    opacity: 1;
+  }
   @media (any-hover: hover) and (any-pointer: fine) {
     .group\/media:hover .media-card-hover-dim {
-      background-color: rgb(0 0 0 / 0.3);
+      opacity: 1;
     }
     .group\/card:hover .media-card-action-trigger,
     .group\/media:hover .media-card-play-trigger {

--- a/web/src/hooks/useAmbientColor.test.tsx
+++ b/web/src/hooks/useAmbientColor.test.tsx
@@ -1,0 +1,38 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useAmbientColor } from "./useAmbientColor";
+
+vi.mock("@/lib/thumbhash", () => ({
+  getAverageColor: (thumbhash: string) =>
+    thumbhash === "first" ? "rgb(10 20 30)" : "rgb(40 50 60)",
+}));
+
+describe("useAmbientColor", () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty("--ambient");
+    vi.unstubAllGlobals();
+  });
+
+  it("does not clear the ambient color between replacing detail surfaces", () => {
+    const cleanups: Array<() => void> = [];
+    vi.stubGlobal("queueMicrotask", (cleanup: () => void) => cleanups.push(cleanup));
+
+    const { rerender, unmount } = renderHook(
+      ({ thumbhash }: { thumbhash: string }) => useAmbientColor(thumbhash),
+      { initialProps: { thumbhash: "first" } },
+    );
+
+    expect(document.documentElement.style.getPropertyValue("--ambient")).toBe("rgb(10 20 30)");
+
+    rerender({ thumbhash: "second" });
+    expect(document.documentElement.style.getPropertyValue("--ambient")).toBe("rgb(40 50 60)");
+
+    act(() => cleanups.splice(0).forEach((cleanup) => cleanup()));
+    expect(document.documentElement.style.getPropertyValue("--ambient")).toBe("rgb(40 50 60)");
+
+    unmount();
+    act(() => cleanups.splice(0).forEach((cleanup) => cleanup()));
+    expect(document.documentElement.style.getPropertyValue("--ambient")).toBe("");
+  });
+});

--- a/web/src/hooks/useAmbientColor.ts
+++ b/web/src/hooks/useAmbientColor.ts
@@ -2,45 +2,48 @@ import { useEffect, useRef } from "react";
 import { getAverageColor } from "@/lib/thumbhash";
 
 const PROPERTY = "--ambient";
+let currentOwner: symbol | null = null;
 
 /**
  * Sets the --ambient CSS custom property on <html> from a thumbhash.
  *
- * When the thumbhash changes, the ambient color updates and the
- * .ambient-glow CSS class handles the smooth visual transition.
- * On unmount or when thumbhash becomes empty, resets --ambient so the
- * CSS fallback `var(--ambient, var(--primary))` takes over.
+ * Ambient surfaces can replace one another in the same route commit. Cleanup
+ * is deferred to a microtask so the outgoing surface cannot briefly clear the
+ * property before the incoming surface publishes its color. That avoids a
+ * full-page gradient repaint between item-detail routes while still restoring
+ * the CSS fallback after the final ambient surface unmounts.
  */
 export function useAmbientColor(thumbhash: string | undefined | null): void {
   const prevRef = useRef<string | null>(null);
 
   useEffect(() => {
     const root = document.documentElement;
+    const owner = Symbol("ambient-color");
 
     if (!thumbhash) {
-      if (prevRef.current !== null) {
-        root.style.removeProperty(PROPERTY);
-        prevRef.current = null;
-      }
       return;
     }
 
     const color = getAverageColor(thumbhash);
     if (!color) {
-      root.style.removeProperty(PROPERTY);
-      prevRef.current = null;
       return;
     }
 
+    currentOwner = owner;
+
     // Only write to DOM if value changed
-    if (color !== prevRef.current) {
+    if (color !== prevRef.current || root.style.getPropertyValue(PROPERTY) !== color) {
       root.style.setProperty(PROPERTY, color);
       prevRef.current = color;
     }
 
     return () => {
-      root.style.removeProperty(PROPERTY);
-      prevRef.current = null;
+      queueMicrotask(() => {
+        if (currentOwner !== owner) return;
+        root.style.removeProperty(PROPERTY);
+        currentOwner = null;
+        prevRef.current = null;
+      });
     };
   }, [thumbhash]);
 }

--- a/web/src/hooks/useCarouselEmbla.test.tsx
+++ b/web/src/hooks/useCarouselEmbla.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import type { EmblaCarouselType } from "embla-carousel";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useEmblaCarousel: vi.fn(),
+  wheelGesturesPlugin: vi.fn(() => ({ name: "wheelGestures" })),
+}));
+
+vi.mock("embla-carousel-react", () => ({ default: mocks.useEmblaCarousel }));
+vi.mock("embla-carousel-wheel-gestures", () => ({
+  WheelGesturesPlugin: mocks.wheelGesturesPlugin,
+}));
+
+import { useCarouselEmbla } from "./useCarouselEmbla";
+
+describe("useCarouselEmbla", () => {
+  let canScrollPrev = false;
+  let canScrollNext = true;
+  let api: EmblaCarouselType;
+  let listeners: Map<string, (api: EmblaCarouselType) => void>;
+
+  beforeEach(() => {
+    canScrollPrev = false;
+    canScrollNext = true;
+    listeners = new Map();
+    const container = document.createElement("div");
+    api = {
+      canScrollPrev: vi.fn(() => canScrollPrev),
+      canScrollNext: vi.fn(() => canScrollNext),
+      containerNode: vi.fn(() => container),
+      on: vi.fn((event: string, callback: (api: EmblaCarouselType) => void) => {
+        listeners.set(event, callback);
+        return api;
+      }),
+      off: vi.fn((event: string) => {
+        listeners.delete(event);
+        return api;
+      }),
+      reInit: vi.fn(),
+      scrollPrev: vi.fn(),
+      scrollNext: vi.fn(),
+    } as unknown as EmblaCarouselType;
+    mocks.useEmblaCarousel.mockReset();
+    mocks.useEmblaCarousel.mockReturnValue([vi.fn(), api]);
+  });
+
+  it("installs the coalesced resize observer and keeps arrow state current after reInit", () => {
+    const { result } = renderHook(() => useCarouselEmbla());
+    const emblaOptions = mocks.useEmblaCarousel.mock.calls[0]?.[0];
+
+    expect(typeof emblaOptions.watchResize).toBe("function");
+    expect(result.current.canScrollPrev).toBe(false);
+    expect(result.current.canScrollNext).toBe(true);
+
+    canScrollPrev = true;
+    canScrollNext = false;
+    act(() => listeners.get("reInit")?.(api));
+
+    expect(result.current.canScrollPrev).toBe(true);
+    expect(result.current.canScrollNext).toBe(false);
+  });
+
+  it("preserves a deliberate resize-observer opt-out", () => {
+    renderHook(() => useCarouselEmbla({ options: { watchResize: false } }));
+
+    expect(mocks.useEmblaCarousel.mock.calls[0]?.[0].watchResize).toBe(false);
+  });
+});

--- a/web/src/hooks/useCarouselEmbla.ts
+++ b/web/src/hooks/useCarouselEmbla.ts
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { EmblaCarouselType, EmblaOptionsType } from "embla-carousel";
 import useEmblaCarousel from "embla-carousel-react";
 import { WheelGesturesPlugin } from "embla-carousel-wheel-gestures";
-import { getCarouselEmblaOptions, getCarouselWheelGestureOptions } from "@/lib/carouselEmbla";
+import {
+  createCarouselResizeController,
+  getCarouselEmblaOptions,
+  getCarouselWheelGestureOptions,
+} from "@/lib/carouselEmbla";
 
 interface UseCarouselEmblaOptions {
   options?: EmblaOptionsType;
@@ -11,14 +15,46 @@ interface UseCarouselEmblaOptions {
 export function useCarouselEmbla({ options }: UseCarouselEmblaOptions = {}) {
   const [canScrollPrev, setCanScrollPrev] = useState(false);
   const [canScrollNext, setCanScrollNext] = useState(false);
-  const emblaOptions = useMemo(() => getCarouselEmblaOptions(options), [options]);
+  const canScrollPrevRef = useRef(false);
+  const canScrollNextRef = useRef(false);
+  const resizeControllerRef = useRef<ReturnType<typeof createCarouselResizeController> | null>(
+    null,
+  );
+  if (resizeControllerRef.current === null) {
+    resizeControllerRef.current = createCarouselResizeController();
+  }
+  const resizeController = resizeControllerRef.current;
+  const emblaOptions = useMemo(
+    () =>
+      getCarouselEmblaOptions({
+        ...options,
+        // Preserve deliberate opt-outs and custom observers. `true` means the
+        // shared default, which is the coalesced path for every Silo carousel.
+        watchResize:
+          options?.watchResize === false || typeof options?.watchResize === "function"
+            ? options.watchResize
+            : resizeController.watchResize,
+      }),
+    [options, resizeController],
+  );
   const emblaPlugins = useMemo(() => [WheelGesturesPlugin(getCarouselWheelGestureOptions())], []);
   const [emblaRef, emblaApi] = useEmblaCarousel(emblaOptions, emblaPlugins);
 
   const updateScrollState = useCallback((api: EmblaCarouselType) => {
-    setCanScrollPrev(api.canScrollPrev());
-    setCanScrollNext(api.canScrollNext());
+    const nextCanScrollPrev = api.canScrollPrev();
+    const nextCanScrollNext = api.canScrollNext();
+
+    if (nextCanScrollPrev !== canScrollPrevRef.current) {
+      canScrollPrevRef.current = nextCanScrollPrev;
+      setCanScrollPrev(nextCanScrollPrev);
+    }
+    if (nextCanScrollNext !== canScrollNextRef.current) {
+      canScrollNextRef.current = nextCanScrollNext;
+      setCanScrollNext(nextCanScrollNext);
+    }
   }, []);
+
+  useEffect(() => () => resizeController.cancel(), [resizeController]);
 
   useEffect(() => {
     if (!emblaApi) return;

--- a/web/src/hooks/useDwellPrefetch.ts
+++ b/web/src/hooks/useDwellPrefetch.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef } from "react";
+
+const DEFAULT_DWELL_DELAY_MS = 140;
+
+/**
+ * Avoids starting network/cache work while the pointer is only sweeping across
+ * a media row. Keyboard focus and touch intent still prefetch immediately.
+ */
+export function useDwellPrefetch(prefetch: () => void, delayMs = DEFAULT_DWELL_DELAY_MS) {
+  const timerRef = useRef<number | null>(null);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current === null) return;
+    window.clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }, []);
+
+  const schedule = useCallback(() => {
+    cancel();
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      prefetch();
+    }, delayMs);
+  }, [cancel, delayMs, prefetch]);
+
+  const immediately = useCallback(() => {
+    cancel();
+    prefetch();
+  }, [cancel, prefetch]);
+
+  useEffect(() => cancel, [cancel]);
+
+  return {
+    onMouseEnter: schedule,
+    onMouseLeave: cancel,
+    onFocus: immediately,
+    onTouchStart: immediately,
+  };
+}

--- a/web/src/hooks/useGridLayout.test.tsx
+++ b/web/src/hooks/useGridLayout.test.tsx
@@ -1,0 +1,88 @@
+import { act, render, screen } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useGridLayout } from "./useGridLayout";
+
+let notifyResize: ResizeObserverCallback | undefined;
+let containerWidth = 400;
+
+class ResizeObserverStub {
+  constructor(callback: ResizeObserverCallback) {
+    notifyResize = callback;
+  }
+
+  observe() {}
+  disconnect() {}
+}
+
+function Harness() {
+  const mounted = useRef(false);
+  const { containerRef, layout } = useGridLayout({ gap: 10, textAreaHeight: 20 });
+
+  return (
+    <div>
+      <output>{`${layout.columnCount}:${layout.rowHeight}`}</output>
+      <div
+        ref={(element) => {
+          containerRef.current = element;
+          if (element && !mounted.current) {
+            Object.defineProperty(element, "clientWidth", {
+              configurable: true,
+              get: () => containerWidth,
+            });
+            mounted.current = true;
+          }
+        }}
+        style={{ display: "grid", gridTemplateColumns: "100px 100px" }}
+      />
+    </div>
+  );
+}
+
+describe("useGridLayout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    containerWidth = 400;
+    notifyResize = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("tracks the first resize frame immediately, then coalesces the rest", () => {
+    render(<Harness />);
+    expect(screen.getByRole("status")).toHaveTextContent("2:322.5");
+
+    // The virtualizer positions absolute rows from this geometry, so deferring
+    // the first frame would leave rows overlapping the already-reflowed grid
+    // for the whole settle window.
+    containerWidth = 360;
+    act(() => notifyResize?.([], {} as ResizeObserver));
+    expect(screen.getByRole("status")).toHaveTextContent("2:292.5");
+  });
+
+  it("reconciles once more after a continuous resize settles", () => {
+    render(<Harness />);
+
+    containerWidth = 360;
+    act(() => notifyResize?.([], {} as ResizeObserver));
+    expect(screen.getByRole("status")).toHaveTextContent("2:292.5");
+
+    // Intermediate frames of the same gesture do not each schedule a render;
+    // they collapse into one trailing reconcile at the final width.
+    containerWidth = 300;
+    act(() => {
+      notifyResize?.([], {} as ResizeObserver);
+      vi.advanceTimersByTime(80);
+      notifyResize?.([], {} as ResizeObserver);
+      vi.advanceTimersByTime(119);
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("2:292.5");
+
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.getByRole("status")).toHaveTextContent("2:247.5");
+  });
+});

--- a/web/src/hooks/useGridLayout.test.tsx
+++ b/web/src/hooks/useGridLayout.test.tsx
@@ -23,6 +23,7 @@ function Harness() {
     <div>
       <output>{`${layout.columnCount}:${layout.rowHeight}`}</output>
       <div
+        data-testid="grid"
         ref={(element) => {
           containerRef.current = element;
           if (element && !mounted.current) {
@@ -62,6 +63,27 @@ describe("useGridLayout", () => {
     containerWidth = 360;
     act(() => notifyResize?.([], {} as ResizeObserver));
     expect(screen.getByRole("status")).toHaveTextContent("2:292.5");
+  });
+
+  it("measures immediately when a resize crosses a column breakpoint", () => {
+    render(<Harness />);
+    expect(screen.getByRole("status")).toHaveTextContent("2:322.5");
+
+    // Begin a drag. The leading edge measures, so later frames coalesce.
+    containerWidth = 360;
+    act(() => notifyResize?.([], {} as ResizeObserver));
+    expect(screen.getByRole("status")).toHaveTextContent("2:292.5");
+
+    // Mid-drag CSS reflows to three columns. `columnCount` slices the item list
+    // (`startIndex = row * columnCount`), so holding the stale 2 until the drag
+    // stopped would omit or duplicate cards for the rest of the gesture — this
+    // one notification must not be coalesced.
+    containerWidth = 340;
+    act(() => {
+      screen.getByTestId("grid").style.gridTemplateColumns = "100px 100px 100px";
+      notifyResize?.([], {} as ResizeObserver);
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("3:190");
   });
 
   it("reconciles once more after a continuous resize settles", () => {

--- a/web/src/hooks/useGridLayout.ts
+++ b/web/src/hooks/useGridLayout.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 
+const RESIZE_SETTLE_DELAY_MS = 120;
+
 interface GridLayout {
   columnCount: number;
   rowHeight: number;
@@ -14,6 +16,7 @@ interface UseGridLayoutOptions {
 
 export function useGridLayout({ gap, textAreaHeight, layoutKey = "" }: UseGridLayoutOptions) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const resizeTimerRef = useRef<number | null>(null);
   const [layout, setLayout] = useState<GridLayout>({
     columnCount: 8,
     rowHeight: 300,
@@ -37,9 +40,34 @@ export function useGridLayout({ gap, textAreaHeight, layoutKey = "" }: UseGridLa
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    const observer = new ResizeObserver(measure);
+    // CSS grid responds to every viewport step without React's help. Re-running
+    // the virtualizer measurement for every ResizeObserver notification does
+    // not: it forces a computed-style read and a React render on each frame of
+    // browser chrome animations (for example Brave's hover sidebar). Keep the
+    // existing virtual row geometry during that short animation, then reconcile
+    // it once the viewport has settled.
+    const scheduleMeasure = () => {
+      // Leading edge: the virtualizer positions absolute rows from rowHeight
+      // and columnCount, so deferring the first measurement of a gesture
+      // leaves rows overlapping the reflowed grid for the whole settle window.
+      if (resizeTimerRef.current === null) measure();
+      else window.clearTimeout(resizeTimerRef.current);
+      // Trailing edge: one reconcile once the viewport stops moving, instead
+      // of a computed-style read and a React render on every resize frame.
+      resizeTimerRef.current = window.setTimeout(() => {
+        resizeTimerRef.current = null;
+        measure();
+      }, RESIZE_SETTLE_DELAY_MS);
+    };
+    const observer = new ResizeObserver(scheduleMeasure);
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (resizeTimerRef.current !== null) {
+        window.clearTimeout(resizeTimerRef.current);
+        resizeTimerRef.current = null;
+      }
+    };
   }, [measure]);
 
   useEffect(() => {

--- a/web/src/hooks/useGridLayout.ts
+++ b/web/src/hooks/useGridLayout.ts
@@ -14,9 +14,15 @@ interface UseGridLayoutOptions {
   layoutKey?: string;
 }
 
+/** Column count as the browser currently renders it, before any coalescing. */
+function countColumns(el: HTMLElement): number {
+  return getComputedStyle(el).gridTemplateColumns.split(" ").length;
+}
+
 export function useGridLayout({ gap, textAreaHeight, layoutKey = "" }: UseGridLayoutOptions) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const resizeTimerRef = useRef<number | null>(null);
+  const columnCountRef = useRef<number | null>(null);
   const [layout, setLayout] = useState<GridLayout>({
     columnCount: 8,
     rowHeight: 300,
@@ -26,8 +32,8 @@ export function useGridLayout({ gap, textAreaHeight, layoutKey = "" }: UseGridLa
     const el = containerRef.current;
     if (!el) return;
 
-    const computed = getComputedStyle(el);
-    const columns = computed.gridTemplateColumns.split(" ").length;
+    const columns = countColumns(el);
+    columnCountRef.current = columns;
     const containerWidth = el.clientWidth;
     const totalGap = gap * (columns - 1);
     const cardWidth = (containerWidth - totalGap) / columns;
@@ -50,10 +56,19 @@ export function useGridLayout({ gap, textAreaHeight, layoutKey = "" }: UseGridLa
       // Leading edge: the virtualizer positions absolute rows from rowHeight
       // and columnCount, so deferring the first measurement of a gesture
       // leaves rows overlapping the reflowed grid for the whole settle window.
-      if (resizeTimerRef.current === null) measure();
-      else window.clearTimeout(resizeTimerRef.current);
+      const isFirstNotification = resizeTimerRef.current === null;
+      // A breakpoint crossing is not coalescable. `columnCount` slices the
+      // item list — `startIndex = row * columnCount` — so holding a stale
+      // count while CSS has already reflowed to a different number of columns
+      // omits or duplicates cards for the rest of the drag. Reading the count
+      // is a style read; it is the React render that the coalescing protects.
+      const crossedBreakpoint =
+        columnCountRef.current !== null && countColumns(el) !== columnCountRef.current;
+
+      if (!isFirstNotification) window.clearTimeout(resizeTimerRef.current!);
+      if (isFirstNotification || crossedBreakpoint) measure();
       // Trailing edge: one reconcile once the viewport stops moving, instead
-      // of a computed-style read and a React render on every resize frame.
+      // of a React render on every resize frame.
       resizeTimerRef.current = window.setTimeout(() => {
         resizeTimerRef.current = null;
         measure();

--- a/web/src/lib/carouselEmbla.test.ts
+++ b/web/src/lib/carouselEmbla.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { getCarouselEmblaOptions, getCarouselWheelGestureOptions } from "./carouselEmbla";
+import type { EmblaCarouselType } from "embla-carousel";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CAROUSEL_RESIZE_SETTLE_DELAY_MS,
+  createCarouselResizeController,
+  getCarouselEmblaOptions,
+  getCarouselWheelGestureOptions,
+} from "./carouselEmbla";
 
 describe("carouselEmbla", () => {
   it("enables drag-free momentum with trimmed edge scrolling", () => {
@@ -16,6 +22,107 @@ describe("carouselEmbla", () => {
     expect(getCarouselWheelGestureOptions(target)).toMatchObject({
       forceWheelAxis: "x",
       target,
+    });
+  });
+
+  describe("resize controller", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    function createApi() {
+      const container = document.createElement("div");
+      const reInit = vi.fn();
+      const api = {
+        containerNode: () => container,
+        reInit,
+      } as unknown as EmblaCarouselType;
+      return { api, container, reInit };
+    }
+
+    function resizeEntry(target: Element, width = 0): ResizeObserverEntry {
+      return {
+        target,
+        contentRect: { width },
+      } as ResizeObserverEntry;
+    }
+
+    it("coalesces continuous container resizing into one settled reInit", () => {
+      const controller = createCarouselResizeController();
+      const { api, container, reInit } = createApi();
+
+      expect(controller.watchResize(api, [resizeEntry(container, 900)])).toBe(true);
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS);
+      expect(reInit).not.toHaveBeenCalled();
+
+      expect(controller.watchResize(api, [resizeEntry(container, 860)])).toBe(false);
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS - 20);
+      expect(controller.watchResize(api, [resizeEntry(container, 820)])).toBe(false);
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS - 1);
+      expect(reInit).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(reInit).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets Embla immediately process an isolated slide-content resize", () => {
+      const controller = createCarouselResizeController();
+      const { api } = createApi();
+      const slide = document.createElement("article");
+
+      expect(controller.watchResize(api, [resizeEntry(slide)])).toBe(true);
+    });
+
+    it("folds slide observations into an active container resize", () => {
+      const controller = createCarouselResizeController();
+      const { api, container, reInit } = createApi();
+      const slide = document.createElement("article");
+
+      controller.watchResize(api, [resizeEntry(container, 900)]);
+      controller.watchResize(api, [resizeEntry(container, 860)]);
+      vi.advanceTimersByTime(20);
+      expect(controller.watchResize(api, [resizeEntry(slide)])).toBe(false);
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS);
+
+      expect(reInit).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancels a pending reInit during teardown", () => {
+      const controller = createCarouselResizeController();
+      const { api, container, reInit } = createApi();
+
+      controller.watchResize(api, [resizeEntry(container, 900)]);
+      controller.watchResize(api, [resizeEntry(container, 860)]);
+      controller.cancel();
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS);
+
+      expect(reInit).not.toHaveBeenCalled();
+    });
+
+    it("does not reinitialize again for the unchanged observer delivery after reInit", () => {
+      const controller = createCarouselResizeController();
+      const { api, container, reInit } = createApi();
+      reInit.mockImplementation(() => {
+        expect(controller.watchResize(api, [resizeEntry(container, 860)])).toBe(true);
+      });
+
+      controller.watchResize(api, [resizeEntry(container, 900)]);
+      controller.watchResize(api, [resizeEntry(container, 860)]);
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS);
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS * 3);
+
+      expect(reInit).toHaveBeenCalledTimes(1);
+    });
+
+    it("accumulates subpixel width changes against the last accepted size", () => {
+      const controller = createCarouselResizeController();
+      const { api, container, reInit } = createApi();
+
+      controller.watchResize(api, [resizeEntry(container, 900)]);
+      controller.watchResize(api, [resizeEntry(container, 899.7)]);
+      controller.watchResize(api, [resizeEntry(container, 899.4)]);
+      vi.advanceTimersByTime(CAROUSEL_RESIZE_SETTLE_DELAY_MS);
+
+      expect(reInit).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/web/src/lib/carouselEmbla.ts
+++ b/web/src/lib/carouselEmbla.ts
@@ -1,4 +1,27 @@
-import type { EmblaOptionsType } from "embla-carousel";
+import type { EmblaCarouselType, EmblaOptionsType } from "embla-carousel";
+
+export const CAROUSEL_RESIZE_SETTLE_DELAY_MS = 120;
+
+type EmblaWatchResize = (api: EmblaCarouselType, entries: ResizeObserverEntry[]) => boolean;
+
+export interface CarouselResizeController {
+  watchResize: EmblaWatchResize;
+  cancel: () => void;
+}
+
+function observedInlineSize(entry: ResizeObserverEntry): number {
+  const borderBoxSize = entry.borderBoxSize;
+  const borderBox = Array.isArray(borderBoxSize) ? borderBoxSize[0] : borderBoxSize;
+  if (borderBox && Number.isFinite(borderBox.inlineSize)) {
+    return borderBox.inlineSize;
+  }
+
+  if (entry.contentRect && Number.isFinite(entry.contentRect.width)) {
+    return entry.contentRect.width;
+  }
+
+  return entry.target.getBoundingClientRect().width;
+}
 
 const CAROUSEL_EMBLA_OPTIONS: EmblaOptionsType = {
   align: "start",
@@ -19,4 +42,76 @@ export function getCarouselWheelGestureOptions(target?: Element | null) {
     forceWheelAxis: "x" as const,
     target: target ?? undefined,
   };
+}
+
+/**
+ * Keeps Embla from rebuilding its measurements on every frame of an animated
+ * viewport resize. A standalone slide resize still uses Embla's immediate
+ * default handler; once a container resize starts, related slide observations
+ * are collected into one reInit after the layout has settled.
+ */
+export function createCarouselResizeController(
+  settleDelayMs = CAROUSEL_RESIZE_SETTLE_DELAY_MS,
+): CarouselResizeController {
+  let resizeTimer: number | null = null;
+  let pendingApi: EmblaCarouselType | null = null;
+  const observedContainerWidths = new WeakMap<Element, number>();
+
+  const cancel = () => {
+    if (resizeTimer !== null) {
+      window.clearTimeout(resizeTimer);
+      resizeTimer = null;
+    }
+    pendingApi = null;
+  };
+
+  const scheduleReInit = (api: EmblaCarouselType) => {
+    if (resizeTimer !== null) {
+      window.clearTimeout(resizeTimer);
+    }
+    pendingApi = api;
+    resizeTimer = window.setTimeout(() => {
+      resizeTimer = null;
+      const apiToReInit = pendingApi;
+      pendingApi = null;
+      apiToReInit?.reInit();
+    }, settleDelayMs);
+  };
+
+  const watchResize: EmblaWatchResize = (api, entries) => {
+    const container = api.containerNode();
+    const containerEntry = entries.find((entry) => entry.target === container);
+
+    if (containerEntry) {
+      const nextWidth = observedInlineSize(containerEntry);
+      const previousWidth = observedContainerWidths.get(container);
+
+      // ResizeObserver delivers the current size as soon as Embla starts
+      // observing. Treat that first delivery as the baseline: scheduling a
+      // reInit for it creates a new observer, which delivers the same initial
+      // entry and can otherwise keep the carousel rebuilding forever.
+      if (previousWidth === undefined) {
+        observedContainerWidths.set(container, nextWidth);
+        return true;
+      }
+
+      if (Math.abs(nextWidth - previousWidth) >= 0.5) {
+        observedContainerWidths.set(container, nextWidth);
+        scheduleReInit(api);
+        return false;
+      }
+
+      // Let Embla compare any slide entries batched with an unchanged
+      // container delivery. Its own cached geometry prevents a rebuild when
+      // this is merely the observer's initial notification after reInit.
+      return resizeTimer === null;
+    }
+
+    if (resizeTimer !== null) return false;
+
+    // Let Embla handle isolated slide-content changes immediately.
+    return true;
+  };
+
+  return { watchResize, cancel };
 }

--- a/web/src/pages/ItemDetail/AudiobookContent.tsx
+++ b/web/src/pages/ItemDetail/AudiobookContent.tsx
@@ -253,7 +253,7 @@ export default function AudiobookContent({
       />
 
       <div
-        className="page-shell space-y-12 py-10 sm:space-y-14"
+        className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14"
         style={isPlayerOpen ? { paddingBottom: "8rem" } : undefined}
       >
         {narrator && <NarratorCard narrator={narrator} />}

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -101,9 +101,8 @@ export default function DetailHero({
       {topNav}
       {(backdropUrl || backdropPlaceholder) && (
         <div
-          className="absolute inset-0 h-full w-full"
+          className="hero-backdrop-artwork absolute inset-0 h-full w-full"
           style={{
-            filter: `brightness(var(--hero-backdrop-brightness, 0.4)) saturate(var(--hero-backdrop-saturate, 1.15))`,
             ...(backdropPlaceholder && !backdropLoaded
               ? {
                   backgroundImage: `url(${backdropPlaceholder})`,
@@ -118,6 +117,7 @@ export default function DetailHero({
               key={backdropUrl}
               src={backdropUrl}
               alt=""
+              decoding="async"
               className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-300 ${backdropLoaded ? "opacity-100" : "opacity-0"}`}
               onLoad={onBackdropLoad}
             />
@@ -125,15 +125,13 @@ export default function DetailHero({
         </div>
       )}
 
-      {/* Left-to-right gradient */}
-      <div className="hero-gradient-left" />
-
-      {/* Ambient glow from artwork */}
-      <div className="ambient-glow" />
-
-      {/* Bottom-to-top gradient */}
-      <div className="hero-gradient" />
-      <div className="hero-vignette" />
+      {/* Keep the detail treatment on three contained paint surfaces while
+          preserving its original stacking: tint/left fade, ambient artwork
+          glow, then the bottom fades and vignette. Previously five full-hero
+          elements were independently invalidated during browser-chrome resize. */}
+      <div className="detail-hero-scrim detail-hero-scrim-under" />
+      <div className="ambient-glow detail-hero-ambient" />
+      <div className="detail-hero-scrim detail-hero-scrim-over" />
 
       <div
         className={`page-shell-wide relative flex flex-col justify-end pb-8 ${
@@ -162,6 +160,7 @@ export default function DetailHero({
                       key={posterUrl}
                       src={posterUrl}
                       alt={title}
+                      decoding="async"
                       className={`w-full object-cover ${posterAspect} ${posterLoaded ? "opacity-100" : "opacity-0"}`}
                       onLoad={onPosterLoad}
                     />
@@ -191,7 +190,7 @@ export default function DetailHero({
 
             {/* Info column */}
             <div
-              className="max-w-3xl"
+              className="detail-hero-copy max-w-3xl"
               style={{ textShadow: "var(--hero-text-shadow, 0 1px 3px rgb(0 0 0 / 40%))" }}
             >
               {context && (
@@ -210,6 +209,7 @@ export default function DetailHero({
                   <img
                     src={logoUrl}
                     alt=""
+                    decoding="async"
                     className="mb-4 max-h-20 max-w-[420px] object-contain object-left lg:max-h-28 lg:max-w-[480px]"
                   />
                 </>
@@ -294,7 +294,7 @@ export default function DetailHero({
               )}
 
               {actions && (
-                <div className="mt-6" style={{ textShadow: "none" }}>
+                <div className="detail-action-bar mt-6" style={{ textShadow: "none" }}>
                   {actions}
                 </div>
               )}

--- a/web/src/pages/ItemDetail/EbookContent.tsx
+++ b/web/src/pages/ItemDetail/EbookContent.tsx
@@ -185,7 +185,7 @@ export default function EbookContent({
         }
       />
 
-      <div className="page-shell space-y-12 py-10 sm:space-y-14">
+      <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
         {item.ebook?.series && item.ebook.series.entries.length > 0 && (
           <RelatedRail
             heading={item.ebook.series.name ? `In ${item.ebook.series.name}` : "In this series"}

--- a/web/src/pages/ItemDetail/EpisodeContent.tsx
+++ b/web/src/pages/ItemDetail/EpisodeContent.tsx
@@ -397,7 +397,7 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
         }
       />
 
-      <div className="page-shell space-y-12 py-10 sm:space-y-14">
+      <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
         {canCurateMetadata && (
           <MediaLocations
             title="Media locations"

--- a/web/src/pages/ItemDetail/MovieContent.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.tsx
@@ -316,7 +316,7 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
         }
       />
 
-      <div className="page-shell space-y-12 py-10 sm:space-y-14">
+      <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
         {canCurateMetadata && (
           <MediaLocations
             title="Media locations"

--- a/web/src/pages/ItemDetail/SeasonContent.tsx
+++ b/web/src/pages/ItemDetail/SeasonContent.tsx
@@ -133,7 +133,7 @@ export default function SeasonContent({ item }: { item: ItemDetail & { type: "se
         }
       />
 
-      <div className="page-shell py-8 sm:py-10">
+      <div className="page-shell detail-supporting-content py-8 sm:py-10">
         <div className="mb-5 flex items-center justify-between gap-3">
           <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>
           <span className="text-muted-foreground text-sm">

--- a/web/src/pages/ItemDetail/SeriesContent.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.tsx
@@ -194,7 +194,7 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
         }
       />
 
-      <div className="page-shell space-y-12 py-10 sm:space-y-14">
+      <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
         {seasonsLoading ? (
           <SeasonCarouselSkeleton />
         ) : singleSeason ? (

--- a/web/src/pages/ItemDetail/components/EpisodeCarousel.test.tsx
+++ b/web/src/pages/ItemDetail/components/EpisodeCarousel.test.tsx
@@ -1,6 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EpisodeCarousel from "./EpisodeCarousel";
@@ -40,32 +39,47 @@ describe("EpisodeCarousel", () => {
     prefetchEpisodeDetail.mockClear();
   });
 
-  it("prefetches episode details when a card shows navigation intent", async () => {
-    render(
-      <MemoryRouter>
-        <EpisodeCarousel
-          currentEpisodeNumber={2}
-          episodes={[
-            {
-              content_id: "ep-1",
-              season_number: 1,
-              episode_number: 1,
-              title: "Pilot",
-              overview: "",
-              air_date: null,
-              runtime: 42,
-              still_url: "",
-              still_thumbhash: "",
-              files: [],
-            },
-          ]}
-        />
-      </MemoryRouter>,
-    );
+  it("prefetches only after a card shows sustained navigation intent", () => {
+    // A pointer sweeping the rail crosses every card; prefetching each one it
+    // passes would start cache work for the whole season. Intent is a dwell.
+    vi.useFakeTimers();
+    try {
+      render(
+        <MemoryRouter>
+          <EpisodeCarousel
+            currentEpisodeNumber={2}
+            episodes={[
+              {
+                content_id: "ep-1",
+                season_number: 1,
+                episode_number: 1,
+                title: "Pilot",
+                overview: "",
+                air_date: null,
+                runtime: 42,
+                still_url: "",
+                still_thumbhash: "",
+                files: [],
+              },
+            ]}
+          />
+        </MemoryRouter>,
+      );
 
-    await userEvent.hover(screen.getAllByRole("link", { name: /Pilot/ })[0]!);
+      const card = screen.getAllByRole("link", { name: /Pilot/ })[0]!.closest("div.group\\/card")!;
 
-    expect(prefetchEpisodeDetail).toHaveBeenCalledWith("ep-1");
+      fireEvent.mouseEnter(card);
+      act(() => vi.advanceTimersByTime(100));
+      fireEvent.mouseLeave(card);
+      act(() => vi.advanceTimersByTime(200));
+      expect(prefetchEpisodeDetail).not.toHaveBeenCalled();
+
+      fireEvent.mouseEnter(card);
+      act(() => vi.advanceTimersByTime(140));
+      expect(prefetchEpisodeDetail).toHaveBeenCalledWith("ep-1");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passes partial-progress restart eligibility to episode menus", () => {

--- a/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
+++ b/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
@@ -10,6 +10,7 @@ import MediaItemMenu from "@/components/MediaItemMenu";
 import type { EpisodeNavigationState } from "../itemDetailLayout";
 import { useCarouselEmbla } from "@/hooks/useCarouselEmbla";
 import { usePrefetchCatalogItemDetail } from "@/hooks/queries/catalogRead";
+import { useDwellPrefetch } from "@/hooks/useDwellPrefetch";
 import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
 import type { CardQuickActionMode } from "@/lib/cardQuickActions";
 
@@ -100,6 +101,7 @@ function EpisodeCarouselCard({
   onPrefetch: () => void;
 }) {
   const cardRef = useRef<HTMLDivElement>(null);
+  const prefetchHandlers = useDwellPrefetch(onPrefetch);
   const thumbhashUrl = ep.still_thumbhash ? decodeThumbhash(ep.still_thumbhash) : "";
   const episodeTitle = ep.title || `Episode ${ep.episode_number}`;
   const progress =
@@ -120,9 +122,7 @@ function EpisodeCarouselCard({
       <div
         ref={cardRef}
         className="media-card-longpress group/card w-[240px]"
-        onMouseEnter={onPrefetch}
-        onFocus={onPrefetch}
-        onTouchStart={onPrefetch}
+        {...prefetchHandlers}
       >
         <div className="relative">
           <Link

--- a/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
+++ b/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
@@ -8,6 +8,7 @@ import MediaItemMenu from "@/components/MediaItemMenu";
 import CardOverlays from "@/components/overlays/CardOverlays";
 import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
 import { usePrefetchCatalogItemDetail } from "@/hooks/queries/catalogRead";
+import { useDwellPrefetch } from "@/hooks/useDwellPrefetch";
 import type { CardQuickActionMode } from "@/lib/cardQuickActions";
 import { overlayDataFromEpisodeListItem, type CardOverlayPrefs } from "@/lib/overlays";
 import { EpisodeGridSkeleton } from "./SectionSkeletons";
@@ -69,6 +70,7 @@ function SeasonEpisodeCard({
   onPrefetch: () => void;
 }) {
   const cardRef = useRef<HTMLDivElement>(null);
+  const prefetchHandlers = useDwellPrefetch(onPrefetch);
   const hasPartialProgress =
     !episode.user_data?.played &&
     (episode.user_data?.position_seconds ?? 0) > 0 &&
@@ -76,13 +78,7 @@ function SeasonEpisodeCard({
   const episodeTitle = episode.title || `Episode ${episode.episode_number}`;
 
   return (
-    <div
-      ref={cardRef}
-      className="group/card media-card media-card-longpress"
-      onMouseEnter={onPrefetch}
-      onFocus={onPrefetch}
-      onTouchStart={onPrefetch}
-    >
+    <div ref={cardRef} className="group/card media-card media-card-longpress" {...prefetchHandlers}>
       <div className="relative">
         <Link to={`/item/${episode.content_id}`} state={episodeLinkState} className="group block">
           <div className="media-card-image relative aspect-video">
@@ -90,6 +86,7 @@ function SeasonEpisodeCard({
               <img
                 src={episode.still_url}
                 alt={episodeTitle}
+                decoding="async"
                 className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
                 loading="lazy"
               />


### PR DESCRIPTION
## Problem

Related issue: N/A — extracted from #805, which has the original profiling.

Browser UI that animates the content viewport — Brave's hover sidebar is the
reproducible case — made detail pages drop frames during resize, scroll and pointer
movement, while Home stayed smooth. @blurbery profiled this with Chrome DevTools
traces on a signed-in deployment; the numbers in #805 show paint down 16.6% and the
max graphics-pipeline slice down 75.1% on the original branch.

## Approach

The cost was concentrated in three places. Everything here stays scoped to detail
pages rather than changing shared primitives — that scoping is the main difference
from #805, which applied several of these fixes app-wide.

**Containment.** The hero becomes one layout/paint boundary, so resizing it cannot
invalidate every rail below it, and its artwork sits behind `contain: strict` on the
browser's cheap image path. Five full-hero gradient elements — a tint, two side fades,
two bottom fades and a vignette — were each independently invalidated per frame; they
collapse into two contained scrim surfaces around the ambient glow, preserving the
original layer order exactly.

The hero backdrop's `brightness()`/`saturate()` filter is replaced by a flat
background wash: a filter on a full-hero element re-rasterizes on every frame of a
resize, a flat tint composites. The wash is exposed as `--hero-backdrop-scrim` so
themes keep the knob `--hero-backdrop-brightness` gave them — including the light
theme, which sets a heavier wash to match its brighter, more desaturated treatment.

**Deferral.** Detail pages stack several image-heavy rails below the fold, so
supporting sections get the same `content-visibility` treatment the home carousels
already use, and each clipped Embla viewport is isolated so one rail cannot invalidate
its neighbours.

`MangaContent` is deliberately excluded. Its only child is a single `<ul>` holding
every chapter, so a 24rem intrinsic placeholder would collapse the whole list and make
"Jump to chapter" smooth-scroll to an offset that is stale the moment the subtree lays
out. #805 applied it there.

**Coalescing.** Embla rebuilt its measurements on every frame of an animated resize;
container resizes now settle into one `reInit` while a standalone slide resize keeps
Embla's immediate path. The virtualized grid measures on the leading edge of a resize
and reconciles once at the end, so row geometry never lags the reflowed grid — a
trailing-only debounce left virtual rows overlapping the already-reflowed grid for the
whole settle window. Ambient colour cleanup is deferred by a microtask so an outgoing
detail surface cannot clear the property before the incoming one publishes, which was
repainting the full-page gradient between routes.

**Interaction.** Hover prefetch waits for a dwell, so a pointer sweeping a rail no
longer starts cache work for every card it crosses; keyboard focus and touch intent
still fire immediately. The card hover dim fades a fixed overlay instead of repainting
a full-card background colour.

## Validation

Confirmed the containment and deferral actually apply in a live signed-in session
rather than only in the stylesheet: `.item-detail-hero` computes `contain: content`,
`.hero-backdrop-artwork` computes `contain: strict` with `filter: none`, the hero
renders two scrim layers around a contained ambient glow, `--hero-backdrop-scrim`
resolves to `25%`, and supporting-section children compute
`content-visibility: auto`.

- `pnpm run build` — passed
- `pnpm exec vitest run` — 2619 passed
- `pnpm run lint` — 0 errors (165 pre-existing warnings, unchanged baseline)
- `pnpm run format:check` — passed

## Risks

`content-visibility: auto` is the sharp edge here: it makes off-screen content
non-laid-out, which breaks anything that measures or scrolls into that subtree. The
MangaContent exclusion above is one instance found by inspection, and it is worth
checking whether any other detail section measures its own children.

The hero treatment is a visual change, not just a perf one — the scrim reproduces the
old gradient stack, but the artwork tint moves from a filter to a background wash.
Worth eyeballing in both light and dark themes; the light-theme scrim value is my
estimate of the equivalent of `brightness(1.15) saturate(0.6)`, not a measurement.

## Provenance

Ports the detail-page performance work from #805 by @blurbery, rebuilt against current
`main` and re-scoped. The app-wide `backdrop-filter` removal and the shared card hover
changes from that branch are deliberately not included; the navigation rewrite is
still open (see #805).

Not ported: the `SeasonCarousel` dwell-prefetch conversion, which needs a component
extraction for a row that typically holds under ten seasons.

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: Fully AI-generated, human verified — @Quick104 set the direction,
  decided which of the original branch's changes were in scope, and reviewed the
  result against a live deployment. The underlying profiling and the original fixes
  are @blurbery's.
- Adversarial review: extracted during a defect-first review of #805. Several changes
  from that branch were deliberately dropped here after review found they were
  app-wide fixes for a detail-page problem, and the MangaContent exclusion is a
  `content-visibility` defect found by that review rather than by the profiler.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
