### PR TITLE
fix(metadata): rename ambiguous image_type variable in ladder reopen trigger

### DIFF
--- a/migrations/sql/20260828235638_fix_reopen_image_ladder_ambiguity.sql
+++ b/migrations/sql/20260828235638_fix_reopen_image_ladder_ambiguity.sql
@@ -1,0 +1,187 @@
+-- +goose Up
+-- reopen_image_ladder_backfill_v2 declared a plpgsql variable named
+-- image_type while its manifest probe filters on the column
+-- artwork_revision_gc_candidates.image_type. The bare right-hand reference in
+-- "manifest.image_type = image_type" matches both, and plpgsql's default
+-- variable_conflict=error raises 42702 the first time the probe runs — which
+-- is only once backfilled_version has reached 2, so every local cached-path
+-- publication on a v2-complete deployment fails outright instead of reopening
+-- the fence. Renaming the variable removes the collision; behavior is
+-- otherwise identical.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.reopen_image_ladder_backfill_v2()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    new_row jsonb := to_jsonb(NEW);
+    old_row jsonb;
+    arg_index integer := 0;
+    path_column text;
+    manifest_image_type text;
+    rung_pattern text;
+    cached_path text;
+    previous_path text;
+    state_version integer;
+    changed_cached_path boolean := false;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        old_row := to_jsonb(OLD);
+    END IF;
+
+    -- Find an affected local cached-path publication before taking the shared
+    -- singleton lock. The lock is still taken even when the state is below v2:
+    -- that closes the ordering with a concurrent final confirmation.
+    WHILE arg_index < TG_NARGS LOOP
+        path_column := TG_ARGV[arg_index];
+        cached_path := new_row ->> path_column;
+        previous_path := CASE WHEN old_row IS NULL THEN NULL ELSE old_row ->> path_column END;
+        IF COALESCE(BTRIM(cached_path), '') <> ''
+           AND cached_path NOT LIKE '%://%'
+           AND (TG_OP = 'INSERT' OR cached_path IS DISTINCT FROM previous_path) THEN
+            changed_cached_path := true;
+            EXIT;
+        END IF;
+        arg_index := arg_index + 3;
+    END LOOP;
+
+    IF NOT changed_cached_path THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT backfilled_version
+    INTO state_version
+    FROM public.image_ladder_backfill_state
+    WHERE id = 1
+    FOR UPDATE;
+
+    IF state_version < 2 THEN
+        RETURN NEW;
+    END IF;
+
+    arg_index := 0;
+    WHILE arg_index < TG_NARGS LOOP
+        path_column := TG_ARGV[arg_index];
+        manifest_image_type := TG_ARGV[arg_index + 1];
+        rung_pattern := TG_ARGV[arg_index + 2];
+        cached_path := new_row ->> path_column;
+        previous_path := CASE WHEN old_row IS NULL THEN NULL ELSE old_row ->> path_column END;
+
+        IF COALESCE(BTRIM(cached_path), '') <> ''
+           AND cached_path NOT LIKE '%://%'
+           AND (TG_OP = 'INSERT' OR cached_path IS DISTINCT FROM previous_path)
+           AND NOT EXISTS (
+               SELECT 1
+               FROM public.artwork_revision_gc_candidates manifest
+               WHERE manifest.original_path = cached_path
+                 AND manifest.image_type = manifest_image_type
+                 AND EXISTS (
+                     SELECT 1
+                     FROM unnest(manifest.object_keys) object_key
+                     WHERE object_key LIKE rung_pattern
+                 )
+           ) THEN
+            UPDATE public.image_ladder_backfill_state
+            SET backfilled_version = LEAST(backfilled_version, 1),
+                last_attempt_at = NULL,
+                updated_at = NOW()
+            WHERE id = 1;
+            RETURN NEW;
+        END IF;
+
+        arg_index := arg_index + 3;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- Restores the previous definition verbatim, including the ambiguous
+-- image_type variable this migration exists to remove.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.reopen_image_ladder_backfill_v2()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    new_row jsonb := to_jsonb(NEW);
+    old_row jsonb;
+    arg_index integer := 0;
+    path_column text;
+    image_type text;
+    rung_pattern text;
+    cached_path text;
+    previous_path text;
+    state_version integer;
+    changed_cached_path boolean := false;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        old_row := to_jsonb(OLD);
+    END IF;
+
+    WHILE arg_index < TG_NARGS LOOP
+        path_column := TG_ARGV[arg_index];
+        cached_path := new_row ->> path_column;
+        previous_path := CASE WHEN old_row IS NULL THEN NULL ELSE old_row ->> path_column END;
+        IF COALESCE(BTRIM(cached_path), '') <> ''
+           AND cached_path NOT LIKE '%://%'
+           AND (TG_OP = 'INSERT' OR cached_path IS DISTINCT FROM previous_path) THEN
+            changed_cached_path := true;
+            EXIT;
+        END IF;
+        arg_index := arg_index + 3;
+    END LOOP;
+
+    IF NOT changed_cached_path THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT backfilled_version
+    INTO state_version
+    FROM public.image_ladder_backfill_state
+    WHERE id = 1
+    FOR UPDATE;
+
+    IF state_version < 2 THEN
+        RETURN NEW;
+    END IF;
+
+    arg_index := 0;
+    WHILE arg_index < TG_NARGS LOOP
+        path_column := TG_ARGV[arg_index];
+        image_type := TG_ARGV[arg_index + 1];
+        rung_pattern := TG_ARGV[arg_index + 2];
+        cached_path := new_row ->> path_column;
+        previous_path := CASE WHEN old_row IS NULL THEN NULL ELSE old_row ->> path_column END;
+
+        IF COALESCE(BTRIM(cached_path), '') <> ''
+           AND cached_path NOT LIKE '%://%'
+           AND (TG_OP = 'INSERT' OR cached_path IS DISTINCT FROM previous_path)
+           AND NOT EXISTS (
+               SELECT 1
+               FROM public.artwork_revision_gc_candidates manifest
+               WHERE manifest.original_path = cached_path
+                 AND manifest.image_type = image_type
+                 AND EXISTS (
+                     SELECT 1
+                     FROM unnest(manifest.object_keys) object_key
+                     WHERE object_key LIKE rung_pattern
+                 )
+           ) THEN
+            UPDATE public.image_ladder_backfill_state
+            SET backfilled_version = LEAST(backfilled_version, 1),
+                last_attempt_at = NULL,
+                updated_at = NOW()
+            WHERE id = 1;
+            RETURN NEW;
+        END IF;
+
+        arg_index := arg_index + 3;
+    END LOOP;
+
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd


### PR DESCRIPTION
## Problem

`reopen_image_ladder_backfill_v2` (from `migrations/sql/20260826010050_fence_image_ladder_backfill.sql`) declares a plpgsql variable named `image_type` while its manifest probe filters on the column `artwork_revision_gc_candidates.image_type`. The bare right-hand reference in `manifest.image_type = image_type` matches both, and plpgsql's default `variable_conflict = error` raises `42702 column reference "image_type" is ambiguous` the first time the probe executes.

The probe only executes once `image_ladder_backfill_state.backfilled_version` has reached 2 — which is why the bug is invisible on fresh databases (the fence migration's own data-fix lowers the version below 2). On a v2-complete deployment, every INSERT or UPDATE that publishes a local cached path on the trigger's tables (`media_items`, `media_item_localizations`, `seasons`, `season_localizations`, `episodes`) fails outright with 42702 — the exact writes the fence exists to catch become errors instead.

Surfaced by `TestImageLadderBackfillLateOldArtworkReopensCompletedVersion`, which fails on `main` when run against a migrated database with `SILO_TEST_DATABASE_URL` set. CI never sets that variable, so CI does not catch it.

## Change

One new Goose migration (created with `make migrate-create`) re-creates the function with the variable renamed to `manifest_image_type`. Behavior is otherwise byte-for-byte identical; the remaining variables were checked against every column name in scope for further collisions (none). The Down restores the previous definition verbatim.

## Validation

- Fresh pgvector/pg18 database, full `--migrate-only` run including the new migration — applies cleanly
- `TestImageLadderBackfillLateOldArtworkReopensCompletedVersion` and `TestImageLadderBackfillFinalConfirmationRejectsLateOldArtwork` — fail on `main`, pass with this migration
- `go test ./internal/metadata/` with the database — entire package green
- Down/up round-trip via `--migrate-down-to 20260828180230` then `--migrate-only` — clean
- `make migrate-validate`, `make verify-local-paths` — pass

Related issue: N/A — narrow fix (bug found while running DB-gated tests during review of #818; no API, client, or jellycompat surface changes)

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-fable-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: The failing test was reproduced on `main` against a migrated database before any change, the ambiguity was traced to the specific plpgsql scoping rule rather than assumed, all other function variables were checked against in-scope column names, and the fix was verified by the previously failing tests plus a Down/up round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
