### PR TITLE
perf(metadata): scale image-cache concurrency with host CPUs

### DIFF
--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -33,7 +33,10 @@ const (
 	ImageCacheStatusSucceeded = "succeeded"
 	ImageCacheStatusFailed    = "failed"
 
-	imageCacheLeaseDuration = 15 * time.Minute
+	// ImageCacheLeaseDuration is stamped on every claimed row up front.
+	// Exported so worker/claim-page sizing can assert a claimed page always
+	// drains inside it (see internal/taskmanager/tasks).
+	ImageCacheLeaseDuration = 15 * time.Minute
 	imageCacheMaxAttempts   = 8
 	imageCacheDeferredRetry = 7 * 24 * time.Hour
 
@@ -427,7 +430,7 @@ func (r *ImageCacheJobRepository) recoverExpiredRunning(ctx context.Context, tar
 		  AND locked_at < NOW() - $1::interval
 	`
 	args := []any{
-		intervalLiteral(imageCacheLeaseDuration),
+		intervalLiteral(ImageCacheLeaseDuration),
 		imageCacheMaxAttempts,
 		intervalLiteral(imageCacheFailedCooldown),
 	}

--- a/internal/metadata/image_cache_processor.go
+++ b/internal/metadata/image_cache_processor.go
@@ -34,11 +34,21 @@ const (
 	imageCacheDiscoveryBatchSize = 1000
 	// Waiting for a background worker to release a job polls with backoff and
 	// gives up after immediateImageCacheIdleTimeout without progress. The
-	// worker's own lease runs for imageCacheLeaseDuration, and its pod can die
+	// worker's own lease runs for ImageCacheLeaseDuration, and its pod can die
 	// while holding it, so an interactive refresh must not wait that long.
 	immediateImageCacheMinPoll     = 100 * time.Millisecond
 	immediateImageCacheMaxPoll     = 2 * time.Second
 	immediateImageCacheIdleTimeout = 30 * time.Second
+
+	// ImageCacheJobTimeout bounds one job end to end: source check, download
+	// (which also has its own 30-second cap in imagecache), variant encode, and
+	// uploads. Only the download had a deadline before; a hung upload or encode
+	// could hold a job past its claim lease, letting another worker reclaim and
+	// duplicate it. Two minutes is generous for the slowest realistic job, and
+	// worker/claim-page sizing (internal/taskmanager/tasks) relies on it to
+	// prove a claimed page always drains inside ImageCacheLeaseDuration. A job
+	// that hits it is marked failed and retried on the normal backoff.
+	ImageCacheJobTimeout = 2 * time.Minute
 )
 
 // ErrTargetArtworkPending reports that some of a refreshed target's artwork was
@@ -434,7 +444,9 @@ loop:
 		go func(job *models.MetadataImageCacheJob) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			result := p.processOne(ctx, job)
+			jobCtx, cancelJob := context.WithTimeout(ctx, ImageCacheJobTimeout)
+			result := p.processOne(jobCtx, job)
+			cancelJob()
 			mu.Lock()
 			switch result.outcome {
 			case "succeeded":

--- a/internal/metadata/image_cache_processor_test.go
+++ b/internal/metadata/image_cache_processor_test.go
@@ -457,7 +457,7 @@ func TestImageCacheProcessorRetriesTargetAfterConcurrentWorkerFinishes(t *testin
 
 func TestImageCacheProcessorStopsWaitingOnStuckBackgroundWorker(t *testing.T) {
 	// A worker that claimed the job and died holds its lease for
-	// imageCacheLeaseDuration. The interactive refresh must not block that
+	// ImageCacheLeaseDuration. The interactive refresh must not block that
 	// long: it gives up and reports the artwork as still pending.
 	jobs := &targetImageCacheJobs{alwaysRunning: true}
 	processor := NewImageCacheProcessorWithTargets(

--- a/internal/nodemetrics/meminfo.go
+++ b/internal/nodemetrics/meminfo.go
@@ -138,6 +138,35 @@ func parseMeminfoLine(line string) (string, int64, bool) {
 	return strings.TrimSpace(key), value, true
 }
 
+// EffectiveMemoryLimitBytes returns the tightest cgroup memory limit in force
+// on this process, or 0 when none is set.
+//
+// The root-level limit files alone are only right inside a cgroup-namespaced
+// container. A systemd unit with MemoryMax=, or a leaf inheriting a tighter
+// limit from a slice or pod ancestor, publishes its limit at this process's
+// own cgroup or somewhere above it while the root file reads "max" — so this
+// walks the process's own cgroup, every ancestor, and the mount root, and
+// takes the tightest concrete limit found, mirroring what the sampler reports
+// (the kernel OOM-kills against the tightest level).
+func EffectiveMemoryLimitBytes() int64 {
+	return effectiveMemoryLimitBytes("/proc", cgroupMemoryUsagePaths)
+}
+
+func effectiveMemoryLimitBytes(procDir string, layouts []cgroupUsagePath) int64 {
+	relative := cgroupRelativePaths(procDir)
+	tightest := int64(0)
+	for _, level := range withCgroupSelfUsagePaths(relative, layouts) {
+		limit, err := ReadCgroupMemoryLimit(level.limit)
+		if err != nil || limit <= 0 {
+			continue
+		}
+		if tightest == 0 || limit < tightest {
+			tightest = limit
+		}
+	}
+	return tightest
+}
+
 // ReadCgroupMemoryLimit reads a cgroup memory-limit file and returns the limit
 // in bytes, or an error when the cgroup imposes none.
 //

--- a/internal/nodemetrics/meminfo_test.go
+++ b/internal/nodemetrics/meminfo_test.go
@@ -1,0 +1,61 @@
+package nodemetrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A systemd unit with MemoryMax= publishes its limit on the slice above the
+// leaf while both the leaf and the mount root read "max". The effective limit
+// must come from whichever level actually binds, not from the root files
+// alone.
+func TestEffectiveMemoryLimitBytesFindsTheBindingAncestor(t *testing.T) {
+	root := t.TempDir()
+	previousRoot := cgroupMountRoot
+	cgroupMountRoot = root
+	t.Cleanup(func() { cgroupMountRoot = previousRoot })
+
+	leaf := filepath.Join(root, "system.slice", "silo.service")
+	if err := os.MkdirAll(leaf, 0o755); err != nil {
+		t.Fatalf("create %s: %v", leaf, err)
+	}
+	write := func(path, body string) {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	procDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(procDir, "self"), 0o755); err != nil {
+		t.Fatalf("create proc self dir: %v", err)
+	}
+	write(filepath.Join(procDir, "self", "cgroup"), "0::/system.slice/silo.service\n")
+
+	layouts := []cgroupUsagePath{{
+		limit:        filepath.Join(root, "memory.max"),
+		usage:        filepath.Join(root, "memory.current"),
+		stat:         filepath.Join(root, "memory.stat"),
+		inactiveFile: cgroupInactiveFileKeyV2,
+	}}
+	const gib = int64(1) << 30
+
+	write(filepath.Join(root, "memory.max"), "max\n")
+	write(filepath.Join(root, "system.slice", "memory.max"), "2147483648\n")
+	write(filepath.Join(leaf, "memory.max"), "max\n")
+	if got := effectiveMemoryLimitBytes(procDir, layouts); got != 2*gib {
+		t.Fatalf("effective limit = %d, want the slice's 2GiB", got)
+	}
+
+	// A leaf tighter than its ancestor binds instead.
+	write(filepath.Join(leaf, "memory.max"), "1073741824\n")
+	if got := effectiveMemoryLimitBytes(procDir, layouts); got != gib {
+		t.Fatalf("effective limit = %d, want the leaf's 1GiB", got)
+	}
+
+	// No concrete limit anywhere reads as no limit, never as a sentinel.
+	write(filepath.Join(leaf, "memory.max"), "max\n")
+	write(filepath.Join(root, "system.slice", "memory.max"), "max\n")
+	if got := effectiveMemoryLimitBytes(procDir, layouts); got != 0 {
+		t.Fatalf("effective limit = %d, want 0 for no limit", got)
+	}
+}

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/nodemetrics"
 	"github.com/Silo-Server/silo-server/internal/taskmanager"
 )
 
@@ -18,6 +21,16 @@ const (
 	cacheMetadataImagesIntervalMs = int64(60 * 1000)
 	cacheMetadataImagesMaxRuntime = 10 * time.Minute
 )
+
+// imageCacheWorkerMemoryBudget is the memory reserved per concurrent image
+// job when sizing the pool against a detected memory bound. A job can hold
+// the compressed download (capped at 25 MiB in imagecache), the libvips
+// working set for the variant ladder, and — today — a full Go-heap decode of
+// the original for thumbhash, which for a large provider poster reaches the
+// low hundreds of MiB. 512 MiB per worker keeps even a burst of worst-case
+// originals from consuming the whole budget, since the baseline server also
+// lives inside it.
+const imageCacheWorkerMemoryBudget = 512 << 20
 
 // imageCacheWorkerCount sizes the image-cache worker pool for the host. Each
 // job downloads an original (30s timeout in imagecache) and runs a libvips
@@ -27,22 +40,56 @@ const (
 // previous fixed pool of 2 measured roughly 60 images/minute on a ~600k-item
 // library; 48 workers measured roughly 2,900/minute over a 60-minute window
 // (RXWatcher/silo-server@3b377f5c2).
-func imageCacheWorkerCount(numCPU int) int {
-	return min(48, 4*max(numCPU, 1))
+//
+// memoryBytes, when positive, is the tightest detected memory bound for this
+// process (GOMEMLIMIT, cgroup limit, or system memory) and caps the pool at
+// one worker per imageCacheWorkerMemoryBudget so a many-core container with a
+// small memory limit cannot be OOM-killed by concurrent decodes. The floor of
+// 2 is the pool size this task shipped with.
+func imageCacheWorkerCount(numCPU int, memoryBytes int64) int {
+	workers := min(48, 4*max(numCPU, 1))
+	if memoryBytes > 0 {
+		workers = min(workers, max(int(memoryBytes/imageCacheWorkerMemoryBudget), 2))
+	}
+	return workers
 }
 
-var cacheMetadataImagesWorkers = imageCacheWorkerCount(runtime.GOMAXPROCS(0))
+// detectImageCacheMemoryBytes returns the tightest memory bound the process
+// can see, or 0 when none is detectable (macOS dev boxes, bare Linux without
+// cgroups): an explicit GOMEMLIMIT first, then the container's cgroup limit,
+// then total system memory.
+func detectImageCacheMemoryBytes() int64 {
+	if limit := debug.SetMemoryLimit(-1); limit > 0 && limit < math.MaxInt64 {
+		return limit
+	}
+	for _, path := range nodemetrics.CgroupMemoryLimitPaths() {
+		if mem, err := nodemetrics.ReadCgroupMemoryLimit(path); err == nil && mem > 0 {
+			return mem
+		}
+	}
+	if mem, err := nodemetrics.ReadMeminfoTotalBytes("/proc/meminfo"); err == nil && mem > 0 {
+		return mem
+	}
+	return 0
+}
 
-// cacheMetadataImagesClaimLimit is the queue page stamped with one lease up
-// front. processClaimedJobs dispatches the page through a semaphore, so a page
-// larger than the worker count keeps the pool saturated instead of waiting on
-// every straggler in a worker-sized batch before the next page can be claimed.
-// The 15-minute lease stamped at claim (imageCacheLeaseDuration) is the
-// ceiling on page size: at 10 jobs per worker the page drains within ten times
-// the worst single job, and the slowest realistic job — a download at the full
-// 30-second timeout plus encode and uploads — keeps that comfortably inside
-// the lease even before the 10-minute task runtime cap stops new claims.
-var cacheMetadataImagesClaimLimit = 10 * cacheMetadataImagesWorkers
+var cacheMetadataImagesWorkers = imageCacheWorkerCount(runtime.GOMAXPROCS(0), detectImageCacheMemoryBytes())
+
+// cacheMetadataImagesClaimPerWorker sizes the queue page stamped with one
+// lease up front. processClaimedJobs dispatches the page through a semaphore,
+// so a page larger than the worker count keeps the pool saturated instead of
+// waiting on every straggler in a worker-sized batch before the next page can
+// be claimed.
+//
+// The page must drain inside metadata.ImageCacheLeaseDuration (15 minutes) or
+// another worker reclaims the unstarted tail and duplicates it. Every job is
+// hard-bounded by metadata.ImageCacheJobTimeout (2 minutes), so a page of N
+// jobs per worker fully drains within N × that timeout: 5 × 2 = 10 minutes,
+// leaving a third of the lease as margin. TestImageCacheWorkerCount asserts
+// this arithmetic against the exported constants.
+const cacheMetadataImagesClaimPerWorker = 5
+
+var cacheMetadataImagesClaimLimit = cacheMetadataImagesClaimPerWorker * cacheMetadataImagesWorkers
 
 type MetadataImageCacheRunner interface {
 	DrainUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error)

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -56,21 +56,29 @@ func imageCacheWorkerCount(numCPU int, memoryBytes int64) int {
 
 // detectImageCacheMemoryBytes returns the tightest memory bound the process
 // can see, or 0 when none is detectable (macOS dev boxes, bare Linux without
-// cgroups): an explicit GOMEMLIMIT first, then the tightest cgroup limit in
-// force on this process — own cgroup, ancestors, and root, so a systemd
+// cgroups). Every source is consulted and the smallest wins, because none
+// implies the others: GOMEMLIMIT can be set looser than a cgroup limit, and
+// the effective cgroup limit — own cgroup, ancestors, and root, so a systemd
 // MemoryMax= or an inherited pod/slice limit binds, not just a namespaced
-// container's root files — then total system memory.
+// container's root files — can sit above or below host memory.
 func detectImageCacheMemoryBytes() int64 {
-	if limit := debug.SetMemoryLimit(-1); limit > 0 && limit < math.MaxInt64 {
-		return limit
+	goLimit := int64(0)
+	if limit := debug.SetMemoryLimit(-1); limit < math.MaxInt64 {
+		goLimit = limit
 	}
-	if limit := nodemetrics.EffectiveMemoryLimitBytes(); limit > 0 {
-		return limit
+	hostTotal, _ := nodemetrics.ReadMeminfoTotalBytes("/proc/meminfo")
+	return tightestMemoryLimit(goLimit, nodemetrics.EffectiveMemoryLimitBytes(), hostTotal)
+}
+
+// tightestMemoryLimit returns the smallest positive limit, or 0 when none is.
+func tightestMemoryLimit(limits ...int64) int64 {
+	tightest := int64(0)
+	for _, limit := range limits {
+		if limit > 0 && (tightest == 0 || limit < tightest) {
+			tightest = limit
+		}
 	}
-	if mem, err := nodemetrics.ReadMeminfoTotalBytes("/proc/meminfo"); err == nil && mem > 0 {
-		return mem
-	}
-	return 0
+	return tightest
 }
 
 var cacheMetadataImagesWorkers = imageCacheWorkerCount(runtime.GOMAXPROCS(0), detectImageCacheMemoryBytes())

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -56,16 +56,16 @@ func imageCacheWorkerCount(numCPU int, memoryBytes int64) int {
 
 // detectImageCacheMemoryBytes returns the tightest memory bound the process
 // can see, or 0 when none is detectable (macOS dev boxes, bare Linux without
-// cgroups): an explicit GOMEMLIMIT first, then the container's cgroup limit,
-// then total system memory.
+// cgroups): an explicit GOMEMLIMIT first, then the tightest cgroup limit in
+// force on this process — own cgroup, ancestors, and root, so a systemd
+// MemoryMax= or an inherited pod/slice limit binds, not just a namespaced
+// container's root files — then total system memory.
 func detectImageCacheMemoryBytes() int64 {
 	if limit := debug.SetMemoryLimit(-1); limit > 0 && limit < math.MaxInt64 {
 		return limit
 	}
-	for _, path := range nodemetrics.CgroupMemoryLimitPaths() {
-		if mem, err := nodemetrics.ReadCgroupMemoryLimit(path); err == nil && mem > 0 {
-			return mem
-		}
+	if limit := nodemetrics.EffectiveMemoryLimitBytes(); limit > 0 {
+		return limit
 	}
 	if mem, err := nodemetrics.ReadMeminfoTotalBytes("/proc/meminfo"); err == nil && mem > 0 {
 		return mem
@@ -82,12 +82,18 @@ var cacheMetadataImagesWorkers = imageCacheWorkerCount(runtime.GOMAXPROCS(0), de
 // be claimed.
 //
 // The page must drain inside metadata.ImageCacheLeaseDuration (15 minutes) or
-// another worker reclaims the unstarted tail and duplicates it. Every job is
-// hard-bounded by metadata.ImageCacheJobTimeout (2 minutes), so a page of N
-// jobs per worker fully drains within N × that timeout: 5 × 2 = 10 minutes,
-// leaving a third of the lease as margin. TestImageCacheWorkerCount asserts
-// this arithmetic against the exported constants.
-const cacheMetadataImagesClaimPerWorker = 5
+// another worker reclaims the unstarted tail and duplicates it. Every job runs
+// under metadata.ImageCacheJobTimeout (2 minutes), but that context cannot
+// preempt the synchronous decode/encode segment (imageutil.Thumbhash,
+// GenerateVariants take no context) — it only stops the job at the next
+// context-aware step. That segment operates on inputs capped at 25 MiB
+// (imagecache's download limit), so its overshoot is bounded by CPU speed,
+// not by the network; 4 jobs per worker budgets the worst chain at
+// 4 × (timeout + overshoot), which stays inside the lease with a generous
+// overshoot allowance of nearly two minutes per job.
+// TestImageCacheWorkerCount asserts the timeout part of this arithmetic
+// against the exported constants.
+const cacheMetadataImagesClaimPerWorker = 4
 
 var cacheMetadataImagesClaimLimit = cacheMetadataImagesClaimPerWorker * cacheMetadataImagesWorkers
 

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/google/uuid"
@@ -15,13 +16,33 @@ import (
 
 const (
 	cacheMetadataImagesIntervalMs = int64(60 * 1000)
-	// Claim only work that can start immediately. Claiming a large queue page
-	// stamps one lease on every row up front; with two workers, the unstarted
-	// tail could expire and be reclaimed before this execution reaches it.
-	cacheMetadataImagesClaimLimit = 2
-	cacheMetadataImagesWorkers    = 2
 	cacheMetadataImagesMaxRuntime = 10 * time.Minute
 )
+
+// imageCacheWorkerCount sizes the image-cache worker pool for the host. Each
+// job downloads an original (30s timeout in imagecache) and runs a libvips
+// WEBP encode ladder, so the work is a CPU/network mix: 4× the scheduler's
+// CPU count keeps cores busy while other workers wait on downloads, and the
+// cap keeps a many-core server from monopolizing provider connections. The
+// previous fixed pool of 2 measured roughly 60 images/minute on a ~600k-item
+// library; 48 workers measured roughly 2,900/minute over a 60-minute window
+// (RXWatcher/silo-server@3b377f5c2).
+func imageCacheWorkerCount(numCPU int) int {
+	return min(48, 4*max(numCPU, 1))
+}
+
+var cacheMetadataImagesWorkers = imageCacheWorkerCount(runtime.GOMAXPROCS(0))
+
+// cacheMetadataImagesClaimLimit is the queue page stamped with one lease up
+// front. processClaimedJobs dispatches the page through a semaphore, so a page
+// larger than the worker count keeps the pool saturated instead of waiting on
+// every straggler in a worker-sized batch before the next page can be claimed.
+// The 15-minute lease stamped at claim (imageCacheLeaseDuration) is the
+// ceiling on page size: at 10 jobs per worker the page drains within ten times
+// the worst single job, and the slowest realistic job — a download at the full
+// 30-second timeout plus encode and uploads — keeps that comfortably inside
+// the lease even before the 10-minute task runtime cap stops new claims.
+var cacheMetadataImagesClaimLimit = 10 * cacheMetadataImagesWorkers
 
 type MetadataImageCacheRunner interface {
 	DrainUntilIdle(ctx context.Context, workerID string, claimLimit int, concurrency int, maxRuntime time.Duration, reportProgress metadata.ImageCacheRunProgressReporter) (metadata.ImageCacheRunStats, error)

--- a/internal/taskmanager/tasks/cache_metadata_images.go
+++ b/internal/taskmanager/tasks/cache_metadata_images.go
@@ -44,8 +44,13 @@ const imageCacheWorkerMemoryBudget = 512 << 20
 // memoryBytes, when positive, is the tightest detected memory bound for this
 // process (GOMEMLIMIT, cgroup limit, or system memory) and caps the pool at
 // one worker per imageCacheWorkerMemoryBudget so a many-core container with a
-// small memory limit cannot be OOM-killed by concurrent decodes. The floor of
-// 2 is the pool size this task shipped with.
+// small memory limit cannot be OOM-killed by concurrent decodes.
+//
+// The floor of 2 is the pool size this task shipped with, and it deliberately
+// overrides the per-worker budget below 2×imageCacheWorkerMemoryBudget: a
+// sub-1GiB deployment ran 2 workers before this sizing existed, so the memory
+// cap never reduces such a host below its long-standing baseline. The budget
+// is a sizing heuristic for how far to scale up, not a reservation.
 func imageCacheWorkerCount(numCPU int, memoryBytes int64) int {
 	workers := min(48, 4*max(numCPU, 1))
 	if memoryBytes > 0 {

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -115,11 +115,11 @@ func TestCacheMetadataImagesTaskReportsStats(t *testing.T) {
 	if err := task.Execute(context.Background(), progress); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if runner.claimLimit != 2 {
-		t.Fatalf("claimLimit = %d, want one immediately-startable job per worker", runner.claimLimit)
+	if runner.claimLimit != cacheMetadataImagesClaimLimit {
+		t.Fatalf("claimLimit = %d, want the shared page size %d", runner.claimLimit, cacheMetadataImagesClaimLimit)
 	}
-	if runner.concurrency != 2 {
-		t.Fatalf("concurrency = %d, want 2", runner.concurrency)
+	if runner.concurrency != cacheMetadataImagesWorkers {
+		t.Fatalf("concurrency = %d, want the shared worker count %d", runner.concurrency, cacheMetadataImagesWorkers)
 	}
 	if runner.maxRuntime != 10*time.Minute {
 		t.Fatalf("maxRuntime = %s, want 10m", runner.maxRuntime)
@@ -161,8 +161,8 @@ func TestBackfillMetadataImagesTaskReportsDiscovery(t *testing.T) {
 	if runner.maxRuntime != 0 {
 		t.Fatalf("maxRuntime = %s, want no deadline for manual backfill", runner.maxRuntime)
 	}
-	if runner.claimLimit != 2 {
-		t.Fatalf("claimLimit = %d, want one immediately-startable job per worker", runner.claimLimit)
+	if runner.claimLimit != cacheMetadataImagesClaimLimit {
+		t.Fatalf("claimLimit = %d, want the shared page size %d", runner.claimLimit, cacheMetadataImagesClaimLimit)
 	}
 	if len(runner.workerIDs) != 1 || !strings.Contains(runner.workerIDs[0], ":backfill:") {
 		t.Fatalf("backfill worker IDs = %#v, want one execution-scoped backfill owner", runner.workerIDs)
@@ -327,5 +327,29 @@ func TestBackfillMetadataImagesTaskProgressDoesNotFallWhenDiscoveryWidensTheRun(
 	}
 	if progress.percents[3] != 75 {
 		t.Fatalf("recovered report = %g, want 75", progress.percents[3])
+	}
+}
+
+func TestImageCacheWorkerCount(t *testing.T) {
+	cases := []struct {
+		numCPU int
+		want   int
+	}{
+		{numCPU: 0, want: 4}, // defensive floor; GOMAXPROCS never reports < 1
+		{numCPU: 1, want: 4}, // small household box: modest but no longer crippled
+		{numCPU: 4, want: 16},
+		{numCPU: 12, want: 48},
+		{numCPU: 16, want: 48}, // cap: more cores must not monopolize providers
+		{numCPU: 64, want: 48},
+	}
+	for _, tc := range cases {
+		if got := imageCacheWorkerCount(tc.numCPU); got != tc.want {
+			t.Errorf("imageCacheWorkerCount(%d) = %d, want %d", tc.numCPU, got, tc.want)
+		}
+	}
+	// The claim page must always drain inside the 15-minute claim lease: 10
+	// jobs per worker at the ~60s worst realistic job is 10 minutes.
+	if cacheMetadataImagesClaimLimit != 10*cacheMetadataImagesWorkers {
+		t.Errorf("claim limit = %d, want 10x workers (%d)", cacheMetadataImagesClaimLimit, 10*cacheMetadataImagesWorkers)
 	}
 }

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -359,10 +359,13 @@ func TestImageCacheWorkerCount(t *testing.T) {
 	}
 	// A claimed page is stamped with one lease up front, so it must fully
 	// drain before the lease expires or another worker reclaims the tail.
-	// Every job is bounded by metadata.ImageCacheJobTimeout, so the page's
-	// worst-case drain is jobs-per-worker times that timeout.
-	if drain := time.Duration(cacheMetadataImagesClaimPerWorker) * metadata.ImageCacheJobTimeout; drain >= metadata.ImageCacheLeaseDuration {
-		t.Errorf("worst-case page drain %s must stay under the %s claim lease", drain, metadata.ImageCacheLeaseDuration)
+	// The job timeout cannot preempt the synchronous decode/encode segment,
+	// so the timeout-based drain must leave real headroom under the lease
+	// for that bounded overshoot — at least one extra timeout per job.
+	drain := time.Duration(cacheMetadataImagesClaimPerWorker) * metadata.ImageCacheJobTimeout
+	overshootBudget := time.Duration(cacheMetadataImagesClaimPerWorker) * metadata.ImageCacheJobTimeout / 2
+	if drain+overshootBudget > metadata.ImageCacheLeaseDuration {
+		t.Errorf("page drain %s plus overshoot budget %s must stay within the %s claim lease", drain, overshootBudget, metadata.ImageCacheLeaseDuration)
 	}
 	if cacheMetadataImagesClaimLimit != cacheMetadataImagesClaimPerWorker*cacheMetadataImagesWorkers {
 		t.Errorf("claim limit = %d, want %d per worker (%d)", cacheMetadataImagesClaimLimit, cacheMetadataImagesClaimPerWorker, cacheMetadataImagesClaimPerWorker*cacheMetadataImagesWorkers)

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -344,7 +344,10 @@ func TestImageCacheWorkerCount(t *testing.T) {
 		{numCPU: 16, memory: 0, want: 48}, // cap: more cores must not monopolize providers
 		{numCPU: 64, memory: 0, want: 48},
 		// A many-core container with a small memory limit is bounded by
-		// memory, never below the original pool of 2.
+		// memory, never below the original pool of 2 — a sub-1GiB deployment
+		// already ran 2 workers before this change, so 2 is the floor, not 1.
+		{numCPU: 16, memory: 256 << 20, want: 2},
+		{numCPU: 16, memory: 512 << 20, want: 2},
 		{numCPU: 16, memory: 1 * gib, want: 2},
 		{numCPU: 16, memory: 2 * gib, want: 4},
 		{numCPU: 16, memory: 8 * gib, want: 16},
@@ -369,5 +372,26 @@ func TestImageCacheWorkerCount(t *testing.T) {
 	}
 	if cacheMetadataImagesClaimLimit != cacheMetadataImagesClaimPerWorker*cacheMetadataImagesWorkers {
 		t.Errorf("claim limit = %d, want %d per worker (%d)", cacheMetadataImagesClaimLimit, cacheMetadataImagesClaimPerWorker, cacheMetadataImagesClaimPerWorker*cacheMetadataImagesWorkers)
+	}
+}
+
+// Conflicting memory bounds resolve to the smallest positive one: GOMEMLIMIT
+// can be set looser than the cgroup limit and the cgroup limit can sit above
+// host memory, so no single source can be preferred outright.
+func TestTightestMemoryLimit(t *testing.T) {
+	const gib = int64(1) << 30
+	cases := []struct {
+		limits []int64
+		want   int64
+	}{
+		{limits: []int64{4 * gib, 2 * gib, 8 * gib}, want: 2 * gib}, // smallest wins
+		{limits: []int64{0, 2 * gib, 0}, want: 2 * gib},             // zeros mean "no bound", not zero bytes
+		{limits: []int64{0, 0, 0}, want: 0},                         // nothing detectable
+		{limits: []int64{6 * gib}, want: 6 * gib},
+	}
+	for _, tc := range cases {
+		if got := tightestMemoryLimit(tc.limits...); got != tc.want {
+			t.Errorf("tightestMemoryLimit(%v) = %d, want %d", tc.limits, got, tc.want)
+		}
 	}
 }

--- a/internal/taskmanager/tasks/cache_metadata_images_test.go
+++ b/internal/taskmanager/tasks/cache_metadata_images_test.go
@@ -331,25 +331,40 @@ func TestBackfillMetadataImagesTaskProgressDoesNotFallWhenDiscoveryWidensTheRun(
 }
 
 func TestImageCacheWorkerCount(t *testing.T) {
+	const gib = int64(1) << 30
 	cases := []struct {
 		numCPU int
+		memory int64
 		want   int
 	}{
-		{numCPU: 0, want: 4}, // defensive floor; GOMAXPROCS never reports < 1
-		{numCPU: 1, want: 4}, // small household box: modest but no longer crippled
-		{numCPU: 4, want: 16},
-		{numCPU: 12, want: 48},
-		{numCPU: 16, want: 48}, // cap: more cores must not monopolize providers
-		{numCPU: 64, want: 48},
+		{numCPU: 0, memory: 0, want: 4}, // defensive floor; GOMAXPROCS never reports < 1
+		{numCPU: 1, memory: 0, want: 4}, // small household box: modest but no longer crippled
+		{numCPU: 4, memory: 0, want: 16},
+		{numCPU: 12, memory: 0, want: 48},
+		{numCPU: 16, memory: 0, want: 48}, // cap: more cores must not monopolize providers
+		{numCPU: 64, memory: 0, want: 48},
+		// A many-core container with a small memory limit is bounded by
+		// memory, never below the original pool of 2.
+		{numCPU: 16, memory: 1 * gib, want: 2},
+		{numCPU: 16, memory: 2 * gib, want: 4},
+		{numCPU: 16, memory: 8 * gib, want: 16},
+		{numCPU: 16, memory: 64 * gib, want: 48},
+		// Plenty of memory but few cores: CPU stays the binding cap.
+		{numCPU: 2, memory: 64 * gib, want: 8},
 	}
 	for _, tc := range cases {
-		if got := imageCacheWorkerCount(tc.numCPU); got != tc.want {
-			t.Errorf("imageCacheWorkerCount(%d) = %d, want %d", tc.numCPU, got, tc.want)
+		if got := imageCacheWorkerCount(tc.numCPU, tc.memory); got != tc.want {
+			t.Errorf("imageCacheWorkerCount(%d, %d) = %d, want %d", tc.numCPU, tc.memory, got, tc.want)
 		}
 	}
-	// The claim page must always drain inside the 15-minute claim lease: 10
-	// jobs per worker at the ~60s worst realistic job is 10 minutes.
-	if cacheMetadataImagesClaimLimit != 10*cacheMetadataImagesWorkers {
-		t.Errorf("claim limit = %d, want 10x workers (%d)", cacheMetadataImagesClaimLimit, 10*cacheMetadataImagesWorkers)
+	// A claimed page is stamped with one lease up front, so it must fully
+	// drain before the lease expires or another worker reclaims the tail.
+	// Every job is bounded by metadata.ImageCacheJobTimeout, so the page's
+	// worst-case drain is jobs-per-worker times that timeout.
+	if drain := time.Duration(cacheMetadataImagesClaimPerWorker) * metadata.ImageCacheJobTimeout; drain >= metadata.ImageCacheLeaseDuration {
+		t.Errorf("worst-case page drain %s must stay under the %s claim lease", drain, metadata.ImageCacheLeaseDuration)
+	}
+	if cacheMetadataImagesClaimLimit != cacheMetadataImagesClaimPerWorker*cacheMetadataImagesWorkers {
+		t.Errorf("claim limit = %d, want %d per worker (%d)", cacheMetadataImagesClaimLimit, cacheMetadataImagesClaimPerWorker, cacheMetadataImagesClaimPerWorker*cacheMetadataImagesWorkers)
 	}
 }


### PR DESCRIPTION
## Problem

The scheduled `cache_metadata_images` task runs 2 workers on a 2-job claim page regardless of hardware. On a ~600k-item library that measured roughly 60 images/minute — the queue takes days to drain after a large scan while artwork sits missing in every client.

The 2/2 sizing predates `processClaimedJobs` dispatching a claimed page through a bounded semaphore. With the semaphore, a page larger than the worker count keeps the pool saturated instead of waiting on every straggler before the next page can be claimed; the tiny fixed constants were the only thing holding throughput back.

## Change

Derived from RXWatcher/silo-server@3b377f5c21cb9d71b6a8a3f8933788873699aeb2, which measured roughly 2,900 images/minute with 48 workers over a 60-minute window on the library above. That commit hard-codes 480/48, which fits a large server but oversubscribes the small end of Silo's deployment spectrum, so this PR scales instead of copying:

- **Workers: `min(48, 4 × GOMAXPROCS)`, additionally capped by memory.** Each job is a mix of a 30-second-capped download and a libvips WEBP encode ladder, so oversubscribing CPUs keeps cores busy during network waits. The cap keeps a many-core server from monopolizing provider connections; the `max(numCPU, 1)` floor gives even a 1-core box 4 workers — still double the old fixed pool. A 4-core household box gets 16; a 12-core server reaches the measured 48.
- **Claim page: 4 jobs per worker, with the lease math enforced.** The 15-minute lease stamped at claim (`metadata.ImageCacheLeaseDuration`) is the ceiling on page size. Review caught that nothing bounded a job end to end — only the download had a deadline — so every job now runs under `metadata.ImageCacheJobTimeout` (2 minutes) in `processClaimedJobs`. That context cannot preempt the synchronous decode/encode segment (also caught in review), but that segment is CPU-bounded on inputs capped at 25 MiB, so the page is sized at 4 × 2 = 8 minutes of timeout-based drain plus nearly two minutes of overshoot allowance per job, inside the 15-minute lease. The sizing test requires that headroom explicitly.
- **Memory bound (review follow-up).** CPU-derived sizing alone could put 48 concurrent jobs inside a container with a small memory limit; each job can hold a 25 MiB download plus a full Go decode of the original for thumbhash. Workers are now also capped at one per 512 MiB of the tightest detectable bound: every source is consulted — GOMEMLIMIT, the tightest cgroup limit in force on this process via a new `nodemetrics.EffectiveMemoryLimitBytes` (own cgroup, ancestors, root — so a systemd `MemoryMax=` or inherited pod/slice limit binds, not just a namespaced container's root files), and `/proc/meminfo` — and the smallest positive one wins. The floor of 2 workers preserves the shipped baseline; sub-1GiB deployments ran 2 workers before this PR too. The thumbhash full-resolution decode itself is being filed separately; it is shared change-detection state with ebook scans and does not belong in this PR.

## Tests

- `TestImageCacheWorkerCount` — CPU scaling curve, memory-capped cases, and the lease invariant: jobs-per-worker × `ImageCacheJobTimeout` plus a 50% overshoot budget must fit inside `ImageCacheLeaseDuration`.
- `TestEffectiveMemoryLimitBytesFindsTheBindingAncestor` — fixture test for the systemd-slice shape: limit on the slice binds while leaf and root read `max`; a tighter leaf wins; all-`max` reads as no limit.
- Existing task tests updated: they asserted the old literal `claimLimit = 2` / `concurrency = 2` and now assert against the shared sizing vars, which is what they were checking all along — that `Execute` passes the task's configured page and pool through to the runner.

## Validation

- `go test ./internal/taskmanager/... ./internal/metadata/ ./internal/nodemetrics/` — passes
- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `golangci-lint run --new-from-merge-base=origin/main ./...` — 0 issues
- Throughput numbers (60 → ~2,900 images/minute) are the fork author's measurements on their production library, not reproduced here; correctness rests on the lease arithmetic above, now asserted by test.

Related issue: N/A — narrow fix (task sizing, a per-job timeout, and an internal memory-limit helper; no API, client, or jellycompat surface changes)

## AI Disclosure

- Tool(s): Claude Code (this PR); the source commit on the fork reports Claude Code as well
- Model(s): claude-fable-5 (analysis and implementation); source commit reports claude-opus-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: The source commit's fixed 480/48 was reviewed against the deployment spectrum before adapting: per-job cost was traced through `processOne` → `imagecache` (30s download timeout, 25MB download cap, libvips encode) to confirm the lease arithmetic, and the fixed worker count was rejected for small hosts in favor of CPU scaling. The two existing tests that encoded the old sizing were updated deliberately, not silenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
