### PR TITLE
fix(search): rebuild stale Meilisearch indexes automatically

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1134,6 +1134,7 @@ func main() {
 		OpsLogRepo:                   opsRepo,
 		FFmpegLogSink:                playback.NewSlogFFmpegLogSink(slog.Default(), nodeID),
 		PublicURL:                    os.Getenv("SILO_PUBLIC_URL"),
+		CatalogSearchSettings:        new(catalogSearchStartupSettings),
 		RequestServerRestart: func(context.Context) error {
 			if !restartRequested.CompareAndSwap(false, true) {
 				return handlers.ErrServerRestartAlreadyRequested
@@ -2382,7 +2383,7 @@ func main() {
 				metadata.NewArtworkRevisionGarbageCollector(deps.DB, deps.S3Public),
 			))
 		}
-		catalogSearchIndexer := catalog.NewCatalogSearchIndexer(deps.DB, settingsRepo)
+		catalogSearchIndexer := catalog.NewCatalogSearchIndexerFromSettings(deps.DB, settingsRepo, catalogSearchStartupSettings)
 		taskMgr.Register(tasks.NewSyncCatalogSearchIndexTask(catalogSearchIndexer))
 		taskMgr.Register(tasks.NewRebuildCatalogSearchIndexTask(catalogSearchIndexer))
 		taskMgr.Register(tasks.NewCatalogSearchEventRetentionTask(catalog.NewSearchIndexEventRepository(deps.DB)))
@@ -2961,9 +2962,8 @@ func main() {
 			if watchProviderService != nil {
 				compatDeps.WatchScrobbler = watchProviderService
 			}
-			compatSearchService := catalog.NewCatalogSearchService(
-				appCtx,
-				settingsRepo,
+			compatSearchService := catalog.NewCatalogSearchServiceFromSettings(
+				catalogSearchStartupSettings,
 				itemRepo,
 				catalog.NewSearchIndexEventRepository(deps.DB),
 				deps.CatalogSearchVectorizer,

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -76,6 +76,21 @@ Some settings are only read at startup. Two routes carry that contract:
 | `restart_mark_count` | int | Increments on every restart-required save. Because the boolean latches, this counter is the only signal that a **new** requirement arrived — the admin UI re-arms its dismissed restart banner on it. |
 | `restart_requested`, `restart_requested_at` | bool, RFC3339 string | An in-app restart was requested, and when. |
 
+## Catalog search status
+
+`GET /api/v1/admin/catalog/search/status` reports the configured search
+provider, the provider currently answering requests, Meilisearch health, index
+state, semantic readiness, and links to the search maintenance tasks.
+
+`active_provider` describes the route requests actually take; it is not merely
+the configured provider. `degraded` and the optional `degraded_reason` explain
+temporary fallback or keyword-only operation. `index.rebuild_required` is true
+when the active index does not match the current settings. Background search
+maintenance runs at startup and every minute: it rebuilds a missing or stale
+index, then resumes incremental event sync. When the prior index is known to
+have the same document and media scope, Meilisearch continues serving keyword
+search while the replacement is built; otherwise searches use PostgreSQL.
+
 ## `GET /api/v1/admin/nodes`
 
 Lists every registered stream node — proxy and transcode alike — with its

--- a/docs/wiki/deployment/docker.md
+++ b/docs/wiki/deployment/docker.md
@@ -325,9 +325,15 @@ alternative provider:
 3. In **Admin > Settings > Search**, select Meilisearch, set the URL to
    `http://meilisearch:7700`, enter the same key as the API key, test the
    connection, and save.
-4. Restart Silo and rebuild the catalog search index from the same page.
+4. Restart Silo. Background search maintenance builds the catalog search index
+   automatically and retries failures every minute. The Search status panel
+   shows whether Meilisearch, keyword-only Meilisearch, or PostgreSQL is serving
+   requests while the build runs; the manual rebuild action remains available.
 
 Silo continues to use PostgreSQL full-text search until Meilisearch is selected.
+Settings that change the index format, including enabling meaning-based search,
+also trigger an automatic background rebuild after restart. A compatible older
+Meilisearch index keeps serving keyword results while its replacement is built.
 
 ## External PostgreSQL and Redis
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -136,6 +136,9 @@ type Dependencies struct {
 	Recommender               recommendations.Recommender // nil when disabled
 	RecWorker                 *recommendations.Worker     // nil when disabled
 	CatalogSearchVectorizer   catalog.CatalogSearchQueryVectorizer
+	// CatalogSearchSettings is the process-lifetime startup snapshot shared by
+	// every native/jellycompat provider and the index maintenance worker.
+	CatalogSearchSettings     *catalog.CatalogSearchSettings
 	RatingsRepo               *catalog.RatingsRepo
 	PersonRepo                *catalog.PersonRepository
 	PersonRefreshQueue        handlers.PersonRefreshQueue
@@ -603,13 +606,22 @@ func NewRouter(deps Dependencies) chi.Router {
 		browseRepo := catalog.NewBrowseRepository(deps.DB)
 		itemRepo = catalog.NewItemRepository(deps.DB)
 		searchIndexEvents := catalog.NewSearchIndexEventRepository(deps.DB)
-		catalogSearchService = catalog.NewCatalogSearchService(
-			context.Background(),
-			settingsRepo,
-			itemRepo,
-			searchIndexEvents,
-			deps.CatalogSearchVectorizer,
-		)
+		if deps.CatalogSearchSettings != nil {
+			catalogSearchService = catalog.NewCatalogSearchServiceFromSettings(
+				*deps.CatalogSearchSettings,
+				itemRepo,
+				searchIndexEvents,
+				deps.CatalogSearchVectorizer,
+			)
+		} else {
+			catalogSearchService = catalog.NewCatalogSearchService(
+				context.Background(),
+				settingsRepo,
+				itemRepo,
+				searchIndexEvents,
+				deps.CatalogSearchVectorizer,
+			)
+		}
 		if catalogSearchService != nil {
 			catalogSearchService.StartCoverageRefresh(deps.AppContext)
 		}

--- a/internal/catalog/search_indexer.go
+++ b/internal/catalog/search_indexer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -22,16 +23,19 @@ type SearchIndexProgressReporter interface {
 }
 
 type CatalogSearchIndexSyncStats struct {
-	Configured      bool   `json:"configured"`
-	Skipped         bool   `json:"skipped"`
-	Reason          string `json:"reason,omitempty"`
-	Events          int    `json:"events"`
-	Upserted        int    `json:"upserted"`
-	Deleted         int    `json:"deleted"`
-	ActiveIndexUID  string `json:"active_index_uid,omitempty"`
-	DocumentCount   int    `json:"document_count"`
-	VectorDocCount  int    `json:"vector_document_count"`
-	LastProcessedID int64  `json:"last_processed_event_id,omitempty"`
+	Configured       bool   `json:"configured"`
+	Skipped          bool   `json:"skipped"`
+	Reason           string `json:"reason,omitempty"`
+	RebuildAttempted bool   `json:"rebuild_attempted"`
+	Rebuilt          bool   `json:"rebuilt"`
+	Events           int    `json:"events"`
+	Upserted         int    `json:"upserted"`
+	Deleted          int    `json:"deleted"`
+	ActiveIndexUID   string `json:"active_index_uid,omitempty"`
+	DocumentCount    int    `json:"document_count"`
+	VectorDocCount   int    `json:"vector_document_count"`
+	RemovedIndexes   int    `json:"removed_indexes"`
+	LastProcessedID  int64  `json:"last_processed_event_id,omitempty"`
 }
 
 type CatalogSearchIndexRebuildStats struct {
@@ -70,6 +74,7 @@ const catalogSearchExcludeMangaChaptersSQL = `NOT EXISTS (SELECT 1 FROM manga_ch
 type CatalogSearchIndexer struct {
 	pool          *pgxpool.Pool
 	settingsStore SettingsStore
+	runtime       *CatalogSearchSettings
 	events        *SearchIndexEventRepository
 }
 
@@ -77,6 +82,21 @@ func NewCatalogSearchIndexer(pool *pgxpool.Pool, settingsStore SettingsStore) *C
 	return &CatalogSearchIndexer{
 		pool:          pool,
 		settingsStore: settingsStore,
+		events:        NewSearchIndexEventRepository(pool),
+	}
+}
+
+// NewCatalogSearchIndexerFromSettings binds scheduled and manual maintenance
+// to the same process-lifetime settings snapshot as the serving search
+// provider. Catalog search settings are restart-bound; rereading saved values
+// on the minute interval could otherwise publish an index the live provider
+// does not understand before the server restarts.
+func NewCatalogSearchIndexerFromSettings(pool *pgxpool.Pool, settingsStore SettingsStore, settings CatalogSearchSettings) *CatalogSearchIndexer {
+	settings.IndexTypes = slices.Clone(settings.IndexTypes)
+	return &CatalogSearchIndexer{
+		pool:          pool,
+		settingsStore: settingsStore,
+		runtime:       new(settings),
 		events:        NewSearchIndexEventRepository(pool),
 	}
 }
@@ -90,8 +110,15 @@ func (i *CatalogSearchIndexer) ShouldSyncRun(ctx context.Context) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	if state.ActiveIndexUID == "" || state.SchemaVersion != catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized) {
-		return false, nil
+	if catalogSearchIndexRequiresRebuild(state, catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized)) {
+		if catalogSearchIndexHasNewerSchema(state) {
+			return false, nil
+		}
+		matches, err := i.runtimeMatchesDesiredSettings(ctx, settings)
+		if err != nil || !matches {
+			return false, err
+		}
+		return true, nil
 	}
 	pending, err := i.events.PendingCount(ctx, SearchProviderMeilisearch)
 	if err != nil {
@@ -137,12 +164,36 @@ func (i *CatalogSearchIndexer) SyncOutbox(ctx context.Context, progress SearchIn
 	if err != nil {
 		return stats, err
 	}
-	if state.ActiveIndexUID == "" || state.SchemaVersion != catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized) {
-		stats.Skipped = true
-		stats.Reason = "active search index is missing or stale; run rebuild_catalog_search_index"
+	if catalogSearchIndexRequiresRebuild(state, catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized)) {
+		if catalogSearchIndexHasNewerSchema(state) {
+			stats.Skipped = true
+			stats.Reason = "active search index was built by a newer server version"
+			setSearchIndexTaskResult(progress, stats)
+			reportSearchIndexProgress(progress, 100, "A newer server version owns the active search index")
+			return stats, nil
+		}
+		matches, matchErr := i.runtimeMatchesDesiredSettings(ctx, settings)
+		if matchErr != nil {
+			return stats, matchErr
+		}
+		if !matches {
+			stats.Skipped = true
+			stats.Reason = "saved search settings are waiting for a server restart"
+			setSearchIndexTaskResult(progress, stats)
+			reportSearchIndexProgress(progress, 100, "Restart Silo before rebuilding the catalog search index")
+			return stats, nil
+		}
+		stats.RebuildAttempted = true
+		rebuildStats, rebuildErr := i.rebuildLocked(ctx, progress, settings, client)
+		stats.Rebuilt = !rebuildStats.Skipped && rebuildErr == nil
+		stats.Skipped = rebuildStats.Skipped
+		stats.Reason = rebuildStats.Reason
+		stats.ActiveIndexUID = rebuildStats.ActiveIndexUID
+		stats.DocumentCount = rebuildStats.DocumentCount
+		stats.VectorDocCount = rebuildStats.VectorDocCount
+		stats.RemovedIndexes = rebuildStats.RemovedIndexes
 		setSearchIndexTaskResult(progress, stats)
-		reportSearchIndexProgress(progress, 100, "Catalog search index needs a rebuild")
-		return stats, nil
+		return stats, rebuildErr
 	}
 	stats.ActiveIndexUID = state.ActiveIndexUID
 
@@ -238,6 +289,14 @@ func (i *CatalogSearchIndexer) SyncOutbox(ctx context.Context, progress SearchIn
 	return stats, nil
 }
 
+func catalogSearchIndexRequiresRebuild(state SearchIndexState, expectedSchemaVersion int) bool {
+	return state.ActiveIndexUID == "" || state.SchemaVersion != expectedSchemaVersion
+}
+
+func catalogSearchIndexHasNewerSchema(state SearchIndexState) bool {
+	return state.ActiveIndexUID != "" && state.SchemaVersion/1_000_000 > SearchMeilisearchSchemaVersion
+}
+
 func (i *CatalogSearchIndexer) Rebuild(ctx context.Context, progress SearchIndexProgressReporter) (CatalogSearchIndexRebuildStats, error) {
 	stats := CatalogSearchIndexRebuildStats{}
 	settings, client, ok, err := i.loadClient(ctx)
@@ -252,6 +311,17 @@ func (i *CatalogSearchIndexer) Rebuild(ctx context.Context, progress SearchIndex
 		return stats, nil
 	}
 	stats.Configured = true
+	matches, err := i.runtimeMatchesDesiredSettings(ctx, settings)
+	if err != nil {
+		return stats, err
+	}
+	if !matches {
+		stats.Skipped = true
+		stats.Reason = "saved search settings are waiting for a server restart"
+		setSearchIndexTaskResult(progress, stats)
+		reportSearchIndexProgress(progress, 100, "Restart Silo before rebuilding the catalog search index")
+		return stats, nil
+	}
 
 	lock, locked, err := pglock.TryAcquire(ctx, i.pool, searchIndexMaintenanceLockID)
 	if err != nil {
@@ -270,6 +340,31 @@ func (i *CatalogSearchIndexer) Rebuild(ctx context.Context, progress SearchIndex
 				"component", "catalog", "error", err)
 		}
 	}()
+	state, err := i.events.GetState(ctx, SearchProviderMeilisearch)
+	if err != nil {
+		return stats, err
+	}
+	if catalogSearchIndexHasNewerSchema(state) {
+		stats.Skipped = true
+		stats.Reason = "active search index was built by a newer server version"
+		setSearchIndexTaskResult(progress, stats)
+		reportSearchIndexProgress(progress, 100, "A newer server version owns the active search index")
+		return stats, nil
+	}
+
+	return i.rebuildLocked(ctx, progress, settings, client)
+}
+
+// rebuildLocked builds and atomically publishes a replacement index. The
+// caller must hold searchIndexMaintenanceLockID so the scheduled sync path and
+// manual forced rebuilds cannot race across server nodes.
+func (i *CatalogSearchIndexer) rebuildLocked(
+	ctx context.Context,
+	progress SearchIndexProgressReporter,
+	settings CatalogSearchSettings,
+	client *meilisearchClient,
+) (CatalogSearchIndexRebuildStats, error) {
+	stats := CatalogSearchIndexRebuildStats{Configured: true}
 
 	rebuildEventHighWater, err := i.events.MaxEventID(ctx, SearchProviderMeilisearch)
 	if err != nil {
@@ -522,6 +617,21 @@ func (i *CatalogSearchIndexer) loadClient(ctx context.Context) (CatalogSearchSet
 }
 
 func (i *CatalogSearchIndexer) loadMeilisearchRuntime(ctx context.Context) (CatalogSearchSettings, bool, error) {
+	if i != nil && i.runtime != nil {
+		settings := *i.runtime
+		if i.settingsStore != nil {
+			var err error
+			settings, err = LoadCatalogSearchSettings(ctx, i.settingsStore)
+			if err != nil {
+				return settings, false, err
+			}
+		}
+		applyCatalogSearchStartupSettings(&settings, *i.runtime)
+		if settings.Provider != SearchProviderMeilisearch || strings.TrimSpace(settings.MeilisearchURL) == "" {
+			return settings, false, nil
+		}
+		return settings, true, nil
+	}
 	settings, err := LoadCatalogSearchSettings(ctx, i.settingsStore)
 	if err != nil {
 		return settings, false, err
@@ -530,6 +640,39 @@ func (i *CatalogSearchIndexer) loadMeilisearchRuntime(ctx context.Context) (Cata
 		return settings, false, nil
 	}
 	return settings, true, nil
+}
+
+func (i *CatalogSearchIndexer) runtimeMatchesDesiredSettings(ctx context.Context, runtime CatalogSearchSettings) (bool, error) {
+	if i == nil || i.runtime == nil || i.settingsStore == nil {
+		return true, nil
+	}
+	desired, err := LoadCatalogSearchSettings(ctx, i.settingsStore)
+	if err != nil {
+		return false, err
+	}
+	return catalogSearchMaintenanceTargetEqual(runtime, desired), nil
+}
+
+func applyCatalogSearchStartupSettings(settings *CatalogSearchSettings, startup CatalogSearchSettings) {
+	settings.Provider = startup.Provider
+	settings.MeilisearchURL = startup.MeilisearchURL
+	settings.MeilisearchAPIKey = startup.MeilisearchAPIKey
+	settings.MeilisearchIndex = startup.MeilisearchIndex
+	settings.IndexTypes = slices.Clone(startup.IndexTypes)
+	settings.SemanticEnabled = startup.SemanticEnabled
+	settings.Embedder = startup.Embedder
+	settings.BinaryQuantized = startup.BinaryQuantized
+}
+
+func catalogSearchMaintenanceTargetEqual(left, right CatalogSearchSettings) bool {
+	return left.Provider == right.Provider &&
+		left.MeilisearchURL == right.MeilisearchURL &&
+		left.MeilisearchAPIKey == right.MeilisearchAPIKey &&
+		left.MeilisearchIndex == right.MeilisearchIndex &&
+		slices.Equal(left.IndexTypes, right.IndexTypes) &&
+		left.SemanticEnabled == right.SemanticEnabled &&
+		left.Embedder == right.Embedder &&
+		left.BinaryQuantized == right.BinaryQuantized
 }
 
 func (i *CatalogSearchIndexer) CheckConnection(ctx context.Context, settings CatalogSearchSettings) error {

--- a/internal/catalog/search_indexer.go
+++ b/internal/catalog/search_indexer.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,11 +107,25 @@ func (i *CatalogSearchIndexer) ShouldSyncRun(ctx context.Context) (bool, error) 
 	if err != nil || !ok || settings.Provider != SearchProviderMeilisearch {
 		return false, err
 	}
+	client, err := newMeilisearchClient(settings.MeilisearchURL, settings.MeilisearchAPIKey, settings.Timeout)
+	if err != nil {
+		return false, err
+	}
 	state, err := i.events.GetState(ctx, SearchProviderMeilisearch)
 	if err != nil {
 		return false, err
 	}
-	if catalogSearchIndexRequiresRebuild(state, catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized)) {
+	rebuildRequired, err := catalogSearchIndexRequiresRebuildOnTarget(
+		ctx,
+		client,
+		state,
+		catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized),
+		settings.MeilisearchIndex,
+	)
+	if err != nil {
+		return false, err
+	}
+	if rebuildRequired {
 		if catalogSearchIndexHasNewerSchema(state) {
 			return false, nil
 		}
@@ -164,7 +179,17 @@ func (i *CatalogSearchIndexer) SyncOutbox(ctx context.Context, progress SearchIn
 	if err != nil {
 		return stats, err
 	}
-	if catalogSearchIndexRequiresRebuild(state, catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized)) {
+	rebuildRequired, err := catalogSearchIndexRequiresRebuildOnTarget(
+		ctx,
+		client,
+		state,
+		catalogSearchMeilisearchSchemaVersion(settings.Embedder, settings.IndexTypes, settings.SemanticEnabled, settings.BinaryQuantized),
+		settings.MeilisearchIndex,
+	)
+	if err != nil {
+		return stats, err
+	}
+	if rebuildRequired {
 		if catalogSearchIndexHasNewerSchema(state) {
 			stats.Skipped = true
 			stats.Reason = "active search index was built by a newer server version"
@@ -289,8 +314,49 @@ func (i *CatalogSearchIndexer) SyncOutbox(ctx context.Context, progress SearchIn
 	return stats, nil
 }
 
-func catalogSearchIndexRequiresRebuild(state SearchIndexState, expectedSchemaVersion int) bool {
-	return state.ActiveIndexUID == "" || state.SchemaVersion != expectedSchemaVersion
+func catalogSearchIndexRequiresRebuildOnTarget(
+	ctx context.Context,
+	client *meilisearchClient,
+	state SearchIndexState,
+	expectedSchemaVersion int,
+	indexPrefix string,
+) (bool, error) {
+	if catalogSearchIndexStateRequiresRebuild(state, expectedSchemaVersion, indexPrefix) {
+		return true, nil
+	}
+	if client == nil {
+		return false, fmt.Errorf("checking active Meilisearch index %q: client is not configured", state.ActiveIndexUID)
+	}
+	if _, err := client.Stats(ctx, state.ActiveIndexUID); err != nil {
+		if isMeilisearchIndexNotFound(err) {
+			return true, nil
+		}
+		return false, fmt.Errorf("checking active Meilisearch index %q: %w", state.ActiveIndexUID, err)
+	}
+	return false, nil
+}
+
+func catalogSearchIndexStateRequiresRebuild(state SearchIndexState, expectedSchemaVersion int, indexPrefix string) bool {
+	return state.ActiveIndexUID == "" ||
+		state.SchemaVersion != expectedSchemaVersion ||
+		!catalogSearchIndexUIDBelongsToPrefix(state.ActiveIndexUID, indexPrefix)
+}
+
+func catalogSearchIndexUIDBelongsToPrefix(uid, indexPrefix string) bool {
+	uid = strings.TrimSpace(uid)
+	indexPrefix = strings.TrimSpace(indexPrefix)
+	if uid == "" || indexPrefix == "" {
+		return false
+	}
+	if uid == indexPrefix {
+		return true
+	}
+	suffix, ok := strings.CutPrefix(uid, indexPrefix+"_rebuild_")
+	if !ok || suffix == "" {
+		return false
+	}
+	timestamp, err := strconv.ParseInt(suffix, 10, 64)
+	return err == nil && timestamp > 0
 }
 
 func catalogSearchIndexHasNewerSchema(state SearchIndexState) bool {

--- a/internal/catalog/search_indexer_test.go
+++ b/internal/catalog/search_indexer_test.go
@@ -109,6 +109,124 @@ func TestStaleCatalogSearchIndexUIDs(t *testing.T) {
 	}
 }
 
+func TestCatalogSearchIndexRequiresRebuild(t *testing.T) {
+	const expected = 123
+	tests := []struct {
+		name  string
+		state SearchIndexState
+		want  bool
+	}{
+		{name: "missing index", state: SearchIndexState{SchemaVersion: expected}, want: true},
+		{name: "stale schema", state: SearchIndexState{ActiveIndexUID: "index", SchemaVersion: expected - 1}, want: true},
+		{name: "current", state: SearchIndexState{ActiveIndexUID: "index", SchemaVersion: expected}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := catalogSearchIndexRequiresRebuild(tc.state, expected); got != tc.want {
+				t.Fatalf("catalogSearchIndexRequiresRebuild() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCatalogSearchIndexerFreezesRuntimeSettings(t *testing.T) {
+	settings := DefaultCatalogSearchSettings()
+	settings.Provider = SearchProviderMeilisearch
+	settings.MeilisearchURL = "http://meilisearch-at-startup:7700"
+	settings.IndexTypes = []string{"movie"}
+	indexer := NewCatalogSearchIndexerFromSettings(nil, nil, settings)
+
+	settings.MeilisearchURL = "http://changed-after-startup:7700"
+	settings.IndexTypes[0] = "series"
+	got, configured, err := indexer.loadMeilisearchRuntime(t.Context())
+	if err != nil {
+		t.Fatalf("loadMeilisearchRuntime() error = %v", err)
+	}
+	if !configured {
+		t.Fatal("loadMeilisearchRuntime() configured = false, want true")
+	}
+	if got.MeilisearchURL != "http://meilisearch-at-startup:7700" {
+		t.Fatalf("MeilisearchURL = %q, want startup value", got.MeilisearchURL)
+	}
+	if len(got.IndexTypes) != 1 || got.IndexTypes[0] != "movie" {
+		t.Fatalf("IndexTypes = %#v, want startup copy", got.IndexTypes)
+	}
+}
+
+func TestCatalogSearchIndexerWaitsForRestartBeforeUsingSavedSchemaSettings(t *testing.T) {
+	startup := DefaultCatalogSearchSettings()
+	startup.Provider = SearchProviderMeilisearch
+	startup.MeilisearchURL = "http://meilisearch:7700"
+	store := &memSettings{m: map[string]string{
+		SearchSettingProvider:                    SearchProviderMeilisearch,
+		SearchSettingMeilisearchURL:              startup.MeilisearchURL,
+		SearchSettingMeilisearchSemanticEnabled:  "true",
+		SearchSettingMeilisearchRebuildBatchSize: "17",
+	}}
+	indexer := NewCatalogSearchIndexerFromSettings(nil, store, startup)
+
+	runtime, configured, err := indexer.loadMeilisearchRuntime(t.Context())
+	if err != nil {
+		t.Fatalf("loadMeilisearchRuntime() error = %v", err)
+	}
+	if !configured {
+		t.Fatal("loadMeilisearchRuntime() configured = false, want true")
+	}
+	if runtime.SemanticEnabled {
+		t.Fatal("saved semantic enablement became active before restart")
+	}
+	if runtime.RebuildBatchSize != 17 {
+		t.Fatalf("RebuildBatchSize = %d, want hot-reloaded 17", runtime.RebuildBatchSize)
+	}
+	matches, err := indexer.runtimeMatchesDesiredSettings(t.Context(), runtime)
+	if err != nil {
+		t.Fatalf("runtimeMatchesDesiredSettings() error = %v", err)
+	}
+	if matches {
+		t.Fatal("saved schema settings should fence rebuilds until restart")
+	}
+}
+
+func TestCatalogSearchMaintenanceTargetEqual(t *testing.T) {
+	startup := DefaultCatalogSearchSettings()
+	startup.Provider = SearchProviderMeilisearch
+	startup.MeilisearchURL = "http://meilisearch:7700"
+	startup.IndexTypes = []string{"movie", "series"}
+
+	tuningOnly := startup
+	tuningOnly.SyncBatchSize++
+	tuningOnly.RebuildBatchSize++
+	tuningOnly.RebuildQueueDepth++
+	if !catalogSearchMaintenanceTargetEqual(startup, tuningOnly) {
+		t.Fatal("hot-reloadable maintenance tuning must not require a restart fence")
+	}
+
+	desired := startup
+	desired.SemanticEnabled = true
+	if catalogSearchMaintenanceTargetEqual(startup, desired) {
+		t.Fatal("semantic setting change must wait for the startup configuration")
+	}
+
+	desired = startup
+	desired.IndexTypes = []string{"movie"}
+	if catalogSearchMaintenanceTargetEqual(startup, desired) {
+		t.Fatal("index scope change must wait for the startup configuration")
+	}
+}
+
+func TestCatalogSearchIndexHasNewerSchema(t *testing.T) {
+	newer := SearchIndexState{
+		ActiveIndexUID: "new-index",
+		SchemaVersion:  (SearchMeilisearchSchemaVersion + 1) * 1_000_000,
+	}
+	if !catalogSearchIndexHasNewerSchema(newer) {
+		t.Fatal("newer schema should fence an older server from rebuilding")
+	}
+	if catalogSearchIndexHasNewerSchema(SearchIndexState{ActiveIndexUID: "index", SchemaVersion: SearchMeilisearchSchemaVersion * 1_000_000}) {
+		t.Fatal("current schema generation should not be treated as newer")
+	}
+}
+
 func TestRebuildIndexingPercent(t *testing.T) {
 	if got := rebuildIndexingPercent(0, 0); got != 50 {
 		t.Fatalf("unknown total should report midpoint, got %v", got)

--- a/internal/catalog/search_indexer_test.go
+++ b/internal/catalog/search_indexer_test.go
@@ -3,6 +3,8 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"slices"
 	"sort"
@@ -109,21 +111,81 @@ func TestStaleCatalogSearchIndexUIDs(t *testing.T) {
 	}
 }
 
-func TestCatalogSearchIndexRequiresRebuild(t *testing.T) {
+func TestCatalogSearchIndexStateRequiresRebuild(t *testing.T) {
 	const expected = 123
 	tests := []struct {
-		name  string
-		state SearchIndexState
-		want  bool
+		name        string
+		state       SearchIndexState
+		indexPrefix string
+		want        bool
 	}{
-		{name: "missing index", state: SearchIndexState{SchemaVersion: expected}, want: true},
-		{name: "stale schema", state: SearchIndexState{ActiveIndexUID: "index", SchemaVersion: expected - 1}, want: true},
-		{name: "current", state: SearchIndexState{ActiveIndexUID: "index", SchemaVersion: expected}, want: false},
+		{name: "missing index", state: SearchIndexState{SchemaVersion: expected}, indexPrefix: "index", want: true},
+		{name: "stale schema", state: SearchIndexState{ActiveIndexUID: "index", SchemaVersion: expected - 1}, indexPrefix: "index", want: true},
+		{name: "changed prefix", state: SearchIndexState{ActiveIndexUID: "old_rebuild_123", SchemaVersion: expected}, indexPrefix: "new", want: true},
+		{name: "current legacy uid", state: SearchIndexState{ActiveIndexUID: "index", SchemaVersion: expected}, indexPrefix: "index", want: false},
+		{name: "current rebuild uid", state: SearchIndexState{ActiveIndexUID: "index_rebuild_123", SchemaVersion: expected}, indexPrefix: "index", want: false},
+		{name: "similar prefix", state: SearchIndexState{ActiveIndexUID: "index_rebuild_rebuild_123", SchemaVersion: expected}, indexPrefix: "index", want: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := catalogSearchIndexRequiresRebuild(tc.state, expected); got != tc.want {
-				t.Fatalf("catalogSearchIndexRequiresRebuild() = %t, want %t", got, tc.want)
+			if got := catalogSearchIndexStateRequiresRebuild(tc.state, expected, tc.indexPrefix); got != tc.want {
+				t.Fatalf("catalogSearchIndexStateRequiresRebuild() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCatalogSearchIndexRequiresRebuildWhenActiveUIDIsMissingFromTarget(t *testing.T) {
+	const (
+		expectedSchema = 123
+		indexPrefix    = "index"
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/indexes/index_rebuild_123/stats":
+			_, _ = w.Write([]byte(`{"numberOfDocuments":42}`))
+		case "/indexes/index_rebuild_456/stats":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Index not found.","code":"index_not_found"}`))
+		case "/indexes/index_rebuild_789/stats":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"message":"Unavailable.","code":"internal"}`))
+		default:
+			t.Errorf("unexpected Meilisearch request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client, err := newMeilisearchClient(server.URL, "", time.Second)
+	if err != nil {
+		t.Fatalf("newMeilisearchClient() error = %v", err)
+	}
+	tests := []struct {
+		name    string
+		uid     string
+		want    bool
+		wantErr bool
+	}{
+		{name: "active uid exists", uid: "index_rebuild_123", want: false},
+		{name: "active uid missing after target move", uid: "index_rebuild_456", want: true},
+		{name: "target temporarily unavailable", uid: "index_rebuild_789", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := catalogSearchIndexRequiresRebuildOnTarget(
+				t.Context(),
+				client,
+				SearchIndexState{ActiveIndexUID: tc.uid, SchemaVersion: expectedSchema},
+				expectedSchema,
+				indexPrefix,
+			)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("catalogSearchIndexRequiresRebuildOnTarget() error = %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("catalogSearchIndexRequiresRebuildOnTarget() = %t, want %t", got, tc.want)
 			}
 		})
 	}

--- a/internal/catalog/search_meilisearch_provider.go
+++ b/internal/catalog/search_meilisearch_provider.go
@@ -189,16 +189,54 @@ func (p *MeilisearchSearchProvider) Search(ctx context.Context, req CatalogSearc
 	if strings.TrimSpace(state.ActiveIndexUID) == "" {
 		return p.fallbackSearch(ctx, req, "meilisearch index has not been built")
 	}
-	if state.SchemaVersion != catalogSearchMeilisearchSchemaVersion(p.config.Embedder, p.config.IndexTypes, p.config.SemanticEnabled, p.config.BinaryQuantized) {
+	compatibility := catalogSearchMeilisearchIndexCompatibility(
+		state.SchemaVersion,
+		p.config.Embedder,
+		p.config.IndexTypes,
+		p.config.SemanticEnabled,
+		p.config.BinaryQuantized,
+	)
+	if compatibility == catalogSearchIndexIncompatible {
 		return p.fallbackSearch(ctx, req, "meilisearch index schema mismatch")
 	}
 
-	result, err := p.searchMeilisearch(ctx, req, state.ActiveIndexUID)
+	keywordOnly := compatibility == catalogSearchIndexKeywordOnly
+	result, err := p.searchMeilisearch(ctx, req, state.ActiveIndexUID, keywordOnly)
 	if err != nil {
 		// The cached state may point at an index a rebuild just swapped away
-		// and deleted; drop it so the next request refetches instead of
-		// failing for the rest of the TTL.
+		// and deleted. Refetch and retry Meilisearch once so every API node's
+		// first post-swap request does not pay the much slower Postgres fallback.
 		p.invalidateIndexState()
+		if isMeilisearchIndexNotFound(err) {
+			refreshedState, refreshedPending, stateErr := p.indexState(ctx)
+			if stateErr == nil && refreshedState.ActiveIndexUID != "" && refreshedState.ActiveIndexUID != state.ActiveIndexUID {
+				refreshedCompatibility := catalogSearchMeilisearchIndexCompatibility(
+					refreshedState.SchemaVersion,
+					p.config.Embedder,
+					p.config.IndexTypes,
+					p.config.SemanticEnabled,
+					p.config.BinaryQuantized,
+				)
+				if refreshedCompatibility != catalogSearchIndexIncompatible {
+					result, retryErr := p.searchMeilisearch(
+						ctx,
+						req,
+						refreshedState.ActiveIndexUID,
+						refreshedCompatibility == catalogSearchIndexKeywordOnly,
+					)
+					if retryErr == nil {
+						result.IndexPendingEvents = refreshedPending
+						if result.FallbackReason != "" {
+							p.markFallback(result.FallbackReason)
+						} else {
+							p.clearFallback()
+						}
+						return result, nil
+					}
+					err = retryErr
+				}
+			}
+		}
 		if p.shouldTripCircuit(err) {
 			p.tripCircuit(err)
 		}
@@ -211,6 +249,12 @@ func (p *MeilisearchSearchProvider) Search(ctx context.Context, req CatalogSearc
 	}
 	result.IndexPendingEvents = pending
 	return result, nil
+}
+
+func isMeilisearchIndexNotFound(err error) bool {
+	var httpErr *meilisearchHTTPError
+	return errors.As(err, &httpErr) &&
+		(httpErr.StatusCode == http.StatusNotFound || strings.EqualFold(strings.TrimSpace(httpErr.Code), "index_not_found"))
 }
 
 func (p *MeilisearchSearchProvider) indexCoversRequest(itemTypes []string) bool {
@@ -269,7 +313,7 @@ func (p *MeilisearchSearchProvider) invalidateIndexState() {
 	p.stateMu.Unlock()
 }
 
-func (p *MeilisearchSearchProvider) searchMeilisearch(ctx context.Context, req CatalogSearchRequest, indexUID string) (*CatalogSearchResult, error) {
+func (p *MeilisearchSearchProvider) searchMeilisearch(ctx context.Context, req CatalogSearchRequest, indexUID string, keywordOnly bool) (*CatalogSearchResult, error) {
 	target := req.Offset + req.Limit + 1
 	if target <= 0 {
 		target = 1
@@ -284,7 +328,14 @@ func (p *MeilisearchSearchProvider) searchMeilisearch(ctx context.Context, req C
 	scanned := 0
 	estimatedTotalHits := 0
 	exhausted := false
-	baseSearchReq, semanticFallback := p.buildMeilisearchSearchRequest(ctx, req)
+	var baseSearchReq meilisearchSearchRequest
+	var semanticFallback string
+	if keywordOnly {
+		baseSearchReq = p.buildMeilisearchKeywordSearchRequest(req)
+		semanticFallback = "search index rebuild required; using Meilisearch keyword search"
+	} else {
+		baseSearchReq, semanticFallback = p.buildMeilisearchSearchRequest(ctx, req)
+	}
 	useFederation := baseSearchReq.Hybrid != nil && searchRequestMixesEpisodeAndMedia(req.ItemTypes)
 	if useFederation && p.isFederationUnsupported() {
 		semanticFallback = "meilisearch federation unsupported; using keyword search"
@@ -416,13 +467,7 @@ func (p *MeilisearchSearchProvider) buildMeilisearchSearchRequest(ctx context.Co
 			AttributesToRetrieve: []string{"content_id"},
 		}, ""
 	}
-	searchReq := meilisearchSearchRequest{
-		Query:                strings.TrimSpace(req.Query),
-		Filter:               meilisearchSearchFilter(req.ItemTypes, req.Access),
-		AttributesToRetrieve: []string{"content_id"},
-		AttributesToSearchOn: p.attributesToSearchOnForRequest(req),
-		MatchingStrategy:     p.matchingStrategyForRequest(req),
-	}
+	searchReq := p.buildMeilisearchKeywordSearchRequest(req)
 	if !p.shouldUseSemanticSearch(req) {
 		return searchReq, ""
 	}
@@ -447,6 +492,16 @@ func (p *MeilisearchSearchProvider) buildMeilisearchSearchRequest(ctx context.Co
 		SemanticRatio: p.config.SemanticRatio,
 	}
 	return searchReq, ""
+}
+
+func (p *MeilisearchSearchProvider) buildMeilisearchKeywordSearchRequest(req CatalogSearchRequest) meilisearchSearchRequest {
+	return meilisearchSearchRequest{
+		Query:                strings.TrimSpace(req.Query),
+		Filter:               meilisearchSearchFilter(req.ItemTypes, req.Access),
+		AttributesToRetrieve: []string{"content_id"},
+		AttributesToSearchOn: p.attributesToSearchOnForRequest(req),
+		MatchingStrategy:     p.matchingStrategyForRequest(req),
+	}
 }
 
 func (p *MeilisearchSearchProvider) shouldUseSemanticSearch(req CatalogSearchRequest) bool {

--- a/internal/catalog/search_meilisearch_provider.go
+++ b/internal/catalog/search_meilisearch_provider.go
@@ -252,8 +252,8 @@ func (p *MeilisearchSearchProvider) Search(ctx context.Context, req CatalogSearc
 }
 
 func isMeilisearchIndexNotFound(err error) bool {
-	var httpErr *meilisearchHTTPError
-	return errors.As(err, &httpErr) &&
+	httpErr, ok := errors.AsType[*meilisearchHTTPError](err)
+	return ok &&
 		(httpErr.StatusCode == http.StatusNotFound || strings.EqualFold(strings.TrimSpace(httpErr.Code), "index_not_found"))
 }
 

--- a/internal/catalog/search_provider.go
+++ b/internal/catalog/search_provider.go
@@ -357,6 +357,8 @@ func normalizeCatalogSearchItemTypes(itemTypes []string) []string {
 type CatalogSearchRuntimeStatus struct {
 	ConfiguredProvider string                        `json:"configured_provider"`
 	ActiveProvider     string                        `json:"active_provider"`
+	Degraded           bool                          `json:"degraded"`
+	DegradedReason     string                        `json:"degraded_reason,omitempty"`
 	Meilisearch        CatalogSearchMeiliStatus      `json:"meilisearch"`
 	Index              CatalogSearchIndexStateStatus `json:"index"`
 	Tasks              []CatalogSearchTaskLink       `json:"tasks"`
@@ -419,6 +421,7 @@ type CatalogSearchIndexStateStatus struct {
 	ActiveIndexUID        string `json:"active_index_uid"`
 	SchemaVersion         int    `json:"schema_version"`
 	ExpectedSchemaVersion int    `json:"expected_schema_version"`
+	RebuildRequired       bool   `json:"rebuild_required"`
 	DocumentCount         int    `json:"document_count"`
 	VectorDocumentCount   int    `json:"vector_document_count"`
 	PendingEvents         int    `json:"pending_events"`
@@ -462,8 +465,10 @@ func catalogSearchMeilisearchEmbedderSettings(embedder string, binaryQuantized b
 // attachDocumentVectors omits _vectors entirely when semantic is off; toggling it
 // on must therefore make the existing (vector-less) index look stale so it is
 // rebuilt rather than serving silently degraded hybrid ranking. A mismatch forces
-// a rebuild (SyncOutbox skips, the provider falls back to keyword) and surfaces as
-// an ExpectedSchemaVersion divergence in the admin status.
+// a rebuild (SyncOutbox skips) and surfaces as an ExpectedSchemaVersion divergence
+// in the admin status. An index whose hash proves that only semantic/vector
+// settings changed remains safe for keyword-only Meilisearch queries while the
+// replacement is built; all other mismatches fall back to Postgres.
 func catalogSearchMeilisearchSchemaVersion(embedder string, itemTypes []string, semanticEnabled, binaryQuantized bool) int {
 	embedder, err := NormalizeCatalogSearchEmbedderName(embedder)
 	if err != nil {
@@ -488,4 +493,42 @@ func catalogSearchMeilisearchSchemaVersion(embedder string, itemTypes []string, 
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(identity))
 	return SearchMeilisearchSchemaVersion*1_000_000 + int(h.Sum32()%1_000_000)
+}
+
+type catalogSearchIndexCompatibility uint8
+
+const (
+	catalogSearchIndexIncompatible catalogSearchIndexCompatibility = iota
+	catalogSearchIndexKeywordOnly
+	catalogSearchIndexCurrent
+)
+
+// catalogSearchMeilisearchIndexCompatibility classifies an active index using
+// only schema identities Silo itself can have published. If the active hash
+// matches the same embedder, vector dimensions, and media scope with a different
+// semantic/binary setting, its document fields and filters are still valid for
+// keyword search. Unknown hashes are not trusted because they may represent a
+// different indexed media scope or document shape.
+func catalogSearchMeilisearchIndexCompatibility(
+	activeVersion int,
+	embedder string,
+	itemTypes []string,
+	semanticEnabled bool,
+	binaryQuantized bool,
+) catalogSearchIndexCompatibility {
+	expected := catalogSearchMeilisearchSchemaVersion(embedder, itemTypes, semanticEnabled, binaryQuantized)
+	if activeVersion == expected {
+		return catalogSearchIndexCurrent
+	}
+	compatibleVersions := [...]int{
+		catalogSearchMeilisearchSchemaVersion(embedder, itemTypes, false, false),
+		catalogSearchMeilisearchSchemaVersion(embedder, itemTypes, true, false),
+		catalogSearchMeilisearchSchemaVersion(embedder, itemTypes, true, true),
+	}
+	for _, version := range compatibleVersions {
+		if activeVersion == version {
+			return catalogSearchIndexKeywordOnly
+		}
+	}
+	return catalogSearchIndexIncompatible
 }

--- a/internal/catalog/search_provider_test.go
+++ b/internal/catalog/search_provider_test.go
@@ -736,11 +736,59 @@ func TestMeilisearchProviderInvalidatesStateCacheOnSearchFailure(t *testing.T) {
 			t.Fatalf("Search %d should surface the fallback error in this setup", i)
 		}
 	}
-	if store.getStateCalls != 2 {
-		t.Fatalf("getStateCalls = %d, want 2 (cache invalidated after failed search)", store.getStateCalls)
+	if store.getStateCalls != 3 {
+		t.Fatalf("getStateCalls = %d, want 3 (each missing-index failure refreshes state immediately)", store.getStateCalls)
 	}
 	if reason, blocked := provider.circuitBlocked(time.Now()); blocked {
 		t.Fatalf("HTTP 404 must not trip the circuit, got open circuit: %s", reason)
+	}
+}
+
+func TestMeilisearchProviderRetriesNewActiveIndexAfterSwap(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/indexes/old-index/search" {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Index old-index not found.","code":"index_not_found"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"hits":[],"estimatedTotalHits":0}`))
+	}))
+	defer server.Close()
+
+	client, err := newMeilisearchClient(server.URL, "", time.Second)
+	if err != nil {
+		t.Fatalf("newMeilisearchClient: %v", err)
+	}
+	schemaVersion := catalogSearchMeilisearchSchemaVersion(DefaultMeilisearchEmbedder, nil, false, false)
+	store := &countingMeilisearchIndexStateStore{state: SearchIndexState{
+		ActiveIndexUID: "new-index",
+		SchemaVersion:  schemaVersion,
+	}}
+	provider := &MeilisearchSearchProvider{
+		stateRepo:     store,
+		fallback:      &PostgresSearchProvider{},
+		client:        client,
+		config:        MeilisearchProviderConfig{MatchingStrategy: DefaultMeilisearchMatchingStrategy, Embedder: DefaultMeilisearchEmbedder},
+		cachedState:   SearchIndexState{ActiveIndexUID: "old-index", SchemaVersion: schemaVersion},
+		stateCachedAt: time.Now(),
+	}
+
+	result, err := provider.Search(t.Context(), CatalogSearchRequest{Query: "space opera", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	wantPaths := []string{"/indexes/old-index/search", "/indexes/new-index/search"}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("Meilisearch paths = %#v, want %#v", paths, wantPaths)
+	}
+	if store.getStateCalls != 1 {
+		t.Fatalf("state refresh calls = %d, want 1", store.getStateCalls)
+	}
+	if result.Provider != SearchProviderMeilisearch {
+		t.Fatalf("provider = %q, want Meilisearch", result.Provider)
 	}
 }
 
@@ -798,6 +846,59 @@ func TestMeilisearchProviderUsesActiveIndexWhenPendingUpdatesExist(t *testing.T)
 	}
 	if result.IndexPendingEvents != 7 {
 		t.Fatalf("IndexPendingEvents = %d, want 7", result.IndexPendingEvents)
+	}
+}
+
+func TestMeilisearchProviderUsesStaleVectorlessIndexForKeywordSearch(t *testing.T) {
+	var searchRequest meilisearchSearchRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/indexes/search-index/search" {
+			t.Fatalf("unexpected Meilisearch request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&searchRequest); err != nil {
+			t.Fatalf("decode search request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"hits":[],"estimatedTotalHits":0}`))
+	}))
+	defer server.Close()
+
+	client, err := newMeilisearchClient(server.URL, "", time.Second)
+	if err != nil {
+		t.Fatalf("newMeilisearchClient: %v", err)
+	}
+	vectorizer := &fakeCatalogSearchVectorizer{vector: []float32{0.1, 0.2}}
+	provider := &MeilisearchSearchProvider{
+		stateRepo: fakeMeilisearchIndexStateStore{state: SearchIndexState{
+			ActiveIndexUID: "search-index",
+			SchemaVersion:  catalogSearchMeilisearchSchemaVersion(DefaultMeilisearchEmbedder, nil, false, false),
+		}},
+		fallback: &PostgresSearchProvider{},
+		client:   client,
+		config: MeilisearchProviderConfig{
+			MatchingStrategy: DefaultMeilisearchMatchingStrategy,
+			Embedder:         DefaultMeilisearchEmbedder,
+			SemanticEnabled:  true,
+			SemanticRatio:    0.5,
+			Vectorizer:       vectorizer,
+		},
+	}
+
+	result, err := provider.Search(t.Context(), CatalogSearchRequest{Query: "space opera", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search returned error: %v", err)
+	}
+	if vectorizer.calls != 0 {
+		t.Fatalf("vectorizer calls = %d, want 0 while the semantic index rebuilds", vectorizer.calls)
+	}
+	if searchRequest.Hybrid != nil || len(searchRequest.Vector) != 0 {
+		t.Fatalf("stale index request used semantic search: hybrid=%#v vector=%v", searchRequest.Hybrid, searchRequest.Vector)
+	}
+	if result.Provider != SearchProviderMeilisearch || result.Mode != "keyword" || result.SemanticUsed {
+		t.Fatalf("result diagnostics = provider %q, mode %q, semantic %t", result.Provider, result.Mode, result.SemanticUsed)
+	}
+	if !strings.Contains(result.FallbackReason, "rebuild required") {
+		t.Fatalf("fallback reason = %q, want rebuild diagnostic", result.FallbackReason)
 	}
 }
 
@@ -869,6 +970,37 @@ func TestMeilisearchSchemaVersionChangesWithSemanticEnabled(t *testing.T) {
 	enabledVersion := catalogSearchMeilisearchSchemaVersion(DefaultMeilisearchEmbedder, nil, true, false)
 	if disabledVersion == enabledVersion {
 		t.Fatal("schema version should change when semantic search is toggled")
+	}
+}
+
+func TestMeilisearchIndexCompatibility(t *testing.T) {
+	itemTypes := []string{"movie", "series"}
+	semanticOff := catalogSearchMeilisearchSchemaVersion(DefaultMeilisearchEmbedder, itemTypes, false, false)
+	semanticOn := catalogSearchMeilisearchSchemaVersion(DefaultMeilisearchEmbedder, itemTypes, true, false)
+	tests := []struct {
+		name          string
+		activeVersion int
+		embedder      string
+		itemTypes     []string
+		semantic      bool
+		binary        bool
+		want          catalogSearchIndexCompatibility
+	}{
+		{name: "current", activeVersion: semanticOn, embedder: DefaultMeilisearchEmbedder, itemTypes: itemTypes, semantic: true, want: catalogSearchIndexCurrent},
+		{name: "semantic enablement", activeVersion: semanticOff, embedder: DefaultMeilisearchEmbedder, itemTypes: itemTypes, semantic: true, want: catalogSearchIndexKeywordOnly},
+		{name: "semantic disablement", activeVersion: semanticOn, embedder: DefaultMeilisearchEmbedder, itemTypes: itemTypes, want: catalogSearchIndexKeywordOnly},
+		{name: "binary setting change", activeVersion: semanticOn, embedder: DefaultMeilisearchEmbedder, itemTypes: itemTypes, semantic: true, binary: true, want: catalogSearchIndexKeywordOnly},
+		{name: "different embedder", activeVersion: semanticOff, embedder: "other_embedder", itemTypes: itemTypes, semantic: true, want: catalogSearchIndexIncompatible},
+		{name: "different media scope", activeVersion: semanticOff, embedder: DefaultMeilisearchEmbedder, itemTypes: []string{"movie"}, semantic: true, want: catalogSearchIndexIncompatible},
+		{name: "unknown schema", activeVersion: 0, embedder: DefaultMeilisearchEmbedder, itemTypes: itemTypes, semantic: true, want: catalogSearchIndexIncompatible},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := catalogSearchMeilisearchIndexCompatibility(tc.activeVersion, tc.embedder, tc.itemTypes, tc.semantic, tc.binary)
+			if got != tc.want {
+				t.Fatalf("compatibility = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/catalog/search_service.go
+++ b/internal/catalog/search_service.go
@@ -158,27 +158,74 @@ func (s *CatalogSearchService) Status(ctx context.Context) CatalogSearchRuntimeS
 		},
 	}
 	if s != nil {
-		if _, ok := s.provider.(*MeilisearchSearchProvider); ok {
-			status.ActiveProvider = SearchProviderMeilisearch
-		}
+		_, meilisearchProviderActive := s.provider.(*MeilisearchSearchProvider)
 		if s.meili != nil {
 			status.Meilisearch = s.meili.Status()
 		}
+		stateAvailable := false
 		if s.state != nil {
 			state, err := s.state.GetState(ctx, SearchProviderMeilisearch)
 			if err == nil {
+				stateAvailable = true
 				status.Index.ActiveIndexUID = state.ActiveIndexUID
 				status.Index.SchemaVersion = state.SchemaVersion
 				status.Index.DocumentCount = state.DocumentCount
 				status.Index.LastRebuildAt = state.LastRebuildAt
 				status.Index.LastSyncAt = state.LastSyncAt
 				status.Index.LastProcessedEventID = state.LastProcessedEventID
+				if meilisearchProviderActive {
+					switch {
+					case state.ActiveIndexUID == "":
+						status.Degraded = true
+						status.DegradedReason = "Meilisearch index has not been built; using Postgres search"
+						status.Index.RebuildRequired = true
+					case catalogSearchMeilisearchIndexCompatibility(
+						state.SchemaVersion,
+						settings.Embedder,
+						settings.IndexTypes,
+						settings.SemanticEnabled,
+						settings.BinaryQuantized,
+					) == catalogSearchIndexCurrent:
+						status.ActiveProvider = SearchProviderMeilisearch
+					case catalogSearchMeilisearchIndexCompatibility(
+						state.SchemaVersion,
+						settings.Embedder,
+						settings.IndexTypes,
+						settings.SemanticEnabled,
+						settings.BinaryQuantized,
+					) == catalogSearchIndexKeywordOnly:
+						status.ActiveProvider = SearchProviderMeilisearch
+						status.Degraded = true
+						status.DegradedReason = "Search index rebuild required; using Meilisearch keyword search"
+						status.Index.RebuildRequired = true
+					case catalogSearchIndexHasNewerSchema(state):
+						status.Degraded = true
+						status.DegradedReason = "A newer server version owns the Meilisearch index; using Postgres search on this node"
+					default:
+						status.Degraded = true
+						status.DegradedReason = "Meilisearch index schema mismatch; using Postgres search"
+						status.Index.RebuildRequired = true
+					}
+				}
 			}
 			if pending, err := s.state.PendingCount(ctx, SearchProviderMeilisearch); err == nil {
 				status.Index.PendingEvents = pending
 			}
 			if deadLettered, err := s.state.DeadLetterCount(ctx, SearchProviderMeilisearch); err == nil {
 				status.Index.DeadLetteredEvents = deadLettered
+			}
+		}
+		if meilisearchProviderActive && !stateAvailable {
+			status.Degraded = true
+			status.DegradedReason = "Meilisearch index state is unavailable; using Postgres search"
+		}
+		if meilisearchProviderActive && !status.Meilisearch.Healthy {
+			status.ActiveProvider = SearchProviderPostgres
+			status.Degraded = true
+			if status.Meilisearch.CircuitReason != "" {
+				status.DegradedReason = "Meilisearch is unavailable; using Postgres search: " + status.Meilisearch.CircuitReason
+			} else {
+				status.DegradedReason = "Meilisearch is unavailable; using Postgres search"
 			}
 		}
 		if s.itemRepo != nil && s.itemRepo.pool != nil {
@@ -196,7 +243,14 @@ func (s *CatalogSearchService) Status(ctx context.Context) CatalogSearchRuntimeS
 		} else {
 			status.Semantic = CatalogSearchSemanticStatus{Ready: false, DisabledReason: "semantic search disabled"}
 		}
-		if s.meili != nil {
+		if status.Index.RebuildRequired {
+			status.Semantic.Ready = false
+			status.Semantic.DisabledReason = "search index rebuild required"
+			status.Semantic.Capability = CatalogSearchSemanticCapability{
+				OK:     false,
+				Reason: "search index rebuild required",
+			}
+		} else if s.meili != nil {
 			status.Semantic.Capability = s.meili.SemanticCapability(ctx)
 		}
 	}

--- a/internal/taskmanager/tasks/catalog_search_index.go
+++ b/internal/taskmanager/tasks/catalog_search_index.go
@@ -25,7 +25,7 @@ func NewSyncCatalogSearchIndexTask(worker CatalogSearchIndexWorker) *SyncCatalog
 func (t *SyncCatalogSearchIndexTask) Key() string  { return "sync_catalog_search_index" }
 func (t *SyncCatalogSearchIndexTask) Name() string { return "Sync Catalog Search Index" }
 func (t *SyncCatalogSearchIndexTask) Description() string {
-	return "Drains catalog search outbox events into the configured Meilisearch index."
+	return "Builds or upgrades the Meilisearch catalog index when needed, then syncs pending catalog changes."
 }
 func (t *SyncCatalogSearchIndexTask) Category() taskmanager.TaskCategory {
 	return taskmanager.TaskCategoryLibrary
@@ -52,7 +52,11 @@ func (t *SyncCatalogSearchIndexTask) Execute(ctx context.Context, progress taskm
 	}
 	stats, err := t.worker.SyncOutbox(ctx, progress)
 	if err != nil {
-		progress.Report(100, fmt.Sprintf("Catalog search sync failed after %d events", stats.Events))
+		if stats.RebuildAttempted {
+			progress.Report(100, fmt.Sprintf("Catalog search rebuild failed after %d documents", stats.DocumentCount))
+		} else {
+			progress.Report(100, fmt.Sprintf("Catalog search sync failed after %d events", stats.Events))
+		}
 		return err
 	}
 	return nil

--- a/internal/taskmanager/tasks/catalog_search_index_test.go
+++ b/internal/taskmanager/tasks/catalog_search_index_test.go
@@ -1,0 +1,79 @@
+package tasks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+type catalogSearchIndexWorkerStub struct {
+	shouldSync bool
+	syncStats  catalog.CatalogSearchIndexSyncStats
+	syncErr    error
+}
+
+func (w catalogSearchIndexWorkerStub) ShouldSyncRun(context.Context) (bool, error) {
+	return w.shouldSync, nil
+}
+
+func (w catalogSearchIndexWorkerStub) SyncOutbox(context.Context, catalog.SearchIndexProgressReporter) (catalog.CatalogSearchIndexSyncStats, error) {
+	return w.syncStats, w.syncErr
+}
+
+type catalogSearchProgressStub struct {
+	message string
+}
+
+func (p *catalogSearchProgressStub) Report(_ float64, message string) { p.message = message }
+func (*catalogSearchProgressStub) SetResultData(json.RawMessage)      {}
+
+func (catalogSearchIndexWorkerStub) Rebuild(context.Context, catalog.SearchIndexProgressReporter) (catalog.CatalogSearchIndexRebuildStats, error) {
+	return catalog.CatalogSearchIndexRebuildStats{}, nil
+}
+
+func TestSyncCatalogSearchIndexTaskRunsAtStartupAndRetries(t *testing.T) {
+	task := NewSyncCatalogSearchIndexTask(catalogSearchIndexWorkerStub{shouldSync: true})
+	triggers := task.DefaultTriggers()
+	if len(triggers) != 2 {
+		t.Fatalf("DefaultTriggers() length = %d, want 2", len(triggers))
+	}
+	if triggers[0].Type != taskmanager.TriggerTypeStartup {
+		t.Fatalf("first trigger = %q, want startup", triggers[0].Type)
+	}
+	if triggers[1].Type != taskmanager.TriggerTypeInterval || triggers[1].IntervalMs != 60*1000 {
+		t.Fatalf("retry trigger = %#v, want 60s interval", triggers[1])
+	}
+	shouldRun, err := task.ShouldRun(t.Context())
+	if err != nil || !shouldRun {
+		t.Fatalf("ShouldRun() = %t, %v, want true, nil", shouldRun, err)
+	}
+}
+
+func TestRebuildCatalogSearchIndexTaskRemainsManualOnly(t *testing.T) {
+	task := NewRebuildCatalogSearchIndexTask(catalogSearchIndexWorkerStub{})
+	if triggers := task.DefaultTriggers(); len(triggers) != 0 {
+		t.Fatalf("DefaultTriggers() = %#v, want manual-only", triggers)
+	}
+}
+
+func TestSyncCatalogSearchIndexTaskReportsAutomaticRebuildFailure(t *testing.T) {
+	worker := catalogSearchIndexWorkerStub{
+		syncStats: catalog.CatalogSearchIndexSyncStats{
+			RebuildAttempted: true,
+			DocumentCount:    42,
+		},
+		syncErr: errors.New("indexing failed"),
+	}
+	progress := &catalogSearchProgressStub{}
+	err := NewSyncCatalogSearchIndexTask(worker).Execute(t.Context(), progress)
+	if !errors.Is(err, worker.syncErr) {
+		t.Fatalf("Execute() error = %v, want %v", err, worker.syncErr)
+	}
+	if progress.message != "Catalog search rebuild failed after 42 documents" {
+		t.Fatalf("progress message = %q", progress.message)
+	}
+}

--- a/web/src/hooks/admin/useSettingsOverview.test.ts
+++ b/web/src/hooks/admin/useSettingsOverview.test.ts
@@ -238,6 +238,24 @@ describe("buildSettingsOverview health tiles", () => {
     expect(pending.action).toBeUndefined();
   });
 
+  it("warns while Meilisearch serves a compatible stale index", () => {
+    const search = tile(
+      {
+        search: {
+          active_provider: "meilisearch",
+          degraded: true,
+          degraded_reason: "Search index rebuild required; using Meilisearch keyword search",
+          meilisearch: { configured: true, healthy: true },
+        } as SettingsOverviewInput["search"],
+      },
+      "search",
+    );
+
+    expect(search.state).toBe("warn");
+    expect(search.detail).toBe("Search index rebuild required; using Meilisearch keyword search");
+    expect(search.action).toEqual({ label: "Fix", page: "library" });
+  });
+
   it("only calls email ready when it is on with a host and a sender address", () => {
     expect(tile({ settings: { "email.enabled": "true" } }, "email").stateText).toBe("Not set up");
     // The server refuses to enable email without a from-address, but legacy

--- a/web/src/hooks/admin/useSettingsOverview.ts
+++ b/web/src/hooks/admin/useSettingsOverview.ts
@@ -236,11 +236,12 @@ function buildTiles(input: SettingsOverviewInput): OverviewTile[] {
   const searchStatusResolved = input.search != null;
   const meiliConfigured = input.search?.meilisearch.configured ?? false;
   const meiliHealthy = input.search?.meilisearch.healthy ?? false;
+  const searchDegraded = input.search?.degraded ?? false;
   const searchState: OverviewState =
     activeSearch === "meilisearch"
       ? !searchStatusResolved
         ? "info"
-        : meiliHealthy
+        : meiliHealthy && !searchDegraded
           ? "ok"
           : "warn"
       : meiliConfigured
@@ -304,9 +305,11 @@ function buildTiles(input: SettingsOverviewInput): OverviewTile[] {
         activeSearch === "meilisearch"
           ? !searchStatusResolved
             ? "Checking connection"
-            : meiliHealthy
-              ? "Meilisearch connected"
-              : "Meilisearch not reachable"
+            : searchDegraded
+              ? (input.search?.degraded_reason ?? "Search is running in a degraded mode")
+              : meiliHealthy
+                ? "Meilisearch connected"
+                : "Meilisearch not reachable"
           : meiliConfigured
             ? "Meilisearch configured but not active"
             : "Meilisearch not connected",

--- a/web/src/hooks/queries/admin/settings.ts
+++ b/web/src/hooks/queries/admin/settings.ts
@@ -39,6 +39,8 @@ function affectsOverlayConfig(key: string) {
 export interface CatalogSearchStatus {
   configured_provider: string;
   active_provider: string;
+  degraded: boolean;
+  degraded_reason?: string;
   meilisearch: {
     configured: boolean;
     healthy: boolean;
@@ -58,6 +60,7 @@ export interface CatalogSearchStatus {
     active_index_uid: string;
     schema_version: number;
     expected_schema_version: number;
+    rebuild_required: boolean;
     document_count: number;
     vector_document_count: number;
     pending_events: number;
@@ -251,6 +254,7 @@ export function useCatalogSearchStatus(enabled = true) {
     queryFn: () => api<CatalogSearchStatus>("/admin/catalog/search/status"),
     enabled,
     staleTime: 15_000,
+    refetchInterval: (query) => (query.state.data?.index.rebuild_required ? 2_000 : false),
   });
 }
 

--- a/web/src/hooks/useSettingsForm.ts
+++ b/web/src/hooks/useSettingsForm.ts
@@ -60,6 +60,8 @@ export function useSettingsForm({ keys }: UseSettingsFormOptions) {
     [localValues, settings],
   );
 
+  const getPersistedValue = useCallback((key: string) => settings?.[key] ?? "", [settings]);
+
   const setValue = useCallback((key: string, value: string) => {
     editVersions.current.set(key, (editVersions.current.get(key) ?? 0) + 1);
     setLocalValues((prev) => ({ ...prev, [key]: value }));
@@ -180,6 +182,7 @@ export function useSettingsForm({ keys }: UseSettingsFormOptions) {
   return {
     isLoading,
     getValue,
+    getPersistedValue,
     setValue,
     resetValue,
     dirtyCount,

--- a/web/src/pages/admin-settings/LibraryMetadataSettings.test.tsx
+++ b/web/src/pages/admin-settings/LibraryMetadataSettings.test.tsx
@@ -39,6 +39,7 @@ function makeForm(values: Record<string, string>, dirty: string[] = []) {
   return {
     isLoading: false,
     getValue: (key: string) => values[key] ?? "",
+    getPersistedValue: (key: string) => values[key] ?? "",
     setValue: vi.fn(),
     resetValue: vi.fn(),
     isDirty: (key: string) => dirtySet.has(key),
@@ -239,5 +240,28 @@ describe("LibraryMetadataSettings", () => {
 
     expect(rendered).toContain("Takes effect after a server restart");
     expect(text(rendered)).not.toContain("Changes apply after a restart");
+  });
+
+  it("warns that enabling meaning-based search rebuilds the index after restart", () => {
+    const values: Record<string, string> = {
+      "catalog.search.provider": "meilisearch",
+      "catalog.search.meilisearch.semantic_enabled": "true",
+    };
+    const form = makeForm(values, ["catalog.search.meilisearch.semantic_enabled"]);
+    form.getPersistedValue = (key: string) =>
+      key === "catalog.search.meilisearch.semantic_enabled" ? "false" : (values[key] ?? "");
+    useSettingsFormMock.mockReturnValue(form);
+
+    const rendered = text(
+      renderToStaticMarkup(
+        <MemoryRouter>
+          <LibraryMetadataSettings />
+        </MemoryRouter>,
+      ),
+    );
+
+    expect(rendered).toContain("Enabling this changes the index format");
+    expect(rendered).toContain("rebuilds the index automatically");
+    expect(rendered).toContain("Keyword search stays available");
   });
 });

--- a/web/src/pages/admin-settings/LibraryMetadataSettings.tsx
+++ b/web/src/pages/admin-settings/LibraryMetadataSettings.tsx
@@ -9,14 +9,17 @@ import { SecretField } from "@/components/settings/SecretField";
 import { SettingsPageHeader } from "@/components/settings/SettingsPageHeader";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useBranding } from "@/hooks/useBranding";
-import { useCheckAdminSettingsConnection } from "@/hooks/queries/admin/settings";
+import {
+  useCatalogSearchStatus,
+  useCheckAdminSettingsConnection,
+} from "@/hooks/queries/admin/settings";
 import { useRestartKeys } from "@/hooks/useRestartKeys";
 import { useSettingsForm } from "@/hooks/useSettingsForm";
 import { FieldGroup } from "./FieldGroup";
 import { MarkerTasksCard } from "./MarkerTasksCard";
 import { SaveBar } from "./SaveBar";
 import { SearchStatusPanel } from "./SearchStatusPanel";
-import { SettingField } from "./SettingField";
+import { SettingField, SettingFieldStatus } from "./SettingField";
 
 const ARTWORK_KEYS = ["metadata.cache_images"];
 
@@ -69,11 +72,16 @@ export default function LibraryMetadataSettings() {
 
   const provider = form.getValue("catalog.search.provider") || "postgres";
   const meiliEnabled = provider === "meilisearch";
+  const { data: searchStatus } = useCatalogSearchStatus(meiliEnabled);
   const anyDirty = (keys: string[]) => keys.some((key) => form.isDirty(key));
   const allRestart = (keys: string[]) => keys.every((key) => restartKeys.has(key));
   // Staged Meilisearch edits stay reachable after switching the provider back,
   // so the save bar can never count a change the admin cannot see.
   const showMeili = meiliEnabled || anyDirty(MEILI_KEYS);
+  const enablingSemanticSearch =
+    form.isDirty("catalog.search.meilisearch.semantic_enabled") &&
+    form.getPersistedValue("catalog.search.meilisearch.semantic_enabled") !== "true" &&
+    form.getValue("catalog.search.meilisearch.semantic_enabled") === "true";
 
   async function handleCheckConnection() {
     try {
@@ -330,6 +338,15 @@ export default function LibraryMetadataSettings() {
                     form.setValue("catalog.search.meilisearch.semantic_enabled", value)
                   }
                   description="Also matches items whose description means something similar."
+                  status={
+                    enablingSemanticSearch ? (
+                      <SettingFieldStatus tone="warn">
+                        Enabling this changes the index format. After you save and restart, Silo
+                        rebuilds the index automatically. Keyword search stays available while it
+                        rebuilds.
+                      </SettingFieldStatus>
+                    ) : undefined
+                  }
                   disabled={!meiliEnabled}
                   restartRequired={restartKeys.has("catalog.search.meilisearch.semantic_enabled")}
                 />
@@ -346,6 +363,30 @@ export default function LibraryMetadataSettings() {
                 />
               </AdvancedSection>
             </>
+          )}
+
+          {meiliEnabled && searchStatus?.degraded && (
+            <div className="py-3.5">
+              <SettingFieldStatus tone="warn">
+                <span>
+                  {searchStatus.degraded_reason ?? "Search is running in a degraded mode."}
+                  {searchStatus.index.rebuild_required && (
+                    <>
+                      {" "}
+                      Automatic search maintenance rebuilds the index in the background and retries
+                      if needed.{" "}
+                      <Link
+                        className="font-medium underline underline-offset-2"
+                        to="/admin/tasks/sync_catalog_search_index"
+                      >
+                        Open maintenance task
+                      </Link>
+                      .
+                    </>
+                  )}
+                </span>
+              </SettingFieldStatus>
+            </div>
           )}
 
           <AdvancedSection id="library.search.status" title="Search status">

--- a/web/src/pages/admin-settings/SearchStatusPanel.test.tsx
+++ b/web/src/pages/admin-settings/SearchStatusPanel.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/hooks/queries/admin/settings", () => ({
 const STATUS = {
   active_provider: "postgres",
   configured_provider: "postgres",
+  degraded: false,
   meilisearch: {
     configured: false,
     healthy: false,
@@ -24,6 +25,7 @@ const STATUS = {
     active_index_uid: "",
     schema_version: 3,
     expected_schema_version: 3,
+    rebuild_required: false,
     document_count: 0,
     vector_document_count: 0,
     pending_events: 0,
@@ -74,7 +76,7 @@ describe("SearchStatusPanel", () => {
     // The maintenance tasks are exactly what an admin wants when the index is
     // unhealthy enough for the status endpoint to fail, so they stay reachable.
     expect(screen.getByRole("link", { name: "Rebuild index" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Sync history" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Automatic maintenance" })).toBeInTheDocument();
   });
 
   it("falls back to a bare message when the failure carries none", () => {
@@ -103,5 +105,30 @@ describe("SearchStatusPanel", () => {
     expect(screen.getByText("Answering searches")).toBeInTheDocument();
     expect(screen.getByText("Postgres full-text")).toBeInTheDocument();
     expect(screen.queryByText(/Couldn't load search status/)).not.toBeInTheDocument();
+  });
+
+  it("shows a stale compatible index as Meilisearch keyword-only", () => {
+    catalogSearchStatusMock.mockReturnValue({
+      data: {
+        ...STATUS,
+        active_provider: "meilisearch",
+        configured_provider: "meilisearch",
+        degraded: true,
+        degraded_reason: "Search index rebuild required; using Meilisearch keyword search",
+        meilisearch: { ...STATUS.meilisearch, configured: true, healthy: true },
+        index: { ...STATUS.index, active_index_uid: "search-index", rebuild_required: true },
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    renderPanel();
+
+    expect(screen.getByText("Meilisearch (keyword only)")).toBeInTheDocument();
+    expect(
+      screen.getByText("Search index rebuild required; using Meilisearch keyword search"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("rebuild required")).toBeInTheDocument();
   });
 });

--- a/web/src/pages/admin-settings/SearchStatusPanel.tsx
+++ b/web/src/pages/admin-settings/SearchStatusPanel.tsx
@@ -44,9 +44,22 @@ export function SearchStatusPanel() {
 
   return (
     <div className="divide-border divide-y">
+      {status.degraded && (
+        <div className="py-3">
+          <SettingFieldStatus tone="warn">
+            {status.degraded_reason ?? "Search is running in a degraded mode."}
+          </SettingFieldStatus>
+        </div>
+      )}
       <StatusRow
         label="Answering searches"
-        value={status.active_provider === "meilisearch" ? "Meilisearch" : "Postgres full-text"}
+        value={
+          status.active_provider === "meilisearch"
+            ? status.index.rebuild_required
+              ? "Meilisearch (keyword only)"
+              : "Meilisearch"
+            : "Postgres full-text"
+        }
         badge={status.configured_provider}
       />
       <StatusRow
@@ -57,7 +70,11 @@ export function SearchStatusPanel() {
       <StatusRow
         label="Active index"
         value={status.index.active_index_uid || "Not built"}
-        badge={`schema ${status.index.schema_version}/${status.index.expected_schema_version}`}
+        badge={
+          status.index.rebuild_required
+            ? "rebuild required"
+            : `schema ${status.index.schema_version}/${status.index.expected_schema_version}`
+        }
       />
       <StatusRow label="Documents" value={String(status.index.document_count)} />
       <StatusRow label="Indexed types" value={formatIndexedTypes(status.meilisearch.index_types)} />
@@ -144,7 +161,7 @@ function SearchTaskLinks() {
         <Link to="/admin/tasks/rebuild_catalog_search_index">Rebuild index</Link>
       </Button>
       <Button asChild size="sm" variant="ghost">
-        <Link to="/admin/tasks/sync_catalog_search_index">Sync history</Link>
+        <Link to="/admin/tasks/sync_catalog_search_index">Automatic maintenance</Link>
       </Button>
     </div>
   );


### PR DESCRIPTION
## Problem

Related issue: #346

Changing a schema-relevant catalog search setting leaves the active Meilisearch index stale after restart. Search then falls back to PostgreSQL until an administrator manually rebuilds the index, but the settings page does not explain that transition. On a large catalog, the fallback can turn an otherwise fast search into a multi-second request.

## Approach

- Use one process-lifetime catalog search settings snapshot for native search, jellycompat search, and index maintenance. Saved restart-bound settings cannot rebuild or swap an index before the server restarts.
- Let the existing hidden sync task rebuild missing or stale indexes on its startup trigger and retry on its one-minute interval. The existing PostgreSQL advisory lock still limits maintenance to one cluster node, and an older server will not replace an index built by a newer schema generation.
- Keep a compatible stale Meilisearch index available for keyword-only requests during the rebuild. This path does not create a query embedding. Unknown or incompatible schemas continue to fall back to PostgreSQL.
- Retry once against the newly active index when a node has a cached UID for an index removed by the atomic swap.
- Expose `degraded`, `degraded_reason`, and `index.rebuild_required` in the admin status response. The settings page warns before semantic search is enabled, shows degraded operation outside the collapsed status panel, polls while a rebuild is required, and links to automatic maintenance.
- Document the automatic rebuild and fallback behavior.

No migration or native client contract change is required. Jellycompat uses the same startup settings and search provider behavior.

## Validation

Repository gate on macOS/arm64:

- `make embed-stub` — passed
- `go build ./...` — passed
- `gofmt -l .` — no output
- `go vet ./...` — passed
- `golangci-lint run --new-from-merge-base="origin/main" ./...` — passed with 0 issues; it emitted one generated-file-filter warning for a deleted file in a different local worktree
- `make test-go` — passed on the clean rerun. The first run, while lint and the frontend gate were also running, hit three unrelated 25 ms timeouts in `internal/policy`; `go test ./internal/policy -count=1` and the subsequent full rerun passed.
- `pnpm install --frozen-lockfile` — passed
- `pnpm run lint` — passed with 0 errors and 168 existing warnings
- `pnpm run format:check` — passed
- `pnpm run build` — passed
- `make test-web` — 338 files and 2,748 tests passed
- `make verify-settings-bindings-all` — passed
- `make verify-playback-fixtures` — passed
- `make verify-local-paths` — passed
- `git diff --check` — passed

Focused checks:

- `go test ./internal/catalog ./internal/taskmanager/tasks ./internal/api -count=1` — passed
- Search settings/status component suites — 36 tests passed

Live validation used an isolated dev-builder sandbox with 134 catalog documents and a separate Meilisearch container:

1. Saved `semantic_enabled=false` without restarting. Eight status samples over 70 seconds kept the same active UID and schema, confirming that saved restart-bound settings do not trigger an early rebuild.
2. Restarted Silo. The status API reported Meilisearch as active, `degraded=true`, `rebuild_required=true`, and keyword-only service from the old UID while the startup task rebuilt all 134 documents.
3. The task completed without a manual rebuild. The active UID changed, the schema matched the expected version, and `degraded`/`rebuild_required` returned to false.
4. A catalog request then reported `provider=meilisearch`, `mode=keyword`, and `semantic_used=false`.
5. `silo-dev-builder doctor` passed before teardown. The isolated sandbox and its Meilisearch container were removed afterward.

The browser reached the sandbox with a clean console but had no authenticated session, so I did not capture the rendered admin warning. The staged-warning and degraded-status UI states are covered by the focused component tests above.

## Risks

- Keyword service during a rebuild is limited to schema hashes that prove the old index has the same document and media scope. Other mismatches use the existing PostgreSQL fallback.
- Task execution state is process-local. In a multi-node deployment, the database-backed search status is authoritative, but the linked task page can show the local node rather than the node holding the maintenance lock.
- The status fields are additive, but administrators or API consumers that derive health only from `active_provider` should also consider `degraded`.

## AI Disclosure

- Tool(s): OpenAI Codex desktop; Codex subagents
- Model(s): `gpt-5.6-sol`
- Involvement: AI-assisted
- Adversarial review: Separate agents reviewed backend rollout and cluster behavior, frontend status UX, and the completed diff/tests. The review found and prompted fixes for pre-restart rebuilds, mixed startup settings snapshots, older-node schema rollback, stale UID cache fallback after atomic swap, a false-green overview state, and misleading task copy. The remaining process-local task-view limitation is called out under Risks.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog search now reports provider health, degraded states, index compatibility, and rebuild requirements.
  * Automatic index rebuilds run after startup, retry failures, and respond to search-setting changes.
  * Compatible older indexes continue supporting keyword search while semantic indexes rebuild.
  * Admin settings display warnings, degradation reasons, rebuild progress, and maintenance links.
* **Bug Fixes**
  * Search retries after an active index becomes available and safely falls back when indexes are incompatible.
* **Documentation**
  * Added catalog search status API details and updated deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->