### PR TITLE
feat(admin): show build number in health strip

### DIFF
--- a/web/src/components/admin/dashboard/widgets/HealthStripWidget.test.tsx
+++ b/web/src/components/admin/dashboard/widgets/HealthStripWidget.test.tsx
@@ -97,7 +97,7 @@ describe("HealthStripWidget", () => {
     mocks.useAdminServerStatus.mockReset();
     mocks.useBuildInfo.mockReset();
     mocks.useAdminNodes.mockReset();
-    mocks.useBuildInfo.mockReturnValue({ data: { display: "v0.9.1" } });
+    mocks.useBuildInfo.mockReturnValue({ data: { display: "v0.9.1", build_number: 411 } });
     mocks.useAdminNodes.mockReturnValue({
       data: [],
       isLoading: false,
@@ -123,13 +123,26 @@ describe("HealthStripWidget", () => {
 
     renderStrip();
 
-    expect(screen.getByText("v0.9.1")).toBeTruthy();
+    expect(screen.getByText("411 · v0.9.1")).toBeTruthy();
     expect(screen.getByText("3h")).toBeTruthy();
     expect(screen.getByText("1.42 ms")).toBeTruthy();
     expect(screen.getByText("0.31 ms")).toBeTruthy();
     expect(screen.getByText("1/2")).toBeTruthy();
     expect(screen.getByText("4")).toBeTruthy();
     expect(screen.getByText("12 warnings")).toBeTruthy();
+  });
+
+  it("falls back to the version when no ordered build number is available", () => {
+    mocks.useAdminServerStatus.mockReturnValue({
+      data: status(),
+      isLoading: false,
+      error: null,
+    });
+    mocks.useBuildInfo.mockReturnValue({ data: { display: "v0.9.1" } });
+
+    renderStrip();
+
+    expect(screen.getByText("v0.9.1")).toBeTruthy();
   });
 
   it("separates an unconfigured dependency from a broken one", () => {

--- a/web/src/components/admin/dashboard/widgets/HealthStripWidget.tsx
+++ b/web/src/components/admin/dashboard/widgets/HealthStripWidget.tsx
@@ -27,6 +27,8 @@ export function HealthStripWidget() {
 
   const status = statusQuery.data;
   const health = status?.health;
+  const buildNumber = buildQuery.data?.build_number ?? 0;
+  const versionDisplay = buildQuery.data?.display || "unknown";
   // Only a successful response may claim "none": while the node list is
   // loading or failed, node status is unknown, and "this server transcodes"
   // would be an invented answer.
@@ -60,7 +62,7 @@ export function HealthStripWidget() {
         <HealthCell
           icon={Tag}
           label="Version"
-          value={buildQuery.data?.display || "unknown"}
+          value={buildNumber > 0 ? `${buildNumber} · ${versionDisplay}` : versionDisplay}
           detail={buildQuery.data?.dirty ? "dirty build" : undefined}
         />
         <HealthCell


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

The admin health strip displayed only the server version, making it harder to identify the exact build currently running.

## Approach

Display the positive build number before the version (for example, `411 · v0.9.1`). Preserve the existing version-only display when no ordered build number is available.

## Validation

- Updated `HealthStripWidget` tests to cover build-number display and the version fallback.
- Tests not run in this change request.

## Risks

None identified. The change is limited to admin dashboard presentation and preserves the existing fallback behavior.

## AI Disclosure

- Tool(s): none
- Model(s): n/a
- Involvement: AI-assisted
- Adversarial review: Reviewed the supplied diff for behavior, fallback handling, compatibility, and test coverage; no unresolved findings.

## Checklist

- [ ] I read and can explain the complete diff.
- [ ] This pull request addresses one concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the health dashboard’s Version display to include the build number when available.
  * Falls back to showing only the display version when no valid build number is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->