### PR TITLE
fix(playback): stop Firefox crackle after AAC transcode

### DIFF
--- a/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
+++ b/docs/design/schemas/playback-v3/v3/fixtures/valid/capability_response.json
@@ -28,7 +28,7 @@
     {
       "name": "audio_to_aac",
       "executor": "server",
-      "recipe_version": "2",
+      "recipe_version": "3",
       "validated_claims": [
         "audio_decode"
       ]

--- a/internal/api/handlers/playback_v3_union_test.go
+++ b/internal/api/handlers/playback_v3_union_test.go
@@ -124,7 +124,7 @@ func TestHLSPlanningRegistryV3UnionsPooledNodeCapabilities(t *testing.T) {
 		}
 		writeJSON(w, http.StatusOK, playback.HWAccelInfo{Transformations: []playback.TransformationV3{
 			{Name: "video_to_h264", Executor: "server", RecipeVersion: "2"},
-			{Name: "audio_to_aac", Executor: "server", RecipeVersion: "2"},
+			{Name: "audio_to_aac", Executor: "server", RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3},
 		}})
 	}))
 	defer remote.Close()
@@ -133,7 +133,7 @@ func TestHLSPlanningRegistryV3UnionsPooledNodeCapabilities(t *testing.T) {
 	handler.JWTSecret = "test-secret"
 	presetLocalRegistryV3(handler, playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{
 		{Name: "video_to_h264", RecipeVersion: "2"},
-		{Name: "audio_to_aac", RecipeVersion: "2"},
+		{Name: "audio_to_aac", RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3},
 		{Name: "server_dv7_to_hdr10", RecipeVersion: "1"},
 	}))
 	handler.NodePlanner = enumeratingNodePlannerV3{urls: []string{remote.URL}}

--- a/internal/downloadprepare/transport.go
+++ b/internal/downloadprepare/transport.go
@@ -187,7 +187,7 @@ func (r Request) AudioRecipeRequested() bool {
 }
 
 // StereoDownmixBoostRequested reports whether this is the complete,
-// source-sensitive audio_to_aac v2 recipe. Prepared encoded audio uses the
+// source-sensitive audio_to_aac recipe. Prepared encoded audio uses the
 // historical stereo default, so only a known surround source qualifies.
 func (r Request) StereoDownmixBoostRequested() bool {
 	return r.AudioRecipeVersion == playback.TransformationAudioToAACRecipeVersionV3 &&

--- a/internal/downloadprepare/transport_test.go
+++ b/internal/downloadprepare/transport_test.go
@@ -148,7 +148,7 @@ func TestRequestExecutionFingerprintBindsRecipeButNotArtifactHandle(t *testing.T
 		t.Fatal("byte-affecting software decode did not change execution fingerprint")
 	}
 	changed = base
-	changed.AudioRecipeVersion = "3"
+	changed.AudioRecipeVersion = base.AudioRecipeVersion + "-changed"
 	if got := changed.ExecutionFingerprint(); got == want {
 		t.Fatal("byte-affecting audio recipe version did not change execution fingerprint")
 	}

--- a/internal/playback/plan_v3_union_test.go
+++ b/internal/playback/plan_v3_union_test.go
@@ -12,7 +12,7 @@ func staticHLSRegistryV3(registry *TransformationRegistryV3) func() *Transformat
 
 func TestTransformationRegistryWithAdvertised(t *testing.T) {
 	registry := NewTransformationRegistryV3([]TransformationSpecV3{
-		{Name: "audio_to_aac", RecipeVersion: "2"},
+		{Name: "audio_to_aac", RecipeVersion: TransformationAudioToAACRecipeVersionV3},
 		{Name: "video_to_h264", RecipeVersion: "2"},
 		{Name: "server_dv7_to_hdr10", RecipeVersion: "1", Available: true},
 	})
@@ -20,7 +20,7 @@ func TestTransformationRegistryWithAdvertised(t *testing.T) {
 		t.Fatal("empty advertisement must return the receiver unchanged")
 	}
 	widened := registry.WithAdvertised([]TransformationV3{
-		{Name: "Audio_To_AAC", Executor: "server", RecipeVersion: "2"},
+		{Name: "Audio_To_AAC", Executor: "server", RecipeVersion: TransformationAudioToAACRecipeVersionV3},
 		{Name: "video_to_h264", Executor: "server", RecipeVersion: "1"},
 		{Name: "made_up_transform", Executor: "server", RecipeVersion: "1"},
 	})
@@ -39,7 +39,7 @@ func TestTransformationRegistryWithAdvertised(t *testing.T) {
 	if registry.Available("audio_to_aac") {
 		t.Fatal("widening must not mutate the receiver")
 	}
-	clientOnly := registry.WithAdvertised([]TransformationV3{{Name: "audio_to_aac", Executor: "client", RecipeVersion: "2"}})
+	clientOnly := registry.WithAdvertised([]TransformationV3{{Name: "audio_to_aac", Executor: "client", RecipeVersion: TransformationAudioToAACRecipeVersionV3}})
 	if clientOnly.Available("audio_to_aac") {
 		t.Fatal("client-executor advertisements must not widen server availability")
 	}
@@ -58,7 +58,7 @@ func TestPlanPlaybackV3TranscodeOffloadsToNodeToolchain(t *testing.T) {
 	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
 	local := NewTransformationRegistryV3([]TransformationSpecV3{
 		{Name: "video_to_h264", RecipeVersion: "2"},
-		{Name: "audio_to_aac", RecipeVersion: "2"},
+		{Name: "audio_to_aac", RecipeVersion: TransformationAudioToAACRecipeVersionV3},
 	})
 	settings := PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}
 
@@ -69,7 +69,7 @@ func TestPlanPlaybackV3TranscodeOffloadsToNodeToolchain(t *testing.T) {
 
 	union := local.WithAdvertised([]TransformationV3{
 		{Name: "video_to_h264", Executor: "server", RecipeVersion: "2"},
-		{Name: "audio_to_aac", Executor: "server", RecipeVersion: "2"},
+		{Name: "audio_to_aac", Executor: "server", RecipeVersion: TransformationAudioToAACRecipeVersionV3},
 	})
 	withNodes := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: settings, Registry: local, HLSRegistry: staticHLSRegistryV3(union)})
 	if withNodes.Plan == nil || withNodes.Plan.Delivery != DeliveryTranscodeHLSV3 {
@@ -87,7 +87,7 @@ func TestPlanPlaybackV3AudioAdaptationOffloadsToHLSRemux(t *testing.T) {
 	req := validStartRequestV3()
 	req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
 	req.Capabilities.HDRDetails = &HDRCapabilitiesV3{HDR10: true}
-	local := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "audio_to_aac", RecipeVersion: "2"}})
+	local := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "audio_to_aac", RecipeVersion: TransformationAudioToAACRecipeVersionV3}})
 	settings := PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}
 
 	withoutNodes := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: settings, Registry: local})
@@ -95,7 +95,7 @@ func TestPlanPlaybackV3AudioAdaptationOffloadsToHLSRemux(t *testing.T) {
 		t.Fatalf("without nodes = %s", ExplainPlannerResultV3(withoutNodes))
 	}
 
-	union := local.WithAdvertised([]TransformationV3{{Name: "audio_to_aac", Executor: "server", RecipeVersion: "2"}})
+	union := local.WithAdvertised([]TransformationV3{{Name: "audio_to_aac", Executor: "server", RecipeVersion: TransformationAudioToAACRecipeVersionV3}})
 	offloaded := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: settings, Registry: local, HLSRegistry: staticHLSRegistryV3(union)})
 	if offloaded.Plan == nil || offloaded.Plan.Delivery != DeliveryRemuxHLSV3 || !offloaded.TranscodeAudio || offloaded.TargetAudioCodec != "aac" {
 		t.Fatalf("with nodes = %s", ExplainPlannerResultV3(offloaded))
@@ -103,7 +103,7 @@ func TestPlanPlaybackV3AudioAdaptationOffloadsToHLSRemux(t *testing.T) {
 
 	// With the toolchain available locally the progressive remux keeps
 	// priority — offloadability must never demote a local-capable route.
-	localCapable := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "audio_to_aac", RecipeVersion: "2", Available: true}})
+	localCapable := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "audio_to_aac", RecipeVersion: TransformationAudioToAACRecipeVersionV3, Available: true}})
 	preserved := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: settings, Registry: localCapable, HLSRegistry: staticHLSRegistryV3(localCapable)})
 	if preserved.Plan == nil || preserved.Plan.Delivery != DeliveryRemuxProgressiveV3 {
 		t.Fatalf("local capable = %s", ExplainPlannerResultV3(preserved))
@@ -145,8 +145,8 @@ func TestPlanPlaybackV3NodeToolchainDoesNotMaskTerminalForProgressiveOnlyClient(
 	req.Capabilities.HDRDetails = &HDRCapabilitiesV3{HDR10: true}
 	delete(req.ClientPlaybackContext.Deliveries, DeliveryClassHLSV3)
 
-	local := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "audio_to_aac", RecipeVersion: "2"}})
-	union := local.WithAdvertised([]TransformationV3{{Name: "audio_to_aac", Executor: "server", RecipeVersion: "2"}})
+	local := NewTransformationRegistryV3([]TransformationSpecV3{{Name: "audio_to_aac", RecipeVersion: TransformationAudioToAACRecipeVersionV3}})
+	union := local.WithAdvertised([]TransformationV3{{Name: "audio_to_aac", Executor: "server", RecipeVersion: TransformationAudioToAACRecipeVersionV3}})
 	result := PlanPlaybackV3(PlannerInputV3{
 		Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
 		Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true},

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -186,7 +186,7 @@ const (
 	TransformationHDRToSDRToneMapV3 = "hdr_to_sdr_tonemap"
 
 	TransformationVideoToH264RecipeVersionV3     = "2"
-	TransformationAudioToAACRecipeVersionV3      = "2"
+	TransformationAudioToAACRecipeVersionV3      = "3"
 	TransformationHDRToSDRToneMapRecipeVersionV3 = "1"
 )
 

--- a/internal/playback/remux_dv_test.go
+++ b/internal/playback/remux_dv_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -72,6 +74,39 @@ func TestBuildRemuxArgsBoostsOnlySurroundToStereoAAC(t *testing.T) {
 				t.Fatalf("downmix boost present=%t, want %t; args=%s", gotBoost, tt.wantBoost, strings.Join(args, " "))
 			}
 		})
+	}
+}
+
+func TestBuildRemuxArgsNormalizesAACAcrossSeekAnchors(t *testing.T) {
+	const wantFilter = "aresample=out_chlayout=stereo:async=1,alimiter=level_in=2:limit=0.794328235:attack=5:release=50:level=false:latency=true"
+	anchors := []struct {
+		name string
+		seek float64
+	}{
+		{name: "initial start", seek: 0},
+		{name: "rewind reanchor", seek: 600},
+		{name: "saved resume", seek: 2201.111},
+		{name: "forward reanchor", seek: 2800},
+	}
+
+	for _, anchor := range anchors {
+		t.Run(anchor.name, func(t *testing.T) {
+			args := buildRemuxArgsWithAudioV3("/movie.mkv", "mp4", anchor.seek, true, 0, 0, false, false, 6, 2, 192)
+			if !argsContainPair(args, "-af", wantFilter) {
+				t.Fatalf("AAC timestamp normalization missing at seek %.3f: %s", anchor.seek, strings.Join(args, " "))
+			}
+			if strings.Contains(strings.Join(args, " "), "first_pts") {
+				t.Fatalf("seek %.3f reset the source clock instead of preserving its anchor: %s", anchor.seek, strings.Join(args, " "))
+			}
+			if anchor.seek > 0 && (!argsContainPair(args, "-ss", strconv.FormatFloat(anchor.seek, 'f', 3, 64)) || !slices.Contains(args, "-noaccurate_seek")) {
+				t.Fatalf("seek %.3f lost the copy-video reanchor recipe: %s", anchor.seek, strings.Join(args, " "))
+			}
+		})
+	}
+
+	codecCopy := buildRemuxArgsWithAudioV3("/movie.mkv", "mp4", 600, false, 0, 0, false, false, 6, 2, 192)
+	if slices.Contains(codecCopy, "-af") {
+		t.Fatalf("codec-copy remux unexpectedly received an audio filter: %s", strings.Join(codecCopy, " "))
 	}
 }
 

--- a/internal/playback/remux_dv_test.go
+++ b/internal/playback/remux_dv_test.go
@@ -45,7 +45,7 @@ func TestBuildRemuxArgsHonorsPlannedAACOutput(t *testing.T) {
 }
 
 func TestBuildRemuxArgsBoostsOnlySurroundToStereoAAC(t *testing.T) {
-	const wantFilter = "aresample=out_chlayout=stereo,alimiter=level_in=2:limit=0.794328235:attack=5:release=50:level=false:latency=true"
+	const wantFilter = "aresample=out_chlayout=stereo:async=1,alimiter=level_in=2:limit=0.794328235:attack=5:release=50:level=false:latency=true"
 	tests := []struct {
 		name           string
 		transcodeAudio bool

--- a/internal/playback/testdata/protocol_v3/attempt_keys.json
+++ b/internal/playback/testdata/protocol_v3/attempt_keys.json
@@ -1,10 +1,10 @@
 [
   {
     "name": "hls_burn_in_sorted_transformations_and_pcm_mutations",
-    "server_plan_attempt_key": "v3:27ee8bdc3ff5b1d7",
-    "replan_echo": "v3:27ee8bdc3ff5b1d7",
+    "server_plan_attempt_key": "v3:e139629390ef6e20",
+    "replan_echo": "v3:e139629390ef6e20",
     "attempted_plan_keys": [
-      "v3:27ee8bdc3ff5b1d7"
+      "v3:e139629390ef6e20"
     ],
     "expected_server_action": "reject_already_attempted_plan"
   },

--- a/internal/playback/testdata/protocol_v3/capability_response.json
+++ b/internal/playback/testdata/protocol_v3/capability_response.json
@@ -28,7 +28,7 @@
     {
       "name": "audio_to_aac",
       "executor": "server",
-      "recipe_version": "2",
+      "recipe_version": "3",
       "validated_claims": [
         "audio_decode"
       ]

--- a/internal/playback/testdata/protocol_v3/conformance_matrix.json
+++ b/internal/playback/testdata/protocol_v3/conformance_matrix.json
@@ -175,8 +175,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_original",
-        "plan_id": "plan:1496ada4f9ff74754e2f14031f86fb21",
-        "plan_attempt_key": "v3:4db9d7afc07c1655",
+        "plan_id": "plan:a8beff7df33c6ca6776a093b840cdea3",
+        "plan_attempt_key": "v3:2cdebc939dc3cf22",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -218,7 +218,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "3",
             "validated_claims": [
               "audio_decode"
             ]
@@ -1862,8 +1862,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:e8ddb06ffa481d3561b07cef06a91ec5",
-        "plan_attempt_key": "v3:4830f767fa704f38",
+        "plan_id": "plan:c2695f5ba02dba71753615a263d2367e",
+        "plan_attempt_key": "v3:4b72643d8afc4436",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -1905,7 +1905,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "3",
             "validated_claims": [
               "audio_decode"
             ]
@@ -2573,8 +2573,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:23105e95d0363c4627ab0f60ed0bfa96",
-        "plan_attempt_key": "v3:8a4c0deb6795be69",
+        "plan_id": "plan:01ff67650a0ef2592ce739121de6d99a",
+        "plan_attempt_key": "v3:adc66f1d69acda72",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -2616,7 +2616,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "3",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3602,8 +3602,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "quality_fixed_rung",
-        "plan_id": "plan:48fee96902632f7f3b70e8e5dd0669f3",
-        "plan_attempt_key": "v3:f7602afa81a3eee0",
+        "plan_id": "plan:5fb510747d6b4314346fc53132de7fe3",
+        "plan_attempt_key": "v3:00106a7fb5f5abfd",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -3645,7 +3645,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "3",
             "validated_claims": [
               "audio_decode"
             ]
@@ -3927,8 +3927,8 @@
         "outcome": "playable",
         "delivery": "server_remux_progressive",
         "decision_reason": "audio_adaptation",
-        "plan_id": "plan:7ae72046390c9f41614fc8a0e7465089",
-        "plan_attempt_key": "v3:8e3e32c8e2e5b895",
+        "plan_id": "plan:acf3864ca5f5b39a7bcbf6133eea24f4",
+        "plan_attempt_key": "v3:be9bbd478b33b39e",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -3962,7 +3962,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "3",
             "validated_claims": [
               "audio_decode"
             ]
@@ -4901,8 +4901,8 @@
         "outcome": "playable",
         "delivery": "server_transcode_hls",
         "decision_reason": "subtitle_burn_in_required",
-        "plan_id": "plan:3fbb45a597dbfeb7ec62888782109a50",
-        "plan_attempt_key": "v3:09c05142189931a3",
+        "plan_id": "plan:ffc560da5dd89610e4e672299601c0f2",
+        "plan_attempt_key": "v3:2156e83ea26e40a0",
         "selected_tracks": {
           "audio": {
             "id": "file:42:audio:0",
@@ -4963,7 +4963,7 @@
           {
             "name": "audio_to_aac",
             "executor": "server",
-            "recipe_version": "2",
+            "recipe_version": "3",
             "validated_claims": [
               "audio_decode"
             ]

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -1379,9 +1379,10 @@ const stereoDownmixBoostFilterV3 = "aresample=out_chlayout=stereo:async=1,alimit
 // the source channels before FFmpeg sums them would still allow the final
 // stereo signal to clip. The limiter's input gain is +6.0206 dB; its -2 dBFS
 // sample ceiling leaves headroom for lossy-codec and inter-sample overshoot.
-// async=1 removes sub-frame input timestamp jitter while retaining the source
-// clock and first packet timestamp. Without it, fixed-duration AAC packets can
-// carry small PTS gaps that Firefox renders as audible zero-fill crackle.
+// async=1 enables FFmpeg's timestamp-matching fill/trim behavior while
+// retaining the source clock and first packet timestamp. On the affected
+// inputs, the resulting fixed-duration AAC packets no longer carry the small
+// PTS gaps that Firefox renders as audible zero-fill crackle.
 func appendStereoDownmixBoostArgs(args []string, sourceChannels, outputChannels int) []string {
 	if sourceChannels <= 2 || outputChannels != 2 {
 		return args

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -1372,13 +1372,16 @@ func IsAudioToAACStereoDownmixV3(sourceChannels int, targetCodecAudio string, ta
 		(targetAudioChannels == 0 || targetAudioChannels == 2)
 }
 
-const stereoDownmixBoostFilterV3 = "aresample=out_chlayout=stereo,alimiter=level_in=2:limit=0.794328235:attack=5:release=50:level=false:latency=true"
+const stereoDownmixBoostFilterV3 = "aresample=out_chlayout=stereo:async=1,alimiter=level_in=2:limit=0.794328235:attack=5:release=50:level=false:latency=true"
 
 // appendStereoDownmixBoostArgs applies the playback downmix policy only after
 // the source is explicitly rematrixed to stereo. The order matters: limiting
 // the source channels before FFmpeg sums them would still allow the final
 // stereo signal to clip. The limiter's input gain is +6.0206 dB; its -2 dBFS
 // sample ceiling leaves headroom for lossy-codec and inter-sample overshoot.
+// async=1 removes sub-frame input timestamp jitter while retaining the source
+// clock and first packet timestamp. Without it, fixed-duration AAC packets can
+// carry small PTS gaps that Firefox renders as audible zero-fill crackle.
 func appendStereoDownmixBoostArgs(args []string, sourceChannels, outputChannels int) []string {
 	if sourceChannels <= 2 || outputChannels != 2 {
 		return args

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -1473,7 +1473,7 @@ func TestIsAudioToAACStereoDownmixV3RequiresExactRecipeShape(t *testing.T) {
 }
 
 func TestAppendAudioArgsBoostsOnlyEncodedSurroundToStereo(t *testing.T) {
-	const wantFilter = "aresample=out_chlayout=stereo,alimiter=level_in=2:limit=0.794328235:attack=5:release=50:level=false:latency=true"
+	const wantFilter = "aresample=out_chlayout=stereo:async=1,alimiter=level_in=2:limit=0.794328235:attack=5:release=50:level=false:latency=true"
 	tests := []struct {
 		name           string
 		codec          string

--- a/internal/playback/transformations_v3.go
+++ b/internal/playback/transformations_v3.go
@@ -65,7 +65,7 @@ func ProbeTransformationRegistryWithToneMapV3Result(ctx context.Context, ffmpegP
 	_, ffmpegErr := exec.LookPath(ffmpegPath)
 	registry := NewTransformationRegistryV3([]TransformationSpecV3{
 		{Name: TransformationServerDV7HDR10V3, RecipeVersion: "1", Available: bytes.Contains(bsfs, []byte("dovi_rpu")), RequiredCapability: "ffmpeg_bsf:dovi_rpu", PromisedDynamicRange: DynamicRangeHDR10V3, ValidatedClaims: DV7ToHDR10ClaimsV3(), TerminalReason: TerminalDVConversionUnsupportedV3},
-		{Name: TransformationAudioToAACV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, Available: ffmpegErr == nil && bytes.Contains(encoders, []byte(" aac ")) && audioRecipeErr == nil, RequiredCapability: "ffmpeg_encoder:aac+ffmpeg_filter_smoke:stereo_downmix_limiter_v2", ValidatedClaims: []string{ClaimAudioDecodeV3}, TerminalReason: TerminalAudioConversionUnsupportedV3},
+		{Name: TransformationAudioToAACV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, Available: ffmpegErr == nil && bytes.Contains(encoders, []byte(" aac ")) && audioRecipeErr == nil, RequiredCapability: "ffmpeg_encoder:aac+ffmpeg_filter_smoke:stereo_downmix_limiter_v3", ValidatedClaims: []string{ClaimAudioDecodeV3}, TerminalReason: TerminalAudioConversionUnsupportedV3},
 		{Name: TransformationVideoToH264V3, RecipeVersion: TransformationVideoToH264RecipeVersionV3, Available: ffmpegErr == nil && h264EncoderAvailableV3(encoders), RequiredCapability: "ffmpeg_encoder:h264", PromisedDynamicRange: DynamicRangeSDRV3, ValidatedClaims: []string{ClaimH264DecodeV3}, TerminalReason: TerminalVideoConversionUnsupportedV3},
 		{Name: TransformationHDRToSDRToneMapV3, RecipeVersion: TransformationHDRToSDRToneMapRecipeVersionV3, Available: len(toneMapCapabilities) > 0, RequiredCapability: "ffmpeg_filter:hdr_to_sdr_tonemap", PromisedDynamicRange: DynamicRangeSDRV3, ValidatedClaims: []string{ClaimHDRMetadataRemovedV3, ClaimSDRBT709OutputV3}, TerminalReason: TerminalHDRTranscodeUnsupportedV3},
 	})
@@ -73,7 +73,7 @@ func ProbeTransformationRegistryWithToneMapV3Result(ctx context.Context, ffmpegP
 }
 
 // An ordinary non-zero FFmpeg exit means the installed filter graph is not a
-// v2 executor; that is a capability result, not a failed inventory. Process
+// v3 executor; that is a capability result, not a failed inventory. Process
 // startup failures and caller cancellation still make the registry uncacheable.
 func audioRecipeProbeInfrastructureError(err error) error {
 	var exitErr *exec.ExitError

--- a/internal/playback/transformations_v3_test.go
+++ b/internal/playback/transformations_v3_test.go
@@ -78,9 +78,9 @@ func TestProbeTransformationRegistryV3AdvertisesVideoToH264RecipeVersion2(t *tes
 	t.Fatal("video_to_h264 was not advertised")
 }
 
-func TestProbeTransformationRegistryV3RequiresVersion2AudioFilterGraph(t *testing.T) {
+func TestProbeTransformationRegistryV3RequiresVersion3AudioFilterGraph(t *testing.T) {
 	ffmpeg := filepath.Join(t.TempDir(), "ffmpeg")
-	// Model an older FFmpeg that lists both filters but rejects one of the v2
+	// Model an older FFmpeg that lists both filters but rejects one of the v3
 	// graph options (notably out_chlayout or alimiter latency compensation).
 	script := "#!/bin/sh\ncase \"$2\" in\n-bsfs) : ;;\n-encoders) echo ' A....D aac AAC' ;;\n-filters) echo ' ... aresample A->A'; echo ' T.C alimiter A->A' ;;\nesac\ncase \" $* \" in\n*\" -f lavfi \"*) exit 1 ;;\nesac\n"
 	if err := os.WriteFile(ffmpeg, []byte(script), 0o755); err != nil {
@@ -92,7 +92,7 @@ func TestProbeTransformationRegistryV3RequiresVersion2AudioFilterGraph(t *testin
 		t.Fatalf("unsupported graph should be a cacheable capability result: %v", err)
 	}
 	if registry.Available(TransformationAudioToAACV3) {
-		t.Fatal("audio_to_aac advertised when the exact version 2 graph was rejected")
+		t.Fatal("audio_to_aac advertised when the exact version 3 graph was rejected")
 	}
 
 	script = "#!/bin/sh\ncase \"$2\" in\n-bsfs) : ;;\n-encoders) echo ' A....D aac AAC' ;;\n-filters) echo ' ... aresample A->A'; echo ' T.C alimiter A->A' ;;\nesac\n"
@@ -108,5 +108,5 @@ func TestProbeTransformationRegistryV3RequiresVersion2AudioFilterGraph(t *testin
 			return
 		}
 	}
-	t.Fatal("audio_to_aac was not advertised with the complete version 2 toolchain")
+	t.Fatal("audio_to_aac was not advertised with the complete version 3 toolchain")
 }


### PR DESCRIPTION
## Problem

Fixes #819.

Firefox can crackle when Silo converts multichannel audio to stereo AAC for progressive MP4 playback. I reproduced it with both DTS and AAC source tracks. Chromium's HLS path was clean, and direct play was unaffected.

The AAC packets had fixed durations but irregular PTS steps. Firefox rendered the gaps as audible zero fill even though the server showed no buffering, HTTP, or decoder failures.

## Approach

- Add bounded timestamp compensation (`aresample=...:async=1`) to the existing surround-to-stereo AAC filter.
- Preserve the source clock, first timestamp, video copy, downmix gain, and limiter headroom.
- Bump the `audio_to_aac` recipe and capability marker from version 2 to version 3 so an older node cannot claim the new byte recipe.
- Regenerate the protocol fixtures.
- Cover initial playback, saved resume, rewind and fast-forward anchors, plus the codec-copy/direct path.

I tested real DTS and AAC samples before choosing this fix. With timestamp compensation, packet steps settled to the expected 21.333/21.334 ms cadence. Changing MP4 flags did not reproduce or improve the fault, so this does not add a Firefox-specific workaround or unrelated container changes.

## Validation

- `go test ./internal/playback -run '(Audio|Remux|Transformation)'`
- `go test ./internal/api/handlers -run '^TestHLSPlanningRegistryV3UnionsPooledNodeCapabilities$'`
- `go test ./internal/downloadprepare -run '^TestRequestExecutionFingerprintBindsRecipeButNotArtifactHandle$'`
- `make verify-playback-fixtures`
- `make verify-local-paths`
- Full Go, Web, and docs CI passed on commit `8c665791`: https://github.com/blurbery/silo-server/actions/runs/33219685461

The equivalent fork change was also deployed and tested in Firefox against live progressive playback. Resume, rewind, fast-forward, fresh playback, and direct play were checked. Firefox's decoded PCM zero-run boundaries dropped from 27 to 5, maximum adjacent sample delta improved from 0.1035 to 0.0936, and RMS stayed equivalent. Playback was then confirmed free of the original crackle.

## Risks

This intentionally changes the output bytes for surround-to-stereo AAC, so the recipe version is bumped. Direct play, codec copy, video handling, and non-downmix paths are unchanged. The protocol capability bump prevents mixed-version nodes from advertising the old recipe as the new one.

There are no schema, migration, or client API changes.

## AI Disclosure

- **Tool(s):** OpenAI Codex desktop
- **Model(s):** GPT-5
- **Involvement:** AI-assisted. I reproduced the Firefox-only crackle, established that both AAC and DTS sources were affected during transcode, tested resume, rewind, fast-forward, fresh playback, and direct play, and verified the deployed result in Firefox. Codex assisted with packet and PCM analysis, porting the focused fix and tests to current upstream, and drafting this PR. I reviewed the complete diff and live behavior.
- **Adversarial review:** I checked progressive and HLS playback, initial and resumed sessions, seek anchors, audio-only behavior, direct play and codec copy, mixed-version nodes, and upstream-only test differences. I rejected synthetic MP4 flag changes because they did not reproduce or improve the fault. Cherry-pick conflicts were resolved by retaining upstream's current Dolby Vision behavior and excluding fork-only code.

## Checklist

- [x] The change is focused on one playback defect.
- [x] Tests cover the new behavior and playback lifecycle paths.
- [x] Protocol fixtures are regenerated and current.
- [x] Full Go, Web, and docs CI passes.
- [x] AI assistance is disclosed with my own testing and review described separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AAC audio timestamp handling during playback and seeking to reduce audible crackle and zero-fill artifacts.
  - Preserved accurate seek and resume behavior across multiple playback positions.
  - Updated audio conversion capability reporting to use the latest recipe version and filter requirements.

- **Tests**
  - Expanded coverage for AAC timestamp normalization, playback seeking, and conversion capabilities.
  - Refreshed expected playback planning, attempt tracking, and conformance results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->