### PR TITLE
perf(metadata): batch artwork reconcile bulk resets

### DIFF
--- a/internal/metadata/artwork_reconcile.go
+++ b/internal/metadata/artwork_reconcile.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -11,8 +12,65 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// Retry parameters for the bulk-reset UPDATEs below. They run concurrently
+// with per-item writes from ordinary metadata refresh jobs touching the same
+// tables (media_items, media_files) in a different row order, which is a real,
+// observed deadlock source (SQLSTATE 40P01) — not a hypothetical one.
+var (
+	artworkReconcileDeadlockMaxAttempts = 5
+	artworkReconcileDeadlockBaseBackoff = 100 * time.Millisecond
+)
+
+// artworkReconcileBulkBatchSize bounds how many rows one bulk-reset statement
+// touches.
+//
+// These resets were originally single full-table UPDATEs. On a large library
+// that is one statement holding row locks on every matching row for as long as
+// it runs — an observed 1h51m on media_items, during which 12 of 16 pool
+// connections sat blocked behind it and ordinary playback/metadata writes
+// stalled. Retrying on deadlock (above) treats the symptom; the lock footprint
+// is the cause.
+//
+// Batching bounds that footprint: each statement locks at most this many rows
+// and commits, so concurrent writers interleave instead of queueing behind a
+// table-wide writer. The loop is self-terminating because both SET clauses
+// falsify the predicate that selected the row — resetSet writes the provider
+// URL into pathCol (which cachedPredicate excludes via NOT LIKE '%://%'), and
+// clearSet empties it.
+//
+// A var, not a const, so DB tests can shrink it to exercise the multi-batch
+// path without seeding thousands of rows.
+var artworkReconcileBulkBatchSize = 5000
+
+// retryOnDeadlock runs op, retrying when Postgres reports a deadlock (40P01)
+// or serialization failure (40001), with exponential backoff. It returns
+// immediately for any other error, and honors context cancellation between
+// attempts.
+func retryOnDeadlock(ctx context.Context, op func() error) error {
+	backoff := artworkReconcileDeadlockBaseBackoff
+	for attempt := 1; ; attempt++ {
+		err := op()
+		if err == nil {
+			return nil
+		}
+		var pgErr *pgconn.PgError
+		if attempt < artworkReconcileDeadlockMaxAttempts && errors.As(err, &pgErr) &&
+			(pgErr.Code == "40P01" || pgErr.Code == "40001") {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+			continue
+		}
+		return err
+	}
+}
 
 // ArtworkObjectChecker is the S3 surface the reconciler needs: existence
 // checks against the public asset bucket. Satisfied by *s3client.Client.
@@ -729,29 +787,71 @@ func (r *ArtworkCacheReconciler) objectExistsWithRetry(ctx context.Context, buck
 // owning pipeline can refill them.
 func (r *ArtworkCacheReconciler) bulkResetSurface(ctx context.Context, s artworkSweepSurface, stats *ArtworkReconcileStats) error {
 	if s.sourceCol != "" {
-		requeue := fmt.Sprintf(
-			`UPDATE %s SET %s WHERE %s AND %s`,
-			s.table, s.resetSet(), s.cachedPredicate(), s.remoteSourcePredicate(),
-		)
-		tag, err := r.pool.Exec(ctx, requeue)
+		requeued, err := r.bulkUpdateInBatches(ctx, s, s.resetSet(),
+			fmt.Sprintf(`%s AND %s`, s.cachedPredicate(), s.remoteSourcePredicate()))
 		if err != nil {
 			return fmt.Errorf("artwork reconcile: bulk reset %s: %w", s.name, err)
 		}
-		stats.Requeued += int(tag.RowsAffected())
-		stats.Checked += int(tag.RowsAffected())
+		stats.Requeued += requeued
+		stats.Checked += requeued
 	}
 
-	clearSQL := fmt.Sprintf(
-		`UPDATE %s SET %s WHERE %s AND NOT (%s)`,
-		s.table, s.clearSet, s.cachedPredicate(), s.remoteSourcePredicate(),
-	)
-	tag, err := r.pool.Exec(ctx, clearSQL)
+	cleared, err := r.bulkUpdateInBatches(ctx, s, s.clearSet,
+		fmt.Sprintf(`%s AND NOT (%s)`, s.cachedPredicate(), s.remoteSourcePredicate()))
 	if err != nil {
 		return fmt.Errorf("artwork reconcile: bulk clear %s: %w", s.name, err)
 	}
-	stats.Cleared += int(tag.RowsAffected())
-	stats.Checked += int(tag.RowsAffected())
+	stats.Cleared += cleared
+	stats.Checked += cleared
 	return nil
+}
+
+// bulkUpdateInBatches applies setClause to every row of s matching where, in
+// batches of artworkReconcileBulkBatchSize, and returns the total row count.
+//
+// Each batch selects its slice through the surface's unique key order and takes
+// row locks with FOR UPDATE before updating. The consistent ordering is what
+// keeps concurrent batches from deadlocking against each other; retryOnDeadlock
+// still covers deadlocks against unrelated writers using a different order.
+// SKIP LOCKED is deliberately NOT used — skipping a contended row would end the
+// loop early and silently leave rows unreset.
+//
+// Callers must pass a where whose rows stop matching once setClause is applied,
+// or this loops forever. Both callers above satisfy that; see the comment on
+// artworkReconcileBulkBatchSize.
+func (r *ArtworkCacheReconciler) bulkUpdateInBatches(ctx context.Context, s artworkSweepSurface, setClause, where string) (int, error) {
+	keyCols := strings.Join(s.keyColumnNames(), ", ")
+	stmt := fmt.Sprintf(`
+		WITH batch AS (
+			SELECT %[1]s FROM %[2]s
+			WHERE %[3]s
+			ORDER BY %[1]s
+			LIMIT %[4]d
+			FOR UPDATE
+		)
+		UPDATE %[2]s SET %[5]s
+		WHERE (%[1]s) IN (SELECT %[1]s FROM batch)`,
+		keyCols, s.table, where, artworkReconcileBulkBatchSize, setClause,
+	)
+
+	total := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		var rows int64
+		if err := retryOnDeadlock(ctx, func() error {
+			tag, err := r.pool.Exec(ctx, stmt)
+			rows = tag.RowsAffected()
+			return err
+		}); err != nil {
+			return total, err
+		}
+		if rows == 0 {
+			return total, nil
+		}
+		total += int(rows)
+	}
 }
 
 // sweptRow is one candidate row in the per-row verification sweep.
@@ -949,27 +1049,51 @@ func (r *ArtworkCacheReconciler) countChapterThumbnailFiles(ctx context.Context)
 }
 
 func (r *ArtworkCacheReconciler) bulkResetChapterThumbnails(ctx context.Context, stats *ArtworkReconcileStats) error {
-	tag, err := r.pool.Exec(ctx, `
+	// Batched for the same reason as bulkUpdateInBatches: unbatched, this locks
+	// every media_files row with chapter thumbnails for the whole run, and the
+	// per-row jsonb_agg rebuild makes it slow. Self-terminating because the SET
+	// empties thumbnail_path on every element the predicate looks for.
+	stmt := `
+		WITH batch AS (
+			SELECT id FROM media_files
+			WHERE ` + chapterThumbnailFilesPredicate + `
+			ORDER BY id
+			LIMIT ` + strconv.Itoa(artworkReconcileBulkBatchSize) + `
+			FOR UPDATE
+		)
 		UPDATE media_files
-		SET chapters = (
-			SELECT jsonb_agg(
-				CASE WHEN coalesce(e->>'thumbnail_path', '') <> ''
-					THEN (e - 'thumbnail_retry_after' - 'thumbnail_failed_at' - 'thumbnail_last_error')
-						|| '{"thumbnail_path": "", "thumbnail_thumbhash": ""}'::jsonb
-					ELSE e
-				END
-				ORDER BY ord
-			)
-			FROM jsonb_array_elements(chapters) WITH ORDINALITY AS t(e, ord)
-		),
-		chapter_thumbnail_retry_after = NULL
-		WHERE `+chapterThumbnailFilesPredicate)
-	if err != nil {
-		return fmt.Errorf("artwork reconcile: bulk clearing chapter thumbnails: %w", err)
+			SET chapters = (
+				SELECT jsonb_agg(
+					CASE WHEN coalesce(e->>'thumbnail_path', '') <> ''
+						THEN (e - 'thumbnail_retry_after' - 'thumbnail_failed_at' - 'thumbnail_last_error')
+							|| '{"thumbnail_path": "", "thumbnail_thumbhash": ""}'::jsonb
+						ELSE e
+					END
+					ORDER BY ord
+				)
+				FROM jsonb_array_elements(chapters) WITH ORDINALITY AS t(e, ord)
+			),
+			chapter_thumbnail_retry_after = NULL
+			WHERE id IN (SELECT id FROM batch)`
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var rows int64
+		if err := retryOnDeadlock(ctx, func() error {
+			tag, execErr := r.pool.Exec(ctx, stmt)
+			rows = tag.RowsAffected()
+			return execErr
+		}); err != nil {
+			return fmt.Errorf("artwork reconcile: bulk clearing chapter thumbnails: %w", err)
+		}
+		if rows == 0 {
+			return nil
+		}
+		stats.Cleared += int(rows)
+		stats.Checked += int(rows)
 	}
-	stats.Cleared += int(tag.RowsAffected())
-	stats.Checked += int(tag.RowsAffected())
-	return nil
 }
 
 // chapterFileRow is one media_files row in the chapter thumbnail sweep.

--- a/internal/metadata/artwork_reconcile.go
+++ b/internal/metadata/artwork_reconcile.go
@@ -786,23 +786,26 @@ func (r *ArtworkCacheReconciler) objectExistsWithRetry(ctx context.Context, buck
 // manual backfill can cache them again. Rows without one are cleared so their
 // owning pipeline can refill them.
 func (r *ArtworkCacheReconciler) bulkResetSurface(ctx context.Context, s artworkSweepSurface, stats *ArtworkReconcileStats) error {
+	// Counts are recorded before the error check: batches commit as they go,
+	// and the task serializes stats on failure, so an interrupted reset must
+	// still report the rows it durably changed.
 	if s.sourceCol != "" {
 		requeued, err := r.bulkUpdateInBatches(ctx, s, s.resetSet(),
 			fmt.Sprintf(`%s AND %s`, s.cachedPredicate(), s.remoteSourcePredicate()))
+		stats.Requeued += requeued
+		stats.Checked += requeued
 		if err != nil {
 			return fmt.Errorf("artwork reconcile: bulk reset %s: %w", s.name, err)
 		}
-		stats.Requeued += requeued
-		stats.Checked += requeued
 	}
 
 	cleared, err := r.bulkUpdateInBatches(ctx, s, s.clearSet,
 		fmt.Sprintf(`%s AND NOT (%s)`, s.cachedPredicate(), s.remoteSourcePredicate()))
+	stats.Cleared += cleared
+	stats.Checked += cleared
 	if err != nil {
 		return fmt.Errorf("artwork reconcile: bulk clear %s: %w", s.name, err)
 	}
-	stats.Cleared += cleared
-	stats.Checked += cleared
 	return nil
 }
 

--- a/internal/metadata/artwork_reconcile.go
+++ b/internal/metadata/artwork_reconcile.go
@@ -819,41 +819,76 @@ func (r *ArtworkCacheReconciler) bulkResetSurface(ctx context.Context, s artwork
 // SKIP LOCKED is deliberately NOT used — skipping a contended row would end the
 // loop early and silently leave rows unreset.
 //
-// Callers must pass a where whose rows stop matching once setClause is applied,
-// or this loops forever. Both callers above satisfy that; see the comment on
-// artworkReconcileBulkBatchSize.
+// A keyset cursor carries each batch's last key into the next batch's WHERE.
+// Without it every iteration restarts the ordered scan at the smallest key and
+// rechecks all previously updated rows — still in the key index but no longer
+// matching — making the sweep O(N²/batchSize) on a large surface. The cursor
+// also makes termination unconditional (keys strictly increase), though both
+// callers additionally pass a where that stops matching once setClause is
+// applied; see the comment on artworkReconcileBulkBatchSize. A row re-cached
+// by a concurrent writer behind the cursor is skipped by this sweep and picked
+// up by the next reconcile, which is the semantics a point-in-time reset wants.
 func (r *ArtworkCacheReconciler) bulkUpdateInBatches(ctx context.Context, s artworkSweepSurface, setClause, where string) (int, error) {
 	keyCols := strings.Join(s.keyColumnNames(), ", ")
-	stmt := fmt.Sprintf(`
-		WITH batch AS (
-			SELECT %[1]s FROM %[2]s
-			WHERE %[3]s
-			ORDER BY %[1]s
-			LIMIT %[4]d
-			FOR UPDATE
+	cursorParams := make([]string, len(s.keyCols))
+	for i := range cursorParams {
+		cursorParams[i] = fmt.Sprintf("$%d", i+1)
+	}
+	stmtFor := func(withCursor bool) string {
+		cursorCond := ""
+		if withCursor {
+			cursorCond = fmt.Sprintf(` AND (%s) > (%s)`, keyCols, strings.Join(cursorParams, ", "))
+		}
+		// The batch CTE both locks the slice and reports its last key; the
+		// updated CTE counts what actually changed. Selecting the last key
+		// from batch rather than from RETURNING keeps the cursor moving even
+		// if a row version no longer matches at update time.
+		return fmt.Sprintf(`
+			WITH batch AS (
+				SELECT %[1]s FROM %[2]s
+				WHERE %[3]s%[4]s
+				ORDER BY %[1]s
+				LIMIT %[5]d
+				FOR UPDATE
+			), updated AS (
+				UPDATE %[2]s SET %[6]s
+				WHERE (%[1]s) IN (SELECT %[1]s FROM batch)
+				RETURNING 1
+			)
+			SELECT (SELECT count(*) FROM updated),
+				(SELECT ARRAY[%[7]s] FROM batch ORDER BY %[1]s DESC LIMIT 1)`,
+			keyCols, s.table, where, cursorCond, artworkReconcileBulkBatchSize,
+			setClause, strings.Join(s.keySelectExpressions(), ", "),
 		)
-		UPDATE %[2]s SET %[5]s
-		WHERE (%[1]s) IN (SELECT %[1]s FROM batch)`,
-		keyCols, s.table, where, artworkReconcileBulkBatchSize, setClause,
-	)
+	}
+	firstStmt, nextStmt := stmtFor(false), stmtFor(true)
 
 	total := 0
+	var cursorArgs []any
 	for {
 		if err := ctx.Err(); err != nil {
 			return total, err
 		}
+		stmt := nextStmt
+		if cursorArgs == nil {
+			stmt = firstStmt
+		}
 		var rows int64
+		var lastKeys []string
 		if err := retryOnDeadlock(ctx, func() error {
-			tag, err := r.pool.Exec(ctx, stmt)
-			rows = tag.RowsAffected()
-			return err
+			return r.pool.QueryRow(ctx, stmt, cursorArgs...).Scan(&rows, &lastKeys)
 		}); err != nil {
 			return total, err
 		}
-		if rows == 0 {
+		total += int(rows)
+		if lastKeys == nil {
 			return total, nil
 		}
-		total += int(rows)
+		parsed, err := s.parseKeys(lastKeys)
+		if err != nil {
+			return total, fmt.Errorf("parsing bulk update cursor: %w", err)
+		}
+		cursorArgs = parsed
 	}
 }
 
@@ -1054,48 +1089,54 @@ func (r *ArtworkCacheReconciler) countChapterThumbnailFiles(ctx context.Context)
 func (r *ArtworkCacheReconciler) bulkResetChapterThumbnails(ctx context.Context, stats *ArtworkReconcileStats) error {
 	// Batched for the same reason as bulkUpdateInBatches: unbatched, this locks
 	// every media_files row with chapter thumbnails for the whole run, and the
-	// per-row jsonb_agg rebuild makes it slow. Self-terminating because the SET
-	// empties thumbnail_path on every element the predicate looks for.
+	// per-row jsonb_agg rebuild makes it slow. The id cursor keeps each batch's
+	// scan from re-evaluating the JSONB predicate over every previously reset
+	// row, and guarantees termination outright; the SET also empties every
+	// thumbnail_path the predicate looks for.
 	stmt := `
 		WITH batch AS (
 			SELECT id FROM media_files
-			WHERE ` + chapterThumbnailFilesPredicate + `
+			WHERE ` + chapterThumbnailFilesPredicate + ` AND id > $1
 			ORDER BY id
 			LIMIT ` + strconv.Itoa(artworkReconcileBulkBatchSize) + `
 			FOR UPDATE
+		), updated AS (
+			UPDATE media_files
+				SET chapters = (
+					SELECT jsonb_agg(
+						CASE WHEN coalesce(e->>'thumbnail_path', '') <> ''
+							THEN (e - 'thumbnail_retry_after' - 'thumbnail_failed_at' - 'thumbnail_last_error')
+								|| '{"thumbnail_path": "", "thumbnail_thumbhash": ""}'::jsonb
+							ELSE e
+						END
+						ORDER BY ord
+					)
+					FROM jsonb_array_elements(chapters) WITH ORDINALITY AS t(e, ord)
+				),
+				chapter_thumbnail_retry_after = NULL
+				WHERE id IN (SELECT id FROM batch)
+				RETURNING 1
 		)
-		UPDATE media_files
-			SET chapters = (
-				SELECT jsonb_agg(
-					CASE WHEN coalesce(e->>'thumbnail_path', '') <> ''
-						THEN (e - 'thumbnail_retry_after' - 'thumbnail_failed_at' - 'thumbnail_last_error')
-							|| '{"thumbnail_path": "", "thumbnail_thumbhash": ""}'::jsonb
-						ELSE e
-					END
-					ORDER BY ord
-				)
-				FROM jsonb_array_elements(chapters) WITH ORDINALITY AS t(e, ord)
-			),
-			chapter_thumbnail_retry_after = NULL
-			WHERE id IN (SELECT id FROM batch)`
+		SELECT (SELECT count(*) FROM updated), (SELECT max(id) FROM batch)`
 
+	cursor := int64(0)
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		var rows int64
+		var lastID *int64
 		if err := retryOnDeadlock(ctx, func() error {
-			tag, execErr := r.pool.Exec(ctx, stmt)
-			rows = tag.RowsAffected()
-			return execErr
+			return r.pool.QueryRow(ctx, stmt, cursor).Scan(&rows, &lastID)
 		}); err != nil {
 			return fmt.Errorf("artwork reconcile: bulk clearing chapter thumbnails: %w", err)
 		}
-		if rows == 0 {
-			return nil
-		}
 		stats.Cleared += int(rows)
 		stats.Checked += int(rows)
+		if lastID == nil {
+			return nil
+		}
+		cursor = *lastID
 	}
 }
 

--- a/internal/metadata/artwork_reconcile_bulk_db_test.go
+++ b/internal/metadata/artwork_reconcile_bulk_db_test.go
@@ -256,6 +256,47 @@ func TestBulkResetChapterThumbnailsBatches(t *testing.T) {
 	}
 }
 
+// TestBulkResetSurfacePartialFailureKeepsCounts interrupts bulkResetSurface
+// after its requeue phase by giving the clear phase a broken SET clause.
+// Batches commit as they go and the task serializes stats on failure, so the
+// rows the requeue phase durably changed must be counted despite the error.
+func TestBulkResetSurfacePartialFailureKeepsCounts(t *testing.T) {
+	pool := localArtworkTestPool(t)
+	ctx := context.Background()
+	shrinkBulkBatchSize(t, 2)
+
+	prefix := fmt.Sprintf("bulkpartial-%d", time.Now().UnixNano())
+	restorePreexistingPosterRows(t, pool, prefix)
+
+	const requeueRows = 5
+	for i := 0; i < requeueRows; i++ {
+		contentID := fmt.Sprintf("%s-%d", prefix, i)
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_items (content_id, type, title, status, genres, poster_path, poster_source_path)
+			VALUES ($1, 'movie', 'Bulk Partial Test', 'matched', '{}'::text[], $2, $3)
+		`, contentID, fmt.Sprintf("metadata/movie/%s/poster/original.webp", contentID),
+			fmt.Sprintf("https://image.example.org/t/p/original/%s-%d.jpg", prefix, i)); err != nil {
+			t.Fatalf("seed item %d: %v", i, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"-%")
+	})
+
+	surface := itemPosterSurface(t)
+	surface.clearSet = `nonexistent_bulk_partial_column = ''`
+
+	r := &ArtworkCacheReconciler{pool: pool}
+	var stats ArtworkReconcileStats
+	err := r.bulkResetSurface(ctx, surface, &stats)
+	if err == nil {
+		t.Fatal("bulkResetSurface succeeded, want the clear phase to fail")
+	}
+	if stats.Requeued < requeueRows {
+		t.Errorf("stats.Requeued = %d after clear-phase failure, want >= %d committed requeues", stats.Requeued, requeueRows)
+	}
+}
+
 func TestRetryOnDeadlock(t *testing.T) {
 	prevBackoff := artworkReconcileDeadlockBaseBackoff
 	artworkReconcileDeadlockBaseBackoff = time.Millisecond

--- a/internal/metadata/artwork_reconcile_bulk_db_test.go
+++ b/internal/metadata/artwork_reconcile_bulk_db_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // shrinkBulkBatchSize forces the bulk-reset loops through multiple batches with
@@ -30,17 +31,95 @@ func itemPosterSurface(t *testing.T) artworkSweepSurface {
 	return artworkSweepSurface{}
 }
 
+// The bulk resets under test sweep their whole table, not just this test's
+// fixtures. The test database may be shared and populated, so each test
+// snapshots every pre-existing row its reset would touch and restores those
+// rows on cleanup; only the seeded fixtures are asserted on.
+
+func restorePreexistingPosterRows(t *testing.T, pool *pgxpool.Pool, seededPrefix string) {
+	t.Helper()
+	ctx := context.Background()
+	surface := itemPosterSurface(t)
+	rows, err := pool.Query(ctx, fmt.Sprintf(
+		`SELECT content_id, poster_path, last_refreshed, updated_at FROM media_items
+		 WHERE %s AND content_id NOT LIKE $1`, surface.cachedPredicate()), seededPrefix+"%")
+	if err != nil {
+		t.Fatalf("snapshot pre-existing poster rows: %v", err)
+	}
+	type itemState struct {
+		contentID     string
+		posterPath    string
+		lastRefreshed *time.Time
+		updatedAt     *time.Time
+	}
+	var snapshot []itemState
+	for rows.Next() {
+		var s itemState
+		if err := rows.Scan(&s.contentID, &s.posterPath, &s.lastRefreshed, &s.updatedAt); err != nil {
+			t.Fatalf("scan poster snapshot: %v", err)
+		}
+		snapshot = append(snapshot, s)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read poster snapshot: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, s := range snapshot {
+			if _, err := pool.Exec(ctx,
+				`UPDATE media_items SET poster_path = $2, last_refreshed = $3, updated_at = $4 WHERE content_id = $1`,
+				s.contentID, s.posterPath, s.lastRefreshed, s.updatedAt); err != nil {
+				t.Errorf("restore poster row %s: %v", s.contentID, err)
+			}
+		}
+	})
+}
+
+func restorePreexistingChapterRows(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	rows, err := pool.Query(ctx,
+		`SELECT id, chapters, chapter_thumbnail_retry_after FROM media_files WHERE `+chapterThumbnailFilesPredicate)
+	if err != nil {
+		t.Fatalf("snapshot pre-existing chapter rows: %v", err)
+	}
+	type fileState struct {
+		id         int64
+		chapters   []byte
+		retryAfter *time.Time
+	}
+	var snapshot []fileState
+	for rows.Next() {
+		var s fileState
+		if err := rows.Scan(&s.id, &s.chapters, &s.retryAfter); err != nil {
+			t.Fatalf("scan chapter snapshot: %v", err)
+		}
+		snapshot = append(snapshot, s)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read chapter snapshot: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, s := range snapshot {
+			if _, err := pool.Exec(ctx,
+				`UPDATE media_files SET chapters = $2::jsonb, chapter_thumbnail_retry_after = $3 WHERE id = $1`,
+				s.id, s.chapters, s.retryAfter); err != nil {
+				t.Errorf("restore chapter row %d: %v", s.id, err)
+			}
+		}
+	})
+}
+
 // TestBulkResetSurfaceBatches drives bulkResetSurface across several batches
 // and verifies both halves: rows with a remote source are requeued (path reset
 // to the source URL), rows without one are cleared. Assertions are scoped to
-// the seeded rows because the reset sweeps the whole table and the test
-// database may hold rows from other tests.
+// the seeded rows; pre-existing rows the sweep touches are snapshot-restored.
 func TestBulkResetSurfaceBatches(t *testing.T) {
 	pool := localArtworkTestPool(t)
 	ctx := context.Background()
 	shrinkBulkBatchSize(t, 3)
 
 	prefix := fmt.Sprintf("bulkreset-%d", time.Now().UnixNano())
+	restorePreexistingPosterRows(t, pool, prefix)
 	const requeueRows, clearRows = 7, 5
 	sourceURL := func(i int) string {
 		return fmt.Sprintf("https://image.example.org/t/p/original/%s-%d.jpg", prefix, i)
@@ -108,6 +187,7 @@ func TestBulkResetChapterThumbnailsBatches(t *testing.T) {
 	pool := localArtworkTestPool(t)
 	ctx := context.Background()
 	shrinkBulkBatchSize(t, 2)
+	restorePreexistingChapterRows(t, pool)
 
 	suffix := time.Now().UnixNano()
 	var folderID int

--- a/internal/metadata/artwork_reconcile_bulk_db_test.go
+++ b/internal/metadata/artwork_reconcile_bulk_db_test.go
@@ -1,0 +1,240 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// shrinkBulkBatchSize forces the bulk-reset loops through multiple batches with
+// a handful of seeded rows instead of thousands.
+func shrinkBulkBatchSize(t *testing.T, size int) {
+	t.Helper()
+	prev := artworkReconcileBulkBatchSize
+	artworkReconcileBulkBatchSize = size
+	t.Cleanup(func() { artworkReconcileBulkBatchSize = prev })
+}
+
+func itemPosterSurface(t *testing.T) artworkSweepSurface {
+	t.Helper()
+	for _, s := range artworkSweepSurfaces() {
+		if s.name == "item posters" {
+			return s
+		}
+	}
+	t.Fatal("item posters surface not found")
+	return artworkSweepSurface{}
+}
+
+// TestBulkResetSurfaceBatches drives bulkResetSurface across several batches
+// and verifies both halves: rows with a remote source are requeued (path reset
+// to the source URL), rows without one are cleared. Assertions are scoped to
+// the seeded rows because the reset sweeps the whole table and the test
+// database may hold rows from other tests.
+func TestBulkResetSurfaceBatches(t *testing.T) {
+	pool := localArtworkTestPool(t)
+	ctx := context.Background()
+	shrinkBulkBatchSize(t, 3)
+
+	prefix := fmt.Sprintf("bulkreset-%d", time.Now().UnixNano())
+	const requeueRows, clearRows = 7, 5
+	sourceURL := func(i int) string {
+		return fmt.Sprintf("https://image.example.org/t/p/original/%s-%d.jpg", prefix, i)
+	}
+
+	var seeded []string
+	for i := 0; i < requeueRows+clearRows; i++ {
+		contentID := fmt.Sprintf("%s-%d", prefix, i)
+		source := ""
+		if i < requeueRows {
+			source = sourceURL(i)
+		}
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO media_items (content_id, type, title, status, genres, poster_path, poster_source_path, last_refreshed)
+			VALUES ($1, 'movie', 'Bulk Reset Test', 'matched', '{}'::text[], $2, $3, NOW())
+		`, contentID, fmt.Sprintf("metadata/movie/%s/poster/original.webp", contentID), source); err != nil {
+			t.Fatalf("seed item %d: %v", i, err)
+		}
+		seeded = append(seeded, contentID)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"-%")
+	})
+
+	r := &ArtworkCacheReconciler{pool: pool}
+	var stats ArtworkReconcileStats
+	if err := r.bulkResetSurface(ctx, itemPosterSurface(t), &stats); err != nil {
+		t.Fatalf("bulkResetSurface: %v", err)
+	}
+	if stats.Requeued < requeueRows {
+		t.Errorf("stats.Requeued = %d, want >= %d", stats.Requeued, requeueRows)
+	}
+	if stats.Cleared < clearRows {
+		t.Errorf("stats.Cleared = %d, want >= %d", stats.Cleared, clearRows)
+	}
+
+	for i, contentID := range seeded {
+		var posterPath string
+		var lastRefreshed *time.Time
+		if err := pool.QueryRow(ctx,
+			`SELECT poster_path, last_refreshed FROM media_items WHERE content_id = $1`,
+			contentID).Scan(&posterPath, &lastRefreshed); err != nil {
+			t.Fatalf("read back item %d: %v", i, err)
+		}
+		if i < requeueRows {
+			if posterPath != sourceURL(i) {
+				t.Errorf("row %d: poster_path = %q, want requeued source %q", i, posterPath, sourceURL(i))
+			}
+		} else {
+			if posterPath != "" {
+				t.Errorf("row %d: poster_path = %q, want cleared", i, posterPath)
+			}
+			if lastRefreshed != nil {
+				t.Errorf("row %d: last_refreshed = %v, want NULL after clear", i, lastRefreshed)
+			}
+		}
+	}
+}
+
+// TestBulkResetChapterThumbnailsBatches drives the chapter-thumbnail reset
+// across several batches and verifies the JSONB rewrite: cached thumbnail
+// elements are emptied and stripped of retry state, elements without a
+// thumbnail survive untouched, and the loop terminates once no row matches.
+func TestBulkResetChapterThumbnailsBatches(t *testing.T) {
+	pool := localArtworkTestPool(t)
+	ctx := context.Background()
+	shrinkBulkBatchSize(t, 2)
+
+	suffix := time.Now().UnixNano()
+	var folderID int
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO media_folders (type, name)
+		VALUES ('movies', $1)
+		RETURNING id`, fmt.Sprintf("bulk-chapter-test-%d", suffix)).Scan(&folderID); err != nil {
+		t.Fatalf("seed media folder: %v", err)
+	}
+	const fileRows = 5
+	fileIDs := make([]int, fileRows)
+	for i := range fileIDs {
+		chapters := fmt.Sprintf(`[
+			{"title": "c1", "thumbnail_path": "chapters/%d-%d/1.webp", "thumbnail_thumbhash": "aa", "thumbnail_retry_after": "2026-01-01T00:00:00Z", "thumbnail_failed_at": "2026-01-01T00:00:00Z", "thumbnail_last_error": "boom"},
+			{"title": "c2"}
+		]`, suffix, i)
+		if err := pool.QueryRow(ctx, `
+			INSERT INTO media_files (media_folder_id, file_path, chapters, chapter_thumbnail_retry_after)
+			VALUES ($1, $2, $3::jsonb, NOW())
+			RETURNING id`, folderID, fmt.Sprintf("/bulk-chapter-test/%d-%d.mkv", suffix, i), chapters).Scan(&fileIDs[i]); err != nil {
+			t.Fatalf("seed media file %d: %v", i, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM media_files WHERE id = ANY($1)`, fileIDs)
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+	})
+
+	r := &ArtworkCacheReconciler{pool: pool}
+	var stats ArtworkReconcileStats
+	if err := r.bulkResetChapterThumbnails(ctx, &stats); err != nil {
+		t.Fatalf("bulkResetChapterThumbnails: %v", err)
+	}
+	if stats.Cleared < fileRows {
+		t.Errorf("stats.Cleared = %d, want >= %d", stats.Cleared, fileRows)
+	}
+
+	for i, id := range fileIDs {
+		var first, second map[string]any
+		var retryAfter *time.Time
+		if err := pool.QueryRow(ctx,
+			`SELECT chapters->0, chapters->1, chapter_thumbnail_retry_after FROM media_files WHERE id = $1`,
+			id).Scan(&first, &second, &retryAfter); err != nil {
+			t.Fatalf("read back file %d: %v", i, err)
+		}
+		if got := first["thumbnail_path"]; got != "" {
+			t.Errorf("file %d: thumbnail_path = %v, want emptied", i, got)
+		}
+		if got := first["thumbnail_thumbhash"]; got != "" {
+			t.Errorf("file %d: thumbnail_thumbhash = %v, want emptied", i, got)
+		}
+		for _, key := range []string{"thumbnail_retry_after", "thumbnail_failed_at", "thumbnail_last_error"} {
+			if _, ok := first[key]; ok {
+				t.Errorf("file %d: %s survived the reset", i, key)
+			}
+		}
+		if got := second["title"]; got != "c2" {
+			t.Errorf("file %d: untouched element title = %v, want c2", i, got)
+		}
+		if _, ok := second["thumbnail_path"]; ok {
+			t.Errorf("file %d: element without a thumbnail gained thumbnail_path", i)
+		}
+		if retryAfter != nil {
+			t.Errorf("file %d: chapter_thumbnail_retry_after = %v, want NULL", i, retryAfter)
+		}
+	}
+}
+
+func TestRetryOnDeadlock(t *testing.T) {
+	prevBackoff := artworkReconcileDeadlockBaseBackoff
+	artworkReconcileDeadlockBaseBackoff = time.Millisecond
+	t.Cleanup(func() { artworkReconcileDeadlockBaseBackoff = prevBackoff })
+
+	deadlock := &pgconn.PgError{Code: "40P01"}
+	ctx := context.Background()
+
+	t.Run("retries deadlocks until success", func(t *testing.T) {
+		calls := 0
+		err := retryOnDeadlock(ctx, func() error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("exec: %w", deadlock)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("retryOnDeadlock: %v", err)
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3", calls)
+		}
+	})
+
+	t.Run("gives up after max attempts", func(t *testing.T) {
+		calls := 0
+		err := retryOnDeadlock(ctx, func() error {
+			calls++
+			return deadlock
+		})
+		if !errors.Is(err, deadlock) {
+			t.Fatalf("err = %v, want the deadlock error", err)
+		}
+		if calls != artworkReconcileDeadlockMaxAttempts {
+			t.Errorf("calls = %d, want %d", calls, artworkReconcileDeadlockMaxAttempts)
+		}
+	})
+
+	t.Run("returns other errors immediately", func(t *testing.T) {
+		calls := 0
+		boom := errors.New("boom")
+		if err := retryOnDeadlock(ctx, func() error {
+			calls++
+			return boom
+		}); !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want boom", err)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1", calls)
+		}
+	})
+
+	t.Run("honors cancellation between attempts", func(t *testing.T) {
+		canceled, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := retryOnDeadlock(canceled, func() error { return deadlock })
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want context.Canceled", err)
+		}
+	})
+}

--- a/internal/metadata/artwork_reconcile_bulk_db_test.go
+++ b/internal/metadata/artwork_reconcile_bulk_db_test.go
@@ -65,6 +65,104 @@ func restoreImageLadderState(t *testing.T, pool *pgxpool.Pool) {
 	})
 }
 
+// restoreDisplacedGCCandidates snapshots the artwork-GC candidate rows the
+// bulk reset can touch and restores them on cleanup. Displacing a cached
+// poster path ending in /original.<ext> fires queue_displaced_artwork_revision,
+// which inserts a candidate for the path or resets an existing candidate's
+// schedule, attempts, lease, and error state — auxiliary shared-database state
+// the media_items row restore alone does not undo. Candidates created for the
+// test's own fixture paths are deleted outright.
+func restoreDisplacedGCCandidates(t *testing.T, pool *pgxpool.Pool, seededPathPattern string) {
+	t.Helper()
+	ctx := context.Background()
+	surface := itemPosterSurface(t)
+
+	var displaced []string
+	rows, err := pool.Query(ctx, fmt.Sprintf(
+		`SELECT poster_path FROM media_items WHERE %s`, surface.cachedPredicate()))
+	if err != nil {
+		t.Fatalf("list displaceable poster paths: %v", err)
+	}
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			t.Fatalf("scan displaceable path: %v", err)
+		}
+		displaced = append(displaced, path)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read displaceable paths: %v", err)
+	}
+
+	type candidate struct {
+		originalPath  string
+		imageType     string
+		objectKeys    []string
+		notBefore     time.Time
+		nextAttemptAt *time.Time
+		deletedAt     *time.Time
+		attemptCount  int
+		lockedAt      *time.Time
+		lockedBy      string
+		lastError     string
+	}
+	var snapshot []candidate
+	snapshotPaths := []string{}
+	rows, err = pool.Query(ctx, `
+		SELECT original_path, image_type, object_keys, not_before, next_attempt_at,
+			deleted_at, attempt_count, locked_at, locked_by, last_error
+		FROM artwork_revision_gc_candidates WHERE original_path = ANY($1)`, displaced)
+	if err != nil {
+		t.Fatalf("snapshot gc candidates: %v", err)
+	}
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.originalPath, &c.imageType, &c.objectKeys, &c.notBefore,
+			&c.nextAttemptAt, &c.deletedAt, &c.attemptCount, &c.lockedAt, &c.lockedBy, &c.lastError); err != nil {
+			t.Fatalf("scan gc candidate: %v", err)
+		}
+		snapshot = append(snapshot, c)
+		snapshotPaths = append(snapshotPaths, c.originalPath)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read gc candidates: %v", err)
+	}
+
+	t.Cleanup(func() {
+		if _, err := pool.Exec(ctx,
+			`DELETE FROM artwork_revision_gc_candidates WHERE original_path LIKE $1`, seededPathPattern); err != nil {
+			t.Errorf("delete fixture gc candidates: %v", err)
+		}
+		if _, err := pool.Exec(ctx, `
+			DELETE FROM artwork_revision_gc_candidates
+			WHERE original_path = ANY($1) AND original_path <> ALL($2)`, displaced, snapshotPaths); err != nil {
+			t.Errorf("delete reset-created gc candidates: %v", err)
+		}
+		for _, c := range snapshot {
+			if _, err := pool.Exec(ctx, `
+				INSERT INTO artwork_revision_gc_candidates (
+					original_path, image_type, object_keys, not_before, next_attempt_at,
+					deleted_at, attempt_count, locked_at, locked_by, last_error, updated_at
+				) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+				ON CONFLICT (original_path) DO UPDATE SET
+					image_type = EXCLUDED.image_type,
+					object_keys = EXCLUDED.object_keys,
+					not_before = EXCLUDED.not_before,
+					next_attempt_at = EXCLUDED.next_attempt_at,
+					deleted_at = EXCLUDED.deleted_at,
+					attempt_count = EXCLUDED.attempt_count,
+					locked_at = EXCLUDED.locked_at,
+					locked_by = EXCLUDED.locked_by,
+					last_error = EXCLUDED.last_error,
+					updated_at = NOW()`,
+				c.originalPath, c.imageType, c.objectKeys, c.notBefore, c.nextAttemptAt,
+				c.deletedAt, c.attemptCount, c.lockedAt, c.lockedBy, c.lastError); err != nil {
+				t.Errorf("restore gc candidate %s: %v", c.originalPath, err)
+			}
+		}
+	})
+}
+
 func restorePreexistingPosterRows(t *testing.T, pool *pgxpool.Pool, seededPrefix string) {
 	t.Helper()
 	ctx := context.Background()
@@ -149,6 +247,7 @@ func TestBulkResetSurfaceBatches(t *testing.T) {
 
 	prefix := fmt.Sprintf("bulkreset-%d", time.Now().UnixNano())
 	restoreImageLadderState(t, pool)
+	restoreDisplacedGCCandidates(t, pool, "metadata/movie/"+prefix+"-%")
 	restorePreexistingPosterRows(t, pool, prefix)
 	const requeueRows, clearRows = 7, 5
 	sourceURL := func(i int) string {
@@ -297,6 +396,7 @@ func TestBulkResetSurfacePartialFailureKeepsCounts(t *testing.T) {
 
 	prefix := fmt.Sprintf("bulkpartial-%d", time.Now().UnixNano())
 	restoreImageLadderState(t, pool)
+	restoreDisplacedGCCandidates(t, pool, "metadata/movie/"+prefix+"-%")
 	restorePreexistingPosterRows(t, pool, prefix)
 
 	const requeueRows = 5

--- a/internal/metadata/artwork_reconcile_bulk_db_test.go
+++ b/internal/metadata/artwork_reconcile_bulk_db_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -35,6 +36,34 @@ func itemPosterSurface(t *testing.T) artworkSweepSurface {
 // fixtures. The test database may be shared and populated, so each test
 // snapshots every pre-existing row its reset would touch and restores those
 // rows on cleanup; only the seeded fixtures are asserted on.
+
+// restoreImageLadderState snapshots the image-ladder backfill singleton and
+// restores it on cleanup. Inserting rows with local cached poster paths fires
+// the reopen_image_ladder_backfill_v2 trigger, which on a database that has
+// completed ladder v2 lowers backfilled_version — durable state a test
+// fixture must not leave behind on a shared database.
+func restoreImageLadderState(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	var version int
+	var lastAttempt *time.Time
+	err := pool.QueryRow(ctx,
+		`SELECT backfilled_version, last_attempt_at FROM image_ladder_backfill_state WHERE id = 1`).
+		Scan(&version, &lastAttempt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return
+		}
+		t.Fatalf("snapshot image ladder state: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := pool.Exec(ctx,
+			`UPDATE image_ladder_backfill_state SET backfilled_version = $1, last_attempt_at = $2, updated_at = NOW() WHERE id = 1`,
+			version, lastAttempt); err != nil {
+			t.Errorf("restore image ladder state: %v", err)
+		}
+	})
+}
 
 func restorePreexistingPosterRows(t *testing.T, pool *pgxpool.Pool, seededPrefix string) {
 	t.Helper()
@@ -119,6 +148,7 @@ func TestBulkResetSurfaceBatches(t *testing.T) {
 	shrinkBulkBatchSize(t, 3)
 
 	prefix := fmt.Sprintf("bulkreset-%d", time.Now().UnixNano())
+	restoreImageLadderState(t, pool)
 	restorePreexistingPosterRows(t, pool, prefix)
 	const requeueRows, clearRows = 7, 5
 	sourceURL := func(i int) string {
@@ -266,6 +296,7 @@ func TestBulkResetSurfacePartialFailureKeepsCounts(t *testing.T) {
 	shrinkBulkBatchSize(t, 2)
 
 	prefix := fmt.Sprintf("bulkpartial-%d", time.Now().UnixNano())
+	restoreImageLadderState(t, pool)
 	restorePreexistingPosterRows(t, pool, prefix)
 
 	const requeueRows = 5


### PR DESCRIPTION
## Problem

`bulkResetSurface` and `bulkResetChapterThumbnails` in `internal/metadata/artwork_reconcile.go` issue single full-table UPDATEs. On a ~600k-item library that is 603k `media_items` rows (1.32M `media_files`) locked by one statement. One observed run held row locks for 1h51m, during which 12 of 16 pool connections sat blocked behind it and ordinary playback and metadata writes stalled.

## Change

Ported from RXWatcher/silo-server@3b377f5c21cb9d71b6a8a3f8933788873699aeb2 (credited as commit author), plus tests written here.

Both resets now update in batches of 5000 through a `FOR UPDATE` CTE over the surface's unique key order, committing per batch, so concurrent writers interleave instead of queueing behind a table-wide writer. A `retryOnDeadlock` helper covers deadlocks against unrelated writers that touch the same rows in a different order (an observed 40P01 source).

Design points, verified against the code rather than taken from the source commit:

- **Termination.** Each loop runs until a batch matches zero rows. Both SET clauses falsify the predicate that selected the row: `resetSet` writes the provider URL into the path column, which `cachedPredicate` excludes via `NOT LIKE '%://%'`; `clearSet` writes `''`, excluded by `NOT IN ('', '-')`. The chapter rewrite empties every `thumbnail_path` element the `EXISTS` predicate looks for.
- **No `SKIP LOCKED`.** Skipping a contended row would end the loop early and silently leave rows unreset; a blocked batch waits instead.
- **Atomicity.** Per-batch commits mean a crash leaves a partial reset, which is safe: the reconciler is idempotent and the remaining rows still match on the next run.

Deviation from the source commit: the batch size is a `var` instead of a `const`, so tests can shrink it to drive the multi-batch path without seeding thousands of rows.

## Tests

New in this PR (the source commit had none):

- `TestBulkResetSurfaceBatches` — drives `bulkResetSurface` across multiple batches against a real database, verifying requeue-vs-clear routing, final row state, and stats.
- `TestBulkResetChapterThumbnailsBatches` — multi-batch JSONB rewrite: cached elements emptied and stripped of retry state, elements without thumbnails untouched, `chapter_thumbnail_retry_after` nulled.
- `TestRetryOnDeadlock` — retry-until-success, attempt exhaustion, non-retryable errors returned immediately, cancellation honored between attempts.

The DB tests gate on `SILO_TEST_DATABASE_URL` like the other `*_db_test.go` files; both pass against a migrated pgvector/pg18 database.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `golangci-lint run --new-from-merge-base=origin/main ./...` — 0 issues
- `make test-go` (CI-equivalent; DB tests skip without `SILO_TEST_DATABASE_URL`) — passes
- `go test ./internal/metadata/...` with `SILO_TEST_DATABASE_URL` pointing at a migrated pgvector/pg18 database — the new DB tests pass; the only failure is `TestImageLadderBackfillLateOldArtworkReopensCompletedVersion`, which fails identically on `origin/main` (pre-existing ambiguous `image_type` column reference, unrelated; being filed separately). Other packages' DB-gated tests also carry pre-existing failures on `origin/main`; CI never sets the variable, so they are not maintained.
- Source commit's EXPLAIN verification on a production-scale database: all three statement shapes (single key, composite key, chapter-thumbnail JSONB) plan as index scans under a bounded Limit

Related issue: N/A — narrow fix (batching an existing maintenance operation; no API, client, or jellycompat surface changes)

## AI Disclosure

- Tool(s): Claude Code (this PR); the source commit on the fork reports Claude Code as well
- Model(s): claude-fable-5 (port, review, and tests); source commit reports claude-opus-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: The port was reviewed independently of the source commit's claims — termination was re-derived from the actual predicates and SET clauses for all three statement shapes, the `(a, b) IN (SELECT ...)` composite-key form and per-statement autocommit behavior were checked, and the loss of whole-reset atomicity was assessed against reconciler idempotence. Findings: the source commit shipped without tests and with a const batch size that made the multi-batch path untestable; both addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of bulk artwork resets by processing records in manageable batches.
  * Added automatic retries for temporary database conflicts.
  * Ensured reset progress and statistics remain accurate across batches.
  * Context cancellation now stops processing cleanly between batches.
  * Improved chapter-thumbnail cleanup reliability during bulk resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->