### PR TITLE
feat(web): directional page motion for nested detail navigation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,7 @@ import { queryClient } from "@/lib/query-client";
 import { AuthProvider, useAuth } from "@/hooks/useAuth";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
 import { useIsActingAdmin } from "@/hooks/useIsActingAdmin";
+import { useNavigationDirection } from "@/hooks/useNavigationDirection";
 import { ThemeProvider } from "@/hooks/useTheme";
 import { DateTimeFormatProvider, useDateTimeFormat } from "@/hooks/useDateTimeFormat";
 import { CustomThemeProvider } from "@/contexts/CustomThemeProvider";
@@ -200,6 +201,17 @@ function RouteAnnouncer() {
 
 function ScrollRestorationManager() {
   useScrollRestoration();
+  return null;
+}
+
+/**
+ * Tracks history provenance and the direction the page is moving in. A leaf
+ * rather than a call inside `AppShell`: the hook reads the location, and
+ * subscribing `AppShell` to it would re-render the whole provider stack on
+ * every navigation.
+ */
+function NavigationDirectionManager() {
+  useNavigationDirection();
   return null;
 }
 
@@ -760,6 +772,7 @@ function AppShell() {
                         <RouteChunkPrewarmer />
                         <RealtimeEventChannels />
                         <ScrollRestorationManager />
+                        <NavigationDirectionManager />
                         <RouteAnnouncer />
                         <QueryCacheManager />
                         <AppChrome />

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -242,6 +242,30 @@
   }
 }
 
+/* Directional page motion for nested navigation. `--nav-slide-shift` is the
+   distance the OUTGOING page travels; the incoming page always enters from the
+   opposite side, so one pair of keyframes covers both directions.            */
+@keyframes nav-slide-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(var(--nav-slide-shift));
+  }
+}
+@keyframes nav-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--nav-slide-shift)));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 /* ================================================================
    VIEW TRANSITIONS — Page navigation animations
    ================================================================
@@ -249,6 +273,31 @@
    route changes. The browser captures old/new page snapshots
    and animates between them.
    ================================================================ */
+
+/* The sidebar collapse (`.sidebar-surface`) is a live CSS transition running
+   across the same navigation. The root snapshot would freeze the old 260px
+   sidebar and cross-fade it over that motion, so inside the sidebar shell the
+   root group is held still and `main-content` carries the whole transition; the
+   rail, the impersonation banner, and the mobile header keep animating in the
+   live document.
+
+   Scoped to `html[data-app-shell]`, which `Layout` sets while it is mounted,
+   because `main-content` is named in `Layout` and nowhere else. Un-naming the
+   root outright would leave the routes that render outside it — /watch,
+   /reader/*, /admin/*, /login — with no captured element at all, so their
+   navigations would have nothing to animate rather than one thing too many. */
+html[data-app-shell]::view-transition-old(root),
+html[data-app-shell]::view-transition-new(root) {
+  animation: none;
+}
+
+/* main-content's own box moves with the rail (`lg:ml-[260px]` to `lg:ml-16`),
+   so the captured group has to travel on the rail's clock rather than the UA's
+   250ms default, or the two edges separate near the end of the collapse.     */
+::view-transition-group(main-content) {
+  animation-duration: var(--duration-sidebar-collapse);
+  animation-timing-function: var(--ease-sidebar-collapse);
+}
 
 ::view-transition-old(main-content) {
   animation: 200ms cubic-bezier(0, 0, 0.2, 1) both fade-out;
@@ -258,9 +307,35 @@
   animation: 300ms cubic-bezier(0, 0, 0.2, 1) both slide-up;
 }
 
+/* Nested detail navigation moves sideways instead, on the sidebar's own tokens,
+   so following a breadcrumb up reads as the reverse of the push that made it.
+   Navigations whose direction is unknowable — a POP whose entry predates this
+   page load, an external pushState — leave the attribute off and fall through
+   to the neutral rules above. Both halves share one duration and easing: the
+   pseudo-elements default to `mix-blend-mode: plus-lighter`, which only
+   cross-fades cleanly while the two opacities sum to 1.                       */
+html[data-navigation-direction="forward"] {
+  --nav-slide-shift: -24px;
+}
+html[data-navigation-direction="back"] {
+  --nav-slide-shift: 24px;
+}
+html[data-navigation-direction]::view-transition-old(main-content) {
+  animation: var(--duration-sidebar-collapse) var(--ease-sidebar-collapse) both nav-slide-out;
+}
+html[data-navigation-direction]::view-transition-new(main-content) {
+  animation: var(--duration-sidebar-collapse) var(--ease-sidebar-collapse) both nav-slide-in;
+}
+
 @media (prefers-reduced-motion: reduce) {
+  /* The directional selectors carry their own specificity — (0,1,2) against the
+     bare pseudo-elements' (0,0,1) — so they have to be suppressed by name here
+     or they would keep animating for someone who asked for no motion.        */
   ::view-transition-old(main-content),
-  ::view-transition-new(main-content) {
+  ::view-transition-new(main-content),
+  ::view-transition-group(main-content),
+  html[data-navigation-direction]::view-transition-old(main-content),
+  html[data-navigation-direction]::view-transition-new(main-content) {
     animation: none;
   }
   :root {

--- a/web/src/components/AdminSidebar.tsx
+++ b/web/src/components/AdminSidebar.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from "lucide-react";
 import type { ReactNode } from "react";
 import { SideNavItem, SideNavSection } from "@/components/SideNav";
 import { SiloBrand } from "@/components/SiloBrand";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 import {
   buildAdminNavSections,
   buildAdminPluginNavItems,
@@ -154,15 +155,17 @@ export default function AdminSidebar({ onNavigate, embedded = false }: AdminSide
             {buildDisplay}
           </div>
         </div>
-        {/* Back to app */}
-        <Link
+        {/* Back to app — admin was almost always entered from the app, so this
+            plays the motion backwards rather than as a descent. */}
+        <ViewTransitionLink
           to="/"
+          up
           onClick={onNavigate}
           className="text-muted-foreground hover:text-foreground hover:bg-accent/70 flex items-center gap-2.5 rounded-xl px-3 py-2.5 text-[13px] font-medium transition-colors duration-150"
         >
           <ArrowLeft className="h-[18px] w-[18px]" />
           <span>Back to App</span>
-        </Link>
+        </ViewTransitionLink>
       </div>
     </aside>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router";
+import { Link, useLocation } from "react-router";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { Menu, Search } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -29,6 +29,7 @@ import {
   type SidebarItemNavigationRequest,
 } from "@/components/sidebarItemNavigation";
 import { useSidebarItemDetailsGate } from "@/hooks/useSidebarItemDetailsGate";
+import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
 import { catalogKeys } from "@/hooks/queries/keys";
 import { fetchCatalogItemDetail } from "@/hooks/queries/catalogRead";
 
@@ -38,7 +39,7 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   const location = useLocation();
-  const navigate = useNavigate();
+  const navigate = useViewTransitionNavigate();
   const queryClient = useQueryClient();
   const [mobileOpen, setMobileOpen] = useState(false);
   // Tracks whether the mobile header should slide off-screen on scroll.
@@ -103,7 +104,6 @@ export default function Layout({ children }: LayoutProps) {
       navigate(request.href, {
         replace: request.replace,
         state: request.state,
-        viewTransition: true,
       });
       return true;
     },
@@ -172,6 +172,12 @@ export default function Layout({ children }: LayoutProps) {
   // a frame late and it would trail the sidebar by ~23px at peak velocity.
   useLayoutEffect(() => {
     const root = document.documentElement;
+    // Marks that this shell is mounted, and with it the only element named
+    // `main-content`. app.css holds the root view-transition group still while
+    // it is set, so the frozen sidebar snapshot cannot cross-fade over the live
+    // collapse — and the routes rendered outside this shell keep the default
+    // root transition, which is the only thing they have to animate.
+    root.dataset.appShell = "true";
     if (targetDetailImmersion) {
       root.dataset.sidebarCollapsed = "true";
     } else {
@@ -183,6 +189,7 @@ export default function Layout({ children }: LayoutProps) {
       delete root.dataset.sidebarVisualCollapsed;
     }
     return () => {
+      delete root.dataset.appShell;
       delete root.dataset.sidebarCollapsed;
       delete root.dataset.sidebarVisualCollapsed;
     };

--- a/web/src/components/PageBack.test.tsx
+++ b/web/src/components/PageBack.test.tsx
@@ -3,6 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { resetNavigationHistory } from "@/lib/navigationHistory";
+
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
 }));
@@ -17,10 +19,17 @@ vi.mock("react-router", async () => {
 
 import PageBack from "./PageBack";
 
+/** Stands in for the browser having committed the entry at `idx`. */
+function commit(idx: number) {
+  window.history.replaceState({ idx }, "");
+}
+
 describe("PageBack", () => {
   afterEach(() => {
     mocks.navigate.mockClear();
+    resetNavigationHistory();
     window.history.replaceState(null, "");
+    delete document.documentElement.dataset.navigationDirection;
   });
 
   it("renders a button with the default 'Go back' aria-label", () => {
@@ -45,7 +54,7 @@ describe("PageBack", () => {
 
   it("falls back to the default route when there is no router history", async () => {
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={["/item/movie-1"]}>
         <PageBack />
       </MemoryRouter>,
     );
@@ -53,11 +62,11 @@ describe("PageBack", () => {
     await userEvent.click(screen.getByRole("button", { name: "Go back" }));
 
     expect(mocks.navigate).toHaveBeenCalledTimes(1);
-    expect(mocks.navigate).toHaveBeenCalledWith("/");
+    expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: false, viewTransition: true });
   });
 
   it("uses browser history when a router history entry is available", async () => {
-    window.history.replaceState({ idx: 1 }, "");
+    commit(1);
     render(
       <MemoryRouter>
         <PageBack />
@@ -70,18 +79,34 @@ describe("PageBack", () => {
     expect(mocks.navigate).toHaveBeenCalledWith(-1);
   });
 
-  it("uses the explicit target when history preference is disabled", async () => {
-    window.history.replaceState({ idx: 1 }, "");
+  it("navigates to the declared ancestor when it is not behind us", async () => {
+    commit(1);
     render(
       <MemoryRouter>
-        <PageBack to="/collections" preferHistory={false} />
+        <PageBack to="/collections" up />
       </MemoryRouter>,
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Go back" }));
 
     expect(mocks.navigate).toHaveBeenCalledTimes(1);
-    expect(mocks.navigate).toHaveBeenCalledWith("/collections");
+    expect(mocks.navigate).toHaveBeenCalledWith("/collections", {
+      replace: false,
+      viewTransition: true,
+    });
+  });
+
+  it("moves the page backwards whichever route it takes", async () => {
+    commit(1);
+    render(
+      <MemoryRouter>
+        <PageBack />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Go back" }));
+
+    expect(document.documentElement.dataset.navigationDirection).toBe("back");
   });
 
   it("applies the documented positioning and glass styling", () => {

--- a/web/src/components/PageBack.tsx
+++ b/web/src/components/PageBack.tsx
@@ -1,12 +1,20 @@
 import { ChevronLeft } from "lucide-react";
-import { type To, useNavigate } from "react-router";
+import { type To } from "react-router";
 
-import { hasRouterHistory } from "@/lib/backNavigation";
+import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
+import { hasEarlierEntry } from "@/lib/navigationHistory";
 
 interface PageBackProps {
   label?: string;
   to?: To;
-  preferHistory?: boolean;
+  /**
+   * `to` is this page's ancestor rather than a bare fallback: go there rather
+   * than stepping back one, and play the motion backwards. Use it wherever the
+   * destination is known — a season's series, a wizard's list — and leave it
+   * off on detail pages, where the page behind is whatever the user was
+   * browsing and `to` only covers a cold entry.
+   */
+  up?: boolean;
   /**
    * When true, pins the button to the viewport on lg+ so it stays visible
    * while scrolling. The offset matches the app sidebar (260px) so the
@@ -18,21 +26,23 @@ interface PageBackProps {
 export default function PageBack({
   label = "Go back",
   to = "/",
-  preferHistory = true,
+  up = false,
   floating = false,
 }: PageBackProps) {
-  const navigate = useNavigate();
+  const navigate = useViewTransitionNavigate();
   const position = floating
     ? "absolute top-4 left-2 sm:top-6 lg:fixed lg:left-[268px]"
     : "absolute top-4 left-2 sm:top-6";
 
   function goBack() {
-    if (preferHistory && hasRouterHistory()) {
-      navigate(-1);
+    // With nothing behind us — a cold entry, a shared link — there is no step
+    // to take, so `to` becomes the destination and still reads as going up.
+    if (up || !hasEarlierEntry()) {
+      navigate(to, { up: true });
       return;
     }
 
-    navigate(to);
+    navigate(-1);
   }
 
   return (

--- a/web/src/components/ViewTransitionLink.test.tsx
+++ b/web/src/components/ViewTransitionLink.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, useLocation, useNavigationType } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { recordNavigation, resetNavigationHistory } from "@/lib/navigationHistory";
+import { resetNavigationHistory, resolveCommittedDirection } from "@/lib/navigationHistory";
 import SidebarItemNavigationProvider from "./SidebarItemNavigationProvider";
 import ViewTransitionLink from "./ViewTransitionLink";
 
@@ -200,7 +200,7 @@ describe("ViewTransitionLink direction", () => {
 
   it("keeps an `up` link a real anchor so modified clicks are the browser's", () => {
     commit(0);
-    recordNavigation();
+    resolveCommittedDirection();
     commit(1);
 
     render(

--- a/web/src/components/ViewTransitionLink.test.tsx
+++ b/web/src/components/ViewTransitionLink.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, useLocation } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter, useLocation, useNavigationType } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { recordNavigation, resetNavigationHistory } from "@/lib/navigationHistory";
 import SidebarItemNavigationProvider from "./SidebarItemNavigationProvider";
 import ViewTransitionLink from "./ViewTransitionLink";
 
@@ -8,6 +9,21 @@ function LocationOutput() {
   const location = useLocation();
   return <output aria-label="location">{location.pathname}</output>;
 }
+
+function NavigationTypeOutput() {
+  return <output aria-label="navigation type">{useNavigationType()}</output>;
+}
+
+/** Stands in for the browser having committed the entry at `idx`. */
+function commit(idx: number) {
+  window.history.replaceState({ idx }, "");
+}
+
+afterEach(() => {
+  resetNavigationHistory();
+  window.history.replaceState(null, "");
+  delete document.documentElement.dataset.navigationDirection;
+});
 
 describe("ViewTransitionLink sidebar navigation", () => {
   it("lets Layout intercept an item navigation with its state intact", () => {
@@ -135,5 +151,92 @@ describe("ViewTransitionLink sidebar navigation", () => {
     fireEvent.click(screen.getByRole("link", { name: "Movie" }));
 
     expect(screen.getByRole("status", { name: "location" })).toHaveTextContent("/item/movie-1");
+  });
+});
+
+describe("ViewTransitionLink direction", () => {
+  it("moves the page forward on an ordinary click", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <ViewTransitionLink to="/item/movie-1">Movie</ViewTransitionLink>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Movie" }));
+
+    expect(document.documentElement.dataset.navigationDirection).toBe("forward");
+  });
+
+  it("replaces rather than pushes a second entry for the current URL", () => {
+    render(
+      <MemoryRouter initialEntries={["/item/movie-1"]}>
+        <ViewTransitionLink to="/item/movie-1">Movie</ViewTransitionLink>
+        <NavigationTypeOutput />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Movie" }));
+
+    expect(screen.getByRole("status", { name: "navigation type" })).toHaveTextContent("REPLACE");
+  });
+
+  it("still navigates an `up` link the history map never recorded", () => {
+    render(
+      <MemoryRouter initialEntries={["/item/season"]}>
+        <ViewTransitionLink to="/item/series" up>
+          Series
+        </ViewTransitionLink>
+        <LocationOutput />
+        <NavigationTypeOutput />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Series" }));
+
+    expect(screen.getByRole("status", { name: "location" })).toHaveTextContent("/item/series");
+    expect(screen.getByRole("status", { name: "navigation type" })).toHaveTextContent("PUSH");
+    expect(document.documentElement.dataset.navigationDirection).toBe("back");
+  });
+
+  it("keeps an `up` link a real anchor so modified clicks are the browser's", () => {
+    commit(0);
+    recordNavigation();
+    commit(1);
+
+    render(
+      <MemoryRouter initialEntries={["/item/series", "/item/season"]} initialIndex={1}>
+        <ViewTransitionLink to="/item/series" up>
+          Series
+        </ViewTransitionLink>
+        <LocationOutput />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole("link", { name: "Series" });
+    expect(link).toHaveAttribute("href", "/item/series");
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true, metaKey: true });
+    fireEvent(link, event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(screen.getByRole("status", { name: "location" })).toHaveTextContent("/item/season");
+  });
+
+  it("does not offer an `up` link to the sidebar item interception", () => {
+    const begin = vi.fn(() => true);
+    render(
+      <MemoryRouter initialEntries={["/item/season"]}>
+        <SidebarItemNavigationProvider begin={begin} itemDetailsReady>
+          <ViewTransitionLink to="/item/series" up>
+            Series
+          </ViewTransitionLink>
+        </SidebarItemNavigationProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Series" }));
+
+    // The interception exists to stage a descent into an item's heavy detail
+    // page; unwinding out of one is the opposite move.
+    expect(begin).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/ViewTransitionLink.tsx
+++ b/web/src/components/ViewTransitionLink.tsx
@@ -2,51 +2,76 @@ import { forwardRef } from "react";
 import { createPath, Link, useResolvedPath } from "react-router";
 import type { LinkProps } from "react-router";
 import { useSidebarItemNavigation } from "@/components/sidebarItemNavigationContext";
+import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
+import { markNavigationDirection } from "@/lib/navigationHistory";
+
+type ViewTransitionLinkProps = LinkProps &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    /**
+     * This link goes back up to an ancestor — a breadcrumb crumb, a "back to
+     * series" link. See `ViewTransitionNavigateOptions.up`; the behaviour is
+     * identical, and this is the only way to express it on a link.
+     */
+    up?: boolean;
+  };
 
 /**
- * Opts into React Router view transitions and lets the desktop layout prepare
- * item-detail navigation so its heavy content cannot overlap sidebar motion.
+ * Opts into React Router view transitions, stamps the direction the page should
+ * move in, and lets the desktop layout prepare item-detail navigation so its
+ * heavy content cannot overlap sidebar motion.
  */
-const ViewTransitionLink = forwardRef<
-  HTMLAnchorElement,
-  LinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement>
->(function ViewTransitionLink({ to, replace, state, onClick, children, ...rest }, ref) {
-  const beginSidebarItemNavigation = useSidebarItemNavigation();
-  const resolvedPath = useResolvedPath(to);
+const ViewTransitionLink = forwardRef<HTMLAnchorElement, ViewTransitionLinkProps>(
+  function ViewTransitionLink({ to, replace, state, up = false, onClick, children, ...rest }, ref) {
+    const beginSidebarItemNavigation = useSidebarItemNavigation();
+    const navigate = useViewTransitionNavigate();
+    const resolvedPath = useResolvedPath(to);
 
-  return (
-    <Link
-      ref={ref}
-      to={to}
-      replace={replace}
-      state={state}
-      onClick={(event) => {
-        onClick?.(event);
-        if (
-          event.defaultPrevented ||
-          event.button !== 0 ||
-          event.metaKey ||
-          event.ctrlKey ||
-          event.shiftKey ||
-          event.altKey ||
-          (rest.target && rest.target !== "_self")
-        ) {
-          return;
-        }
+    return (
+      <Link
+        ref={ref}
+        to={to}
+        replace={replace}
+        state={state}
+        onClick={(event) => {
+          onClick?.(event);
+          if (
+            event.defaultPrevented ||
+            event.button !== 0 ||
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.altKey ||
+            (rest.target && rest.target !== "_self")
+          ) {
+            return;
+          }
 
-        const intercepted = beginSidebarItemNavigation?.({
-          href: createPath(resolvedPath),
-          replace,
-          state,
-        });
-        if (intercepted) event.preventDefault();
-      }}
-      viewTransition
-      {...rest}
-    >
-      {children}
-    </Link>
-  );
-});
+          if (up) {
+            // Still a real `<a href>`, so middle-click, "open in new tab" and
+            // "copy link" keep working; only the plain left-click is ours.
+            event.preventDefault();
+            navigate(resolvedPath, { up: true, replace, state });
+            return;
+          }
+
+          // A same-URL click needs no guard here: React Router turns a `<Link>`
+          // with no explicit `replace` into one, and the interception below
+          // hands off to the same imperative chokepoint, which has its own.
+          markNavigationDirection("forward");
+          const intercepted = beginSidebarItemNavigation?.({
+            href: createPath(resolvedPath),
+            replace,
+            state,
+          });
+          if (intercepted) event.preventDefault();
+        }}
+        viewTransition
+        {...rest}
+      >
+        {children}
+      </Link>
+    );
+  },
+);
 
 export default ViewTransitionLink;

--- a/web/src/hooks/useNavigationDirection.test.tsx
+++ b/web/src/hooks/useNavigationDirection.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useNavigate } from "react-router";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { markNavigationDirection, resetNavigationHistory } from "@/lib/navigationHistory";
+
+import { useNavigationDirection } from "./useNavigationDirection";
+
+/**
+ * jsdom has no `document.startViewTransition`, so React Router takes its early
+ * return and no view transition runs. That is fine here: the attribute is
+ * written from the popstate listener, well before the router would open one.
+ *
+ * MemoryRouter keeps its own history, so `window.history.state.idx` — the index
+ * the hook reads — is set by hand, exactly as the browser would have.
+ */
+function Harness({ to }: { to?: string }) {
+  useNavigationDirection();
+  const navigate = useNavigate();
+  if (!to) return null;
+  return <button onClick={() => navigate(to)}>go</button>;
+}
+
+/** Stands in for the browser committing an entry and dispatching its popstate. */
+function pop(idx: number | undefined) {
+  act(() => {
+    window.history.replaceState(idx === undefined ? {} : { idx }, "");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+}
+
+function direction() {
+  return document.documentElement.dataset.navigationDirection;
+}
+
+beforeEach(() => {
+  resetNavigationHistory();
+  window.history.replaceState({ idx: 0 }, "");
+  delete document.documentElement.dataset.navigationDirection;
+});
+
+afterEach(() => {
+  window.history.replaceState(null, "");
+  delete document.documentElement.dataset.navigationDirection;
+});
+
+describe("useNavigationDirection", () => {
+  it("stamps back when the browser commits an earlier entry", () => {
+    window.history.replaceState({ idx: 2 }, "");
+    render(
+      <MemoryRouter>
+        <Harness />
+      </MemoryRouter>,
+    );
+
+    pop(1);
+
+    expect(direction()).toBe("back");
+  });
+
+  it("stamps forward when the browser commits a later entry", () => {
+    window.history.replaceState({ idx: 2 }, "");
+    render(
+      <MemoryRouter>
+        <Harness />
+      </MemoryRouter>,
+    );
+
+    pop(1);
+    pop(2);
+
+    expect(direction()).toBe("forward");
+  });
+
+  it("clears a stale direction when the pop's direction is unknowable", () => {
+    render(
+      <MemoryRouter>
+        <Harness />
+      </MemoryRouter>,
+    );
+    markNavigationDirection("back");
+
+    // No router index on the entry: something outside the router pushed it.
+    pop(undefined);
+
+    expect(direction()).toBeUndefined();
+  });
+
+  it("leaves the pushing caller's direction standing when the location commits", () => {
+    render(
+      <MemoryRouter initialEntries={["/item/series"]}>
+        <Harness to="/item/season" />
+      </MemoryRouter>,
+    );
+
+    // A push stamps its direction at click time. The effect that records the
+    // new location flushes before the browser captures the new snapshot, so
+    // clearing there would erase the direction mid-transition.
+    markNavigationDirection("forward");
+    window.history.replaceState({ idx: 1 }, "");
+    fireEvent.click(screen.getByRole("button", { name: "go" }));
+
+    expect(direction()).toBe("forward");
+  });
+
+  it("tracks the committed index so the next pop has an origin to compare", () => {
+    render(
+      <MemoryRouter initialEntries={["/item/series"]}>
+        <Harness to="/item/season" />
+      </MemoryRouter>,
+    );
+
+    window.history.replaceState({ idx: 1 }, "");
+    fireEvent.click(screen.getByRole("button", { name: "go" }));
+
+    // Without the location effect recording idx 1, this pop would have no
+    // origin and would fall back to the neutral, directionless transition.
+    pop(0);
+    expect(direction()).toBe("back");
+  });
+
+  it("stops listening once unmounted", () => {
+    window.history.replaceState({ idx: 2 }, "");
+    const { unmount } = render(
+      <MemoryRouter>
+        <Harness />
+      </MemoryRouter>,
+    );
+    unmount();
+
+    pop(1);
+
+    expect(direction()).toBeUndefined();
+  });
+});

--- a/web/src/hooks/useNavigationDirection.test.tsx
+++ b/web/src/hooks/useNavigationDirection.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter, useNavigate } from "react-router";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -9,26 +9,43 @@ import { markNavigationDirection, resetNavigationHistory } from "@/lib/navigatio
 import { useNavigationDirection } from "./useNavigationDirection";
 
 /**
- * jsdom has no `document.startViewTransition`, so React Router takes its early
- * return and no view transition runs. That is fine here: the attribute is
- * written from the popstate listener, well before the router would open one.
+ * These drive real router navigations rather than synthetic `popstate` events,
+ * because the navigation type is what the hook branches on and only the router
+ * can produce it.
  *
- * MemoryRouter keeps its own history, so `window.history.state.idx` — the index
- * the hook reads — is set by hand, exactly as the browser would have.
+ * What they still cannot prove is listener ordering against a real browser
+ * history — MemoryRouter keeps its own stack and registers no `popstate`
+ * listener at all. An earlier revision derived direction from a listener and
+ * every test here passed while browser Back was a silent no-op in the app. The
+ * ordering is now structural rather than racy — one writer, in the location
+ * effect — which is what makes these tests meaningful; they pin the arithmetic,
+ * not the race.
+ *
+ * `window.history.state.idx` is the index the hook reads, and MemoryRouter never
+ * writes it, so each test sets it by hand exactly as the browser would have
+ * before the router commits.
  */
 function Harness({ to }: { to?: string }) {
   useNavigationDirection();
   const navigate = useNavigate();
-  if (!to) return null;
-  return <button onClick={() => navigate(to)}>go</button>;
+  return (
+    <>
+      {to ? <button onClick={() => navigate(to)}>push</button> : null}
+      <button onClick={() => navigate(-1)}>back</button>
+      <button onClick={() => navigate(1)}>forward</button>
+    </>
+  );
 }
 
-/** Stands in for the browser committing an entry and dispatching its popstate. */
-function pop(idx: number | undefined) {
-  act(() => {
-    window.history.replaceState(idx === undefined ? {} : { idx }, "");
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  });
+/** The index the browser is already on when the tree mounts. */
+function startAt(idx: number) {
+  window.history.replaceState({ idx }, "");
+}
+
+/** Commits the index the browser would have installed, then navigates. */
+function travel(button: "push" | "back" | "forward", idx: number | undefined) {
+  window.history.replaceState(idx === undefined ? {} : { idx }, "");
+  fireEvent.click(screen.getByRole("button", { name: button }));
 }
 
 function direction() {
@@ -47,90 +64,90 @@ afterEach(() => {
 });
 
 describe("useNavigationDirection", () => {
-  it("stamps back when the browser commits an earlier entry", () => {
-    window.history.replaceState({ idx: 2 }, "");
+  it("stamps back when the router commits an earlier entry", () => {
+    startAt(1);
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={["/a", "/b"]} initialIndex={1}>
         <Harness />
       </MemoryRouter>,
     );
 
-    pop(1);
+    travel("back", 0);
 
     expect(direction()).toBe("back");
   });
 
-  it("stamps forward when the browser commits a later entry", () => {
-    window.history.replaceState({ idx: 2 }, "");
+  it("stamps forward when the router commits a later entry", () => {
+    startAt(1);
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={["/a", "/b"]} initialIndex={1}>
         <Harness />
       </MemoryRouter>,
     );
 
-    pop(1);
-    pop(2);
+    travel("back", 0);
+    travel("forward", 1);
 
     expect(direction()).toBe("forward");
   });
 
   it("clears a stale direction when the pop's direction is unknowable", () => {
+    startAt(1);
     render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={["/a", "/b"]} initialIndex={1}>
         <Harness />
       </MemoryRouter>,
     );
     markNavigationDirection("back");
 
     // No router index on the entry: something outside the router pushed it.
-    pop(undefined);
+    travel("back", undefined);
 
     expect(direction()).toBeUndefined();
   });
 
-  it("leaves the pushing caller's direction standing when the location commits", () => {
+  it("leaves the pushing caller's direction standing", () => {
     render(
       <MemoryRouter initialEntries={["/item/series"]}>
         <Harness to="/item/season" />
       </MemoryRouter>,
     );
 
-    // A push stamps its direction at click time. The effect that records the
-    // new location flushes before the browser captures the new snapshot, so
-    // clearing there would erase the direction mid-transition.
+    // A push is stamped at click time by whoever knew the intent. Re-deriving it
+    // from the index here could only agree — or, for a replace, wrongly clear it.
     markNavigationDirection("forward");
-    window.history.replaceState({ idx: 1 }, "");
-    fireEvent.click(screen.getByRole("button", { name: "go" }));
+    travel("push", 1);
 
     expect(direction()).toBe("forward");
   });
 
-  it("tracks the committed index so the next pop has an origin to compare", () => {
+  it("compares against the entry we came from, not the last one committed", () => {
+    startAt(2);
     render(
-      <MemoryRouter initialEntries={["/item/series"]}>
-        <Harness to="/item/season" />
+      <MemoryRouter initialEntries={["/a", "/b", "/c"]} initialIndex={2}>
+        <Harness />
       </MemoryRouter>,
     );
 
-    window.history.replaceState({ idx: 1 }, "");
-    fireEvent.click(screen.getByRole("button", { name: "go" }));
-
-    // Without the location effect recording idx 1, this pop would have no
-    // origin and would fall back to the neutral, directionless transition.
-    pop(0);
+    travel("back", 1);
     expect(direction()).toBe("back");
+
+    // Without advancing the tracked index on every commit, returning to idx 2
+    // would compare 2 against 2 and lose the direction.
+    travel("forward", 2);
+    expect(direction()).toBe("forward");
   });
 
-  it("stops listening once unmounted", () => {
-    window.history.replaceState({ idx: 2 }, "");
+  it("stops stamping once unmounted", () => {
+    startAt(1);
     const { unmount } = render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={["/a", "/b"]} initialIndex={1}>
         <Harness />
       </MemoryRouter>,
     );
     unmount();
 
-    pop(1);
+    window.history.replaceState({ idx: 0 }, "");
 
     expect(direction()).toBeUndefined();
   });

--- a/web/src/hooks/useNavigationDirection.ts
+++ b/web/src/hooks/useNavigationDirection.ts
@@ -1,11 +1,7 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router";
+import { useLocation, useNavigationType } from "react-router";
 
-import {
-  markNavigationDirection,
-  recordNavigation,
-  resolvePopDirection,
-} from "@/lib/navigationHistory";
+import { markNavigationDirection, resolveCommittedDirection } from "@/lib/navigationHistory";
 
 /**
  * Keeps `html[data-navigation-direction]` in step with the browser. Mount once,
@@ -13,37 +9,31 @@ import {
  * transitions outside `Layout`, and the tracked index has to survive the
  * auth-gated routes that unmount it.
  *
- * Push direction comes from the caller, at click time. Back/forward direction
- * cannot: React Router swaps currentLocation and nextLocation on a reverse POP,
- * so both legs of a back-and-forth produce the byte-identical pair and
- * `useViewTransitionState` is blind to direction by construction. The delta
- * only exists inside the router's private history, so an app-level popstate
- * listener recomputing it from the previous index is the only source.
+ * Push direction comes from the caller, at click time, because only the caller
+ * knows whether a link is a descent or a step back up the hierarchy. Back and
+ * forward cannot come from there: React Router swaps currentLocation and
+ * nextLocation on a reverse POP, so both legs of a back-and-forth produce the
+ * byte-identical pair and `useViewTransitionState` is blind to direction by
+ * construction. The committed history index is the only signal left.
  *
- * The race is not close. React Router's own popstate handler is registered
- * during App's first render, so this one runs second, and from there every path
- * to `startViewTransition` goes through an awaited loader pass and two React
- * commits. The synchronous branch needs `flushSync`, which a POP never carries.
+ * Deriving it from the location effect rather than from a `popstate` listener is
+ * what makes it work at all — see `resolveCommittedDirection`. A listener cannot
+ * be registered before the router's, and the router's runs React's state update
+ * synchronously, so by the time a listener fires, the index it needed to compare
+ * against has already been advanced.
  */
 export function useNavigationDirection(): void {
   const location = useLocation();
+  const navigationType = useNavigationType();
 
   useEffect(() => {
-    const handlePopState = () => {
-      // Null clears the attribute rather than leaving the last push's direction
-      // standing — an unknowable direction gets the neutral transition.
-      markNavigationDirection(resolvePopDirection());
-    };
-    window.addEventListener("popstate", handlePopState);
-    return () => window.removeEventListener("popstate", handlePopState);
-  }, []);
-
-  useEffect(() => {
-    // Index bookkeeping only, so the next popstate has something to compare
-    // against. This must never touch the direction attribute: passive effects
-    // for the new location flush before React Router's commit barrier resolves,
-    // and therefore before the browser captures the new snapshot, so clearing
-    // here would erase the direction mid-transition.
-    recordNavigation();
-  }, [location]);
+    const direction = resolveCommittedDirection();
+    // A push or replace was already stamped at click time by whoever knew the
+    // intent; re-deriving it here would only ever agree, or — for a replace,
+    // which does not move the index — wrongly clear it. A POP has no click to
+    // have stamped it, so this is the only chance, including when the answer is
+    // null: that takes the attribute off and plays the neutral transition
+    // rather than leaving the previous navigation's direction standing.
+    if (navigationType === "POP") markNavigationDirection(direction);
+  }, [location, navigationType]);
 }

--- a/web/src/hooks/useNavigationDirection.ts
+++ b/web/src/hooks/useNavigationDirection.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+import {
+  markNavigationDirection,
+  recordNavigation,
+  resolvePopDirection,
+} from "@/lib/navigationHistory";
+
+/**
+ * Keeps `html[data-navigation-direction]` in step with the browser. Mount once,
+ * above every route — `WatchPlaybackChrome` and `WatchTogetherJoin` start view
+ * transitions outside `Layout`, and the tracked index has to survive the
+ * auth-gated routes that unmount it.
+ *
+ * Push direction comes from the caller, at click time. Back/forward direction
+ * cannot: React Router swaps currentLocation and nextLocation on a reverse POP,
+ * so both legs of a back-and-forth produce the byte-identical pair and
+ * `useViewTransitionState` is blind to direction by construction. The delta
+ * only exists inside the router's private history, so an app-level popstate
+ * listener recomputing it from the previous index is the only source.
+ *
+ * The race is not close. React Router's own popstate handler is registered
+ * during App's first render, so this one runs second, and from there every path
+ * to `startViewTransition` goes through an awaited loader pass and two React
+ * commits. The synchronous branch needs `flushSync`, which a POP never carries.
+ */
+export function useNavigationDirection(): void {
+  const location = useLocation();
+
+  useEffect(() => {
+    const handlePopState = () => {
+      // Null clears the attribute rather than leaving the last push's direction
+      // standing — an unknowable direction gets the neutral transition.
+      markNavigationDirection(resolvePopDirection());
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
+  useEffect(() => {
+    // Index bookkeeping only, so the next popstate has something to compare
+    // against. This must never touch the direction attribute: passive effects
+    // for the new location flush before React Router's commit barrier resolves,
+    // and therefore before the browser captures the new snapshot, so clearing
+    // here would erase the direction mid-transition.
+    recordNavigation();
+  }, [location]);
+}

--- a/web/src/hooks/useViewTransition.test.tsx
+++ b/web/src/hooks/useViewTransition.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from "react-router";
 import type { To } from "react-router";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { recordNavigation, resetNavigationHistory } from "@/lib/navigationHistory";
+import { resetNavigationHistory, resolveCommittedDirection } from "@/lib/navigationHistory";
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -97,7 +97,7 @@ describe("useViewTransitionNavigate", () => {
 
   it("pushes an `up` target, stamping only the direction", async () => {
     commit(0);
-    recordNavigation();
+    resolveCommittedDirection();
 
     render(<Harness to="/item/series" options={{ up: true }} />);
     await go();

--- a/web/src/hooks/useViewTransition.test.tsx
+++ b/web/src/hooks/useViewTransition.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import type { To } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { recordNavigation, resetNavigationHistory } from "@/lib/navigationHistory";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+}));
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual<typeof import("react-router")>("react-router");
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+import { useViewTransitionNavigate, type ViewTransitionNavigateOptions } from "./useViewTransition";
+
+/** Stands in for the browser having committed the entry at `idx`. */
+function commit(idx: number) {
+  window.history.replaceState({ idx }, "");
+}
+
+function Harness({
+  to,
+  options,
+  at = "/item/season",
+}: {
+  to: To | number;
+  options?: ViewTransitionNavigateOptions;
+  at?: string;
+}) {
+  function Trigger() {
+    const navigate = useViewTransitionNavigate();
+    return (
+      <button type="button" onClick={() => navigate(to, options)}>
+        go
+      </button>
+    );
+  }
+
+  return (
+    <MemoryRouter initialEntries={[at]}>
+      <Trigger />
+    </MemoryRouter>
+  );
+}
+
+async function go() {
+  await userEvent.click(screen.getByRole("button", { name: "go" }));
+}
+
+afterEach(() => {
+  mocks.navigate.mockClear();
+  resetNavigationHistory();
+  window.history.replaceState(null, "");
+  delete document.documentElement.dataset.navigationDirection;
+});
+
+describe("useViewTransitionNavigate", () => {
+  it("opts an ordinary navigation into a forward view transition", async () => {
+    render(<Harness to="/item/episode" />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/item/episode", {
+      replace: false,
+      viewTransition: true,
+    });
+    expect(document.documentElement.dataset.navigationDirection).toBe("forward");
+  });
+
+  it("replaces rather than pushes a second entry for the current URL", async () => {
+    render(<Harness to="/item/season?tab=extras" at="/item/season?tab=extras" />);
+    await go();
+
+    // React Router does this for `<Link>`; imperative callers get nothing, and
+    // a duplicate entry makes the browser's back button look broken.
+    expect(mocks.navigate).toHaveBeenCalledWith("/item/season?tab=extras", {
+      replace: true,
+      viewTransition: true,
+    });
+  });
+
+  it("leaves an explicit replace alone", async () => {
+    render(<Harness to="/item/episode" options={{ replace: false }} />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/item/episode", {
+      replace: false,
+      viewTransition: true,
+    });
+  });
+
+  it("pushes an `up` target, stamping only the direction", async () => {
+    commit(0);
+    recordNavigation();
+
+    render(<Harness to="/item/series" options={{ up: true }} />);
+    await go();
+
+    // `up` changes the motion, never the entry: backwards animation, ordinary
+    // push, every NavigateOptions field forwarded.
+    expect(mocks.navigate).toHaveBeenCalledWith("/item/series", {
+      replace: false,
+      viewTransition: true,
+    });
+    expect(document.documentElement.dataset.navigationDirection).toBe("back");
+  });
+
+  it("will not push a duplicate entry for an `up` link to the current URL", async () => {
+    render(<Harness to="/item/season" options={{ up: true }} at="/item/season" />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/item/season", {
+      replace: true,
+      viewTransition: true,
+    });
+  });
+
+  it("reads direction off the sign of a raw delta", async () => {
+    render(<Harness to={-1} />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith(-1);
+    expect(document.documentElement.dataset.navigationDirection).toBe("back");
+  });
+
+  it("does not forward `up` to the router as a navigate option", async () => {
+    render(<Harness to="/item/series" options={{ up: true, state: { from: "crumb" } }} />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/item/series", {
+      state: { from: "crumb" },
+      replace: false,
+      viewTransition: true,
+    });
+  });
+});

--- a/web/src/hooks/useViewTransition.ts
+++ b/web/src/hooks/useViewTransition.ts
@@ -1,20 +1,73 @@
-import { useNavigate } from "react-router";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { createPath, resolvePath, useLocation, useNavigate } from "react-router";
 import type { NavigateOptions, To } from "react-router";
 
+import { markNavigationDirection } from "@/lib/navigationHistory";
+
+export interface ViewTransitionNavigateOptions extends NavigateOptions {
+  /**
+   * The destination is an ancestor of where we are now, not a new place: play
+   * the page motion backwards.
+   *
+   * Direction only. It deliberately does not unwind to an existing entry —
+   * see the note in `@/lib/navigationHistory` for why that cannot be made
+   * sound against React Router's history indices.
+   */
+  up?: boolean;
+}
+
 /**
- * A wrapper around React Router's `useNavigate` that uses the
- * View Transitions API for smooth page transitions.
+ * The app's imperative navigation chokepoint: opts every navigation into React
+ * Router's view transitions and stamps the direction `main-content` should move
+ * in before the router opens the transition.
  *
- * Falls back to regular navigation in browsers that don't support
- * the View Transitions API.
+ * `up` is the only way to express intent, here and on `ViewTransitionLink`. It
+ * is a boolean rather than a direction string because forward is the default
+ * and back/forward direction is never a caller's concern — `useNavigationDirection`
+ * derives that from the history index the browser has already committed.
+ *
+ * Falls back to regular navigation in browsers without the View Transitions API.
  */
 export function useViewTransitionNavigate() {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // The current location is read at click time, so it must stay out of the
+  // callback's dependencies: consumers hold this function in effect deps
+  // (SearchBar's search-as-you-type), and an identity that changed on every
+  // navigation would make those effects navigate again in a loop.
+  const locationRef = useRef(location);
+  useEffect(() => {
+    locationRef.current = location;
+  }, [location]);
 
   return useCallback(
-    (to: To, options?: NavigateOptions) => {
-      navigate(to, { ...options, viewTransition: true });
+    (to: To | number, options?: ViewTransitionNavigateOptions) => {
+      if (typeof to === "number") {
+        // A delta is already a POP, so the popstate listener derives the same
+        // answer a tick later; stamping here just gets it in before the router.
+        markNavigationDirection(to < 0 ? "back" : "forward");
+        navigate(to);
+        return;
+      }
+
+      const { up = false, ...navigateOptions } = options ?? {};
+      const current = locationRef.current;
+      // React Router resolves a relative `to` against the matched route rather
+      // than the raw pathname. Every href this app navigates with is absolute,
+      // where the two agree; a relative `to` could disagree and turn a push
+      // into a replace, so callers pass absolute paths.
+      const target = createPath(resolvePath(to, current.pathname));
+      // React Router gives `<Link>` the same-URL guard for free; the imperative
+      // path gets nothing, and a second identical entry makes the browser's
+      // back button look broken.
+      const replace = navigateOptions.replace ?? target === createPath(current);
+
+      // Direction is the only thing `up` changes; the navigation itself is a
+      // normal push either way, so every caller keeps its own entry semantics
+      // and every NavigateOptions field is forwarded on both paths.
+      markNavigationDirection(up ? "back" : "forward");
+      navigate(to, { ...navigateOptions, replace, viewTransition: true });
     },
     [navigate],
   );

--- a/web/src/lib/backNavigation.ts
+++ b/web/src/lib/backNavigation.ts
@@ -1,8 +1,0 @@
-// hasRouterHistory reports whether the current entry has in-app router
-// history behind it, i.e. navigate(-1) stays inside the app. React Router
-// stamps its entry index on window.history.state.idx; the first in-app entry
-// has idx 0.
-export function hasRouterHistory(): boolean {
-  const historyIndex = (window.history.state as { idx?: unknown } | null)?.idx;
-  return typeof historyIndex === "number" && historyIndex > 0;
-}

--- a/web/src/lib/navigationHistory.test.ts
+++ b/web/src/lib/navigationHistory.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  hasEarlierEntry,
+  markNavigationDirection,
+  recordNavigation,
+  resetNavigationHistory,
+  resolvePopDirection,
+} from "./navigationHistory";
+
+/** Stands in for the browser having committed the entry at `idx`. */
+function commit(idx: number) {
+  window.history.replaceState({ idx }, "");
+}
+
+/** Walks an index in from a cold start, as a run of pushes would. */
+function pushAll(depth: number) {
+  for (let idx = 0; idx < depth; idx += 1) {
+    commit(idx);
+    recordNavigation();
+  }
+}
+
+beforeEach(() => {
+  resetNavigationHistory();
+  window.history.replaceState(null, "");
+  delete document.documentElement.dataset.navigationDirection;
+});
+
+afterEach(() => {
+  window.history.replaceState(null, "");
+  delete document.documentElement.dataset.navigationDirection;
+});
+
+describe("markNavigationDirection", () => {
+  it("stamps the direction CSS selects page motion on", () => {
+    markNavigationDirection("forward");
+    expect(document.documentElement.dataset.navigationDirection).toBe("forward");
+
+    markNavigationDirection("back");
+    expect(document.documentElement.dataset.navigationDirection).toBe("back");
+  });
+
+  it("removes the attribute for an unknowable direction rather than guessing", () => {
+    markNavigationDirection("back");
+    markNavigationDirection(null);
+
+    // Absent, not "forward": the neutral transition is the honest default, and
+    // a stale "back" would play the wrong way on the next navigation.
+    expect(document.documentElement.dataset.navigationDirection).toBeUndefined();
+  });
+});
+
+describe("resolvePopDirection", () => {
+  it("reads back and forward off the committed history index", () => {
+    pushAll(3);
+
+    commit(1);
+    expect(resolvePopDirection()).toBe("back");
+
+    commit(2);
+    expect(resolvePopDirection()).toBe("forward");
+  });
+
+  it("reports a multi-entry jump as back", () => {
+    pushAll(4);
+
+    commit(0);
+    expect(resolvePopDirection()).toBe("back");
+  });
+
+  it("compares against the entry we came from, not the last one recorded", () => {
+    pushAll(2);
+
+    commit(0);
+    expect(resolvePopDirection()).toBe("back");
+    // Without advancing the tracked index on every pop, returning to idx 1
+    // would compare 1 against 1 and lose the direction.
+    commit(1);
+    expect(resolvePopDirection()).toBe("forward");
+  });
+
+  it("returns null for a pop that lands on the same index", () => {
+    pushAll(1);
+
+    commit(0);
+    expect(resolvePopDirection()).toBeNull();
+  });
+
+  it("returns null when nothing has stamped an index yet", () => {
+    commit(3);
+    expect(resolvePopDirection()).toBeNull();
+  });
+
+  it("returns null for an entry the router never indexed", () => {
+    pushAll(2);
+
+    window.history.replaceState({}, "");
+    expect(resolvePopDirection()).toBeNull();
+  });
+});
+
+describe("hasEarlierEntry", () => {
+  it("reports whether stepping back one entry stays in the app", () => {
+    commit(0);
+    expect(hasEarlierEntry()).toBe(false);
+
+    commit(1);
+    expect(hasEarlierEntry()).toBe(true);
+  });
+
+  it("survives a reload, because the index lives in history.state", () => {
+    pushAll(2);
+    resetNavigationHistory();
+    commit(1);
+
+    // "Is there something behind me" is answerable from the index alone. "What
+    // is behind me" is not, which is why nothing here answers it — see the note
+    // in navigationHistory.ts.
+    expect(hasEarlierEntry()).toBe(true);
+  });
+
+  it("is false for an entry the router never indexed", () => {
+    window.history.replaceState({}, "");
+    expect(hasEarlierEntry()).toBe(false);
+  });
+});
+
+describe("unindexed entries", () => {
+  it("degrades direction to null rather than to a wrong answer", () => {
+    // React Router derives a push index as `getIndex() + 1` over a nullable
+    // history state, so an entry that lands without an idx — this app's raw
+    // `<a href="#main-content">` skip links do exactly that — silently restarts
+    // its numbering. A path-to-index map cannot survive that: the delta stops
+    // matching real stack positions and `navigate(-n)` lands somewhere the user
+    // never asked for. Direction can survive it, because the honest answer to
+    // an unreadable index is "no attribute, neutral motion".
+    pushAll(2);
+
+    window.history.replaceState(null, "");
+    expect(resolvePopDirection()).toBeNull();
+    expect(hasEarlierEntry()).toBe(false);
+  });
+});

--- a/web/src/lib/navigationHistory.test.ts
+++ b/web/src/lib/navigationHistory.test.ts
@@ -3,9 +3,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   hasEarlierEntry,
   markNavigationDirection,
-  recordNavigation,
+  resolveCommittedDirection,
   resetNavigationHistory,
-  resolvePopDirection,
 } from "./navigationHistory";
 
 /** Stands in for the browser having committed the entry at `idx`. */
@@ -17,7 +16,7 @@ function commit(idx: number) {
 function pushAll(depth: number) {
   for (let idx = 0; idx < depth; idx += 1) {
     commit(idx);
-    recordNavigation();
+    resolveCommittedDirection();
   }
 }
 
@@ -51,52 +50,52 @@ describe("markNavigationDirection", () => {
   });
 });
 
-describe("resolvePopDirection", () => {
+describe("resolveCommittedDirection", () => {
   it("reads back and forward off the committed history index", () => {
     pushAll(3);
 
     commit(1);
-    expect(resolvePopDirection()).toBe("back");
+    expect(resolveCommittedDirection()).toBe("back");
 
     commit(2);
-    expect(resolvePopDirection()).toBe("forward");
+    expect(resolveCommittedDirection()).toBe("forward");
   });
 
   it("reports a multi-entry jump as back", () => {
     pushAll(4);
 
     commit(0);
-    expect(resolvePopDirection()).toBe("back");
+    expect(resolveCommittedDirection()).toBe("back");
   });
 
   it("compares against the entry we came from, not the last one recorded", () => {
     pushAll(2);
 
     commit(0);
-    expect(resolvePopDirection()).toBe("back");
+    expect(resolveCommittedDirection()).toBe("back");
     // Without advancing the tracked index on every pop, returning to idx 1
     // would compare 1 against 1 and lose the direction.
     commit(1);
-    expect(resolvePopDirection()).toBe("forward");
+    expect(resolveCommittedDirection()).toBe("forward");
   });
 
   it("returns null for a pop that lands on the same index", () => {
     pushAll(1);
 
     commit(0);
-    expect(resolvePopDirection()).toBeNull();
+    expect(resolveCommittedDirection()).toBeNull();
   });
 
   it("returns null when nothing has stamped an index yet", () => {
     commit(3);
-    expect(resolvePopDirection()).toBeNull();
+    expect(resolveCommittedDirection()).toBeNull();
   });
 
   it("returns null for an entry the router never indexed", () => {
     pushAll(2);
 
     window.history.replaceState({}, "");
-    expect(resolvePopDirection()).toBeNull();
+    expect(resolveCommittedDirection()).toBeNull();
   });
 });
 
@@ -138,7 +137,7 @@ describe("unindexed entries", () => {
     pushAll(2);
 
     window.history.replaceState(null, "");
-    expect(resolvePopDirection()).toBeNull();
+    expect(resolveCommittedDirection()).toBeNull();
     expect(hasEarlierEntry()).toBe(false);
   });
 });

--- a/web/src/lib/navigationHistory.ts
+++ b/web/src/lib/navigationHistory.ts
@@ -62,35 +62,34 @@ export function markNavigationDirection(direction: NavigationDirection | null): 
 }
 
 /**
- * Direction of the POP the browser has just committed, and null when it cannot
- * be derived — an entry from before this page load, an index the router never
- * stamped, or a same-index pop such as a bare hash change.
+ * Direction of the navigation React Router has just committed, and null when it
+ * cannot be derived — an entry from before this page load, an index the router
+ * never stamped, or a same-index commit such as a replace or a bare hash change.
  *
- * Advances the tracked index, so it must be called once per popstate: the
- * comparison is against the entry we came from, not against the last entry
- * React Router happened to commit.
+ * Advances the tracked index, so it must be called exactly once per commit: the
+ * comparison is against the entry we came from, not against the last entry the
+ * router happened to commit.
+ *
+ * This is the ONLY writer of the tracked index, and it is called from the
+ * location effect rather than from a `popstate` listener. That is not a
+ * preference. `popstate` is a discrete event, so React flushes the router's
+ * state update synchronously inside the router's own listener — and the router
+ * registers that listener when it is created, where ours can only be registered
+ * later, from an effect. A second writer therefore always lost the race: the
+ * location effect advanced the index to the destination before the listener
+ * could read the origin, so every pop compared an index against itself,
+ * resolved to null, and browser Back silently fell back to the neutral
+ * animation. One writer removes the ordering question entirely.
  *
  * An unindexed entry in the stack degrades this to null — no attribute, neutral
- * motion — rather than to a wrong answer, which is why the index is safe to use
- * for direction even though it was not safe to use for deltas.
+ * motion — rather than to a wrong answer.
  */
-export function resolvePopDirection(): NavigationDirection | null {
+export function resolveCommittedDirection(): NavigationDirection | null {
   const destination = readHistoryIndex();
   const origin = trackedIndex;
   trackedIndex = destination;
   if (destination === null || origin === null || destination === origin) return null;
   return destination < origin ? "back" : "forward";
-}
-
-/**
- * Records the index React Router has just committed, so the next popstate has
- * something to compare against. Safe to call from a location effect: the history
- * entry exists by the time the router notifies subscribers.
- */
-export function recordNavigation(): void {
-  const idx = readHistoryIndex();
-  if (idx === null) return;
-  trackedIndex = idx;
 }
 
 /**

--- a/web/src/lib/navigationHistory.ts
+++ b/web/src/lib/navigationHistory.ts
@@ -1,0 +1,112 @@
+/**
+ * The one bit of navigation state CSS needs: which way the page is moving.
+ *
+ * React Router stamps its own entry index on `window.history.state.idx`. That is
+ * the only ordering signal a history entry carries — `location.key` changes on
+ * every visit and the History API exposes neither the stack nor the delta to an
+ * arbitrary entry — so comparing it across a popstate is the only way to tell a
+ * Back from a Forward.
+ *
+ * It is deliberately used for nothing more than that. An earlier revision also
+ * mirrored idx -> path so a breadcrumb could `navigate(-n)` and unwind to an
+ * ancestor already behind the user instead of pushing a duplicate. That map
+ * cannot be made sound here: React Router's `push()` computes
+ * `index = getIndex() + 1` over `(globalHistory.state || { idx: null }).idx`
+ * (react-router/dist/development/lib/router/history.js), so any entry that lands
+ * without an `idx` makes `null + 1 === 1` and silently restarts the numbering
+ * while the real stack keeps growing. This app ships that trigger: the
+ * "Skip to content" links in Layout and AdminLayout are raw `<a href="#...">`,
+ * and a same-document fragment navigation pushes an unindexed entry and fires
+ * `hashchange`, which the router does not listen for. From then on a recorded
+ * index is no longer a fixed offset from a real stack position, and the delta
+ * lands the user on a page they never asked for. Pushing a duplicate entry is a
+ * cosmetic annoyance; navigating somewhere unrelated is not, so the unwind is
+ * gone and breadcrumbs push like any other link.
+ */
+
+export type NavigationDirection = "forward" | "back";
+
+/**
+ * The index the browser has committed. During a popstate this is already the
+ * DESTINATION entry — the browser installs it before dispatching the event.
+ * Null when nothing stamped an index: a first load before React Router writes
+ * its state, or an entry pushed by something outside the router.
+ */
+function readHistoryIndex(): number | null {
+  if (typeof window === "undefined") return null;
+  const idx = (window.history.state as { idx?: unknown } | null)?.idx;
+  return typeof idx === "number" ? idx : null;
+}
+
+/** Index of the entry we believe is current; null until the first navigation. */
+let trackedIndex: number | null = null;
+
+/**
+ * Writes the direction CSS selects page motion on. Pass null when the direction
+ * is genuinely unknowable; the attribute comes off and `main-content` falls back
+ * to the neutral, non-directional transition rather than guessing a side.
+ *
+ * Must be called BEFORE the navigation starts. React Router opens the view
+ * transition two commits later and the browser resolves `::view-transition-*`
+ * styles later still, so nothing may clear this from a location effect — that
+ * would erase the direction for the transition it belongs to. The attribute is
+ * overwritten at the start of the next navigation; that is its whole lifecycle.
+ */
+export function markNavigationDirection(direction: NavigationDirection | null): void {
+  if (typeof document === "undefined") return;
+  if (direction === null) {
+    delete document.documentElement.dataset.navigationDirection;
+    return;
+  }
+  document.documentElement.dataset.navigationDirection = direction;
+}
+
+/**
+ * Direction of the POP the browser has just committed, and null when it cannot
+ * be derived — an entry from before this page load, an index the router never
+ * stamped, or a same-index pop such as a bare hash change.
+ *
+ * Advances the tracked index, so it must be called once per popstate: the
+ * comparison is against the entry we came from, not against the last entry
+ * React Router happened to commit.
+ *
+ * An unindexed entry in the stack degrades this to null — no attribute, neutral
+ * motion — rather than to a wrong answer, which is why the index is safe to use
+ * for direction even though it was not safe to use for deltas.
+ */
+export function resolvePopDirection(): NavigationDirection | null {
+  const destination = readHistoryIndex();
+  const origin = trackedIndex;
+  trackedIndex = destination;
+  if (destination === null || origin === null || destination === origin) return null;
+  return destination < origin ? "back" : "forward";
+}
+
+/**
+ * Records the index React Router has just committed, so the next popstate has
+ * something to compare against. Safe to call from a location effect: the history
+ * entry exists by the time the router notifies subscribers.
+ */
+export function recordNavigation(): void {
+  const idx = readHistoryIndex();
+  if (idx === null) return;
+  trackedIndex = idx;
+}
+
+/**
+ * Whether stepping back one entry stays inside the app. React Router numbers its
+ * entries from 0, so anything above that has an in-app entry behind it.
+ *
+ * Unlike a path map this survives a reload — the index lives in `history.state`,
+ * not in memory — and it asks nothing about *which* page is behind, only that
+ * one is, which is all a plain "go back one" needs.
+ */
+export function hasEarlierEntry(): boolean {
+  const idx = readHistoryIndex();
+  return idx !== null && idx > 0;
+}
+
+/** Test seam: module state outlives a render, so tests have to reset it. */
+export function resetNavigationHistory(): void {
+  trackedIndex = null;
+}

--- a/web/src/navigationTransitionCss.test.ts
+++ b/web/src/navigationTransitionCss.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Directional page motion lives entirely in CSS — the app only writes
+ * `html[data-navigation-direction]` — so these are contract tests over app.css,
+ * the same shape as `sidebarCollapseCss.test.ts`.
+ *
+ * What matters: the root is never captured (its snapshot would freeze the
+ * sidebar mid-collapse), the directional keyframes run on the sidebar's clock,
+ * and reduced motion actually reaches them despite their higher specificity.
+ */
+const css = readFileSync(fileURLToPath(new URL("./app.css", import.meta.url)), "utf8");
+
+/** Body of the first `@media (prefers-reduced-motion: reduce)` block. */
+function reducedMotionBlock(): string {
+  const start = css.indexOf("@media (prefers-reduced-motion: reduce)");
+  expect(start).toBeGreaterThan(-1);
+  let depth = 0;
+  for (let i = css.indexOf("{", start); i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}" && --depth === 0) return css.slice(start, i + 1);
+  }
+  throw new Error("unterminated prefers-reduced-motion block");
+}
+
+describe("navigation view-transition CSS", () => {
+  it("holds the root group still inside the sidebar shell, and only there", () => {
+    // The UA stylesheet names the root by default; unanimated, the old page's
+    // 260px sidebar would cross-fade on top of the rail as it travels to 64px.
+    expect(css).toMatch(
+      /html\[data-app-shell\]::view-transition-old\(root\),\s*html\[data-app-shell\]::view-transition-new\(root\) \{\s*animation: none;/,
+    );
+    // Scoped, not global. `main-content` is named only inside Layout, so
+    // un-naming the root outright would leave /watch, /reader/*, /admin/* and
+    // the auth screens with no captured element at all.
+    expect(css).not.toMatch(/:root \{\s*view-transition-name: none;/);
+  });
+
+  it("moves main-content's box on the sidebar's clock, not the UA's 250ms", () => {
+    expect(css).toMatch(
+      /::view-transition-group\(main-content\) \{\s*animation-duration: var\(--duration-sidebar-collapse\);\s*animation-timing-function: var\(--ease-sidebar-collapse\);/,
+    );
+  });
+
+  it("mirrors the two directions off one shift token", () => {
+    expect(css).toMatch(
+      /html\[data-navigation-direction="forward"\] \{\s*--nav-slide-shift: -24px;/,
+    );
+    expect(css).toMatch(/html\[data-navigation-direction="back"\] \{\s*--nav-slide-shift: 24px;/);
+    // The incoming page enters from the side the outgoing page left towards.
+    expect(css).toContain("transform: translateX(var(--nav-slide-shift))");
+    expect(css).toContain("transform: translateX(calc(-1 * var(--nav-slide-shift)))");
+  });
+
+  it("runs both halves of the cross-fade on identical timing", () => {
+    // The pseudo-elements default to `mix-blend-mode: plus-lighter`, which only
+    // cross-fades cleanly while the two opacities sum to 1. Different easing
+    // curves would break that sum and flash bright mid-transition.
+    const timing = "var(--duration-sidebar-collapse) var(--ease-sidebar-collapse) both";
+    expect(css).toContain(
+      `html[data-navigation-direction]::view-transition-old(main-content) {\n  animation: ${timing} nav-slide-out;`,
+    );
+    expect(css).toContain(
+      `html[data-navigation-direction]::view-transition-new(main-content) {\n  animation: ${timing} nav-slide-in;`,
+    );
+  });
+
+  it("attaches the pseudo-element to the root rather than descending from it", () => {
+    // `html[...] ::view-transition-old(...)` — with a combinator — parses fine
+    // and silently never matches, so the whole feature would go quiet.
+    expect(css).not.toMatch(/html\[data-navigation-direction[^\]]*\]\s+::view-transition/);
+  });
+
+  it("suppresses the directional rules under reduced motion despite their specificity", () => {
+    const block = reducedMotionBlock();
+    for (const selector of [
+      "::view-transition-old(main-content),",
+      "::view-transition-new(main-content),",
+      "::view-transition-group(main-content),",
+      "html[data-navigation-direction]::view-transition-old(main-content),",
+      "html[data-navigation-direction]::view-transition-new(main-content)",
+    ]) {
+      expect(block).toContain(selector);
+    }
+  });
+});

--- a/web/src/pages/CollectionEditor.tsx
+++ b/web/src/pages/CollectionEditor.tsx
@@ -32,7 +32,7 @@ export default function CollectionEditor() {
   if (id && !collection && !isLoading) {
     return (
       <div className="page-shell relative space-y-4 py-4 sm:py-6">
-        <PageBack to="/collections" preferHistory={false} />
+        <PageBack to="/collections" up />
         <Card className="surface-panel mt-10 rounded-[1.7rem] border-0 shadow-none sm:mt-12">
           <CardHeader>
             <CardTitle>Collection not found</CardTitle>
@@ -46,7 +46,7 @@ export default function CollectionEditor() {
   if (collection && isImportedCollection(collection)) {
     return (
       <div className="page-shell relative space-y-6 py-4 sm:py-6">
-        <PageBack to="/collections" preferHistory={false} />
+        <PageBack to="/collections" up />
         <div className="mt-10 sm:mt-12">
           <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">{collection.name}</h1>
           <p className="page-subtitle mt-1 text-sm sm:text-base">
@@ -68,7 +68,7 @@ export default function CollectionEditor() {
   if (collection && collection.collection_type === "manual") {
     return (
       <div className="page-shell relative space-y-6 py-4 sm:py-6">
-        <PageBack to="/collections" preferHistory={false} />
+        <PageBack to="/collections" up />
         <div className="mt-10 sm:mt-12">
           <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Edit {collection.name}</h1>
           <p className="page-subtitle mt-1 text-sm sm:text-base">

--- a/web/src/pages/EbookReader.tsx
+++ b/web/src/pages/EbookReader.tsx
@@ -42,7 +42,8 @@ import { Button } from "@/components/ui/button";
 import { useScreenWakeLock } from "@/hooks/useScreenWakeLock";
 import { useTTS } from "@/hooks/useTTS";
 import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
-import { hasRouterHistory } from "@/lib/backNavigation";
+import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
+import { hasEarlierEntry } from "@/lib/navigationHistory";
 import { buildItemHref, buildMediaPlayHref } from "@/lib/mediaNavigation";
 import { buildMangaList, flattenMangaList } from "@/lib/mangaChapters";
 import { cn } from "@/lib/utils";
@@ -196,7 +197,10 @@ function isEditableTarget(target: EventTarget | null): boolean {
 
 export default function EbookReader() {
   const { contentId = "" } = useParams<{ contentId: string }>();
+  // Swapping the open file re-renders the reader in place, so it stays on the
+  // plain navigate; only leaving the reader is a page transition.
   const navigate = useNavigate();
+  const exitReader = useViewTransitionNavigate();
   const [searchParams] = useSearchParams();
   const requestedFileID = Number(searchParams.get("file_id") || "");
   const libraryIdParam = searchParams.get("libraryId");
@@ -617,11 +621,11 @@ export default function EbookReader() {
                   return;
                 }
                 event.preventDefault();
-                if (hasRouterHistory()) {
-                  navigate(-1);
-                } else {
-                  navigate(backHref, { replace: true });
+                if (hasEarlierEntry()) {
+                  exitReader(-1);
+                  return;
                 }
+                exitReader(backHref, { up: true, replace: true });
               }}
             >
               <ArrowLeft className="size-5" />

--- a/web/src/pages/ItemDetail/EbookContent.tsx
+++ b/web/src/pages/ItemDetail/EbookContent.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { BookOpen, Check, Download } from "lucide-react";
-import { Link } from "react-router";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 import type { FileVersion, ItemDetail } from "@/api/types";
 import DownloadVersionPicker from "@/components/DownloadVersionPicker";
 import MediaLocations from "@/components/MediaLocations";
@@ -149,7 +149,7 @@ export default function EbookContent({
                 asChild
                 className="h-11 gap-2.5 rounded-full px-6 text-[15px] font-bold tracking-wide shadow-md"
               >
-                <Link to={readerHref}>
+                <ViewTransitionLink to={readerHref}>
                   <BookOpen className="size-[18px]" />
                   {hasSavedProgress ? "Continue" : "Read"}
                   {progressLabel && (
@@ -157,7 +157,7 @@ export default function EbookContent({
                       {progressLabel}
                     </span>
                   )}
-                </Link>
+                </ViewTransitionLink>
               </Button>
             )}
             {canDownload && (

--- a/web/src/pages/ItemDetail/MangaContent.tsx
+++ b/web/src/pages/ItemDetail/MangaContent.tsx
@@ -10,13 +10,13 @@ import {
   MoreVertical,
   RefreshCw,
 } from "lucide-react";
-import { Link } from "react-router";
 import { toast } from "sonner";
 import type { FileVersion, ItemDetail, MangaChapter } from "@/api/types";
 import DownloadVersionPicker from "@/components/DownloadVersionPicker";
 import MangaFilesDialog from "@/components/MangaFilesDialog";
 import PageBack from "@/components/PageBack";
 import RefreshMetadataDialog from "@/components/RefreshMetadataDialog";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -153,7 +153,7 @@ function MangaRow({
       id={`manga-chapter-${chapter.content_id}`}
       className="hover:bg-muted/40 flex items-center gap-3 px-4 py-2 transition-colors"
     >
-      <Link to={readerHref} className="flex min-w-0 flex-1 items-center gap-3">
+      <ViewTransitionLink to={readerHref} className="flex min-w-0 flex-1 items-center gap-3">
         {chapter.poster_url ? (
           <img
             src={chapter.poster_url}
@@ -190,7 +190,7 @@ function MangaRow({
             <span className="text-muted-foreground text-[11px] tabular-nums">{progressPct}%</span>
           </span>
         )}
-      </Link>
+      </ViewTransitionLink>
       <div className="flex flex-shrink-0 items-center gap-1">
         <Button
           type="button"
@@ -325,13 +325,15 @@ export default function MangaContent({
                 asChild
                 className="h-11 gap-2.5 rounded-full px-6 text-[15px] font-bold tracking-wide shadow-md"
               >
-                <Link to={chapterReaderHref(cta.chapter.content_id, item.content_id, libraryId)}>
+                <ViewTransitionLink
+                  to={chapterReaderHref(cta.chapter.content_id, item.content_id, libraryId)}
+                >
                   <BookOpen className="size-[18px]" />
                   {cta.verb}
                   <span className="text-primary-foreground/75 text-xs font-semibold">
                     {cta.label}
                   </span>
-                </Link>
+                </ViewTransitionLink>
               </Button>
             )}
             <DropdownMenu modal={false}>

--- a/web/src/pages/ItemDetail/SeasonCarousel.tsx
+++ b/web/src/pages/ItemDetail/SeasonCarousel.tsx
@@ -1,10 +1,10 @@
-import { Link } from "react-router";
 import { Check, ChevronLeft, ChevronRight } from "lucide-react";
 import type { Season } from "@/api/types";
 import { usePrefetchCatalogSeason } from "@/hooks/queries/catalogRead";
 import { useCarouselEmbla } from "@/hooks/useCarouselEmbla";
 import { formatSeasonMeta, getSeasonDisplayTitle } from "./itemDetailLayout";
 import CardPlayOverlay from "@/components/CardPlayOverlay";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 
 interface SeasonCarouselProps {
   seasons: Season[];
@@ -62,7 +62,7 @@ export default function SeasonCarousel({ seasons }: SeasonCarouselProps) {
                   >
                     {/* Poster */}
                     <div className="group/media relative">
-                      <Link
+                      <ViewTransitionLink
                         to={`/item/${season.content_id}`}
                         className="media-card-image relative block aspect-[2/3] overflow-hidden rounded-xl"
                       >
@@ -100,7 +100,7 @@ export default function SeasonCarousel({ seasons }: SeasonCarouselProps) {
                             />
                           </div>
                         )}
-                      </Link>
+                      </ViewTransitionLink>
                       {season.play_content_id ? (
                         <CardPlayOverlay
                           contentId={season.play_content_id}
@@ -111,7 +111,10 @@ export default function SeasonCarousel({ seasons }: SeasonCarouselProps) {
                     </div>
 
                     {/* Info — always the same height */}
-                    <Link to={`/item/${season.content_id}`} className="block px-0.5 pt-2.5">
+                    <ViewTransitionLink
+                      to={`/item/${season.content_id}`}
+                      className="block px-0.5 pt-2.5"
+                    >
                       <div className="truncate text-[13px] font-semibold">
                         {getSeasonDisplayTitle(season)}
                       </div>
@@ -120,7 +123,7 @@ export default function SeasonCarousel({ seasons }: SeasonCarouselProps) {
                           ? `${userData.watched_count} of ${season.episode_count} episodes`
                           : formatSeasonMeta(season)}
                       </div>
-                    </Link>
+                    </ViewTransitionLink>
                   </div>
                 </li>
               );

--- a/web/src/pages/ItemDetail/SeasonContent.tsx
+++ b/web/src/pages/ItemDetail/SeasonContent.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router";
+import { useNavigate } from "react-router";
 import type { ItemDetail } from "@/api/types";
 import { useItemEpisodes } from "@/hooks/queries/episodes";
 import { useRefreshItemMetadata } from "@/hooks/queries/items";
@@ -12,6 +12,7 @@ import CastCarousel from "@/components/CastCarousel";
 import CrewList from "@/components/CrewList";
 import EditMetadataDialog from "@/components/EditMetadataDialog";
 import PageBack from "@/components/PageBack";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 import DetailHero from "./DetailHero";
 import MetadataBadges from "./components/MetadataBadges";
 import WatchedActionBar from "./components/WatchedActionBar";
@@ -71,12 +72,13 @@ export default function SeasonContent({ item }: { item: ItemDetail & { type: "se
   if (episodesError) {
     return (
       <div className="px-4 py-6 sm:px-6 sm:py-10 lg:px-12">
-        <Link
+        <ViewTransitionLink
           to={seriesId ? `/item/${seriesId}` : "/"}
+          up
           className="text-muted-foreground hover:text-foreground text-sm"
         >
           &larr; Back to {seriesTitle}
-        </Link>
+        </ViewTransitionLink>
         <p className="text-muted-foreground mt-6 text-sm">
           {episodesError instanceof Error ? episodesError.message : "Season not found"}
         </p>

--- a/web/src/pages/ItemDetail/components/DetailBreadcrumb.test.tsx
+++ b/web/src/pages/ItemDetail/components/DetailBreadcrumb.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, useLocation, useNavigationType } from "react-router";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resetNavigationHistory } from "@/lib/navigationHistory";
+import DetailBreadcrumb from "./DetailBreadcrumb";
+
+function RouteOutput() {
+  const location = useLocation();
+  return (
+    <>
+      <output aria-label="location">{location.pathname}</output>
+      <output aria-label="navigation type">{useNavigationType()}</output>
+    </>
+  );
+}
+
+const segments = [
+  { label: "The Series", href: "/item/series" },
+  { label: "Season 1", href: "/item/season" },
+  { label: "Episode 1" },
+];
+
+afterEach(() => {
+  resetNavigationHistory();
+  window.history.replaceState(null, "");
+  delete document.documentElement.dataset.navigationDirection;
+});
+
+describe("DetailBreadcrumb", () => {
+  it("renders every crumb, linking all but the current page", () => {
+    render(
+      <MemoryRouter initialEntries={["/item/episode"]}>
+        <DetailBreadcrumb segments={segments} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "The Series" })).toHaveAttribute(
+      "href",
+      "/item/series",
+    );
+    expect(screen.getByRole("link", { name: "Season 1" })).toHaveAttribute("href", "/item/season");
+    expect(screen.queryByRole("link", { name: "Episode 1" })).not.toBeInTheDocument();
+    expect(screen.getByText("Episode 1")).toHaveAttribute("aria-current", "page");
+  });
+
+  it("renders nothing without segments", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <DetailBreadcrumb segments={[]} />
+      </MemoryRouter>,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("navigates backwards to a crumb this page load never recorded", () => {
+    // Landing straight on the episode — a shared link, or a reload — leaves the
+    // map empty, so the crumb pushes. The motion is still backwards.
+    render(
+      <MemoryRouter initialEntries={["/item/episode"]}>
+        <DetailBreadcrumb segments={segments} />
+        <RouteOutput />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Season 1" }));
+
+    expect(screen.getByRole("status", { name: "location" })).toHaveTextContent("/item/season");
+    expect(screen.getByRole("status", { name: "navigation type" })).toHaveTextContent("PUSH");
+    expect(document.documentElement.dataset.navigationDirection).toBe("back");
+  });
+});

--- a/web/src/pages/ItemDetail/components/DetailBreadcrumb.tsx
+++ b/web/src/pages/ItemDetail/components/DetailBreadcrumb.tsx
@@ -1,5 +1,6 @@
-import { Link } from "react-router";
 import { ChevronRight } from "lucide-react";
+
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 
 interface BreadcrumbSegment {
   label: string;
@@ -22,12 +23,15 @@ export default function DetailBreadcrumb({ segments }: DetailBreadcrumbProps) {
             <span key={i} className="flex items-center gap-1.5">
               {i > 0 && <ChevronRight className="text-muted-foreground/40 size-4" />}
               {segment.href && !isLast ? (
-                <Link
+                // Every crumb is an ancestor of this page, so the motion should
+                // read as going up rather than as another descent.
+                <ViewTransitionLink
                   to={segment.href}
+                  up
                   className="text-muted-foreground hover:text-foreground text-[13px] transition-colors"
                 >
                   {segment.label}
-                </Link>
+                </ViewTransitionLink>
               ) : (
                 <span
                   className="text-muted-foreground/60 text-[13px]"

--- a/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
+++ b/web/src/pages/ItemDetail/components/EpisodeCarousel.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from "react";
-import { Link } from "react-router";
 import { Play, ChevronLeft, ChevronRight } from "lucide-react";
 import type { EpisodeListItem } from "@/api/types";
 import { WatchedCheckIndicator } from "@/components/CardWatchedBadge";
@@ -7,6 +6,7 @@ import { toEpisodeUserState } from "@/components/episodeUserState";
 import { decodeThumbhash } from "@/lib/thumbhash";
 import { cn } from "@/lib/utils";
 import MediaItemMenu from "@/components/MediaItemMenu";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 import type { EpisodeNavigationState } from "../itemDetailLayout";
 import { useCarouselEmbla } from "@/hooks/useCarouselEmbla";
 import { usePrefetchCatalogItemDetail } from "@/hooks/queries/catalogRead";
@@ -125,7 +125,7 @@ function EpisodeCarouselCard({
         {...prefetchHandlers}
       >
         <div className="relative">
-          <Link
+          <ViewTransitionLink
             to={`/item/${ep.content_id}`}
             state={episodeLinkState}
             aria-current={isCurrent ? "page" : undefined}
@@ -175,7 +175,7 @@ function EpisodeCarouselCard({
                 </div>
               )}
             </div>
-          </Link>
+          </ViewTransitionLink>
           <MediaItemMenu
             contentId={ep.content_id}
             mediaType="episode"
@@ -189,7 +189,7 @@ function EpisodeCarouselCard({
             itemTitle={episodeTitle}
           />
         </div>
-        <Link
+        <ViewTransitionLink
           to={`/item/${ep.content_id}`}
           state={episodeLinkState}
           aria-current={isCurrent ? "page" : undefined}
@@ -206,7 +206,7 @@ function EpisodeCarouselCard({
             {episodeTitle}
           </p>
           {ep.runtime > 0 && <p className="text-muted-foreground/70 text-xs">{ep.runtime}m</p>}
-        </Link>
+        </ViewTransitionLink>
       </div>
     </li>
   );

--- a/web/src/pages/ItemDetail/components/HeroCrewLine.tsx
+++ b/web/src/pages/ItemDetail/components/HeroCrewLine.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 import type { CrewMember } from "@/api/types";
 import { buildPersonCatalogHref } from "@/pages/catalogSearchParams";
 
@@ -20,12 +20,12 @@ function CrewNames({ people }: { people: CrewPerson[] }) {
         <span key={p.name}>
           {i > 0 && ", "}
           {p.personId ? (
-            <Link
+            <ViewTransitionLink
               to={buildPersonCatalogHref(p.personId)}
               className="text-foreground/70 hover:text-foreground/90 font-medium transition-colors"
             >
               {p.name}
-            </Link>
+            </ViewTransitionLink>
           ) : (
             <span className="text-foreground/70 font-medium">{p.name}</span>
           )}

--- a/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
+++ b/web/src/pages/ItemDetail/components/SeasonEpisodeGrid.tsx
@@ -1,11 +1,11 @@
 import { useRef } from "react";
-import { Link } from "react-router";
 import { Play } from "lucide-react";
 import type { EpisodeListItem } from "@/api/types";
 import { WatchedCheckIndicator } from "@/components/CardWatchedBadge";
 import { toEpisodeUserState } from "@/components/episodeUserState";
 import MediaItemMenu from "@/components/MediaItemMenu";
 import CardOverlays from "@/components/overlays/CardOverlays";
+import ViewTransitionLink from "@/components/ViewTransitionLink";
 import { useOverlayPrefs } from "@/hooks/useOverlayPrefs";
 import { usePrefetchCatalogItemDetail } from "@/hooks/queries/catalogRead";
 import { useDwellPrefetch } from "@/hooks/useDwellPrefetch";
@@ -98,7 +98,11 @@ function SeasonEpisodeCard({
   return (
     <div ref={cardRef} className="group/card media-card media-card-longpress" {...prefetchHandlers}>
       <div className="relative">
-        <Link to={`/item/${episode.content_id}`} state={episodeLinkState} className="group block">
+        <ViewTransitionLink
+          to={`/item/${episode.content_id}`}
+          state={episodeLinkState}
+          className="group block"
+        >
           <div className="media-card-image relative aspect-video">
             {episode.still_url ? (
               <img
@@ -140,7 +144,7 @@ function SeasonEpisodeCard({
               </div>
             )}
           </div>
-        </Link>
+        </ViewTransitionLink>
         <MediaItemMenu
           contentId={episode.content_id}
           mediaType="episode"
@@ -154,7 +158,11 @@ function SeasonEpisodeCard({
           itemTitle={episodeTitle}
         />
       </div>
-      <Link to={`/item/${episode.content_id}`} state={episodeLinkState} className="block">
+      <ViewTransitionLink
+        to={`/item/${episode.content_id}`}
+        state={episodeLinkState}
+        className="block"
+      >
         <div className="text-muted-foreground mt-2 flex items-center gap-2 text-xs">
           <span>Episode {episode.episode_number}</span>
           {episode.user_data?.played && <WatchedCheckIndicator className="ml-auto" />}
@@ -179,7 +187,7 @@ function SeasonEpisodeCard({
             </p>
           )}
         </div>
-      </Link>
+      </ViewTransitionLink>
     </div>
   );
 }

--- a/web/src/pages/RecommendationsSection.tsx
+++ b/web/src/pages/RecommendationsSection.tsx
@@ -83,7 +83,7 @@ export default function RecommendationsSection() {
 
   return (
     <div className="relative space-y-6 px-4 pt-6 pb-12 sm:px-6 lg:px-10 xl:px-12">
-      <PageBack to="/recommendations" preferHistory={false} />
+      <PageBack to="/recommendations" up />
       <div className="mt-10 flex flex-col gap-1.5 sm:mt-12">
         <h1 className="text-foreground text-2xl font-bold tracking-tight sm:text-3xl">{title}</h1>
         {data && data.items.length > 0 && (

--- a/web/src/pages/RequestBrowse.tsx
+++ b/web/src/pages/RequestBrowse.tsx
@@ -84,7 +84,7 @@ export default function RequestBrowse({ kind }: RequestBrowseProps) {
   if (browse.isError && (browse.error as { status?: number }).status === 404) {
     return (
       <div className="relative space-y-4 py-10 text-center">
-        <PageBack to="/requests" preferHistory={false} />
+        <PageBack to="/requests" up />
         <p className="text-foreground mt-10 text-lg font-semibold sm:mt-12">
           {kind === "studio" ? "Studio" : kind === "network" ? "Network" : "Genre"} not found.
         </p>
@@ -94,7 +94,7 @@ export default function RequestBrowse({ kind }: RequestBrowseProps) {
 
   return (
     <div className="relative space-y-6 py-6 sm:py-8">
-      <PageBack to="/requests" preferHistory={false} />
+      <PageBack to="/requests" up />
       <div className="mt-10 space-y-4 px-4 sm:mt-12 sm:px-6 lg:px-10 xl:px-12">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div className="flex min-w-0 items-center gap-4">

--- a/web/src/pages/SettingsLayout.tsx
+++ b/web/src/pages/SettingsLayout.tsx
@@ -527,7 +527,7 @@ export default function SettingsLayout() {
         {activeSegment ? (
           <>
             <div className="hidden lg:block">
-              <PageBack to="/" preferHistory={false} floating />
+              <PageBack to="/" up floating />
             </div>
             <Link
               to="/settings"
@@ -599,7 +599,7 @@ export default function SettingsLayout() {
           </>
         ) : (
           <>
-            <PageBack to="/" preferHistory={false} floating />
+            <PageBack to="/" up floating />
             <div className="page-header mt-10 mb-6 gap-5 sm:mt-12 sm:mb-8">
               <div className="min-w-0 space-y-3">
                 <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Settings</h1>

--- a/web/src/pages/SmartCollectionWizard.tsx
+++ b/web/src/pages/SmartCollectionWizard.tsx
@@ -125,7 +125,7 @@ export default function SmartCollectionWizard(wizard: SmartCollectionWizardProps
 
   return (
     <div className="page-shell-wide relative space-y-6 py-4 sm:py-6">
-      <PageBack to={backTarget} preferHistory={false} />
+      <PageBack to={backTarget} up />
       <WizardHeader title={headerTitle} step={step} isEdit={isEdit} />
 
       {step === 1 ? (

--- a/web/src/pages/WatchTogetherJoin.tsx
+++ b/web/src/pages/WatchTogetherJoin.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useSearchParams } from "react-router";
 import { ApiClientError } from "@/api/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
 import {
   createWatchTogetherRoom,
   joinWatchTogetherRoom,
@@ -43,7 +44,7 @@ const selectionModeOptions = [
 
 export default function WatchTogetherJoin() {
   useDocumentTitle("Watch Party");
-  const navigate = useNavigate();
+  const navigate = useViewTransitionNavigate();
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token")?.trim() ?? "";
   const [code, setCode] = useState("");
@@ -91,7 +92,6 @@ export default function WatchTogetherJoin() {
         }
         navigate(`/rooms/${response.room.room_id}?room_token=${response.room_access_token}`, {
           replace: true,
-          viewTransition: true,
         });
       } catch (joinError) {
         setError(describeJoinError(joinError));
@@ -112,7 +112,6 @@ export default function WatchTogetherJoin() {
       }
       navigate(`/rooms/${response.room.room_id}?room_token=${response.room_access_token}`, {
         replace: true,
-        viewTransition: true,
       });
     } catch (createError) {
       setError(createError instanceof Error ? createError.message : "Failed to create room.");

--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -13,7 +13,7 @@ import {
 import { flushSync } from "react-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { Pause, PictureInPicture2, Play, SkipBack, SkipForward, Tv, X } from "lucide-react";
-import { useLocation, useNavigate } from "react-router";
+import { useLocation } from "react-router";
 import type { WatchDetail } from "@/api/types";
 import { getAccessToken, getOrCreateDeviceId, getProfileToken } from "@/api/client";
 import { Button } from "@/components/ui/button";
@@ -33,6 +33,7 @@ import { applyPlaybackProgressToCache } from "@/hooks/queries/playbackProgressCa
 import { invalidatePlaybackSurfaceQueries } from "@/hooks/queries/playbackSurfaceRefresh";
 import { useAuth } from "@/hooks/useAuth";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
+import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
 import { PlayerConfigProvider, type PlayerConfig } from "@/player/context/PlayerConfigContext";
 import type {
   EpisodeRef,
@@ -170,7 +171,7 @@ function PlaybackPreparingScreen() {
 }
 
 export function WatchPlaybackProvider({ children }: { children: ReactNode }) {
-  const navigate = useNavigate();
+  const navigate = useViewTransitionNavigate();
   const [state, dispatch] = useReducer(watchPlaybackReducer, undefined, createEmptyPlaybackState);
   const stateRef = useRef(state);
   const suppressNextPictureInPictureExitRef = useRef<string | null>(null);
@@ -233,7 +234,6 @@ export function WatchPlaybackProvider({ children }: { children: ReactNode }) {
 
         navigate(buildWatchHref(request), {
           state: buildWatchLocationState(request),
-          viewTransition: true,
         });
       };
 
@@ -309,7 +309,6 @@ export function WatchPlaybackProvider({ children }: { children: ReactNode }) {
     navigate(buildWatchHref(request), {
       replace: true,
       state: buildWatchLocationState(request),
-      viewTransition: true,
     });
   }, [navigate]);
 
@@ -415,7 +414,7 @@ export function WatchPlaybackHost() {
   } = controller;
   const queryClient = useQueryClient();
   const location = useLocation();
-  const navigate = useNavigate();
+  const navigate = useViewTransitionNavigate();
   const { user } = useAuth();
   const { profile: currentProfile } = useCurrentProfile();
   const canEditMarkers = canEditMarkersForUser(user, currentProfile);
@@ -526,7 +525,7 @@ export function WatchPlaybackHost() {
     const prefetchAndNavigate = async () => {
       if (request.returnHref) {
         clearPendingReturnNavigation(request.requestKey);
-        navigate(returnHref, { replace: true });
+        navigate(returnHref, { up: true, replace: true });
         return;
       }
 
@@ -541,7 +540,7 @@ export function WatchPlaybackHost() {
 
       if (!cancelled) {
         clearPendingReturnNavigation(request.requestKey);
-        navigate(fallbackItemHref, { replace: true });
+        navigate(fallbackItemHref, { up: true, replace: true });
       }
     };
 
@@ -606,9 +605,11 @@ export function WatchPlaybackHost() {
       if (activeRequest) {
         if (exitState?.destinationHref) {
           exitPlayback({ destinationHref: exitState.destinationHref });
+          // Leaving playback is backward motion, but `replace` still stands:
+          // the watch entry must not survive for Forward to walk back into.
           navigate(exitState.destinationHref, {
+            up: true,
             replace: true,
-            viewTransition: true,
           });
           return;
         }
@@ -616,8 +617,8 @@ export function WatchPlaybackHost() {
         if (activeRequest.roomId && activeRequest.roomToken) {
           exitPlayback();
           navigate(`/rooms/${activeRequest.roomId}?room_token=${activeRequest.roomToken}`, {
+            up: true,
             replace: true,
-            viewTransition: true,
             state: {
               suppressAutoStartSelection: {
                 contentId: activeRequest.contentId,
@@ -631,8 +632,8 @@ export function WatchPlaybackHost() {
 
         exitPlayback();
         navigate(buildPlaybackReturnHref(activeRequest), {
+          up: true,
           replace: true,
-          viewTransition: true,
         });
         return;
       }
@@ -656,8 +657,8 @@ export function WatchPlaybackHost() {
         minimizePlayback();
       });
       navigate(returnHref, {
+        up: true,
         replace: true,
-        viewTransition: true,
       });
     },
     [activeRequest, applyExitStateToCache, minimizePlayback, navigate, state.mode],
@@ -669,7 +670,6 @@ export function WatchPlaybackHost() {
       if (activeRequest.roomId && activeRequest.roomToken) {
         navigate(`/rooms/${activeRequest.roomId}?room_token=${activeRequest.roomToken}`, {
           replace: true,
-          viewTransition: true,
         });
         return;
       }
@@ -739,8 +739,8 @@ export function WatchPlaybackHost() {
       if (activeRequest?.roomId && activeRequest.roomToken) {
         stopPlayback();
         navigate(`/rooms/${activeRequest.roomId}?room_token=${activeRequest.roomToken}`, {
+          up: true,
           replace: true,
-          viewTransition: true,
         });
         return;
       }
@@ -774,7 +774,7 @@ export function WatchPlaybackHost() {
       if (!activeItem?.series_id) {
         if (activeRequest) {
           stopPlayback();
-          navigate(buildWatchItemHref(activeRequest));
+          navigate(buildWatchItemHref(activeRequest), { up: true });
         }
         return;
       }
@@ -799,7 +799,7 @@ export function WatchPlaybackHost() {
   const handlePostRollClose = useCallback(() => {
     if (activeRequest) {
       stopPlayback();
-      navigate(buildWatchItemHref(activeRequest));
+      navigate(buildWatchItemHref(activeRequest), { up: true });
     }
   }, [activeRequest, stopPlayback, navigate]);
 


### PR DESCRIPTION
## Problem

Related issue: N/A — the last outstanding piece of #805, rebuilt against `main`.

Series → Season → Episode never moved. Those navigations do not cross the
Home/item boundary, so the sidebar collapse that gives Home → item its motion never
runs, and `main-content` fell back to the same fade-out/slide-up used for an
unrelated route change. Going *up* a breadcrumb looked identical to going down.

## Approach

`main-content` slides horizontally on the sidebar's own duration and easing tokens,
in the direction the navigation is travelling, so a breadcrumb reads as the reverse
of the push that created it. Direction is stamped on
`html[data-navigation-direction]` before the router opens the transition; when it
cannot be derived the attribute is absent and the neutral transition plays rather
than guessing a side.

**This is deliberately not a navigation provider.** #805 proposed 568 lines that
hand-rolled a view-transition commit barrier, sequence numbers, an abandonment
timeout and a WAAPI slide, because `BrowserRouter`'s POP is async. `main` has since
moved to a data router, and reading the installed react-router 8.3.0 source shows it
owns all of that: `RouterProvider` holds its update callback until
`state.location.key === pendingState.location.key` (`lib/components.js:237`),
restarts on interruption, and replays transitions on POP from
`appliedViewTransitions` (`lib/router/router.js`). What is left is the one thing the
router does not do — which way the page is moving — and that is all this adds.

**Two decisions worth reviewing:**

*Root snapshot scoping.* The sidebar collapse is a live CSS transition running across
the same navigation, and a frozen root snapshot cross-fades the old 260px sidebar
over it. The root group is held still **inside the sidebar shell only**, keyed off
`data-app-shell`. `main-content` is named in `Layout` and nowhere else, so
suppressing the root globally would leave `/watch`, `/reader/*`, `/admin/*` and the
auth screens with no captured element at all — trading one visual defect for a
broader one.

*No history provenance map.* A path→index mirror would let a breadcrumb
`navigate(-n)` and unwind to an entry already behind the user instead of pushing a
duplicate. It cannot be made sound here: React Router derives a push index as
`getIndex() + 1` over `(globalHistory.state || { idx: null }).idx`
(`lib/router/history.js:282-284`, `:300`), so an entry landing without an `idx`
makes `null + 1 === 1` and restarts the numbering while the real stack keeps
growing. This app ships the trigger — the "Skip to content" links in `Layout` and
`AdminLayout` are raw `<a href="#main-content">`, which push an unindexed entry and
fire `hashchange`, which the router does not listen for. A stale delta lands the user
on a page they never asked for; a duplicate history entry is merely untidy.
Breadcrumbs push.

## Resolved during review: the Back half

The first revision of this branch shipped with browser Back falling back to the
neutral animation. Recorded here because the failure mode is worth knowing about.

`popstate` is a discrete event, so React flushes the router's state update
*synchronously inside the router's own listener*, which is registered at router
creation where ours could only be registered later from an effect. Ours always ran
second, after the location effect had advanced the tracked index to the destination,
so every pop compared an index against itself and cleared the attribute.

The flaw was two writers to the tracked index with no guaranteed order. The fix is
one writer: `resolveCommittedDirection` runs from the location effect, the only place
that sees every commit exactly once, and the popstate listener is gone. Fixed in
21d853ad and verified in a real browser — link click stamps `forward`, browser Back
stamps `back`, browser Forward stamps `forward`.

Worth knowing for how you weigh the tests: **every direction test uses `MemoryRouter`,
which registers no popstate listener at all**, so the entire suite passed while half
the feature was dead. The tests now drive real router navigations and say so in the
file header. They pin the arithmetic; the ordering is structural rather than racy,
which is what makes them meaningful.

## Validation

- `pnpm run build` — passed
- `pnpm exec vitest run` — 2667 passed
- `pnpm run lint` — 0 errors (168 warnings, unchanged from this branch's base)
- `pnpm run format:check` — passed

Verified live in a signed-in session: `data-app-shell` is set inside `Layout`, the
scoped root rule applies, the root still computes `view-transition-name: root` (so
routes outside `Layout` keep their snapshot), and a forward navigation stamps
`data-navigation-direction="forward"`.

## Risks

The direction attribute's whole value depends on landing before the browser
snapshots. Both directions are confirmed live, but only in Chrome — the ordering
argument is about React's discrete-event flushing rather than anything
browser-specific, so it should hold, but it has not been checked elsewhere.

`data-app-shell` is a new coupling between `Layout` and `app.css`. It is asserted in
`navigationTransitionCss.test.ts`, but that test greps stylesheet source — it cannot
prove a rule matches at runtime.

## Provenance

Replaces the navigation half of #805 by @blurbery. The profiling and the original
problem statement are theirs; the implementation is new, because the premise that
branch was built on (BrowserRouter, no native commit barrier) no longer holds.

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-opus-5[1m]
- Involvement: Fully AI-generated, human verified — @Quick104 chose to drop the
  history-provenance unwind after review and directed the scope.
- Adversarial review: built by a multi-agent workflow (recon → implement → verify)
  whose review agent found a blocker and three majors against the first draft. The
  blocker (the provenance map sending users to the wrong page) and two majors were
  resolved by dropping the unwind entirely; the third by scoping the root
  suppression. The router-ownership claims were verified against the installed
  react-router source, not documentation, and a second opinion from a different
  model independently confirmed them before any code was written. The Back-half
  defect above was then found by live browser verification after the gate was green.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

