### PR TITLE
perf(images): downscale via libvips before decoding for thumbhash

### DIFF
--- a/internal/imageutil/imageutil.go
+++ b/internal/imageutil/imageutil.go
@@ -157,22 +157,40 @@ func GenerateSquareVariants(data []byte, sizes []int) (*VariantResult, error) {
 
 // Thumbhash computes a base64-encoded thumbhash from raw image bytes.
 // The image is scaled to max 100x100 before hashing.
+//
+// The downscale happens in libvips before the Go-side decode, not after:
+// decoding a full provider original in Go materializes the whole raster on
+// the heap — well over a hundred MiB for a large poster — per concurrent
+// caller, while vips shrinks it to thumbhashSourceDimension with
+// shrink-on-load and hands Go a raster of a few KiB. The pure-Go decode of
+// the raw bytes remains as the fallback for anything vips cannot parse.
+//
+// Changing this pipeline changes the emitted hash bytes for a given image.
+// Stored thumbhashes remain valid placeholders, and the one site that
+// compares hashes for equality (ebook scan cover change detection) stores
+// the freshly computed hash whenever it re-caches, so a pipeline change
+// costs one re-cache per scan-covered ebook and then converges.
 func Thumbhash(data []byte) (string, error) {
-	img, _, err := image.Decode(bytes.NewReader(data))
+	img, err := decodeThumbhashSource(data)
 	if err != nil {
-		normalized, normalizeErr := normalizeThumbhashSource(data)
-		if normalizeErr != nil {
-			return "", fmt.Errorf("imageutil: decode for thumbhash: %w", err)
-		}
-		img, _, err = image.Decode(bytes.NewReader(normalized))
-		if err != nil {
-			return "", fmt.Errorf("imageutil: decode normalized thumbhash source: %w", err)
-		}
+		return "", err
 	}
-
-	scaled := scaleImage(img, 100)
+	scaled := scaleImage(img, thumbhashSourceDimension)
 	hashBytes := thumbhash.EncodeImage(scaled)
 	return base64.StdEncoding.EncodeToString(hashBytes), nil
+}
+
+func decodeThumbhashSource(data []byte) (image.Image, error) {
+	if normalized, err := normalizeThumbhashSource(data); err == nil {
+		if img, _, err := image.Decode(bytes.NewReader(normalized)); err == nil {
+			return img, nil
+		}
+	}
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("imageutil: decode for thumbhash: %w", err)
+	}
+	return img, nil
 }
 
 func normalizeThumbhashSource(data []byte) ([]byte, error) {

--- a/internal/imageutil/imageutil_test.go
+++ b/internal/imageutil/imageutil_test.go
@@ -1,0 +1,91 @@
+package imageutil
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"runtime"
+	"testing"
+)
+
+// largeTestJPEG encodes a width×height gradient so the bytes are a real,
+// decodable JPEG of meaningful dimensions rather than a fixture file.
+func largeTestJPEG(t testing.TB, width, height int) []byte {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.SetNRGBA(x, y, color.NRGBA{
+				R: uint8(x * 255 / width),
+				G: uint8(y * 255 / height),
+				B: uint8((x + y) * 255 / (width + height)),
+				A: 255,
+			})
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: 85}); err != nil {
+		t.Fatalf("encode test jpeg: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestThumbhashDeterministic(t *testing.T) {
+	data := largeTestJPEG(t, 1200, 800)
+	first, err := Thumbhash(data)
+	if err != nil {
+		t.Fatalf("Thumbhash: %v", err)
+	}
+	if first == "" {
+		t.Fatal("Thumbhash returned empty hash")
+	}
+	second, err := Thumbhash(data)
+	if err != nil {
+		t.Fatalf("Thumbhash (second call): %v", err)
+	}
+	if first != second {
+		t.Fatalf("Thumbhash not deterministic: %q vs %q", first, second)
+	}
+}
+
+func TestThumbhashRejectsGarbage(t *testing.T) {
+	if _, err := Thumbhash([]byte("not an image at all")); err == nil {
+		t.Fatal("Thumbhash accepted garbage input")
+	}
+}
+
+// TestThumbhashDoesNotDecodeFullRasterInGo pins the reason the vips downscale
+// runs before the Go decode: hashing must not materialize the original's full
+// raster on the Go heap. A 6000×4000 JPEG decodes to ≥36 MiB in pure Go, and
+// under tens of concurrent image-cache workers that is an OOM risk; through
+// the vips path the Go side only ever decodes a ≤100px PNG. The 15 MiB bound
+// is far above the new path's real footprint and far below the old one's.
+func TestThumbhashDoesNotDecodeFullRasterInGo(t *testing.T) {
+	data := largeTestJPEG(t, 6000, 4000)
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	if _, err := Thumbhash(data); err != nil {
+		t.Fatalf("Thumbhash: %v", err)
+	}
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	allocated := after.TotalAlloc - before.TotalAlloc
+	if allocated > 15<<20 {
+		t.Fatalf("Thumbhash allocated %d bytes on the Go heap; the full raster is being decoded in Go", allocated)
+	}
+}
+
+func BenchmarkThumbhashLargeJPEG(b *testing.B) {
+	data := largeTestJPEG(b, 6000, 4000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Thumbhash(data); err != nil {
+			b.Fatalf("Thumbhash: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`imageutil.Thumbhash` decodes the full original bytes in pure Go before scaling to 100px. A large provider poster materializes well over a hundred MiB of raster on the Go heap, and this runs once per concurrent image-cache worker — under the raised worker pool from #817, several GiB of transient decode memory in the worst case. The memory-efficient path already existed (`normalizeThumbhashSource` shrinks to 100px through libvips with shrink-on-load) but only ran as a fallback when the Go decode failed.

## Change

The order is reversed: libvips downscales first and Go decodes the resulting ≤100px PNG, with the pure-Go decode of the raw bytes kept as the fallback for anything libvips cannot parse — the supported format set is unchanged. Hashing a 6000×4000 JPEG now allocates ~0.5 MiB on the Go heap instead of 36+ MiB.

**Hash-stability analysis (done before changing anything):** the emitted hash bytes change for a given image, so every comparison site was audited. All four `Thumbhash` callers were checked (`imagecache.CacheBytes`, collection artwork, chapter thumbnails, ebook scan); only one compares hashes for equality: ebook scan cover change detection (`internal/scanner/ebook_scan.go`). That site stores the freshly computed hash whenever it re-caches, so the pipeline change costs one re-cache per scan-covered ebook on its next scan and then converges — it cannot loop. Stored thumbhashes elsewhere are display placeholders and stay valid; nothing needs regeneration.

## Tests

- `TestThumbhashDoesNotDecodeFullRasterInGo` — pins the property this PR exists for: hashing a 6000×4000 JPEG must not allocate more than 15 MiB on the Go heap (the old path allocates 36+ MiB, the new one ~0.5 MiB).
- `TestThumbhashDeterministic`, `TestThumbhashRejectsGarbage` — the package previously had no tests.
- `BenchmarkThumbhashLargeJPEG` — ~9.5 ms/op, ~538 KB/op, 6.7k allocs/op on a 6000×4000 JPEG (Apple M4 Max).

## Validation

- `make test-go` (CI-equivalent) — passes, including the consumer packages: `imagecache`, `scanner` (ebook cover change detection), `chapterthumbs`, `api/handlers`, `ebooks`, `audiobooks`
- `go build ./...`, `go vet`, `gofmt -l` clean
- `golangci-lint run --new-from-merge-base=origin/main ./...` — 0 issues

Related issue: N/A — narrow fix (flagged during review of #817; internal helper only, no API, client, or jellycompat surface changes)

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-fable-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: The main risk was hash instability breaking equality comparisons, so every `Thumbhash` call site was traced before the change: the ebook scan comparison was confirmed self-healing (it stores the hash it computes on re-cache, so the mismatch fires once per item, not per scan), and the other three sites were confirmed display-only. The memory claim is enforced by a test, not asserted in prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
