### PR TITLE
chore(web): land the remaining small fixes from #805

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,12 @@
-import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   createBrowserRouter,
   createRoutesFromElements,
@@ -162,7 +170,10 @@ const HOT_ROUTE_CHUNKS: readonly RouteChunkImport[] = [
  */
 function useScrollRestoration() {
   const { pathname } = useLocation();
-  useEffect(() => {
+  // Layout effect, not effect: after paint the browser has already shown one
+  // frame of the new route at the old route's scroll offset, which reads as
+  // a jump to the top rather than an arrival at it.
+  useLayoutEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
 }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -727,6 +727,17 @@
     font-size: calc(32px * var(--ui-text-scale-factor)) !important;
   }
   html[data-text-scale="large"] .text-\[38px\],
+  /* Buttons are activatable, so they get the activatable cursor. Declared in
+     `base` rather than as a utility, so an explicit `cursor-*` class — a
+     disabled player control, a non-interactive tooltip target — still wins. */
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
+  }
   html[data-text-scale="x-large"] .text-\[38px\] {
     font-size: calc(38px * var(--ui-text-scale-factor)) !important;
   }

--- a/web/src/components/CastCarousel.tsx
+++ b/web/src/components/CastCarousel.tsx
@@ -101,6 +101,7 @@ function CastCard({ member, href }: { member: CastMember; href: string | null })
             alt={member.name}
             className="h-full w-full object-cover transition-transform duration-300 group-hover/cast:scale-105"
             loading="lazy"
+            decoding="async"
           />
         ) : (
           <div className="bg-surface text-muted-foreground flex h-full w-full items-center justify-center text-lg font-semibold">

--- a/web/src/components/ContinueWatchingCard.tsx
+++ b/web/src/components/ContinueWatchingCard.tsx
@@ -242,6 +242,7 @@ export default function ContinueWatchingCard(props: ContinueWatchingCardProps) {
                 alt={heading}
                 className="h-full w-full object-cover transition-transform duration-300 group-hover/media:scale-105"
                 loading="lazy"
+                decoding="async"
               />
             ) : (
               <div className="text-muted-foreground bg-surface flex h-full w-full items-center justify-center text-sm">

--- a/web/src/components/EpisodeRow.tsx
+++ b/web/src/components/EpisodeRow.tsx
@@ -50,6 +50,7 @@ export default function EpisodeRow({ episode, rating, watched, progress }: Episo
             alt={episode.title || `Episode ${episode.episode_number}`}
             className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
             loading="lazy"
+            decoding="async"
           />
         ) : (
           <div className="text-muted-foreground/50 flex h-full w-full items-center justify-center">

--- a/web/src/components/RecommendationGrid.tsx
+++ b/web/src/components/RecommendationGrid.tsx
@@ -28,6 +28,8 @@ function RecommendationItemCard({ itemId }: RecommendationItemCardProps) {
               <img
                 src={item.poster_url}
                 alt={item.title}
+                loading="lazy"
+                decoding="async"
                 className="h-full w-full object-cover transition-transform group-hover:scale-105"
               />
             ) : (

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -59,7 +59,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive! relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive! relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -77,7 +77,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -108,7 +108,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -180,7 +180,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -98,7 +98,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}
@@ -136,7 +136,7 @@ function SelectScrollUpButton({
   return (
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
-      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      className={cn("flex cursor-pointer items-center justify-center py-1", className)}
       {...props}
     >
       <ChevronUpIcon className="size-4" />
@@ -151,7 +151,7 @@ function SelectScrollDownButton({
   return (
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
-      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      className={cn("flex cursor-pointer items-center justify-center py-1", className)}
       {...props}
     >
       <ChevronDownIcon className="size-4" />

--- a/web/src/pages/ItemDetail/MangaContent.tsx
+++ b/web/src/pages/ItemDetail/MangaContent.tsx
@@ -159,6 +159,7 @@ function MangaRow({
             src={chapter.poster_url}
             alt=""
             loading="lazy"
+            decoding="async"
             className="h-12 w-8 flex-shrink-0 rounded object-cover"
           />
         ) : (

--- a/web/src/pages/ItemDetail/SeasonCarousel.tsx
+++ b/web/src/pages/ItemDetail/SeasonCarousel.tsx
@@ -72,6 +72,7 @@ export default function SeasonCarousel({ seasons }: SeasonCarouselProps) {
                             alt={getSeasonDisplayTitle(season)}
                             className="h-full w-full object-cover transition-transform duration-300 group-hover/season:scale-105"
                             loading="lazy"
+                            decoding="async"
                           />
                         ) : (
                           <div className="text-muted-foreground bg-surface flex h-full items-center justify-center p-4 text-center text-sm font-medium">

--- a/web/src/pages/ItemDetail/SeasonContent.tsx
+++ b/web/src/pages/ItemDetail/SeasonContent.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 import type { ItemDetail } from "@/api/types";
 import { useItemEpisodes } from "@/hooks/queries/episodes";
-import { useRefreshItemMetadata, useWatchedStateMutation } from "@/hooks/queries/items";
+import { useRefreshItemMetadata } from "@/hooks/queries/items";
 import { useAmbientColor } from "@/hooks/useAmbientColor";
 import { useAuth } from "@/hooks/useAuth";
 import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
@@ -14,11 +14,10 @@ import EditMetadataDialog from "@/components/EditMetadataDialog";
 import PageBack from "@/components/PageBack";
 import DetailHero from "./DetailHero";
 import MetadataBadges from "./components/MetadataBadges";
-import ActionBar from "./components/ActionBar";
+import WatchedActionBar from "./components/WatchedActionBar";
 import DetailBreadcrumb from "./components/DetailBreadcrumb";
 import SeasonEpisodeGrid from "./components/SeasonEpisodeGrid";
 import type { EpisodeNavigationState } from "./itemDetailLayout";
-import { getWatchedActionLabel } from "./watchedState";
 import { canCurateMetadata as canCurateMetadataForUser } from "@/lib/permissions";
 
 function seasonLabel(seasonNumber: number, title?: string) {
@@ -37,7 +36,6 @@ export default function SeasonContent({ item }: { item: ItemDetail & { type: "se
   const { profile: currentProfile } = useCurrentProfile();
   const canCurateMetadata = canCurateMetadataForUser(user, currentProfile);
   const [editOpen, setEditOpen] = useState(false);
-  const watchedMutation = useWatchedStateMutation(item);
   const refreshMetadataMutation = useRefreshItemMetadata();
 
   const {
@@ -108,13 +106,11 @@ export default function SeasonContent({ item }: { item: ItemDetail & { type: "se
         overviewTranslating={overviewTranslating}
         onTranslateOverview={onTranslateOverview}
         actions={
-          <ActionBar
+          <WatchedActionBar
+            item={item}
             contentId={item.content_id}
             playHref={firstEpisode ? `/watch/${firstEpisode.content_id}` : undefined}
             playLabel="Play First Episode"
-            watchedLabel={getWatchedActionLabel(item)}
-            onToggleWatched={() => watchedMutation.mutate(!(item.user_data?.played ?? false))}
-            isUpdatingWatched={watchedMutation.isPending}
             onRefresh={
               canCurateMetadata
                 ? (mode) =>

--- a/web/src/pages/ItemDetail/SeriesContent.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.tsx
@@ -1,13 +1,10 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import type { ItemDetail } from "@/api/types";
-import { useToggleFavorite } from "@/hooks/queries/favorites";
-import { useToggleWatchlist } from "@/hooks/queries/watchlist";
-import { useRefreshItemMetadata, useWatchedStateMutation } from "@/hooks/queries/items";
+import { useRefreshItemMetadata } from "@/hooks/queries/items";
 import { useSimilarItems } from "@/hooks/queries/recommendations";
 import { useItemEpisodes, useSeasons } from "@/hooks/queries/episodes";
 import { useContinueWatching } from "@/hooks/queries/progress";
-import { useSetRating, useDeleteRating } from "@/hooks/queries/ratings";
 import { useAmbientColor } from "@/hooks/useAmbientColor";
 import { useAuth } from "@/hooks/useAuth";
 import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
@@ -28,10 +25,9 @@ import TrailersSection from "./components/TrailersSection";
 import ExtrasSection from "./components/ExtrasSection";
 import ScoreRow from "./components/ScoreRow";
 import HeroCrewLine from "./components/HeroCrewLine";
-import ActionBar from "./components/ActionBar";
+import MediaUserActionBar from "./components/MediaUserActionBar";
 import { SeasonCarouselSkeleton, RecommendationGridSkeleton } from "./components/SectionSkeletons";
 import { getSeasonDisplayTitle, resolveSeriesPrimaryAction } from "./itemDetailLayout";
-import { getWatchedActionLabel } from "./watchedState";
 import { canCurateMetadata as canCurateMetadataForUser } from "@/lib/permissions";
 
 export default function SeriesContent({ item }: { item: ItemDetail & { type: "series" } }) {
@@ -44,14 +40,7 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
   const { profile: currentProfile } = useCurrentProfile();
   const canCurateMetadata = canCurateMetadataForUser(user, currentProfile);
 
-  const isFavorite = item.user_state?.is_favorite ?? false;
-  const inWatchlist = item.user_state?.in_watchlist ?? false;
-  const toggleFavoriteMutation = useToggleFavorite(item.content_id);
-  const toggleWatchlistMutation = useToggleWatchlist(item.content_id);
   const refreshMetadataMutation = useRefreshItemMetadata();
-  const watchedMutation = useWatchedStateMutation(item);
-  const setRatingMutation = useSetRating(item.content_id);
-  const deleteRatingMutation = useDeleteRating(item.content_id);
 
   const [editOpen, setEditOpen] = useState(false);
   const [matchOpen, setMatchOpen] = useState(false);
@@ -60,14 +49,6 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
   const { data: similarData, isLoading: similarLoading } = useSimilarItems(item.content_id);
   const seasons = useMemo(() => seasonsData?.seasons ?? [], [seasonsData?.seasons]);
   const { items: continueWatchingItems } = useContinueWatching();
-
-  const handleRatingChange = (rating: number | null) => {
-    if (rating === null) {
-      deleteRatingMutation.mutate();
-    } else {
-      setRatingMutation.mutate(rating);
-    }
-  };
 
   const title = item.title ?? "";
   const firstYear = item.first_air_date?.slice(0, 4);
@@ -160,18 +141,12 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
           <HeroCrewLine crew={item.crew ?? []} genres={item.genres} jobLabel="Created by" />
         }
         actions={
-          <ActionBar
+          <MediaUserActionBar
+            item={item}
             contentId={item.content_id}
             playHref={resolvedPrimaryHref}
             playLabel={primaryAction.label}
             playLoading={primaryActionLoading}
-            watchedLabel={getWatchedActionLabel(item)}
-            onToggleWatched={() => watchedMutation.mutate(!(item.user_data?.played ?? false))}
-            isUpdatingWatched={watchedMutation.isPending}
-            onToggleFavorite={() => toggleFavoriteMutation.mutate(isFavorite)}
-            isFavorite={isFavorite}
-            onToggleWatchlist={() => toggleWatchlistMutation.mutate(inWatchlist)}
-            inWatchlist={inWatchlist}
             onRefresh={
               canCurateMetadata
                 ? (mode) =>
@@ -188,8 +163,6 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
             onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
             onMatchItem={canCurateMetadata ? () => setMatchOpen(true) : undefined}
             onSplitItem={canCurateMetadata ? () => setSplitOpen(true) : undefined}
-            rating={item.user_rating ?? null}
-            onRatingChange={handleRatingChange}
           />
         }
       />

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -74,7 +74,7 @@ function DetailOverflowMenuItem({
       {...props}
       type="button"
       role="menuitem"
-      className={`focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 ${className ?? ""}`}
+      className={`focus:bg-accent focus:text-accent-foreground hover:bg-accent hover:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 ${className ?? ""}`}
       onClick={() => {
         closeMenu();
         onAction?.();

--- a/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
+++ b/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
@@ -150,6 +150,7 @@ function EpisodeCarouselCard({
                   alt={episodeTitle}
                   className="h-full w-full object-cover"
                   loading="lazy"
+                  decoding="async"
                 />
               ) : (
                 <div className="bg-accent/30 flex h-full w-full items-center justify-center">

--- a/web/src/pages/ItemDetail/components/TrailersSection.tsx
+++ b/web/src/pages/ItemDetail/components/TrailersSection.tsx
@@ -80,6 +80,7 @@ function TrailerCard({ video, onPlay }: { video: ItemVideo; onPlay: () => void }
           alt={label}
           className="h-full w-full object-cover transition-transform duration-300 group-hover/trailer:scale-105"
           loading="lazy"
+          decoding="async"
         />
         <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors duration-200 group-hover/trailer:bg-black/30">
           <span className="flex h-11 w-11 items-center justify-center rounded-full bg-black/60 opacity-0 backdrop-blur-sm transition-opacity duration-200 group-hover/trailer:opacity-100 group-focus-visible/trailer:opacity-100">


### PR DESCRIPTION
## Problem

Related issue: N/A — the tail of #805, after #810, #811 and #812.

Auditing what was left of @blurbery's #805 turned up four small, independent
fixes that hadn't landed with the three extracted PRs and were worth keeping.
Each is a separate commit.

**1. Series and Season hand-wired their action bars.** `MediaUserActionBar` and
`WatchedActionBar` already exist and Movie and Episode already use them, but
`SeriesContent` still wired eight mutation-hook references and `SeasonContent`
two, plus a local `handleRatingChange` duplicating the shared one exactly. The
point of those wrappers is that the mutation hooks sit below the page content
boundary, so a pending/settled notification re-renders the action bar rather than
the hero and everything under it — Series and Season weren't getting that.

**2. Menu rows showed an arrow cursor.** shadcn ships `cursor-default` on
dropdown-menu items, select items and the select scroll buttons, so every menu
row in the app looked unclickable. The detail overflow menu had inherited it too.

**3. Eight card images decoded synchronously**, blocking interaction while a row
scrolled into view. RecommendationGrid's poster was also the one card image still
fetching eagerly.

**4. Scroll-to-top ran after paint**, so the browser showed one frame of the new
route at the previous route's scroll offset. Deep in a long season and opening an
episode, that frame reads as a jump to the top rather than an arrival at it.

## Approach

The cursor rules go in `@layer base` rather than as utilities, so an explicit
`cursor-*` class still wins. That matters: the two deliberate `cursor-default`
uses in the tree — a non-interactive tooltip target in the subtitle dialog, and
the player's audio-track button in its disabled state — are unaffected, and were
checked rather than assumed.

> [!NOTE]
> This is four concerns in one PR rather than the usual one, which is a
> deliberate exception: they are small, independent, and the alternative is four
> PRs of ~12 lines each. They're split into four commits so each can be read on
> its own, and any one can be dropped without touching the others.

## Validation

Confirmed live in a signed-in session that an enabled button computes
`cursor: pointer` and a disabled one `cursor: not-allowed`, and that 111 of the
295 images on Home now carry `decoding="async"`.

- `pnpm run build` — passed
- `pnpm exec vitest run` — 2627 passed
- `pnpm run lint` — 0 errors (165 pre-existing warnings, unchanged baseline)
- `pnpm run format:check` — passed

Commit 1 is behaviour-preserving; the existing Series and Season detail tests
cover the action bar props and still pass unchanged.

## Risks

The cursor rule is global. It is scoped to `button` and `[role="button"]` and
loses to any explicit utility, but it is the one change here that touches every
page, so it is worth a look at anything that styles a button as non-interactive.

## Provenance

Completes the port of #805 by @blurbery. With this merged, the only part of that
branch still outstanding is the navigation rewrite, which needs re-scoping
against the data router now on `main` — see the closing comment on #805.

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: Fully AI-generated, human verified — @Quick104 reviewed the audit
  of what was left from #805 and approved landing these four together.
- Adversarial review: produced by auditing the original branch against `main`
  feature by feature rather than by re-reading the diff, which is how these were
  found after the first three PRs. The `cursor-default` sweep was checked against
  every occurrence in the tree rather than applied blindly; two were intentional
  and left alone.

## Checklist

- [x] I read and can explain the complete diff.
- [ ] This pull request addresses one concern. — four small ones, see the note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
