### PR TITLE
perf(search): optimize PostgreSQL lookup and live UI

### DIFF
--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -119,16 +119,7 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 	if groupedByWork {
 		result, entries, err := h.resolveGroupedCatalogByWork(r, req, accessFilter)
 		if err != nil {
-			if errors.Is(err, catalog.ErrInvalidCatalogRequest) {
-				writeError(w, http.StatusBadRequest, "bad_request", err.Error())
-				return
-			}
-			if errors.Is(err, catalog.ErrCatalogSourceNotFound) {
-				writeError(w, http.StatusNotFound, "not_found", "Catalog source not found")
-				return
-			}
-			slog.ErrorContext(r.Context(), "catalog: resolve grouped by work failed", "component", "api", "err_msg", err.Error())
-			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve catalog")
+			handleCatalogResolveError(w, r, err, "catalog: resolve grouped by work failed")
 			return
 		}
 
@@ -145,23 +136,31 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 
 	result, err := h.resolver.Resolve(r.Context(), req, accessFilter)
 	if err != nil {
-		if errors.Is(err, catalog.ErrInvalidCatalogRequest) {
-			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
-			return
-		}
-		if errors.Is(err, catalog.ErrCatalogSourceNotFound) {
-			writeError(w, http.StatusNotFound, "not_found", "Catalog source not found")
-			return
-		}
-		if handleCatalogSearchContextError(w, r, err) {
-			return
-		}
-		slog.ErrorContext(r.Context(), "catalog: resolve failed", "component", "api", "err_msg", err.Error())
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve catalog")
+		handleCatalogResolveError(w, r, err, "catalog: resolve failed")
 		return
 	}
 	items := h.catalogItemResponses(r, result.Items, catalogSortMetricField(req, result), playableTargetLibraryIDs(req), accessFilter)
 	h.writeCatalogResponse(w, result, items, groupedByWork)
+}
+
+// handleCatalogResolveError keeps grouped and ordinary catalogue resolution on
+// the same error contract. In particular, a grouped search still runs through
+// the bounded PostgreSQL path and must return search_timeout rather than hiding
+// a deadline behind the generic 500 response.
+func handleCatalogResolveError(w http.ResponseWriter, r *http.Request, err error, failureLog string) {
+	if errors.Is(err, catalog.ErrInvalidCatalogRequest) {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if errors.Is(err, catalog.ErrCatalogSourceNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "Catalog source not found")
+		return
+	}
+	if handleCatalogSearchContextError(w, r, err) {
+		return
+	}
+	slog.ErrorContext(r.Context(), failureLog, "component", "api", "err_msg", err.Error())
+	writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve catalog")
 }
 
 // handleCatalogSearchContextError translates bounded-search termination without

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -152,12 +153,32 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusNotFound, "not_found", "Catalog source not found")
 			return
 		}
+		if handleCatalogSearchContextError(w, r, err) {
+			return
+		}
 		slog.ErrorContext(r.Context(), "catalog: resolve failed", "component", "api", "err_msg", err.Error())
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve catalog")
 		return
 	}
 	items := h.catalogItemResponses(r, result.Items, catalogSortMetricField(req, result), playableTargetLibraryIDs(req), accessFilter)
 	h.writeCatalogResponse(w, result, items, groupedByWork)
+}
+
+// handleCatalogSearchContextError translates bounded-search termination without
+// treating it as an ordinary server fault. Superseded live queries cancel their
+// request context, so there is no client left to receive a response. A server
+// deadline is different: the client is still present and gets a retryable 504
+// instead of a misleading 500 while the database work is already stopped.
+func handleCatalogSearchContextError(w http.ResponseWriter, r *http.Request, err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		slog.WarnContext(r.Context(), "catalog: search deadline exceeded", "component", "api")
+		writeError(w, http.StatusGatewayTimeout, "search_timeout", "Search took too long and was stopped")
+		return true
+	}
+	return false
 }
 
 // catalogSortMetricField is the field the returned items are actually ordered

--- a/internal/api/handlers/catalog.go
+++ b/internal/api/handlers/catalog.go
@@ -119,7 +119,7 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 	if groupedByWork {
 		result, entries, err := h.resolveGroupedCatalogByWork(r, req, accessFilter)
 		if err != nil {
-			handleCatalogResolveError(w, r, err, "catalog: resolve grouped by work failed")
+			handleCatalogResolveError(w, r, err, true)
 			return
 		}
 
@@ -136,18 +136,18 @@ func (h *CatalogHandler) HandleGetCatalog(w http.ResponseWriter, r *http.Request
 
 	result, err := h.resolver.Resolve(r.Context(), req, accessFilter)
 	if err != nil {
-		handleCatalogResolveError(w, r, err, "catalog: resolve failed")
+		handleCatalogResolveError(w, r, err, false)
 		return
 	}
 	items := h.catalogItemResponses(r, result.Items, catalogSortMetricField(req, result), playableTargetLibraryIDs(req), accessFilter)
 	h.writeCatalogResponse(w, result, items, groupedByWork)
 }
 
-// handleCatalogResolveError keeps grouped and ordinary catalogue resolution on
+// handleCatalogResolveError keeps grouped and ordinary catalog resolution on
 // the same error contract. In particular, a grouped search still runs through
 // the bounded PostgreSQL path and must return search_timeout rather than hiding
 // a deadline behind the generic 500 response.
-func handleCatalogResolveError(w http.ResponseWriter, r *http.Request, err error, failureLog string) {
+func handleCatalogResolveError(w http.ResponseWriter, r *http.Request, err error, groupedByWork bool) {
 	if errors.Is(err, catalog.ErrInvalidCatalogRequest) {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
@@ -159,7 +159,13 @@ func handleCatalogResolveError(w http.ResponseWriter, r *http.Request, err error
 	if handleCatalogSearchContextError(w, r, err) {
 		return
 	}
-	slog.ErrorContext(r.Context(), failureLog, "component", "api", "err_msg", err.Error())
+	slog.ErrorContext(
+		r.Context(),
+		"catalog: resolve failed",
+		"component", "api",
+		"grouped_by_work", groupedByWork,
+		"err_msg", err.Error(),
+	)
 	writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve catalog")
 }
 

--- a/internal/api/handlers/catalog_diagnostics_test.go
+++ b/internal/api/handlers/catalog_diagnostics_test.go
@@ -153,3 +153,24 @@ func TestHandleCatalogSearchContextError_CanceledRequestWritesNothing(t *testing
 		t.Fatalf("canceled request wrote a response body: %q", rec.Body.String())
 	}
 }
+
+func TestHandleCatalogResolveError_GroupedDeadlineReturnsRetryableTimeout(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog?source=query&q=slow&group=work", nil)
+	handleCatalogResolveError(
+		rec,
+		req,
+		errors.Join(errors.New("grouped search failed"), context.DeadlineExceeded),
+		"catalog: resolve grouped by work failed",
+	)
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusGatewayTimeout, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode grouped timeout body: %v; body=%s", err, rec.Body.String())
+	}
+	if body["error"] != "search_timeout" {
+		t.Fatalf("error = %v, want search_timeout; body=%v", body["error"], body)
+	}
+}

--- a/internal/api/handlers/catalog_diagnostics_test.go
+++ b/internal/api/handlers/catalog_diagnostics_test.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -119,5 +122,34 @@ func TestWriteCatalogResponse_GroupedByWorkOmitsDiagnostics(t *testing.T) {
 	// Grouped responses force total_exact false regardless of result.TotalExact.
 	if body["total_exact"].(bool) != false {
 		t.Fatalf("grouped total_exact = %v, want false", body["total_exact"])
+	}
+}
+
+func TestHandleCatalogSearchContextError_DeadlineReturnsRetryableTimeout(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog?source=query&q=slow", nil)
+	if !handleCatalogSearchContextError(rec, req, errors.Join(errors.New("search failed"), context.DeadlineExceeded)) {
+		t.Fatal("deadline error was not handled")
+	}
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusGatewayTimeout, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode timeout body: %v; body=%s", err, rec.Body.String())
+	}
+	if body["error"] != "search_timeout" {
+		t.Fatalf("error = %v, want search_timeout; body=%v", body["error"], body)
+	}
+}
+
+func TestHandleCatalogSearchContextError_CanceledRequestWritesNothing(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/catalog?source=query&q=replaced", nil)
+	if !handleCatalogSearchContextError(rec, req, context.Canceled) {
+		t.Fatal("canceled request was not handled")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("canceled request wrote a response body: %q", rec.Body.String())
 	}
 }

--- a/internal/api/handlers/catalog_diagnostics_test.go
+++ b/internal/api/handlers/catalog_diagnostics_test.go
@@ -161,7 +161,7 @@ func TestHandleCatalogResolveError_GroupedDeadlineReturnsRetryableTimeout(t *tes
 		rec,
 		req,
 		errors.Join(errors.New("grouped search failed"), context.DeadlineExceeded),
-		"catalog: resolve grouped by work failed",
+		true,
 	)
 	if rec.Code != http.StatusGatewayTimeout {
 		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusGatewayTimeout, rec.Body.String())

--- a/internal/catalog/item_alias_repo_test.go
+++ b/internal/catalog/item_alias_repo_test.go
@@ -457,3 +457,53 @@ func TestItemRepositorySearchesPersistedAliasesAcrossExactFTSAndFuzzyPaths(t *te
 		}
 	}
 }
+
+func TestItemRepositoryFuzzySearchRanksPhraseTyposAboveSingleWordDistractors(t *testing.T) {
+	pool := newSemanticCoverageTestPool(t)
+	ctx := context.Background()
+	seedID := time.Now().UnixNano()
+
+	type seededTitle struct {
+		contentID string
+		title     string
+		mediaType string
+	}
+	seeded := []seededTitle{
+		{fmt.Sprintf("fuzzy-game-%d", seedID), "Game of Thrones", catalogTestContentTypeSeries},
+		{fmt.Sprintf("fuzzy-throne-%d", seedID), "Justice League: Throne of Atlantis", catalogTestContentTypeSeries},
+		{fmt.Sprintf("fuzzy-harry-%d", seedID), "Harry Potter and the Order of the Phoenix", "movie"},
+		{fmt.Sprintf("fuzzy-potter-%d", seedID), "Miss Potter", "movie"},
+	}
+	for _, item := range seeded {
+		seedSemanticCoverageMediaItem(t, pool, item.contentID, item.mediaType, "matched")
+		if _, err := pool.Exec(ctx, `UPDATE media_items SET title = $2, original_title = $2 WHERE content_id = $1`, item.contentID, item.title); err != nil {
+			t.Fatalf("seed fuzzy title %q: %v", item.title, err)
+		}
+		contentID := item.contentID
+		t.Cleanup(func() {
+			_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = $1`, contentID)
+		})
+	}
+
+	repo := NewItemRepository(pool)
+	for _, tc := range []struct {
+		query     string
+		itemTypes []string
+		wantID    string
+	}{
+		{"Gane of Throns", []string{catalogTestContentTypeSeries}, seeded[0].contentID}, //nolint:misspell
+		{"Hary Poter", []string{"movie"}, seeded[2].contentID},                          //nolint:misspell
+	} {
+		items, _, err := repo.Search(ctx, tc.query, tc.itemTypes, 20, 0, AccessFilter{})
+		if err != nil {
+			t.Fatalf("Search(%q): %v", tc.query, err)
+		}
+		if len(items) == 0 || items[0].ContentID != tc.wantID {
+			got := "<none>"
+			if len(items) > 0 {
+				got = fmt.Sprintf("%s (%s)", items[0].Title, items[0].ContentID)
+			}
+			t.Fatalf("Search(%q) first result = %s, want content_id %s", tc.query, got, tc.wantID)
+		}
+	}
+}

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -138,6 +139,12 @@ const overviewMatchFloor = 0.15
 // never consume a connection and CPU for minutes after the user has moved on.
 const postgresSearchTimeout = 3 * time.Second
 
+// A timed-out fuzzy query leaves its transaction needing a rollback, but the
+// request context is already unusable at that point. Give cleanup its own
+// short bound so the pool can reuse the connection instead of discarding it;
+// this is cleanup-only and cannot extend the search response deadline.
+const postgresSearchRollbackTimeout = time.Second
+
 // fuzzyFallbackThreshold is the FTS result count below which SearchPage reaches
 // for the trigram fuzzy fallback (buildFuzzySearchSQL). At or above it the FTS
 // result set is considered rich enough that a "did you mean" pass would only add
@@ -152,6 +159,19 @@ const fuzzyFallbackThreshold = 5
 // to paginate hundreds of low-similarity typo matches; when the true match count
 // exceeds this, the overflow is logged and the total is reported as inexact.
 const fuzzyMaxResults = 50
+
+// fuzzyRerankMaxAliasesPerItem bounds the only extra metadata the in-process
+// typo reranker may read. Candidate rows are already capped by fuzzyMaxResults,
+// so this makes its worst case 50 items / 200 relevant aliases regardless of
+// total library size.
+const fuzzyRerankMaxAliasesPerItem = 4
+
+const (
+	fuzzyRerankMaxQueryTokens = 16
+	fuzzyRerankMaxTitleTokens = 64
+	fuzzyRerankMaxTokenRunes  = 64
+	fuzzyRerankMaxTitleBytes  = 1024
+)
 
 // trgmWordSimilarityThreshold pins pg_trgm.strict_word_similarity_threshold
 // for the fuzzy query via SET LOCAL. The <<% operator's selectivity is
@@ -1046,6 +1066,14 @@ func (r *ItemRepository) searchWithFuzzyFallback(
 	if !includeTotal && limit-len(ftsBlock) < fuzzyLimit {
 		fuzzyLimit = limit - len(ftsBlock)
 	}
+	// An exact normalized title is already the strongest possible correction.
+	// The sparse FTS block is complete here, and it already includes related
+	// prefix/title matches, so a second trigram scan can only add latency and
+	// noisy near-matches. Misspellings and alias-only hits still take the fuzzy
+	// path because their hydrated title does not equal the query.
+	if searchBlockHasExactTitle(ftsBlock, parsed.ExactTitleHint) {
+		fuzzyLimit = 0
+	}
 	minSimilarity := 0.0
 	if len(ftsBlock) > 0 {
 		minSimilarity = fuzzyAugmentSimilarityFloor
@@ -1056,7 +1084,7 @@ func (r *ItemRepository) searchWithFuzzyFallback(
 		fuzzySQL, _, fuzzyArgs := r.buildFuzzySearchFromParsed(parsed, itemTypes, fuzzyLimit+1, 0, filter, false, contentIDsFromMediaItems(ftsBlock), minSimilarity)
 		if fuzzySQL != "" {
 			var err error
-			fuzzyBlock, fuzzyTruncated, err = r.execFuzzyBlock(ctx, fuzzySQL, fuzzyArgs, fuzzyLimit)
+			fuzzyBlock, fuzzyTruncated, err = r.execFuzzyBlock(ctx, searchTextFromParsed(parsed), fuzzySQL, fuzzyArgs, fuzzyLimit)
 			if err != nil {
 				return nil, 0, false, includeTotal, err
 			}
@@ -1099,17 +1127,33 @@ func (r *ItemRepository) searchWithFuzzyFallback(
 	return page, total, hi < total, !fuzzyTruncated, nil
 }
 
+func searchBlockHasExactTitle(items []*models.MediaItem, normalizedTitle string) bool {
+	if normalizedTitle == "" {
+		return false
+	}
+	for _, item := range items {
+		if item != nil && normalizeTitleForComparison(item.Title) == normalizedTitle {
+			return true
+		}
+	}
+	return false
+}
+
 // execFuzzyBlock runs the fuzzy data query inside a transaction that pins
 // pg_trgm.strict_word_similarity_threshold, so the <<% operator's selectivity
 // cannot drift with cluster configuration (its 0.6 server default would reject
 // ordinary typos outright). The query was built with LIMIT fuzzyLimit+1; the
 // extra row only signals truncation and is trimmed from the returned block.
-func (r *ItemRepository) execFuzzyBlock(ctx context.Context, dataSQL string, args []any, fuzzyLimit int) ([]*models.MediaItem, bool, error) {
+func (r *ItemRepository) execFuzzyBlock(ctx context.Context, searchText, dataSQL string, args []any, fuzzyLimit int) ([]*models.MediaItem, bool, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
 		return nil, false, fmt.Errorf("beginning fuzzy search tx: %w", err)
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer func() {
+		rollbackCtx, cancel := context.WithTimeout(context.Background(), postgresSearchRollbackTimeout)
+		defer cancel()
+		_ = tx.Rollback(rollbackCtx)
+	}()
 
 	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL pg_trgm.strict_word_similarity_threshold = %g", trgmWordSimilarityThreshold)); err != nil {
 		return nil, false, fmt.Errorf("pinning trigram word-similarity threshold: %w", err)
@@ -1118,10 +1162,274 @@ func (r *ItemRepository) execFuzzyBlock(ctx context.Context, dataSQL string, arg
 	if err != nil {
 		return nil, false, err
 	}
+	if len(block) > 1 {
+		aliases, err := loadFuzzyRerankAliases(ctx, tx, searchText, block)
+		if err != nil {
+			return nil, false, err
+		}
+		if err := rerankFuzzyItems(ctx, searchText, block, aliases); err != nil {
+			return nil, false, err
+		}
+	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, false, fmt.Errorf("committing fuzzy search tx: %w", err)
 	}
 	return block, truncated, nil
+}
+
+// loadFuzzyRerankAliases reads only aliases that passed the same indexed
+// strict-word predicate as the fuzzy candidate query. ROW_NUMBER applies the
+// cap per content ID; an item with pathological alias history cannot inflate
+// the in-process relevance workload.
+func loadFuzzyRerankAliases(ctx context.Context, q searchQuerier, searchText string, items []*models.MediaItem) (map[string][]string, error) {
+	contentIDs := contentIDsFromMediaItems(items)
+	if len(contentIDs) == 0 {
+		return nil, nil
+	}
+	rows, err := q.Query(ctx, `
+		WITH matched AS (
+			SELECT
+				mia.content_id,
+				mia.normalized_title,
+				ROW_NUMBER() OVER (
+					PARTITION BY mia.content_id
+					ORDER BY
+						0.65 * similarity(public.normalize_search_text($2), mia.normalized_title)
+							+ 0.35 * strict_word_similarity(public.normalize_search_text($2), mia.normalized_title) DESC,
+						mia.normalized_title ASC
+				) AS alias_rank
+			FROM media_item_aliases mia
+			WHERE mia.content_id = ANY($1)
+			  AND public.normalize_search_text($2) <<% mia.normalized_title
+		)
+		SELECT content_id, normalized_title
+		FROM matched
+		WHERE alias_rank <= $3`, contentIDs, searchText, fuzzyRerankMaxAliasesPerItem)
+	if err != nil {
+		return nil, fmt.Errorf("loading bounded fuzzy aliases: %w", err)
+	}
+	defer rows.Close()
+
+	aliases := make(map[string][]string, len(contentIDs))
+	for rows.Next() {
+		var contentID, normalizedTitle string
+		if err := rows.Scan(&contentID, &normalizedTitle); err != nil {
+			return nil, fmt.Errorf("scanning fuzzy alias: %w", err)
+		}
+		aliases[contentID] = append(aliases[contentID], normalizedTitle)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating fuzzy aliases: %w", err)
+	}
+	return aliases, nil
+}
+
+type fuzzyTitleScore struct {
+	exact         bool
+	contiguous    bool
+	matchedTokens int
+	editDistance  int
+	extraTokens   int
+}
+
+type fuzzyRankedItem struct {
+	item  *models.MediaItem
+	score fuzzyTitleScore
+	order int
+}
+
+// rerankFuzzyItems is a deliberately tiny relevance layer over PostgreSQL's
+// indexed candidate set, not another search index. Its edit limits mirror the
+// auto-fuzziness policy used by Bleve (Apache-2.0): 0 edits for <=2 characters,
+// 1 for 3-5, and at most 2 for longer tokens. PostgreSQL still decides which
+// rows are candidates; this only prevents one strongly matching word from
+// outranking a phrase whose every token is a plausible typo correction.
+func rerankFuzzyItems(ctx context.Context, searchText string, items []*models.MediaItem, aliases map[string][]string) error {
+	query := normalizeTitleForComparison(searchText)
+	queryTokens, ok := boundedFuzzyTokens(query, fuzzyRerankMaxQueryTokens)
+	if !ok || len(queryTokens) == 0 || len(items) < 2 {
+		return nil
+	}
+
+	ranked := make([]fuzzyRankedItem, 0, len(items))
+	for i, item := range items {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var variants []string
+		if item != nil {
+			variants = append(variants, aliases[item.ContentID]...)
+		}
+		if item != nil && len(item.Title) <= fuzzyRerankMaxTitleBytes {
+			variants = append(variants, item.Title)
+		}
+		score := fuzzyTitleScore{editDistance: int(^uint(0) >> 1), extraTokens: int(^uint(0) >> 1)}
+		for _, variant := range variants {
+			candidate := scoreFuzzyTitleVariant(query, queryTokens, variant)
+			if fuzzyTitleScoreBetter(candidate, score) {
+				score = candidate
+			}
+		}
+		ranked = append(ranked, fuzzyRankedItem{item: item, score: score, order: i})
+	}
+
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if fuzzyTitleScoreBetter(ranked[i].score, ranked[j].score) {
+			return true
+		}
+		if fuzzyTitleScoreBetter(ranked[j].score, ranked[i].score) {
+			return false
+		}
+		return ranked[i].order < ranked[j].order
+	})
+	for i := range ranked {
+		items[i] = ranked[i].item
+	}
+	return nil
+}
+
+func scoreFuzzyTitleVariant(query string, queryTokens [][]rune, rawTitle string) fuzzyTitleScore {
+	title := normalizeTitleForComparison(rawTitle)
+	titleTokens, ok := boundedFuzzyTokens(title, fuzzyRerankMaxTitleTokens)
+	if !ok || len(titleTokens) == 0 {
+		return fuzzyTitleScore{editDistance: int(^uint(0) >> 1), extraTokens: int(^uint(0) >> 1)}
+	}
+	score := fuzzyTitleScore{
+		exact:       title == query,
+		contiguous:  strings.Contains(title, query),
+		extraTokens: absInt(len(titleTokens) - len(queryTokens)),
+	}
+	for _, queryToken := range queryTokens {
+		maxEdits := fuzzyAutoMaxEdits(len(queryToken))
+		best := maxEdits + 1
+		for _, titleToken := range titleTokens {
+			distance := boundedLevenshteinRunes(queryToken, titleToken, maxEdits)
+			if distance < best {
+				best = distance
+			}
+		}
+		if best <= maxEdits {
+			score.matchedTokens++
+		}
+		score.editDistance += best
+	}
+	return score
+}
+
+func fuzzyTitleScoreBetter(a, b fuzzyTitleScore) bool {
+	if a.exact != b.exact {
+		return a.exact
+	}
+	if a.matchedTokens != b.matchedTokens {
+		return a.matchedTokens > b.matchedTokens
+	}
+	if a.contiguous != b.contiguous {
+		return a.contiguous
+	}
+	if a.editDistance != b.editDistance {
+		return a.editDistance < b.editDistance
+	}
+	return a.extraTokens < b.extraTokens
+}
+
+func boundedFuzzyTokens(normalized string, maxTokens int) ([][]rune, bool) {
+	fields := strings.Fields(normalized)
+	if len(fields) > maxTokens {
+		return nil, false
+	}
+	tokens := make([][]rune, 0, len(fields))
+	for _, field := range fields {
+		runes := []rune(field)
+		if len(runes) > fuzzyRerankMaxTokenRunes {
+			return nil, false
+		}
+		tokens = append(tokens, runes)
+	}
+	return tokens, true
+}
+
+func fuzzyAutoMaxEdits(tokenRunes int) int {
+	switch {
+	case tokenRunes <= 2:
+		return 0
+	case tokenRunes <= 5:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// boundedLevenshteinRunes computes only the small edit bands used by typo
+// search. Rows that cannot finish within maxEdits return maxEdits+1 early, so
+// CPU and scratch memory are bounded by short title-token lengths.
+func boundedLevenshteinRunes(a, b []rune, maxEdits int) int {
+	if absInt(len(a)-len(b)) > maxEdits {
+		return maxEdits + 1
+	}
+	if len(a) == 0 {
+		if len(b) <= maxEdits {
+			return len(b)
+		}
+		return maxEdits + 1
+	}
+	if len(b) == 0 {
+		if len(a) <= maxEdits {
+			return len(a)
+		}
+		return maxEdits + 1
+	}
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+
+	previous := make([]int, len(a)+1)
+	current := make([]int, len(a)+1)
+	for i := range previous {
+		previous[i] = i
+	}
+	for row, right := range b {
+		current[0] = row + 1
+		rowMin := current[0]
+		for col, left := range a {
+			cost := 0
+			if left != right {
+				cost = 1
+			}
+			current[col+1] = minInt(
+				previous[col+1]+1,
+				current[col]+1,
+				previous[col]+cost,
+			)
+			if current[col+1] < rowMin {
+				rowMin = current[col+1]
+			}
+		}
+		if rowMin > maxEdits {
+			return maxEdits + 1
+		}
+		previous, current = current, previous
+	}
+	if previous[len(a)] > maxEdits {
+		return maxEdits + 1
+	}
+	return previous[len(a)]
+}
+
+func minInt(values ...int) int {
+	minimum := values[0]
+	for _, value := range values[1:] {
+		if value < minimum {
+			minimum = value
+		}
+	}
+	return minimum
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
 }
 
 // searchQuerier is the subset of pgxpool.Pool / pgx.Tx that execSearchBlock
@@ -1289,7 +1597,7 @@ func appendSearchScopeFilters(itemTypes []string, filter AccessFilter, condition
 // SearchPage only when the FTS query is sparse. Unlike buildSearchSQLWithTotal,
 // the sole match predicate is the pg_trgm strict-word-similarity operator
 // (<<%) against the indexed title_normalized generated column (migration 105's
-// gin_trgm_ops index serves it), and the ranking signals are
+// gin_trgm_ops index serves it), and the ranking signal blends
 // strict_word_similarity()/similarity() on that same column. Crucially it
 // never references the title tsvectors, so the low-similarity rows the
 // operator can surface never pay a per-row tsvector rebuild — that rebuild
@@ -1333,26 +1641,19 @@ func (r *ItemRepository) buildFuzzySearchFromParsed(parsed parsedSearchQuery, it
 	// word-boundary extent of the title instead, and at equal thresholds it is
 	// a strict superset of % (the whole string is itself a valid extent). The
 	// same gin_trgm_ops index serves both operators.
-	// The alias arm is a scalar array subquery (InitPlan) for the same reason
-	// as the FTS builder's alias arms: `= ANY(param)` keeps the outer OR a
-	// BitmapOr over the two gin_trgm_ops indexes, where an `IN (subquery)` arm
-	// would force a seq scan evaluating <<% against every media_items row.
-	conditions := []string{`(
-		public.normalize_search_text($1) <<% mi.title_normalized OR
-		mi.content_id = ANY(COALESCE((
-			SELECT array_agg(DISTINCT mia.content_id) FROM media_item_aliases mia
-			WHERE public.normalize_search_text($1) <<% mia.normalized_title
-		), '{}'::text[]))
-	)`}
+	// Title and alias candidates are independent indexed arms. They are unioned
+	// by content_id before media_items is hydrated. Do not correlate alias
+	// scoring back to each media row: PostgreSQL can turn that shape into a full
+	// alias-index filter for every candidate (observed cost >112k and a real
+	// 3-second timeout for "Gane of Throns"). This shape scans each trigram GIN
+	// index once and scores only the rows it returned.
+	var conditions []string
 	if minSimilarity > 0 {
 		// The floor is whole-title similarity, NOT word similarity: augmenting
 		// a query that already has hits must only admit near-identical titles,
 		// and word similarity rates embedded prefix words far too high (see
 		// fuzzyAugmentSimilarityFloor).
-		conditions = append(conditions, fmt.Sprintf(`GREATEST(
-			similarity(public.normalize_search_text($1), mi.title_normalized),
-			COALESCE((SELECT MAX(similarity(public.normalize_search_text($1), mia.normalized_title)) FROM media_item_aliases mia WHERE mia.content_id = mi.content_id), 0)
-		) >= $%d`, argIdx))
+		conditions = append(conditions, fmt.Sprintf("cs.fuzzy_full_rank >= $%d", argIdx))
 		args = append(args, minSimilarity)
 		argIdx++
 	}
@@ -1365,35 +1666,61 @@ func (r *ItemRepository) buildFuzzySearchFromParsed(parsed parsedSearchQuery, it
 		argIdx++
 	}
 
-	whereClause := "WHERE " + strings.Join(conditions, " AND ")
+	whereClause := ""
+	if len(conditions) > 0 {
+		whereClause = "WHERE " + strings.Join(conditions, " AND ")
+	}
 
-	// GROUP BY is required so the MAX(similarity(...)) ranking aggregate is legal,
-	// mirroring buildSearchSQLWithTotal; COUNT(*) OVER () then counts distinct
-	// content_ids. qualifiedItemColumns aliases the coalesced columns so the outer
-	// SELECT can re-reference them; GROUP BY uses the raw refs.
+	// candidate_scores has exactly one row per content_id, so hydration needs no
+	// wide GROUP BY over all media columns. COUNT(*) OVER () therefore counts
+	// distinct visible items directly.
 	qualifiedCols := qualifiedItemColumns("mi")
-	groupByCols := qualifiedItemColumnRefs("mi")
-	// fuzzy_rank orders by how well the query matches SOME word extent of the
-	// title; fuzzy_full_rank tie-breaks by whole-title closeness so "The
-	// Avengers" sorts above "Avengers: Endgame" for the typo "avegners". Both
-	// are computed only over the matched candidate set.
+	// Candidate recall uses strict word similarity so a typo can still reach a
+	// long title. Ranking cannot use that score alone: a single matching word
+	// can otherwise outrank the intended phrase (for example "Gane of Throns"
+	// used to rank "Justice League: Throne of Atlantis" above "Game of
+	// Thrones"). Blend mostly whole-title closeness with enough word similarity
+	// to keep long-title typo recovery useful (for example "Hary Poter" still
+	// prefers a Harry Potter title over "Miss Potter"). The whole-title score
+	// remains the deterministic first tie-break. Both signals are computed only
+	// over the indexed candidate set, never the full catalog.
 	scoredCTE := fmt.Sprintf(`
-		WITH scored AS (
+		WITH alias_candidates AS MATERIALIZED (
+			SELECT
+				mia.content_id,
+				MAX(
+					0.65 * similarity(public.normalize_search_text($1), mia.normalized_title)
+						+ 0.35 * strict_word_similarity(public.normalize_search_text($1), mia.normalized_title)
+				) AS fuzzy_rank,
+				MAX(similarity(public.normalize_search_text($1), mia.normalized_title)) AS fuzzy_full_rank
+			FROM media_item_aliases mia
+			WHERE public.normalize_search_text($1) <<%% mia.normalized_title
+			GROUP BY mia.content_id
+		), candidates AS (
+			SELECT
+				mi.content_id,
+				0.65 * similarity(public.normalize_search_text($1), mi.title_normalized)
+					+ 0.35 * strict_word_similarity(public.normalize_search_text($1), mi.title_normalized) AS fuzzy_rank,
+				similarity(public.normalize_search_text($1), mi.title_normalized) AS fuzzy_full_rank
+			FROM media_items mi
+			WHERE public.normalize_search_text($1) <<%% mi.title_normalized
+			UNION ALL
+			SELECT content_id, fuzzy_rank, fuzzy_full_rank
+			FROM alias_candidates
+		), candidate_scores AS (
+			SELECT content_id, MAX(fuzzy_rank) AS fuzzy_rank, MAX(fuzzy_full_rank) AS fuzzy_full_rank
+			FROM candidates
+			GROUP BY content_id
+		), scored AS (
 			SELECT
 				%s,
-				MAX(GREATEST(
-					strict_word_similarity(public.normalize_search_text($1), mi.title_normalized),
-					COALESCE((SELECT MAX(strict_word_similarity(public.normalize_search_text($1), mia.normalized_title)) FROM media_item_aliases mia WHERE mia.content_id = mi.content_id), 0)
-				)) AS fuzzy_rank,
-				MAX(GREATEST(
-					similarity(public.normalize_search_text($1), mi.title_normalized),
-					COALESCE((SELECT MAX(similarity(public.normalize_search_text($1), mia.normalized_title)) FROM media_item_aliases mia WHERE mia.content_id = mi.content_id), 0)
-				)) AS fuzzy_full_rank
+				cs.fuzzy_rank,
+				cs.fuzzy_full_rank
 			FROM %s
+			JOIN candidate_scores cs ON cs.content_id = mi.content_id
 			%s
-			GROUP BY %s
 		)
-	`, qualifiedCols, fromClause, whereClause, groupByCols)
+	`, qualifiedCols, fromClause, whereClause)
 
 	totalColumn := ""
 	if includeTotal {

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -133,6 +133,11 @@ func (r *ItemRepository) GetPosterPath(ctx context.Context, contentID string) (s
 // incidental one-mention hits that flooded results before.
 const overviewMatchFloor = 0.15
 
+// A catalog search is interactive work. Bound the complete PostgreSQL FTS +
+// fuzzy path independently of client cancellation so a pathological query can
+// never consume a connection and CPU for minutes after the user has moved on.
+const postgresSearchTimeout = 3 * time.Second
+
 // fuzzyFallbackThreshold is the FTS result count below which SearchPage reaches
 // for the trigram fuzzy fallback (buildFuzzySearchSQL). At or above it the FTS
 // result set is considered rich enough that a "did you mean" pass would only add
@@ -920,6 +925,8 @@ func (r *ItemRepository) SearchPage(
 	if filter.AllowedLibraryIDs != nil && len(filter.AllowedLibraryIDs) == 0 {
 		return []*models.MediaItem{}, 0, false, includeTotal, nil
 	}
+	ctx, cancel := context.WithTimeout(ctx, postgresSearchTimeout)
+	defer cancel()
 
 	parsed := parseSearchQuery(query)
 

--- a/internal/catalog/item_repo.go
+++ b/internal/catalog/item_repo.go
@@ -1518,6 +1518,7 @@ func (r *ItemRepository) execSearchBlock(ctx context.Context, q searchQuerier, d
 //	$2               titlePrefixTsQuery (always)
 //	itemType placeholders, allowed/disabled libraries, MaxContentRating
 //	parsed.ExactTitleHint
+//	parsed.NormalizedText (leading-short title lookups only)
 //	parsed.Year (or NULL)
 //	parsed.Phrase
 //	limit, offset

--- a/internal/catalog/item_repo_test.go
+++ b/internal/catalog/item_repo_test.go
@@ -388,14 +388,17 @@ func TestEligibleForFuzzy(t *testing.T) {
 		query string
 		want  bool
 	}{
-		{"avegners", true},   // 8-char typo
-		{"sponge bob", true}, // longest token "sponge" (6)
-		{"a vengers", true},  // judged on "vengers" (7), not "a"
-		{"dune", true},       // exactly at the floor
-		{"the", false},       // 3 chars
-		{"a b c", false},     // all short
-		{"and the", false},   // "and" normalized away, "the" is 3
-		{"   ", false},       // empty
+		{"avegners", true},         // 8-char typo
+		{"sponge bob", true},       // unquoted input retains fuzzy typo recovery
+		{"a vengers", true},        // judged on "vengers" (7), not "a"
+		{"dune", true},             // exactly at the floor
+		{"star wars", true},        // final token is long enough for normal fuzzy fallback
+		{"star w", true},           // unquoted typeahead retains fuzzy augmentation
+		{`"Star Wars" zen`, false}, // quoted remainder stays on the leading-title path
+		{"the", false},             // 3 chars
+		{"a b c", false},           // all short
+		{"and the", false},         // "and" normalized away, "the" is 3
+		{"   ", false},             // empty
 	}
 	for _, tc := range cases {
 		if got := eligibleForFuzzy(parseSearchQuery(tc.query)); got != tc.want {
@@ -527,6 +530,32 @@ func TestItemRepo_Search_ShortFinalTokenUsesLeadingTitleIndexes(t *testing.T) {
 	}
 	if strings.Contains(dataSQL, "search_overview_vector") {
 		t.Fatalf("leading-title transition must not expand into overview FTS:\n%s", dataSQL)
+	}
+}
+
+func TestItemRepo_Search_QuotedPhraseShortRemainderUsesFullLeadingTitle(t *testing.T) {
+	repo := &ItemRepository{}
+	dataSQL, _, args := repo.buildSearchSQLWithTotal(`"Star Wars" z`, nil, 20, 0, AccessFilter{}, false)
+
+	lookupArg := -1
+	for i, arg := range args {
+		if arg == "star wars z" {
+			lookupArg = i + 1
+			break
+		}
+	}
+	if lookupArg < 0 {
+		t.Fatalf("leading-title lookup must bind the full normalized query; got args %#v", args)
+	}
+
+	for _, want := range []string{
+		fmt.Sprintf("mi.title_normalized LIKE $%d || '%%'", lookupArg),
+		fmt.Sprintf("mia.normalized_title LIKE $%d || '%%'", lookupArg),
+		fmt.Sprintf("ece.search_title_normalized LIKE $%d || '%%'", lookupArg),
+	} {
+		if !strings.Contains(dataSQL, want) {
+			t.Fatalf("quoted leading-title transition missing %q:\n%s", want, dataSQL)
+		}
 	}
 }
 

--- a/internal/catalog/item_repo_test.go
+++ b/internal/catalog/item_repo_test.go
@@ -299,10 +299,9 @@ func TestItemRepo_Search_UsesWindowCount(t *testing.T) {
 }
 
 // TestItemRepo_Search_TitleGate_UsesWindowCount asserts the unified query
-// pairs the scored CTE with a stats CTE that derives has_title_match, and
-// that the window count runs on the final filtered result so the total
-// reflects the title-gate CROSS JOIN filter rather than the broader
-// pre-filter set.
+// materializes title candidates once and gates overview candidates behind a
+// one-time NOT EXISTS test. The window count runs on the selected candidate
+// block, so title hits and overview fallback rows can never mix.
 func TestItemRepo_Search_TitleGate_UsesWindowCount(t *testing.T) {
 	repo := &ItemRepository{}
 	sql, _, _ := repo.buildSearchSQL("the matrix reloaded", []string{"movie"}, 20, 0, AccessFilter{})
@@ -312,31 +311,26 @@ func TestItemRepo_Search_TitleGate_UsesWindowCount(t *testing.T) {
 	if strings.Count(sql, "WITH scored AS") != 1 {
 		t.Fatalf("expected exactly one scored CTE; got %s", sql)
 	}
-	if !strings.Contains(sql, "stats AS") {
-		t.Fatalf("expected stats CTE; got %s", sql)
+	if !strings.Contains(sql, "title_scored AS MATERIALIZED") {
+		t.Fatalf("expected materialized title candidates; got %s", sql)
 	}
-	if !strings.Contains(sql, "has_title_match") {
-		t.Fatalf("expected has_title_match predicate; got %s", sql)
+	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM title_scored)") {
+		t.Fatalf("expected overview fallback to be gated by title existence; got %s", sql)
 	}
 }
 
 // TestItemRepo_Search_SingleWordEnablesTitleGate pins the bug fix for the
 // "obsession returns 2000 results" report: even single-word queries must
-// route through the stats CTE + CROSS JOIN, so overview-only matches are
-// suppressed whenever any title match exists. Prior to this, single-word
-// queries skipped the stats CTE entirely and returned every row where the
-// search term appeared in the description.
+// route through the title-first candidate CTE, so overview-only matches are
+// suppressed whenever any title match exists.
 func TestItemRepo_Search_SingleWordEnablesTitleGate(t *testing.T) {
 	repo := &ItemRepository{}
 	sql, _, _ := repo.buildSearchSQL("obsession", []string{"movie"}, 20, 0, AccessFilter{})
-	if !strings.Contains(sql, "stats AS") {
-		t.Fatalf("expected single-word query to include the stats CTE; got %s", sql)
+	if !strings.Contains(sql, "title_scored AS MATERIALIZED") {
+		t.Fatalf("expected single-word query to materialize title candidates; got %s", sql)
 	}
-	if !strings.Contains(sql, "CROSS JOIN stats") {
-		t.Fatalf("expected single-word query to CROSS JOIN stats; got %s", sql)
-	}
-	if !strings.Contains(sql, "scored.title_rank > 0") {
-		t.Fatalf("expected title gate to use title_rank > 0; got %s", sql)
+	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM title_scored)") {
+		t.Fatalf("expected single-word overview fallback to test title candidates; got %s", sql)
 	}
 }
 
@@ -348,7 +342,7 @@ func TestItemRepo_Search_SingleWordEnablesTitleGate(t *testing.T) {
 func TestItemRepo_Search_AppliesOverviewRankFloor(t *testing.T) {
 	repo := &ItemRepository{}
 	dataSQL, countSQL, _ := repo.buildSearchSQL("obsession", []string{"movie"}, 20, 0, AccessFilter{})
-	want := fmt.Sprintf("scored.overview_rank >= %g", overviewMatchFloor)
+	want := fmt.Sprintf("overview_scored.overview_rank >= %g", overviewMatchFloor)
 	if !strings.Contains(dataSQL, want) {
 		t.Fatalf("expected %q in dataSQL; got %s", want, dataSQL)
 	}
@@ -459,6 +453,55 @@ func TestItemRepo_Search_FTSQueryHasNoFuzzyArm(t *testing.T) {
 		if strings.Contains(sql, "similarity(") {
 			t.Fatalf("FTS query must not compute similarity(); got:\n%s", sql)
 		}
+	}
+}
+
+func TestItemRepo_Search_AliasScoresUseOneUncorrelatedPass(t *testing.T) {
+	repo := &ItemRepository{}
+	dataSQL, countSQL, _ := repo.buildSearchSQL("lanterns", nil, 20, 0, AccessFilter{})
+	for _, sql := range []string{dataSQL, countSQL} {
+		if strings.Count(sql, "alias_scores AS MATERIALIZED") != 1 {
+			t.Fatalf("expected one materialized alias scoring pass; got:\n%s", sql)
+		}
+		if !strings.Contains(sql, "LEFT JOIN alias_scores search_alias") {
+			t.Fatalf("expected media ranking to reuse alias_scores; got:\n%s", sql)
+		}
+		if strings.Contains(sql, "FROM media_item_aliases mia WHERE mia.content_id = mi.content_id") {
+			t.Fatalf("search must not rescan every alias row per media candidate; got:\n%s", sql)
+		}
+	}
+}
+
+func TestItemRepo_Search_ShortSingleTokenUsesExactTitlePath(t *testing.T) {
+	repo := &ItemRepository{}
+	for _, query := range []string{"x", "up", "her"} {
+		dataSQL, _, args := repo.buildSearchSQLWithTotal(query, nil, 20, 0, AccessFilter{}, false)
+		if !strings.Contains(dataSQL, "mi.title_normalized = $") {
+			t.Fatalf("short query %q must use exact normalized media titles; got:\n%s", query, dataSQL)
+		}
+		if !strings.Contains(dataSQL, "ece.search_title_normalized = $") {
+			t.Fatalf("short query %q must use the indexed exact episode title; got:\n%s", query, dataSQL)
+		}
+		if strings.Contains(dataSQL, "idx_episodes_search_overview") || args[1] != "" {
+			t.Fatalf("short query %q must not enable broad prefix search; args=%#v\n%s", query, args, dataSQL)
+		}
+	}
+}
+
+func TestItemRepo_Search_ShortFinalTokenUsesLeadingTitleIndexes(t *testing.T) {
+	repo := &ItemRepository{}
+	dataSQL, _, _ := repo.buildSearchSQLWithTotal("the m", nil, 20, 0, AccessFilter{}, false)
+	for _, want := range []string{
+		"mi.title_normalized LIKE $",
+		"mia.normalized_title LIKE $",
+		"ece.search_title_normalized LIKE $",
+	} {
+		if !strings.Contains(dataSQL, want) {
+			t.Fatalf("leading-title transition missing %q:\n%s", want, dataSQL)
+		}
+	}
+	if strings.Contains(dataSQL, "search_overview_vector") {
+		t.Fatalf("leading-title transition must not expand into overview FTS:\n%s", dataSQL)
 	}
 }
 
@@ -630,18 +673,16 @@ func TestItemRepo_Search_UsesTitleNormalizedColumn(t *testing.T) {
 }
 
 // TestItemRepo_Search_NormalizesTsqueryInput asserts that the user's search
-// text is wrapped in public.normalize_search_text() before being handed to
-// websearch_to_tsquery on the title arm, and to phraseto_tsquery for the
-// phrase rank. The tsvector side of @@ applies the same normalization, so
-// title normalization stays symmetric end-to-end. The overview arm is
+// text is normalized in Go before being bound to the prefix to_tsquery, and
+// that quoted phrase ranking normalizes its input in SQL. The overview arm is
 // intentionally left unwrapped — the 'english' config already treats "and"
 // as a stop word.
 func TestItemRepo_Search_NormalizesTsqueryInput(t *testing.T) {
 	repo := &ItemRepository{}
 	sql, _, _ := repo.buildSearchSQL("law and order", []string{"movie"}, 20, 0, AccessFilter{})
 
-	if !strings.Contains(sql, "websearch_to_tsquery('simple', public.normalize_search_text($1))") {
-		t.Fatalf("title arm must normalize the query input; got:\n%s", sql)
+	if !strings.Contains(sql, "to_tsquery('simple', $2)") {
+		t.Fatalf("title arm must use the normalized prefix query argument; got:\n%s", sql)
 	}
 	if !strings.Contains(sql, "public.normalize_search_text(COALESCE(mi.title, ''))") {
 		t.Fatalf("title tsvector must normalize mi.title to match the GIN index expression; got:\n%s", sql)
@@ -727,7 +768,10 @@ func TestItemRepo_Search_ScoredCTEIsLean(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dataSQL, countSQL, _ := repo.buildSearchSQL("avatar", test.itemTypes, 20, 0, AccessFilter{})
 			for _, sql := range []string{dataSQL, countSQL} {
-				end := strings.Index(sql, "), stats AS")
+				end := strings.Index(sql, "), page AS")
+				if countEnd := strings.Index(sql, ")\nSELECT COUNT(*)"); end < 0 || (countEnd >= 0 && countEnd < end) {
+					end = countEnd
+				}
 				if end < 0 {
 					t.Fatalf("expected scored CTE boundary; got:\n%s", sql)
 				}
@@ -746,9 +790,9 @@ func TestItemRepo_Search_UnscopedIncludesEpisodeCandidateBranch(t *testing.T) {
 	repo := &ItemRepository{}
 	sql, _, _ := repo.buildSearchSQL("Who Are You?", nil, 20, 0, AccessFilter{})
 	for _, want := range []string{
-		"FROM episodes e JOIN media_items si",
+		"FROM episode_catalog_entries ece JOIN media_items si",
 		"si.type = 'series'",
-		"FROM episode_libraries available_el",
+		"ece.search_title_vector",
 		"UNION ALL",
 	} {
 		if !strings.Contains(sql, want) {
@@ -760,7 +804,7 @@ func TestItemRepo_Search_UnscopedIncludesEpisodeCandidateBranch(t *testing.T) {
 func TestItemRepo_Search_EpisodeScopeOmitsMediaItemCandidateBranch(t *testing.T) {
 	repo := &ItemRepository{}
 	sql, _, _ := repo.buildSearchSQL("Who Are You?", []string{"episode"}, 20, 0, AccessFilter{})
-	scoredEnd := strings.Index(sql, "), stats AS")
+	scoredEnd := strings.Index(sql, "), page AS")
 	if scoredEnd < 0 {
 		t.Fatalf("expected scored CTE boundary; got:\n%s", sql)
 	}
@@ -768,7 +812,7 @@ func TestItemRepo_Search_EpisodeScopeOmitsMediaItemCandidateBranch(t *testing.T)
 	if strings.Contains(scored, "FROM media_items mi") {
 		t.Fatalf("episode-only candidate set must not scan media_items directly:\n%s", scored)
 	}
-	if !strings.Contains(scored, "FROM episodes e JOIN media_items si") {
+	if !strings.Contains(scored, "FROM episode_catalog_entries ece JOIN media_items si") {
 		t.Fatalf("episode-only candidate set missing episode branch:\n%s", scored)
 	}
 }
@@ -779,15 +823,15 @@ func TestItemRepo_Search_EpisodeAccessUsesIndependentMembershipPredicates(t *tes
 		AllowedLibraryIDs:  []int{1},
 		DisabledLibraryIDs: []int{2},
 	})
-	if !strings.Contains(sql, "FROM episode_libraries allowed_el") {
-		t.Fatalf("episode search missing allowed-library EXISTS:\n%s", sql)
+	if !strings.Contains(sql, "ece.media_folder_id = ANY($") {
+		t.Fatalf("episode search missing direct allowed-library catalog filter:\n%s", sql)
 	}
-	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM episode_libraries disabled_el") {
+	if !strings.Contains(sql, "NOT EXISTS (SELECT 1 FROM episode_catalog_entries disabled_ece") {
 		t.Fatalf("episode search missing independent disabled-library NOT EXISTS:\n%s", sql)
 	}
-	assertEpisodeParentDisabledAccess(t, sql, "e.series_id")
-	if strings.Contains(sql, "WHERE e_parent.content_id = e.content_id") {
-		t.Fatalf("episode candidate branch must use e.series_id without an episode lookup:\n%s", sql)
+	assertEpisodeParentDisabledAccess(t, sql, "ece.series_id")
+	if strings.Contains(sql, "WHERE e_parent.content_id = ece.episode_id") {
+		t.Fatalf("episode candidate branch must use ece.series_id without an episode lookup:\n%s", sql)
 	}
 }
 

--- a/internal/catalog/item_repo_test.go
+++ b/internal/catalog/item_repo_test.go
@@ -491,6 +491,9 @@ func TestItemRepo_Search_AliasScoresUseOneUncorrelatedPass(t *testing.T) {
 		if strings.Contains(sql, "FROM media_item_aliases mia WHERE mia.content_id = mi.content_id") {
 			t.Fatalf("search must not rescan every alias row per media candidate; got:\n%s", sql)
 		}
+		if strings.Contains(sql, "title_rank") {
+			t.Fatalf("search must not retain the removed constant title_rank sort key; got:\n%s", sql)
+		}
 	}
 }
 

--- a/internal/catalog/item_repo_test.go
+++ b/internal/catalog/item_repo_test.go
@@ -1,10 +1,14 @@
 package catalog
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
 )
 
 // TestItemRepo_GetByIDsWithAccess_SingleQueryWithLibraryFilter verifies that
@@ -422,6 +426,24 @@ func TestSearchTextFromParsed(t *testing.T) {
 	}
 }
 
+func TestSearchBlockHasExactTitle(t *testing.T) {
+	items := []*models.MediaItem{
+		{Title: "Game of Thrones"},
+		{Title: "Dune: Part Two"},
+		nil,
+	}
+	for _, query := range []string{"game of thrones", "dune part 2"} {
+		if !searchBlockHasExactTitle(items, query) {
+			t.Fatalf("expected normalized exact title %q to suppress fuzzy fallback", query)
+		}
+	}
+	for _, query := range []string{"", "game throne", "breking bad"} {
+		if searchBlockHasExactTitle(items, query) {
+			t.Fatalf("non-exact title %q must retain fuzzy fallback", query)
+		}
+	}
+}
+
 // TestParseSearchQuery_NormalizedText asserts parseSearchQuery precomputes the
 // full normalized text that eligibleForFuzzy's token gate reads (so the gate
 // does not re-normalize on every sparse search).
@@ -505,10 +527,42 @@ func TestItemRepo_Search_ShortFinalTokenUsesLeadingTitleIndexes(t *testing.T) {
 	}
 }
 
+// TestItemRepo_Search_NarrowTitlePathTypesSearchTextParameter guards a
+// prepare-time failure that only appeared after the user finished a short
+// final token: "breaking" used the regular FTS path, while "Breaking Bad"
+// suppressed the overview arm and therefore left the still-bound $1 without a
+// PostgreSQL type (SQLSTATE 42P18). Every physical source and both page/count
+// statements must carry the explicit, parameter-only type guard.
+func TestItemRepo_Search_NarrowTitlePathTypesSearchTextParameter(t *testing.T) {
+	repo := &ItemRepository{}
+	for _, test := range []struct {
+		name      string
+		query     string
+		itemTypes []string
+	}{
+		{name: "mixed multiword", query: "Breaking Bad"},
+		{name: "media multiword", query: "Breaking Bad", itemTypes: []string{"movie", "series"}},
+		{name: "episode multiword", query: "Who Are You?", itemTypes: []string{"episode"}},
+		{name: "mixed short title", query: "Up"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dataSQL, countSQL, args := repo.buildSearchSQLWithTotal(test.query, test.itemTypes, 20, 0, AccessFilter{}, true)
+			if len(args) < 2 || args[0] != test.query {
+				t.Fatalf("unexpected fixed search arguments: %#v", args)
+			}
+			for _, sql := range []string{dataSQL, countSQL} {
+				if !strings.Contains(sql, "$1::text IS NOT NULL") {
+					t.Fatalf("narrow search must type bound $1 in both statements; got:\n%s", sql)
+				}
+			}
+		})
+	}
+}
+
 // TestItemRepo_BuildFuzzySearchSQL asserts that the fuzzy fallback query scores
 // only on indexed normalized title/alias columns (no title tsvector rebuild),
 // matches via strict word similarity so long titles stay reachable, ranks by
-// descending word similarity with whole-title closeness as tie-break, excludes
+// a whole-title-weighted blend (rather than one matching word alone), excludes
 // already-seen content_ids, and applies the same scope filters (type, manga
 // exclusion) as the FTS query.
 func TestItemRepo_BuildFuzzySearchSQL(t *testing.T) {
@@ -520,14 +574,24 @@ func TestItemRepo_BuildFuzzySearchSQL(t *testing.T) {
 	if !strings.Contains(dataSQL, "public.normalize_search_text($1) <<% mi.title_normalized") {
 		t.Fatalf("expected strict-word-similarity arm against title_normalized; got:\n%s", dataSQL)
 	}
-	if !strings.Contains(dataSQL, "strict_word_similarity(public.normalize_search_text($1), mi.title_normalized)") || !strings.Contains(dataSQL, "AS fuzzy_rank") {
-		t.Fatalf("expected strict word similarity ranking on title_normalized; got:\n%s", dataSQL)
+	if !strings.Contains(dataSQL, "0.65 * similarity(public.normalize_search_text($1), mi.title_normalized)") ||
+		!strings.Contains(dataSQL, "+ 0.35 * strict_word_similarity(public.normalize_search_text($1), mi.title_normalized)") ||
+		!strings.Contains(dataSQL, "AS fuzzy_rank") {
+		t.Fatalf("expected whole-title-weighted fuzzy ranking on title_normalized; got:\n%s", dataSQL)
 	}
 	if !strings.Contains(dataSQL, "similarity(public.normalize_search_text($1), mi.title_normalized)") || !strings.Contains(dataSQL, "AS fuzzy_full_rank") {
 		t.Fatalf("expected whole-title similarity tie-break rank; got:\n%s", dataSQL)
 	}
 	if !strings.Contains(dataSQL, "<<% mia.normalized_title") {
 		t.Fatalf("expected alias trigram candidates; got:\n%s", dataSQL)
+	}
+	if !strings.Contains(dataSQL, "WITH alias_candidates AS MATERIALIZED") ||
+		!strings.Contains(dataSQL, "candidate_scores AS") ||
+		!strings.Contains(dataSQL, "JOIN candidate_scores cs ON cs.content_id = mi.content_id") {
+		t.Fatalf("expected independently indexed title/alias candidate arms before hydration; got:\n%s", dataSQL)
+	}
+	if strings.Contains(dataSQL, "FROM media_item_aliases mia WHERE mia.content_id = mi.content_id") {
+		t.Fatalf("fuzzy ranking must not rescan the alias index per media candidate; got:\n%s", dataSQL)
 	}
 	// The whole point of the separate query: it must never rebuild the title
 	// tsvectors that made the fused query slow.
@@ -574,7 +638,7 @@ func TestItemRepo_BuildFuzzySearchSQL_CursorModeOmitsWindowCount(t *testing.T) {
 }
 
 // TestItemRepo_BuildFuzzySearchSQL_SimilarityFloor asserts the augment floor
-// contract: minSimilarity > 0 adds an explicit similarity() >= $n predicate
+// contract: minSimilarity > 0 adds an explicit fuzzy_full_rank >= $n predicate
 // (used when the FTS block had real hits, so augmentation only admits
 // near-certain corrections), and minSimilarity == 0 omits it so zero-hit typo
 // queries keep the base pinned threshold's recall.
@@ -585,7 +649,7 @@ func TestItemRepo_BuildFuzzySearchSQL_SimilarityFloor(t *testing.T) {
 	// Whole-title similarity, not word similarity: the augment floor must not
 	// admit embedded prefix words ("coral" scores 0.5 word-similarity to
 	// "coraline").
-	if !strings.Contains(floorSQL, ") >= $2") || !strings.Contains(floorSQL, "mia.normalized_title") {
+	if !strings.Contains(floorSQL, "cs.fuzzy_full_rank >= $2") {
 		t.Fatalf("expected explicit whole-title similarity floor predicate as $2; got:\n%s", floorSQL)
 	}
 	if len(floorArgs) < 2 || floorArgs[1] != fuzzyAugmentSimilarityFloor {
@@ -597,7 +661,7 @@ func TestItemRepo_BuildFuzzySearchSQL_SimilarityFloor(t *testing.T) {
 	}
 
 	baseSQL, _, baseArgs := repo.buildFuzzySearchSQL("avegners", []string{"movie"}, 20, 0, AccessFilter{}, true, nil, 0)
-	if strings.Contains(baseSQL, ") >= $2") {
+	if strings.Contains(baseSQL, "cs.fuzzy_full_rank >= $2") {
 		t.Fatalf("zero floor must not add a similarity predicate; got:\n%s", baseSQL)
 	}
 	if len(baseArgs) != len(floorArgs)-1 {
@@ -860,5 +924,106 @@ func TestItemRepo_ListUnmatchedByFolderAndPathPrefix_ExcludesMangaChapters(t *te
 	}
 	if len(args) != 4 {
 		t.Fatalf("expected 4 args with limit; got %v", args)
+	}
+}
+
+func TestRerankFuzzyItemsUsesTokenEditCoverage(t *testing.T) {
+	items := []*models.MediaItem{
+		{ContentID: "throne", Title: "Justice League: Throne of Atlantis"},
+		{ContentID: "game", Title: "Game of Thrones"},
+		{ContentID: "last-watch", Title: "Game of Thrones: The Last Watch"},
+	}
+	if err := rerankFuzzyItems(context.Background(), "Gane of Throns", items, nil); err != nil { //nolint:misspell
+		t.Fatalf("rerank: %v", err)
+	}
+	if items[0].ContentID != "game" {
+		t.Fatalf("first result = %q (%s), want Game of Thrones", items[0].Title, items[0].ContentID)
+	}
+
+	items = []*models.MediaItem{
+		{ContentID: "miss", Title: "Miss Potter"},
+		{ContentID: "harry", Title: "Harry Potter and the Order of the Phoenix"},
+	}
+	if err := rerankFuzzyItems(context.Background(), "Hary Poter", items, nil); err != nil { //nolint:misspell
+		t.Fatalf("rerank: %v", err)
+	}
+	if items[0].ContentID != "harry" {
+		t.Fatalf("first result = %q (%s), want Harry Potter title", items[0].Title, items[0].ContentID)
+	}
+}
+
+func TestRerankFuzzyItemsUsesBoundedAliases(t *testing.T) {
+	items := []*models.MediaItem{
+		{ContentID: "distractor", Title: "Tokyo Ghoul"},
+		{ContentID: "localized", Title: "倒凶十将伝"},
+	}
+	aliases := map[string][]string{
+		"localized": {"10 tokyo warriors"},
+	}
+	if err := rerankFuzzyItems(context.Background(), "Tokyo Warriros", items, aliases); err != nil { //nolint:misspell
+		t.Fatalf("rerank: %v", err)
+	}
+	if items[0].ContentID != "localized" {
+		t.Fatalf("first result = %q (%s), want alias-backed localized item", items[0].Title, items[0].ContentID)
+	}
+}
+
+func TestRerankFuzzyItemsHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	items := []*models.MediaItem{{ContentID: "one", Title: "One"}, {ContentID: "two", Title: "Two"}}
+	if err := rerankFuzzyItems(ctx, "three", items, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("rerank error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFuzzyAutoMaxEditsMirrorsBoundedSearchEnginePolicy(t *testing.T) {
+	for _, tc := range []struct {
+		length int
+		want   int
+	}{{1, 0}, {2, 0}, {3, 1}, {5, 1}, {6, 2}, {20, 2}} {
+		if got := fuzzyAutoMaxEdits(tc.length); got != tc.want {
+			t.Fatalf("fuzzyAutoMaxEdits(%d) = %d, want %d", tc.length, got, tc.want)
+		}
+	}
+}
+
+func TestBoundedLevenshteinRunes(t *testing.T) {
+	for _, tc := range []struct {
+		a, b string
+		max  int
+		want int
+	}{
+		{"game", "gane", 1, 1},
+		{"breaking", "breking", 2, 1},
+		{"furious", "furios", 2, 1},
+		{"thrones", "throns", 2, 1},
+		{"game", "throne", 2, 3},
+	} {
+		if got := boundedLevenshteinRunes([]rune(tc.a), []rune(tc.b), tc.max); got != tc.want {
+			t.Fatalf("boundedLevenshteinRunes(%q, %q, %d) = %d, want %d", tc.a, tc.b, tc.max, got, tc.want)
+		}
+	}
+}
+
+func BenchmarkRerankFuzzyItemsCappedCandidateSet(b *testing.B) {
+	items := make([]*models.MediaItem, fuzzyMaxResults)
+	aliases := make(map[string][]string, fuzzyMaxResults)
+	for i := range items {
+		contentID := fmt.Sprintf("item-%d", i)
+		items[i] = &models.MediaItem{ContentID: contentID, Title: fmt.Sprintf("Related Fantasy Title %d", i)}
+		for alias := 0; alias < fuzzyRerankMaxAliasesPerItem; alias++ {
+			aliases[contentID] = append(aliases[contentID], fmt.Sprintf("Alternate Fantasy Title %d %d", i, alias))
+		}
+	}
+	items[len(items)-1].Title = "Game of Thrones"
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		working := append([]*models.MediaItem(nil), items...)
+		if err := rerankFuzzyItems(context.Background(), "Gane of Throns", working, aliases); err != nil { //nolint:misspell
+			b.Fatal(err)
+		}
 	}
 }

--- a/internal/catalog/search_episode_db_test.go
+++ b/internal/catalog/search_episode_db_test.go
@@ -103,6 +103,71 @@ func TestEpisodeSearchPostgresAndDocumentSource(t *testing.T) {
 	}
 }
 
+func TestEpisodeSearchOverviewVectorRefreshesOnOverviewUpdate(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := t.Context()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	suffix := time.Now().UnixNano()
+	seriesID := fmt.Sprintf("episode-overview-series-%d", suffix)
+	episodeID := fmt.Sprintf("episode-overview-episode-%d", suffix)
+	var folderID int
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO media_folders (type, name, enabled) VALUES ('series', $1, true) RETURNING id`,
+		seriesID,
+	).Scan(&folderID); err != nil {
+		t.Fatalf("seed folder: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO media_items (content_id, type, title, status, genres)
+		VALUES ($1, 'series', 'Overview Trigger Fixture', 'matched', '{}'::text[])
+	`, seriesID); err != nil {
+		t.Fatalf("seed series: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO episodes (content_id, series_id, season_number, episode_number, title, overview)
+		VALUES ($1, $2, 1, 1, 'Overview Trigger Episode', 'A buried signal returns.')
+	`, episodeID, seriesID); err != nil {
+		t.Fatalf("seed episode: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO episode_libraries (episode_id, media_folder_id, first_seen_at)
+		VALUES ($1, $2, NOW())
+	`, episodeID, folderID); err != nil {
+		t.Fatalf("seed episode membership: %v", err)
+	}
+
+	if _, err := tx.Exec(ctx, `UPDATE episodes SET overview = 'A quartzbeacon constellation appears.' WHERE content_id = $1`, episodeID); err != nil {
+		t.Fatalf("update episode overview: %v", err)
+	}
+	var hasUpdatedOverview, hasOldOverview bool
+	if err := tx.QueryRow(ctx, `
+		SELECT
+			search_overview_vector @@ plainto_tsquery('english', 'quartzbeacon constellation'),
+			search_overview_vector @@ plainto_tsquery('english', 'buried signal')
+		FROM episode_catalog_entries
+		WHERE episode_id = $1
+	`, episodeID).Scan(&hasUpdatedOverview, &hasOldOverview); err != nil {
+		t.Fatalf("read refreshed episode overview vector: %v", err)
+	}
+	if !hasUpdatedOverview || hasOldOverview {
+		t.Fatalf("overview vector after overview-only update = updated %v old %v", hasUpdatedOverview, hasOldOverview)
+	}
+}
+
 func TestEpisodeSearchOutboxStatementTriggers(t *testing.T) {
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {

--- a/internal/catalog/search_postgres_mixed.go
+++ b/internal/catalog/search_postgres_mixed.go
@@ -155,6 +155,12 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 	exactIdx := argIdx
 	args = append(args, parsed.ExactTitleHint)
 	argIdx++
+	titleLookupIdx := exactIdx
+	if leadingShortTitle {
+		titleLookupIdx = argIdx
+		args = append(args, parsed.NormalizedText)
+		argIdx++
+	}
 	var yearArg any
 	if parsed.Year != nil {
 		yearArg = *parsed.Year
@@ -172,7 +178,7 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 		if exactShortTitle {
 			mediaMatch = fmt.Sprintf("(mi.title_normalized = $%d OR %s)", exactIdx, aliasCandidateArm)
 		} else if leadingShortTitle {
-			mediaMatch = fmt.Sprintf("(mi.title_normalized LIKE $%d || '%%' OR %s)", exactIdx, aliasCandidateArm)
+			mediaMatch = fmt.Sprintf("(mi.title_normalized LIKE $%d || '%%' OR %s)", titleLookupIdx, aliasCandidateArm)
 		}
 		mediaTitleConditions = append([]string{mediaMatch}, mediaConditions...)
 		if !narrowTitleLookup {
@@ -185,7 +191,7 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 		if exactShortTitle {
 			episodeMatch = fmt.Sprintf("ece.search_title_normalized = $%d", exactIdx)
 		} else if leadingShortTitle {
-			episodeMatch = fmt.Sprintf("ece.search_title_normalized LIKE $%d || '%%'", exactIdx)
+			episodeMatch = fmt.Sprintf("ece.search_title_normalized LIKE $%d || '%%'", titleLookupIdx)
 		}
 		episodeTitleConditions = append([]string{episodeMatch}, episodeConditions...)
 		if !narrowTitleLookup {
@@ -248,7 +254,7 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 
 	innerCTEs := make([]string, 0, 2)
 	if includeMediaItems {
-		innerCTEs = append(innerCTEs, buildMixedSearchAliasScoresCTE(exactIdx, exactShortTitle, leadingShortTitle))
+		innerCTEs = append(innerCTEs, buildMixedSearchAliasScoresCTE(exactIdx, titleLookupIdx, exactShortTitle, leadingShortTitle))
 	}
 	titleScoredBody := strings.Join(titleBranches, "\nUNION ALL\n")
 	var scoredBody string
@@ -367,13 +373,13 @@ func searchOverviewMatchCondition(overviewVector string) string {
 // index once per media candidate when PostgreSQL failed to parameterize them.
 // On large alias catalogs that turned a selective search into millions of
 // index-entry visits and pushed the plan over the JIT threshold.
-func buildMixedSearchAliasScoresCTE(exactIdx int, exactShortTitle, leadingShortTitle bool) string {
+func buildMixedSearchAliasScoresCTE(exactIdx, titleLookupIdx int, exactShortTitle, leadingShortTitle bool) string {
 	aliasVector := `to_tsvector('simple', mia.normalized_title)`
 	weightedAliasVector := `setweight(to_tsvector('simple', mia.normalized_title), 'A')`
 	prefixQuery := `to_tsquery('simple', $2)`
 	matchCondition := fmt.Sprintf("mia.normalized_title = $%d", exactIdx)
 	if leadingShortTitle {
-		matchCondition = fmt.Sprintf("mia.normalized_title LIKE $%d || '%%'", exactIdx)
+		matchCondition = fmt.Sprintf("mia.normalized_title LIKE $%d || '%%'", titleLookupIdx)
 	} else if !exactShortTitle {
 		matchCondition = fmt.Sprintf("$2 <> '' AND %s @@ %s", aliasVector, prefixQuery)
 	}

--- a/internal/catalog/search_postgres_mixed.go
+++ b/internal/catalog/search_postgres_mixed.go
@@ -276,6 +276,16 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 	}
 	scoredCTE := "WITH scored AS (\n" + scoredBody + "\n)"
 	postFilter := `FROM scored`
+	if narrowTitleLookup {
+		// Narrow title searches intentionally skip the overview branch. That
+		// branch is normally what gives $1 (searchText) its PostgreSQL type;
+		// without it, queries such as "Breaking Bad" reference $2 and later
+		// placeholders but fail at parse time with SQLSTATE 42P18 because $1 is
+		// untyped. This parameter-only guard is always true for a built search
+		// (empty input returned above), types $1 explicitly, and is planned as a
+		// one-time filter without widening either indexed title lookup.
+		postFilter += ` WHERE $1::text IS NOT NULL`
+	}
 
 	pageTotalColumn := ""
 	finalTotalColumn := ""

--- a/internal/catalog/search_postgres_mixed.go
+++ b/internal/catalog/search_postgres_mixed.go
@@ -78,7 +78,7 @@ const mediaSearchTitleVector = `(
 const mediaSearchOverviewVector = `to_tsvector('english', COALESCE(mi.overview, ''))`
 
 const mixedSearchOrder = `exact_title_match DESC, contiguous_title_match DESC, year_match DESC,
-	phrase_rank DESC, title_rank DESC, title_prefix_rank DESC, overview_rank DESC,
+	phrase_rank DESC, title_prefix_rank DESC, overview_rank DESC,
 	LOWER(title) ASC, content_id ASC`
 
 // buildMixedSearchSQLFromParsed builds one ranked candidate set from the two
@@ -382,7 +382,6 @@ func buildMixedSearchAliasScoresCTE(exactIdx int, exactShortTitle, leadingShortT
 			mia.content_id,
 			MAX(CASE WHEN mia.normalized_title = $%d THEN 1 ELSE 0 END) AS exact_title_match,
 			MAX(CASE WHEN mia.normalized_title LIKE '%%' || $%d || '%%' THEN 1 ELSE 0 END) AS contiguous_title_match,
-			0::real AS title_rank,
 			MAX(CASE WHEN $2 <> '' THEN ts_rank_cd(%s, %s) ELSE 0 END) AS title_prefix_rank
 		FROM media_item_aliases mia
 		WHERE %s
@@ -419,7 +418,6 @@ func buildMixedSearchCandidateBranch(
 		contiguousArms = append(contiguousArms, fmt.Sprintf("%s LIKE '%%' || $%d || '%%'", expr, exactIdx))
 	}
 	prefixQuery := `to_tsquery('simple', $2)`
-	titleRankExpr := "0::real"
 	prefixRankExpr := fmt.Sprintf("ts_rank_cd(%s, %s)", titleVector, prefixQuery)
 	if aliasArms != nil {
 		// Alias exact/contiguous arms are hashed subplans in the CASE select
@@ -445,7 +443,6 @@ func buildMixedSearchCandidateBranch(
 			CASE WHEN $%d <> '' AND (%s) THEN 1 ELSE 0 END AS exact_title_match,
 			CASE WHEN $%d <> '' AND (%s) THEN 1 ELSE 0 END AS contiguous_title_match,
 			CASE WHEN $%d::int IS NOT NULL AND (%s) = $%d::int THEN 1 ELSE 0 END AS year_match,
-			%s AS title_rank,
 			CASE WHEN $2 <> '' THEN %s ELSE 0 END AS title_prefix_rank,
 			%s AS overview_rank,
 			CASE WHEN $%d <> '' THEN ts_rank_cd(%s, phraseto_tsquery('simple', public.normalize_search_text($%d))) ELSE 0 END AS phrase_rank
@@ -455,7 +452,6 @@ func buildMixedSearchCandidateBranch(
 		exactIdx, strings.Join(exactArms, " OR "),
 		exactIdx, strings.Join(contiguousArms, " OR "),
 		yearIdx, yearExpr, yearIdx,
-		titleRankExpr,
 		prefixRankExpr,
 		overviewRankExpr,
 		phraseIdx, titleVector, phraseIdx,

--- a/internal/catalog/search_postgres_mixed.go
+++ b/internal/catalog/search_postgres_mixed.go
@@ -63,14 +63,19 @@ func (r *ItemRepository) GetSearchItemsByIDsWithAccess(
 	return scanItems(rows)
 }
 
-const episodeSearchTitleExpr = `COALESCE(NULLIF(BTRIM(e.title), ''), 'Episode ' || e.episode_number::text)`
+const episodeSearchTitleExpr = `ece.title`
 
-const episodeSearchTitleVector = `setweight(
-	to_tsvector('simple', public.normalize_search_text(COALESCE(NULLIF(BTRIM(e.title), ''), 'Episode ' || e.episode_number::text))),
-	'A'
+const episodeSearchTitleVector = `ece.search_title_vector`
+
+const episodeSearchOverviewVector = `ece.search_overview_vector`
+
+const mediaSearchTitleVector = `(
+	setweight(to_tsvector('simple', public.normalize_search_text(COALESCE(mi.title, ''))), 'A') ||
+	setweight(to_tsvector('simple', public.normalize_search_text(COALESCE(mi.original_title, ''))), 'A') ||
+	setweight(to_tsvector('simple', public.normalize_search_text(COALESCE(mi.sort_title, ''))), 'B')
 )`
 
-const episodeSearchOverviewVector = `to_tsvector('english', COALESCE(e.overview, ''))`
+const mediaSearchOverviewVector = `to_tsvector('english', COALESCE(mi.overview, ''))`
 
 const mixedSearchOrder = `exact_title_match DESC, contiguous_title_match DESC, year_match DESC,
 	phrase_rank DESC, title_rank DESC, title_prefix_rank DESC, overview_rank DESC,
@@ -100,17 +105,17 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 
 	args = []any{searchText, buildTitlePrefixTsQuery(searchText)}
 	argIdx := 3
-	var branches []string
+	var titleBranches []string
+	var overviewBranches []string
+	exactShortTitle := useExactShortTitleSearch(parsed)
+	leadingShortTitle := useLeadingShortTitleSearch(parsed)
+	narrowTitleLookup := exactShortTitle || leadingShortTitle
+	aliasCandidateArm := `mi.content_id = ANY(COALESCE((
+		SELECT array_agg(alias_scores.content_id) FROM alias_scores
+	), '{}'::text[]))`
 
 	mediaConditions := []string{}
 	if includeMediaItems {
-		mediaTitleVector := `(
-			setweight(to_tsvector('simple', public.normalize_search_text(COALESCE(mi.title, ''))), 'A') ||
-			setweight(to_tsvector('simple', public.normalize_search_text(COALESCE(mi.original_title, ''))), 'A') ||
-			setweight(to_tsvector('simple', public.normalize_search_text(COALESCE(mi.sort_title, ''))), 'B')
-		)`
-		mediaOverviewVector := `to_tsvector('english', COALESCE(mi.overview, ''))`
-		mediaConditions = append(mediaConditions, searchMatchCondition(mediaTitleVector, mediaOverviewVector, mediaSearchAliasMatchArms()...))
 		if len(itemTypes) > 0 {
 			mediaConditions = append(mediaConditions, fmt.Sprintf("mi.type = ANY($%d)", argIdx))
 			args = append(args, mediaTypes)
@@ -128,16 +133,14 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 	if includeEpisodes {
 		episodeConditions = append(episodeConditions,
 			"si.type = 'series'",
-			`EXISTS (SELECT 1 FROM episode_libraries available_el WHERE available_el.episode_id = e.content_id)`,
-			searchMatchCondition(episodeSearchTitleVector, episodeSearchOverviewVector),
 		)
-		appendEpisodeLibrarySearchAccess("e.content_id", "e.series_id", filter, &episodeConditions, &args, &argIdx)
+		appendEpisodeCatalogSearchAccess("ece", filter, &episodeConditions, &args, &argIdx)
 		if filter.MaxContentRating != "" {
 			allowedRatings := access.AllowedRatingsUpTo(filter.MaxContentRating)
 			if len(allowedRatings) == 0 {
 				episodeConditions = append(episodeConditions, "1 = 0")
 			} else {
-				episodeConditions = append(episodeConditions, fmt.Sprintf("si.content_rating = ANY($%d)", argIdx))
+				episodeConditions = append(episodeConditions, fmt.Sprintf("ece.content_rating = ANY($%d)", argIdx))
 				args = append(args, allowedRatings)
 				argIdx++
 			}
@@ -163,9 +166,40 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 	args = append(args, parsed.Phrase)
 	argIdx++
 
+	var mediaTitleConditions, mediaOverviewConditions []string
 	if includeMediaItems {
-		mediaAliasArms := mediaSearchAliasArms(exactIdx)
-		branches = append(branches, buildMixedSearchCandidateBranch(
+		mediaMatch := searchTitleMatchCondition(mediaSearchTitleVector, aliasCandidateArm)
+		if exactShortTitle {
+			mediaMatch = fmt.Sprintf("(mi.title_normalized = $%d OR %s)", exactIdx, aliasCandidateArm)
+		} else if leadingShortTitle {
+			mediaMatch = fmt.Sprintf("(mi.title_normalized LIKE $%d || '%%' OR %s)", exactIdx, aliasCandidateArm)
+		}
+		mediaTitleConditions = append([]string{mediaMatch}, mediaConditions...)
+		if !narrowTitleLookup {
+			mediaOverviewConditions = append([]string{searchOverviewMatchCondition(mediaSearchOverviewVector)}, mediaConditions...)
+		}
+	}
+	var episodeTitleConditions, episodeOverviewConditions []string
+	if includeEpisodes {
+		episodeMatch := searchTitleMatchCondition(episodeSearchTitleVector)
+		if exactShortTitle {
+			episodeMatch = fmt.Sprintf("ece.search_title_normalized = $%d", exactIdx)
+		} else if leadingShortTitle {
+			episodeMatch = fmt.Sprintf("ece.search_title_normalized LIKE $%d || '%%'", exactIdx)
+		}
+		episodeTitleConditions = append([]string{episodeMatch}, episodeConditions...)
+		if !narrowTitleLookup {
+			episodeOverviewConditions = append([]string{searchOverviewMatchCondition(episodeSearchOverviewVector)}, episodeConditions...)
+		}
+	}
+
+	if includeMediaItems {
+		mediaAliasArms := mixedSearchAliasArms{
+			exactArm:      "COALESCE(search_alias.exact_title_match, 0) > 0",
+			contiguousArm: "COALESCE(search_alias.contiguous_title_match, 0) > 0",
+			prefixRank:    "COALESCE(search_alias.title_prefix_rank, 0)",
+		}
+		titleBranches = append(titleBranches, buildMixedSearchCandidateBranch(
 			"mi.content_id", "mi.type", "mi.title", "mi.year",
 			`(
 				setweight(to_tsvector('simple', public.normalize_search_text(COALESCE(mi.title, ''))), 'A') ||
@@ -174,33 +208,74 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 			)`,
 			`to_tsvector('english', COALESCE(mi.overview, ''))`,
 			[]string{`mi.title_normalized`, `public.normalize_search_text(mi.original_title)`, `public.normalize_search_text(mi.sort_title)`},
-			"media_items mi", mediaConditions, exactIdx, yearIdx, phraseIdx,
-			&mediaAliasArms,
+			"media_items mi LEFT JOIN alias_scores search_alias ON search_alias.content_id = mi.content_id",
+			mediaTitleConditions, exactIdx, yearIdx, phraseIdx,
+			&mediaAliasArms, false, false,
 		))
+		if !narrowTitleLookup {
+			overviewBranches = append(overviewBranches, buildMixedSearchCandidateBranch(
+				"mi.content_id", "mi.type", "mi.title", "mi.year",
+				mediaSearchTitleVector, mediaSearchOverviewVector,
+				[]string{`mi.title_normalized`, `public.normalize_search_text(mi.original_title)`, `public.normalize_search_text(mi.sort_title)`},
+				"media_items mi", mediaOverviewConditions, exactIdx, yearIdx, phraseIdx,
+				nil, true, false,
+			))
+		}
 	}
 	if includeEpisodes {
-		episodeNormalizedTitle := `public.normalize_search_text(` + episodeSearchTitleExpr + `)`
-		branches = append(branches, buildMixedSearchCandidateBranch(
-			"e.content_id", "'episode'::text", episodeSearchTitleExpr,
-			"COALESCE(si.year, EXTRACT(YEAR FROM e.air_date)::integer, 0)",
+		episodeNormalizedTitle := `ece.search_title_normalized`
+		titleBranches = append(titleBranches, buildMixedSearchCandidateBranch(
+			"ece.episode_id", "'episode'::text", episodeSearchTitleExpr,
+			"ece.year",
 			episodeSearchTitleVector, episodeSearchOverviewVector,
 			[]string{episodeNormalizedTitle},
-			"episodes e JOIN media_items si ON si.content_id = e.series_id",
-			episodeConditions, exactIdx, yearIdx, phraseIdx,
-			nil,
+			"episode_catalog_entries ece JOIN media_items si ON si.content_id = ece.series_id",
+			episodeTitleConditions, exactIdx, yearIdx, phraseIdx,
+			nil, false, true,
 		))
+		if !narrowTitleLookup {
+			overviewBranches = append(overviewBranches, buildMixedSearchCandidateBranch(
+				"ece.episode_id", "'episode'::text", episodeSearchTitleExpr,
+				"ece.year",
+				episodeSearchTitleVector, episodeSearchOverviewVector,
+				[]string{episodeNormalizedTitle},
+				"episode_catalog_entries ece JOIN media_items si ON si.content_id = ece.series_id",
+				episodeOverviewConditions, exactIdx, yearIdx, phraseIdx,
+				nil, true, true,
+			))
+		}
 	}
 
-	scoredCTE := "WITH scored AS (\n" + strings.Join(branches, "\nUNION ALL\n") + "\n)"
-	statsCTE := `, stats AS (
-		SELECT MAX(CASE WHEN title_rank > 0 OR title_prefix_rank > 0 THEN 1 ELSE 0 END) AS has_title_match
-		FROM scored
-	)`
-	postFilter := fmt.Sprintf(`FROM scored
-		CROSS JOIN stats
-		WHERE scored.title_rank > 0
-		   OR scored.title_prefix_rank > 0
-		   OR (COALESCE(stats.has_title_match, 0) = 0 AND scored.overview_rank >= %g)`, overviewMatchFloor)
+	innerCTEs := make([]string, 0, 2)
+	if includeMediaItems {
+		innerCTEs = append(innerCTEs, buildMixedSearchAliasScoresCTE(exactIdx, exactShortTitle, leadingShortTitle))
+	}
+	titleScoredBody := strings.Join(titleBranches, "\nUNION ALL\n")
+	var scoredBody string
+	if len(overviewBranches) > 0 {
+		// Overview is a true fallback: it is useful only when the complete
+		// accessible catalog contains no title (or alias) hit. Keeping the two
+		// candidate paths separate lets PostgreSQL gate the overview branch with
+		// a one-time NOT EXISTS test. Broad overview terms can otherwise create
+		// thousands of episode/library probes that are ranked and then discarded
+		// whenever even one title match exists.
+		innerCTEs = append(innerCTEs, "title_scored AS MATERIALIZED (\n"+titleScoredBody+"\n)")
+		scoredBody = fmt.Sprintf(`SELECT * FROM title_scored
+		UNION ALL
+		SELECT *
+		FROM (
+			%s
+		) overview_scored
+		WHERE NOT EXISTS (SELECT 1 FROM title_scored)
+		  AND overview_scored.overview_rank >= %g`, strings.Join(overviewBranches, "\nUNION ALL\n"), overviewMatchFloor)
+	} else {
+		scoredBody = titleScoredBody
+	}
+	if len(innerCTEs) > 0 {
+		scoredBody = "WITH " + strings.Join(innerCTEs, ",\n") + "\n" + scoredBody
+	}
+	scoredCTE := "WITH scored AS (\n" + scoredBody + "\n)"
+	postFilter := `FROM scored`
 
 	pageTotalColumn := ""
 	finalTotalColumn := ""
@@ -230,12 +305,12 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 		  AND mi.content_id = page.content_id
 	) hydrated`, qualifiedItemColumns("hydrated_mi"), qualifiedItemColumns("mi"), episodeCatalogBaseRelation)
 
-	dataSQL = scoredCTE + statsCTE + pageCTE + fmt.Sprintf(`
+	dataSQL = scoredCTE + pageCTE + fmt.Sprintf(`
 		SELECT %s%s
 		FROM page
 		JOIN %s ON true
 		ORDER BY page.ordinal`, qualifiedItemColumns("hydrated"), finalTotalColumn, hydratedRelation)
-	countSQL = scoredCTE + statsCTE + fmt.Sprintf("\nSELECT COUNT(*)\n%s", postFilter)
+	countSQL = scoredCTE + fmt.Sprintf("\nSELECT COUNT(*)\n%s", postFilter)
 	return dataSQL, countSQL, args
 }
 
@@ -262,36 +337,51 @@ func splitSearchItemTypes(itemTypes []string) (mediaTypes []string, includeEpiso
 	return mediaTypes, includeEpisodes
 }
 
-func searchMatchCondition(titleVector, overviewVector string, extraArms ...string) string {
-	titleQuery := `websearch_to_tsquery('simple', public.normalize_search_text($1))`
+func searchTitleMatchCondition(titleVector string, extraArms ...string) string {
 	prefixQuery := `to_tsquery('simple', $2)`
 	arms := []string{
-		fmt.Sprintf(`(%s) @@ %s`, titleVector, titleQuery),
 		fmt.Sprintf(`($2 <> '' AND (%s) @@ %s)`, titleVector, prefixQuery),
-		fmt.Sprintf(`(%s) @@ websearch_to_tsquery('english', $1)`, overviewVector),
 	}
 	arms = append(arms, extraArms...)
 	return "(" + strings.Join(arms, " OR ") + ")"
 }
 
-// mediaSearchAliasMatchArms are the alias arms OR'd into the media branch's
-// match condition. They are scalar array subqueries (InitPlans), NOT `IN
-// (subquery)` arms: an uncorrelated subquery result is a plain parameter, so
-// `content_id = ANY(...)` stays index-served and participates in the BitmapOr
-// with the title/overview GIN arms. An `IN (SELECT ...)` arm inside an OR has
-// no index path and forces a seq scan of media_items that rebuilds every
-// tsvector per row.
-func mediaSearchAliasMatchArms() []string {
-	return []string{
-		`mi.content_id = ANY(COALESCE((
-			SELECT array_agg(DISTINCT mia.content_id) FROM media_item_aliases mia
-			WHERE to_tsvector('simple', mia.normalized_title) @@ websearch_to_tsquery('simple', public.normalize_search_text($1))
-		), '{}'::text[]))`,
-		`($2 <> '' AND mi.content_id = ANY(COALESCE((
-			SELECT array_agg(DISTINCT mia.content_id) FROM media_item_aliases mia
-			WHERE to_tsvector('simple', mia.normalized_title) @@ to_tsquery('simple', $2)
-		), '{}'::text[])))`,
+func searchOverviewMatchCondition(overviewVector string) string {
+	return fmt.Sprintf(`(%s) @@ websearch_to_tsquery('english', $1)`, overviewVector)
+}
+
+// buildMixedSearchAliasScoresCTE performs one index-backed pass over aliases
+// matching the exact, leading-prefix, or FTS-prefix path, then reuses those
+// scores for candidate admission and ranking. Keeping this work uncorrelated is
+// critical: the former rank subqueries could scan the complete covering alias
+// index once per media candidate when PostgreSQL failed to parameterize them.
+// On large alias catalogs that turned a selective search into millions of
+// index-entry visits and pushed the plan over the JIT threshold.
+func buildMixedSearchAliasScoresCTE(exactIdx int, exactShortTitle, leadingShortTitle bool) string {
+	aliasVector := `to_tsvector('simple', mia.normalized_title)`
+	weightedAliasVector := `setweight(to_tsvector('simple', mia.normalized_title), 'A')`
+	prefixQuery := `to_tsquery('simple', $2)`
+	matchCondition := fmt.Sprintf("mia.normalized_title = $%d", exactIdx)
+	if leadingShortTitle {
+		matchCondition = fmt.Sprintf("mia.normalized_title LIKE $%d || '%%'", exactIdx)
+	} else if !exactShortTitle {
+		matchCondition = fmt.Sprintf("$2 <> '' AND %s @@ %s", aliasVector, prefixQuery)
 	}
+	return fmt.Sprintf(`alias_scores AS MATERIALIZED (
+		SELECT
+			mia.content_id,
+			MAX(CASE WHEN mia.normalized_title = $%d THEN 1 ELSE 0 END) AS exact_title_match,
+			MAX(CASE WHEN mia.normalized_title LIKE '%%' || $%d || '%%' THEN 1 ELSE 0 END) AS contiguous_title_match,
+			0::real AS title_rank,
+			MAX(CASE WHEN $2 <> '' THEN ts_rank_cd(%s, %s) ELSE 0 END) AS title_prefix_rank
+		FROM media_item_aliases mia
+		WHERE %s
+		GROUP BY mia.content_id
+	)`,
+		exactIdx, exactIdx,
+		weightedAliasVector, prefixQuery,
+		matchCondition,
+	)
 }
 
 // mixedSearchAliasArms carries the media branch's provider-alias extensions to
@@ -299,36 +389,7 @@ func mediaSearchAliasMatchArms() []string {
 type mixedSearchAliasArms struct {
 	exactArm      string // OR'd into exact_title_match
 	contiguousArm string // OR'd into contiguous_title_match
-	titleRank     string // GREATEST'd with title_rank
 	prefixRank    string // GREATEST'd with title_prefix_rank
-}
-
-// mediaSearchAliasArms builds the alias ranking arms for the media branch.
-// The correlated rank subqueries run per matched row only (content_id
-// lookups), and setweight(..., 'A') makes an alias hit rank like a real title
-// hit — an unweighted tsvector defaults to weight D (0.1), which buried exact
-// alias matches ~10x below partial real-title matches. The WHERE arms above
-// stay unweighted to keep matching idx_media_item_aliases_search_vector's
-// indexed expression.
-func mediaSearchAliasArms(exactIdx int) mixedSearchAliasArms {
-	return mixedSearchAliasArms{
-		exactArm: fmt.Sprintf(`mi.content_id IN (
-			SELECT mia.content_id FROM media_item_aliases mia
-			WHERE mia.normalized_title = $%d
-		)`, exactIdx),
-		contiguousArm: fmt.Sprintf(`mi.content_id IN (
-			SELECT mia.content_id FROM media_item_aliases mia
-			WHERE mia.normalized_title LIKE '%%' || $%d || '%%'
-		)`, exactIdx),
-		titleRank: `COALESCE((
-			SELECT MAX(ts_rank_cd(setweight(to_tsvector('simple', mia.normalized_title), 'A'), websearch_to_tsquery('simple', public.normalize_search_text($1))))
-			FROM media_item_aliases mia WHERE mia.content_id = mi.content_id
-		), 0)`,
-		prefixRank: `COALESCE((
-			SELECT MAX(ts_rank_cd(setweight(to_tsvector('simple', mia.normalized_title), 'A'), to_tsquery('simple', $2)))
-			FROM media_item_aliases mia WHERE mia.content_id = mi.content_id
-		), 0)`,
-	}
 }
 
 func buildMixedSearchCandidateBranch(
@@ -338,6 +399,8 @@ func buildMixedSearchCandidateBranch(
 	conditions []string,
 	exactIdx, yearIdx, phraseIdx int,
 	aliasArms *mixedSearchAliasArms,
+	rankOverview bool,
+	distinctRows bool,
 ) string {
 	exactArms := make([]string, 0, len(exactTitleExprs)+1)
 	contiguousArms := make([]string, 0, len(exactTitleExprs)+1)
@@ -345,9 +408,8 @@ func buildMixedSearchCandidateBranch(
 		exactArms = append(exactArms, fmt.Sprintf("%s = $%d", expr, exactIdx))
 		contiguousArms = append(contiguousArms, fmt.Sprintf("%s LIKE '%%' || $%d || '%%'", expr, exactIdx))
 	}
-	titleQuery := `websearch_to_tsquery('simple', public.normalize_search_text($1))`
 	prefixQuery := `to_tsquery('simple', $2)`
-	titleRankExpr := fmt.Sprintf("ts_rank_cd(%s, %s)", titleVector, titleQuery)
+	titleRankExpr := "0::real"
 	prefixRankExpr := fmt.Sprintf("ts_rank_cd(%s, %s)", titleVector, prefixQuery)
 	if aliasArms != nil {
 		// Alias exact/contiguous arms are hashed subplans in the CASE select
@@ -355,11 +417,18 @@ func buildMixedSearchCandidateBranch(
 		// per-row correlated content_id lookups over the matched set only.
 		exactArms = append(exactArms, aliasArms.exactArm)
 		contiguousArms = append(contiguousArms, aliasArms.contiguousArm)
-		titleRankExpr = fmt.Sprintf("GREATEST(%s, %s)", titleRankExpr, aliasArms.titleRank)
 		prefixRankExpr = fmt.Sprintf("GREATEST(%s, %s)", prefixRankExpr, aliasArms.prefixRank)
 	}
+	overviewRankExpr := "0::real"
+	if rankOverview {
+		overviewRankExpr = fmt.Sprintf("ts_rank_cd(%s, websearch_to_tsquery('english', $1))", overviewVector)
+	}
+	selectModifier := ""
+	if distinctRows {
+		selectModifier = "DISTINCT "
+	}
 	return fmt.Sprintf(`
-		SELECT
+		SELECT %s
 			%s AS content_id,
 			%s AS type,
 			%s AS title,
@@ -368,19 +437,48 @@ func buildMixedSearchCandidateBranch(
 			CASE WHEN $%d::int IS NOT NULL AND (%s) = $%d::int THEN 1 ELSE 0 END AS year_match,
 			%s AS title_rank,
 			CASE WHEN $2 <> '' THEN %s ELSE 0 END AS title_prefix_rank,
-			ts_rank_cd(%s, websearch_to_tsquery('english', $1)) AS overview_rank,
+			%s AS overview_rank,
 			CASE WHEN $%d <> '' THEN ts_rank_cd(%s, phraseto_tsquery('simple', public.normalize_search_text($%d))) ELSE 0 END AS phrase_rank
 		FROM %s
 		WHERE %s`,
-		contentIDExpr, typeExpr, titleExpr,
+		selectModifier, contentIDExpr, typeExpr, titleExpr,
 		exactIdx, strings.Join(exactArms, " OR "),
 		exactIdx, strings.Join(contiguousArms, " OR "),
 		yearIdx, yearExpr, yearIdx,
 		titleRankExpr,
 		prefixRankExpr,
-		overviewVector,
+		overviewRankExpr,
 		phraseIdx, titleVector, phraseIdx,
 		fromClause, strings.Join(conditions, " AND "))
+}
+
+// appendEpisodeCatalogSearchAccess applies episode-library policy directly to
+// the maintained episode_catalog_entries relation. Each row is already proof
+// that an episode is available in one library, so the common unrestricted path
+// needs no per-candidate lookup into episode_libraries. DISTINCT in the episode
+// candidate branch collapses the uncommon episode linked to multiple folders.
+func appendEpisodeCatalogSearchAccess(
+	alias string,
+	filter AccessFilter,
+	conditions *[]string,
+	args *[]any,
+	argIdx *int,
+) {
+	if filter.AllowedLibraryIDs != nil {
+		*conditions = append(*conditions, fmt.Sprintf("%s.media_folder_id = ANY($%d)", alias, *argIdx))
+		*args = append(*args, filter.AllowedLibraryIDs)
+		*argIdx++
+	}
+	if len(filter.DisabledLibraryIDs) > 0 {
+		*conditions = append(*conditions, fmt.Sprintf(
+			"NOT EXISTS (SELECT 1 FROM episode_catalog_entries disabled_ece WHERE disabled_ece.episode_id = %s.episode_id AND disabled_ece.media_folder_id = ANY($%d))",
+			alias, *argIdx))
+		*args = append(*args, filter.DisabledLibraryIDs)
+		*argIdx++
+	}
+	// The parent series can be library-restricted independently of its episode
+	// files, so retain that policy check even though availability is denormalized.
+	appendEpisodeParentLibraryAccess(alias+".series_id", filter, conditions, args, argIdx)
 }
 
 func appendEpisodeLibrarySearchAccess(

--- a/internal/catalog/search_query.go
+++ b/internal/catalog/search_query.go
@@ -55,6 +55,13 @@ func parseSearchQuery(raw string) parsedSearchQuery {
 // short token ("a vengers") is judged on "vengers", not "a".
 const fuzzyMinTokenLen = 4
 
+// Single-token inputs shorter than this stay on the exact whole-title path.
+// Even a non-prefix FTS lexeme such as "la" or "the" can match a large share
+// of a multilingual catalog; ranking that set while the user is still typing
+// is both wasteful and visibly slow. Multi-word input with a short final token
+// uses the separate leading-title B-tree transition path below.
+const searchPrefixMinTokenLen = 4
+
 // eligibleForFuzzy reports whether a parsed query clears the min-token gate for
 // the trigram fuzzy title fallback.
 func eligibleForFuzzy(parsed parsedSearchQuery) bool {
@@ -65,6 +72,21 @@ func eligibleForFuzzy(parsed parsedSearchQuery) bool {
 		}
 	}
 	return longest >= fuzzyMinTokenLen
+}
+
+func useExactShortTitleSearch(parsed parsedSearchQuery) bool {
+	fields := strings.Fields(parsed.NormalizedText)
+	return len(fields) == 1 && len([]rune(fields[0])) < searchPrefixMinTokenLen
+}
+
+// useLeadingShortTitleSearch handles the brief typeahead state where the user
+// has completed at least one word but the final word is still too short for a
+// selective catalog-wide lexeme expansion (for example, "the m"). A normalized
+// leading-title B-tree lookup is deterministic and cheap during those few
+// keystrokes; regular word-prefix FTS resumes at searchPrefixMinTokenLen.
+func useLeadingShortTitleSearch(parsed parsedSearchQuery) bool {
+	fields := strings.Fields(parsed.NormalizedText)
+	return len(fields) > 1 && len([]rune(fields[len(fields)-1])) < searchPrefixMinTokenLen
 }
 
 func extractBalancedPhrase(input string) (string, string) {
@@ -132,6 +154,15 @@ func buildTitlePrefixTsQuery(input string) string {
 
 	fields := strings.Fields(normalized)
 	if len(fields) == 0 {
+		return ""
+	}
+	// A one- to three-character prefix over the whole catalog is not selective:
+	// it can expand to a large fraction of episode titles and aliases while the
+	// user is still typing. Keep exact FTS available for genuinely short titles,
+	// but wait for four characters before enabling an unconstrained prefix.
+	// Multi-word queries remain safe because their completed terms constrain the
+	// final partial token (for example, "star w:*").
+	if len(fields) == 1 && len([]rune(fields[0])) < searchPrefixMinTokenLen {
 		return ""
 	}
 

--- a/internal/catalog/search_query.go
+++ b/internal/catalog/search_query.go
@@ -13,8 +13,8 @@ type parsedSearchQuery struct {
 	ExactTitleHint string
 	// NormalizedText is normalizeTitleForComparison(Text) computed once at parse
 	// time. Text already folds phrase + remainder together, so this is the full
-	// normalized query used by eligibleForFuzzy's token gate (which would
-	// otherwise re-normalize on every sparse search).
+	// normalized query used by the fuzzy gate and leading-title lookup (which
+	// would otherwise re-normalize on every sparse search).
 	NormalizedText string
 	Year           *int
 }
@@ -62,9 +62,14 @@ const fuzzyMinTokenLen = 4
 // uses the separate leading-title B-tree transition path below.
 const searchPrefixMinTokenLen = 4
 
-// eligibleForFuzzy reports whether a parsed query clears the min-token gate for
-// the trigram fuzzy title fallback.
+// eligibleForFuzzy reports whether a parsed query should use the trigram fuzzy
+// title fallback. A quoted phrase with a short remainder stays exclusively on
+// the indexed leading-title path so fuzzy matching cannot reintroduce results
+// that satisfy only the phrase and omit the remainder.
 func eligibleForFuzzy(parsed parsedSearchQuery) bool {
+	if parsed.Phrase != "" && useLeadingShortTitleSearch(parsed) {
+		return false
+	}
 	longest := 0
 	for _, tok := range strings.Fields(parsed.NormalizedText) {
 		if n := len([]rune(tok)); n > longest {

--- a/internal/catalog/search_query_test.go
+++ b/internal/catalog/search_query_test.go
@@ -77,6 +77,10 @@ func TestBuildTitlePrefixTsQuery(t *testing.T) {
 		{"Pride and P", "pride & p:*"},
 		{"Law & Ord", "law & ord:*"},
 		{"Dune: Part Two", "dune & part & 2:*"},
+		{"l", ""},
+		{"la", ""},
+		{"lan", ""},
+		{"lant", "lant:*"},
 		{"and", ""},
 		{"   ", ""},
 	}
@@ -87,5 +91,18 @@ func TestBuildTitlePrefixTsQuery(t *testing.T) {
 				t.Fatalf("buildTitlePrefixTsQuery(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestUseLeadingShortTitleSearch(t *testing.T) {
+	for _, query := range []string{"the m", "harry p", "law ord"} {
+		if !useLeadingShortTitleSearch(parseSearchQuery(query)) {
+			t.Fatalf("%q should use the leading-title transition path", query)
+		}
+	}
+	for _, query := range []string{"lan", "the matr", "star wars"} {
+		if useLeadingShortTitleSearch(parseSearchQuery(query)) {
+			t.Fatalf("%q should use exact-short or regular FTS, not leading-title transition", query)
+		}
 	}
 }

--- a/internal/catalog/window_count_test.go
+++ b/internal/catalog/window_count_test.go
@@ -292,9 +292,8 @@ func TestBuildBrowseFavoritesPlan_CountSQL_OmitsLimitOffsetOrderBy(t *testing.T)
 
 // TestItemRepo_Search_CountSQL_OmitsLimitOffsetOrderBy pins the same
 // empty-page fallback contract for the Search path. The count sibling must
-// preserve the title-gate CROSS JOIN filter so the recovered total reflects
-// the post-filter row count (matching COUNT(*) OVER () semantics on the
-// data SELECT). Single-word and multi-word queries share one SQL shape.
+// preserve the title-first/overview-fallback gate so the recovered total
+// reflects the same candidate block as COUNT(*) OVER () in the data SELECT.
 func TestItemRepo_Search_CountSQL_OmitsLimitOffsetOrderBy(t *testing.T) {
 	repo := &ItemRepository{}
 
@@ -304,14 +303,11 @@ func TestItemRepo_Search_CountSQL_OmitsLimitOffsetOrderBy(t *testing.T) {
 			if !strings.Contains(countSQL, "WITH scored AS") {
 				t.Fatalf("countSQL must include scored CTE; got:\n%s", countSQL)
 			}
-			if !strings.Contains(countSQL, "stats AS") {
-				t.Fatalf("countSQL must include stats CTE; got:\n%s", countSQL)
+			if !strings.Contains(countSQL, "title_scored AS MATERIALIZED") {
+				t.Fatalf("countSQL must include title candidate CTE; got:\n%s", countSQL)
 			}
-			if !strings.Contains(countSQL, "CROSS JOIN stats") {
-				t.Fatalf("countSQL must CROSS JOIN stats so the recovered total reflects the post-filter set; got:\n%s", countSQL)
-			}
-			if !strings.Contains(countSQL, "has_title_match") {
-				t.Fatalf("countSQL must apply the title-gate predicate; got:\n%s", countSQL)
+			if !strings.Contains(countSQL, "NOT EXISTS (SELECT 1 FROM title_scored)") {
+				t.Fatalf("countSQL must gate overview fallback on title existence; got:\n%s", countSQL)
 			}
 			if !strings.Contains(countSQL, "SELECT COUNT(*)") {
 				t.Fatalf("expected SELECT COUNT(*); got:\n%s", countSQL)

--- a/migrations/postgres_search_exact_indexes_test.go
+++ b/migrations/postgres_search_exact_indexes_test.go
@@ -53,10 +53,14 @@ func TestPostgresSearchExactTitleIndexesAreConcurrentAndRetrySafe(t *testing.T) 
 	for _, required := range []string{
 		"CREATE TRIGGER trg_episode_catalog_entries_episodes_overview",
 		"AFTER UPDATE OF overview ON public.episodes",
-		"DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes_overview ON public.episodes",
 	} {
-		if !strings.Contains(sql, required) {
+		if !strings.Contains(upSQL, required) {
 			t.Fatalf("migration missing race-safe overview trigger clause %q:\n%s", required, sql)
 		}
+	}
+	downSQL := sql[downMarker:]
+	const overviewTriggerDrop = "DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes_overview ON public.episodes"
+	if !strings.Contains(downSQL, overviewTriggerDrop) {
+		t.Fatalf("migration down path missing overview trigger cleanup %q:\n%s", overviewTriggerDrop, sql)
 	}
 }

--- a/migrations/postgres_search_exact_indexes_test.go
+++ b/migrations/postgres_search_exact_indexes_test.go
@@ -19,7 +19,6 @@ func TestPostgresSearchExactTitleIndexesAreConcurrentAndRetrySafe(t *testing.T) 
 		"ADD COLUMN IF NOT EXISTS search_overview_vector tsvector",
 		"CREATE OR REPLACE FUNCTION public.set_episode_catalog_entry_search_fields()",
 		"CREATE TRIGGER trg_episode_catalog_entries_search_fields",
-		"still_thumbhash, overview, created_at OR DELETE",
 		"UPDATE public.episode_catalog_entries ece",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_items_title_normalized_exact",
 		"ON public.media_items (title_normalized text_pattern_ops, content_id)",
@@ -39,7 +38,25 @@ func TestPostgresSearchExactTitleIndexesAreConcurrentAndRetrySafe(t *testing.T) 
 		}
 	}
 	downMarker := strings.Index(sql, "-- +goose Down")
-	if downMarker < 0 || !strings.Contains(sql[downMarker:], "still_thumbhash, created_at OR DELETE") {
-		t.Fatalf("migration down path does not restore the original episode refresh trigger:\n%s", sql)
+	if downMarker < 0 {
+		t.Fatalf("migration is missing its down marker:\n%s", sql)
+	}
+	upSQL := sql[:downMarker]
+	for _, forbidden := range []string{
+		"DROP TRIGGER IF EXISTS trg_episode_catalog_entries_search_fields ON public.episode_catalog_entries",
+		"DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes ON public.episodes",
+	} {
+		if strings.Contains(upSQL, forbidden) {
+			t.Fatalf("migration must not run %q in its non-transactional up path:\n%s", forbidden, sql)
+		}
+	}
+	for _, required := range []string{
+		"CREATE TRIGGER trg_episode_catalog_entries_episodes_overview",
+		"AFTER UPDATE OF overview ON public.episodes",
+		"DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes_overview ON public.episodes",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("migration missing race-safe overview trigger clause %q:\n%s", required, sql)
+		}
 	}
 }

--- a/migrations/postgres_search_exact_indexes_test.go
+++ b/migrations/postgres_search_exact_indexes_test.go
@@ -1,0 +1,40 @@
+package migrations
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPostgresSearchExactTitleIndexesAreConcurrentAndRetrySafe(t *testing.T) {
+	data, err := os.ReadFile("sql/20260829025159_optimize_postgres_search_exact_titles.sql")
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	sql := string(data)
+	for _, required := range []string{
+		"-- +goose NO TRANSACTION",
+		"ADD COLUMN IF NOT EXISTS search_title_normalized text",
+		"ADD COLUMN IF NOT EXISTS search_title_vector tsvector",
+		"ADD COLUMN IF NOT EXISTS search_overview_vector tsvector",
+		"CREATE OR REPLACE FUNCTION public.set_episode_catalog_entry_search_fields()",
+		"CREATE TRIGGER trg_episode_catalog_entries_search_fields",
+		"UPDATE public.episode_catalog_entries ece",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_items_title_normalized_exact",
+		"ON public.media_items (title_normalized text_pattern_ops, content_id)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_item_aliases_normalized_content",
+		"ON public.media_item_aliases (normalized_title text_pattern_ops, content_id)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_title_normalized",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_title",
+		"ON public.episode_catalog_entries USING gin (search_title_vector)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_overview",
+		"ON public.episode_catalog_entries USING gin (search_overview_vector)",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_episode",
+		"ON public.episode_catalog_entries (episode_id, media_folder_id)",
+		"AND NOT i.indisvalid",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("migration missing %q:\n%s", required, sql)
+		}
+	}
+}

--- a/migrations/postgres_search_exact_indexes_test.go
+++ b/migrations/postgres_search_exact_indexes_test.go
@@ -19,6 +19,7 @@ func TestPostgresSearchExactTitleIndexesAreConcurrentAndRetrySafe(t *testing.T) 
 		"ADD COLUMN IF NOT EXISTS search_overview_vector tsvector",
 		"CREATE OR REPLACE FUNCTION public.set_episode_catalog_entry_search_fields()",
 		"CREATE TRIGGER trg_episode_catalog_entries_search_fields",
+		"still_thumbhash, overview, created_at OR DELETE",
 		"UPDATE public.episode_catalog_entries ece",
 		"CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_items_title_normalized_exact",
 		"ON public.media_items (title_normalized text_pattern_ops, content_id)",
@@ -36,5 +37,9 @@ func TestPostgresSearchExactTitleIndexesAreConcurrentAndRetrySafe(t *testing.T) 
 		if !strings.Contains(sql, required) {
 			t.Fatalf("migration missing %q:\n%s", required, sql)
 		}
+	}
+	downMarker := strings.Index(sql, "-- +goose Down")
+	if downMarker < 0 || !strings.Contains(sql[downMarker:], "still_thumbhash, created_at OR DELETE") {
+		t.Fatalf("migration down path does not restore the original episode refresh trigger:\n%s", sql)
 	}
 }

--- a/migrations/sql/20260829025159_optimize_postgres_search_exact_titles.sql
+++ b/migrations/sql/20260829025159_optimize_postgres_search_exact_titles.sql
@@ -1,0 +1,126 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- PostgreSQL search reads the already-maintained episode_catalog_entries table
+-- instead of rebuilding vectors from episodes and probing episode_libraries for
+-- every candidate. These nullable columns are metadata-only additions; the one
+-- bounded UPDATE below builds the disk-backed search documents before the
+-- indexes become visible to the application.
+ALTER TABLE public.episode_catalog_entries
+    ADD COLUMN IF NOT EXISTS search_title_normalized text,
+    ADD COLUMN IF NOT EXISTS search_title_vector tsvector,
+    ADD COLUMN IF NOT EXISTS search_overview_vector tsvector;
+
+-- The existing episode-catalog refresh path always writes title during an
+-- episode refresh. Hook that write so future episode/library changes keep the
+-- search document synchronous without a queue, worker, or external RAM service.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.set_episode_catalog_entry_search_fields()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    source_overview text;
+BEGIN
+    SELECT COALESCE(e.overview, '')
+    INTO source_overview
+    FROM public.episodes e
+    WHERE e.content_id = NEW.episode_id;
+
+    NEW.search_title_normalized := public.normalize_search_text(NEW.title);
+    NEW.search_title_vector := setweight(
+        to_tsvector('simple', NEW.search_title_normalized),
+        'A'
+    );
+    NEW.search_overview_vector := to_tsvector('english', COALESCE(source_overview, ''));
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS trg_episode_catalog_entries_search_fields ON public.episode_catalog_entries;
+CREATE TRIGGER trg_episode_catalog_entries_search_fields
+BEFORE INSERT OR UPDATE OF episode_id, title ON public.episode_catalog_entries
+FOR EACH ROW EXECUTE FUNCTION public.set_episode_catalog_entry_search_fields();
+
+UPDATE public.episode_catalog_entries ece
+SET
+    search_title_normalized = public.normalize_search_text(ece.title),
+    search_title_vector = setweight(
+        to_tsvector('simple', public.normalize_search_text(ece.title)),
+        'A'
+    ),
+    search_overview_vector = to_tsvector('english', COALESCE(e.overview, ''))
+FROM public.episodes e
+WHERE e.content_id = ece.episode_id
+  AND (
+      ece.search_title_normalized IS NULL
+      OR ece.search_title_vector IS NULL
+      OR ece.search_overview_vector IS NULL
+  );
+
+-- Short interactive queries use exact normalized-title lookups, while longer
+-- queries use stored vectors. Build every index concurrently so the catalog
+-- remains readable and writable throughout the index phase.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    index_name text;
+BEGIN
+    FOREACH index_name IN ARRAY ARRAY[
+        'idx_media_items_title_normalized_exact',
+        'idx_media_item_aliases_normalized_content',
+        'idx_episode_catalog_entries_search_title_normalized',
+        'idx_episode_catalog_entries_search_title',
+        'idx_episode_catalog_entries_search_overview',
+        'idx_episode_catalog_entries_search_episode'
+    ] LOOP
+        IF EXISTS (
+            SELECT 1
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_index i ON i.indexrelid = c.oid
+            WHERE n.nspname = 'public'
+              AND c.relname = index_name
+              AND NOT i.indisvalid
+        ) THEN
+            EXECUTE format('DROP INDEX public.%I', index_name);
+        END IF;
+    END LOOP;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_items_title_normalized_exact
+    ON public.media_items (title_normalized text_pattern_ops, content_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_item_aliases_normalized_content
+    ON public.media_item_aliases (normalized_title text_pattern_ops, content_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_title_normalized
+    ON public.episode_catalog_entries (search_title_normalized text_pattern_ops, episode_id, media_folder_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_title
+    ON public.episode_catalog_entries USING gin (search_title_vector);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_overview
+    ON public.episode_catalog_entries USING gin (search_overview_vector);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_episode
+    ON public.episode_catalog_entries (episode_id, media_folder_id);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_episode;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_overview;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_title;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_title_normalized;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_item_aliases_normalized_content;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_items_title_normalized_exact;
+
+DROP TRIGGER IF EXISTS trg_episode_catalog_entries_search_fields ON public.episode_catalog_entries;
+DROP FUNCTION IF EXISTS public.set_episode_catalog_entry_search_fields();
+
+ALTER TABLE public.episode_catalog_entries
+    DROP COLUMN IF EXISTS search_overview_vector,
+    DROP COLUMN IF EXISTS search_title_vector,
+    DROP COLUMN IF EXISTS search_title_normalized;

--- a/migrations/sql/20260829025159_optimize_postgres_search_exact_titles.sql
+++ b/migrations/sql/20260829025159_optimize_postgres_search_exact_titles.sql
@@ -38,20 +38,42 @@ END;
 $$;
 -- +goose StatementEnd
 
-DROP TRIGGER IF EXISTS trg_episode_catalog_entries_search_fields ON public.episode_catalog_entries;
-CREATE TRIGGER trg_episode_catalog_entries_search_fields
-BEFORE INSERT OR UPDATE OF episode_id, title ON public.episode_catalog_entries
-FOR EACH ROW EXECUTE FUNCTION public.set_episode_catalog_entry_search_fields();
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'trg_episode_catalog_entries_search_fields'
+          AND tgrelid = 'public.episode_catalog_entries'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        EXECUTE 'CREATE TRIGGER trg_episode_catalog_entries_search_fields BEFORE INSERT OR UPDATE OF episode_id, title ON public.episode_catalog_entries FOR EACH ROW EXECUTE FUNCTION public.set_episode_catalog_entry_search_fields()';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
 
--- Migration 142 refreshes episode_catalog_entries when searchable episode
--- metadata changes. Include overview in that existing trigger so editing an
--- episode description rewrites the stored overview vector as well; without
--- this, overview search stays stale until another episode field changes.
-DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes ON public.episodes;
-CREATE TRIGGER trg_episode_catalog_entries_episodes
-AFTER INSERT OR UPDATE OF content_id, series_id, title, episode_number, air_date, runtime, rating_imdb, rating_tmdb, still_path, still_thumbhash, overview, created_at OR DELETE
-ON public.episodes
-FOR EACH ROW EXECUTE FUNCTION public.episode_catalog_entries_episodes_trigger();
+-- Migration 142's trigger already refreshes episode_catalog_entries for all
+-- fields except overview. Keep that live trigger in place and add the missing
+-- event separately: this migration must remain non-transactional for the
+-- concurrent indexes below, so replacing the existing trigger would open a
+-- committed write gap between DROP TRIGGER and CREATE TRIGGER.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'trg_episode_catalog_entries_episodes_overview'
+          AND tgrelid = 'public.episodes'::regclass
+          AND NOT tgisinternal
+    ) THEN
+        EXECUTE 'CREATE TRIGGER trg_episode_catalog_entries_episodes_overview AFTER UPDATE OF overview ON public.episodes FOR EACH ROW EXECUTE FUNCTION public.episode_catalog_entries_episodes_trigger()';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
 
 UPDATE public.episode_catalog_entries ece
 SET
@@ -120,13 +142,7 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_episo
     ON public.episode_catalog_entries (episode_id, media_folder_id);
 
 -- +goose Down
--- Restore migration 142's original refresh set when the stored overview search
--- document is removed.
-DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes ON public.episodes;
-CREATE TRIGGER trg_episode_catalog_entries_episodes
-AFTER INSERT OR UPDATE OF content_id, series_id, title, episode_number, air_date, runtime, rating_imdb, rating_tmdb, still_path, still_thumbhash, created_at OR DELETE
-ON public.episodes
-FOR EACH ROW EXECUTE FUNCTION public.episode_catalog_entries_episodes_trigger();
+DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes_overview ON public.episodes;
 
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_episode;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_overview;

--- a/migrations/sql/20260829025159_optimize_postgres_search_exact_titles.sql
+++ b/migrations/sql/20260829025159_optimize_postgres_search_exact_titles.sql
@@ -43,6 +43,16 @@ CREATE TRIGGER trg_episode_catalog_entries_search_fields
 BEFORE INSERT OR UPDATE OF episode_id, title ON public.episode_catalog_entries
 FOR EACH ROW EXECUTE FUNCTION public.set_episode_catalog_entry_search_fields();
 
+-- Migration 142 refreshes episode_catalog_entries when searchable episode
+-- metadata changes. Include overview in that existing trigger so editing an
+-- episode description rewrites the stored overview vector as well; without
+-- this, overview search stays stale until another episode field changes.
+DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes ON public.episodes;
+CREATE TRIGGER trg_episode_catalog_entries_episodes
+AFTER INSERT OR UPDATE OF content_id, series_id, title, episode_number, air_date, runtime, rating_imdb, rating_tmdb, still_path, still_thumbhash, overview, created_at OR DELETE
+ON public.episodes
+FOR EACH ROW EXECUTE FUNCTION public.episode_catalog_entries_episodes_trigger();
+
 UPDATE public.episode_catalog_entries ece
 SET
     search_title_normalized = public.normalize_search_text(ece.title),
@@ -110,6 +120,14 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episode_catalog_entries_search_episo
     ON public.episode_catalog_entries (episode_id, media_folder_id);
 
 -- +goose Down
+-- Restore migration 142's original refresh set when the stored overview search
+-- document is removed.
+DROP TRIGGER IF EXISTS trg_episode_catalog_entries_episodes ON public.episodes;
+CREATE TRIGGER trg_episode_catalog_entries_episodes
+AFTER INSERT OR UPDATE OF content_id, series_id, title, episode_number, air_date, runtime, rating_imdb, rating_tmdb, still_path, still_thumbhash, created_at OR DELETE
+ON public.episodes
+FOR EACH ROW EXECUTE FUNCTION public.episode_catalog_entries_episodes_trigger();
+
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_episode;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_overview;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_episode_catalog_entries_search_title;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -2100,6 +2100,16 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.04);
   }
 
+  /* Search controls repaint on the hottest route in the app. Keep them on the
+     same opaque paint surface as the page: no backdrop sampling, alpha blend,
+     or blur layer needs to be recomposited while results replace underneath. */
+  .search-paint-surface {
+    background: var(--background);
+    border-color: color-mix(in srgb, var(--border) 72%, transparent);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
   /* Panel chrome only once there is a sidebar to enclose. Below this the
      settings detail view is already a stack of surface-panel groups, and a
      panel around them would nest a card in a card. */

--- a/web/src/components/GlobalSearch.test.tsx
+++ b/web/src/components/GlobalSearch.test.tsx
@@ -43,13 +43,15 @@ vi.mock("@/components/RequestToAddSection", () => ({
     variant,
     query,
     libraryHadHits,
+    libraryResultsKnown,
   }: {
     variant: string;
     query: string;
     libraryHadHits: boolean;
+    libraryResultsKnown?: boolean;
   }) => (
     <div data-testid="request-section">
-      {`variant="${variant}" query="${query}" libraryHadHits="${String(libraryHadHits)}"`}
+      {`variant="${variant}" query="${query}" libraryHadHits="${String(libraryHadHits)}" libraryResultsKnown="${String(libraryResultsKnown)}"`}
     </div>
   ),
 }));
@@ -428,6 +430,7 @@ describe("GlobalSearch + RequestToAddSection wiring", () => {
 
     expect(markup).toContain('data-testid="request-section"');
     expect(markup).toContain("libraryHadHits=&quot;true&quot;");
+    expect(markup).toContain("libraryResultsKnown=&quot;true&quot;");
     expect(markup).toContain("variant=&quot;dialog&quot;");
   });
 
@@ -463,6 +466,43 @@ describe("GlobalSearch + RequestToAddSection wiring", () => {
     const markup = renderSearchMarkup({ defaultOpen: true, initialQuery: "ThisDoesNotExist" });
 
     expect(markup).toContain("libraryHadHits=&quot;false&quot;");
+    expect(markup).toContain("libraryResultsKnown=&quot;true&quot;");
+  });
+
+  it("marks library results unknown while the local preview is still pending", () => {
+    mocks.useCanRequest.mockReturnValue({
+      discoveryEnabled: true,
+      isResolving: false,
+      submitDisabledReason: null,
+    });
+    mocks.useQuery.mockReturnValue({
+      data: undefined,
+      isFetching: true,
+      isError: false,
+    });
+    mocks.useRequestSearch.mockReturnValue({
+      data: {
+        page: 1,
+        total_pages: 1,
+        total_results: 1,
+        results: [
+          {
+            media_type: "movie",
+            tmdb_id: 1,
+            title: "X",
+            availability: "missing",
+            request: { requestable: true },
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const markup = renderSearchMarkup({ defaultOpen: true, initialQuery: "Dune" });
+
+    expect(markup).toContain("libraryHadHits=&quot;false&quot;");
+    expect(markup).toContain("libraryResultsKnown=&quot;false&quot;");
   });
 
   it("does not call useRequestSearch with enabled=true when discoveryEnabled is false", () => {
@@ -478,6 +518,8 @@ describe("GlobalSearch + RequestToAddSection wiring", () => {
       enabled: false,
       requireProfile: true,
       staleTime: 5 * 60 * 1000,
+      gcTime: 30_000,
+      retry: false,
     });
   });
 

--- a/web/src/components/GlobalSearch.tsx
+++ b/web/src/components/GlobalSearch.tsx
@@ -22,6 +22,7 @@ import CardPlayOverlay from "./CardPlayOverlay";
 const PREVIEW_LIMIT = 8;
 const DEBOUNCE_MS = 200;
 const TMDB_DEBOUNCE_MS = 400;
+const INTERACTIVE_SEARCH_GC_TIME_MS = 30_000;
 
 function typeLabel(type: BrowseItem["type"]): string {
   switch (type) {
@@ -155,6 +156,8 @@ export function GlobalSearch({
     enabled: canRequest.discoveryEnabled,
     requireProfile: true,
     staleTime: 5 * 60 * 1000,
+    gcTime: INTERACTIVE_SEARCH_GC_TIME_MS,
+    retry: false,
   });
   const tmdbMissingCount =
     tmdbQuery.data?.results?.filter((result) => result.availability !== "available").length ?? 0;
@@ -201,6 +204,8 @@ export function GlobalSearch({
     queryFn: ({ signal }) => fetchCatalogPage(searchState, PREVIEW_LIMIT, 0, { signal }, false),
     enabled: open && debouncedQuery.length > 0,
     staleTime: 60 * 1000,
+    gcTime: INTERACTIVE_SEARCH_GC_TIME_MS,
+    retry: false,
   });
 
   useEffect(() => {
@@ -369,6 +374,7 @@ export function GlobalSearch({
                   variant="dialog"
                   query={tmdbDebouncedQuery}
                   libraryHadHits={items.length > 0}
+                  libraryResultsKnown={!previewQuery.isFetching && !previewQuery.isError}
                 />
               )}
             </div>

--- a/web/src/components/RequestPosterCard.test.tsx
+++ b/web/src/components/RequestPosterCard.test.tsx
@@ -59,4 +59,23 @@ describe("RequestPosterCard (discover variant)", () => {
     // its absence is the strongest signal that the button was suppressed.
     expect(markup).not.toContain("<button");
   });
+
+  it("shows the media type so same-title movies and series stay distinguishable", () => {
+    const movieMarkup = renderToStaticMarkup(
+      <MemoryRouter>
+        <RequestPosterCard variant="discover" item={requestable} />
+      </MemoryRouter>,
+    );
+    const seriesMarkup = renderToStaticMarkup(
+      <MemoryRouter>
+        <RequestPosterCard
+          variant="discover"
+          item={{ ...requestable, media_type: "series", tmdb_id: 43 }}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(movieMarkup).toContain(">Movie<");
+    expect(seriesMarkup).toContain(">Series<");
+  });
 });

--- a/web/src/components/RequestPosterCard.tsx
+++ b/web/src/components/RequestPosterCard.tsx
@@ -325,8 +325,16 @@ function CardMeta({
       {hasMeta && (
         <div className="text-muted-foreground mt-1 flex items-center gap-1.5 text-[11px]">
           {mediaType && (
-            <Icon className="h-3 w-3 shrink-0 opacity-60" strokeWidth={2} aria-hidden />
+            <>
+              <Icon className="h-3 w-3 shrink-0 opacity-60" strokeWidth={2} aria-hidden />
+              <span>{mediaType === "series" ? "Series" : "Movie"}</span>
+            </>
           )}
+          {mediaType && year ? (
+            <span aria-hidden className="text-muted-foreground/40">
+              ·
+            </span>
+          ) : null}
           {year ? <span className="tabular-nums">{year}</span> : null}
           {(year || mediaType) && rating ? (
             <span aria-hidden className="text-muted-foreground/40">

--- a/web/src/components/RequestToAddSection.test.tsx
+++ b/web/src/components/RequestToAddSection.test.tsx
@@ -99,6 +99,8 @@ describe("RequestToAddSection (dialog variant)", () => {
       enabled: false,
       requireProfile: true,
       staleTime: 5 * 60 * 1000,
+      gcTime: 30_000,
+      retry: false,
     });
   });
 
@@ -121,6 +123,8 @@ describe("RequestToAddSection (dialog variant)", () => {
       enabled: true,
       requireProfile: true,
       staleTime: 5 * 60 * 1000,
+      gcTime: 30_000,
+      retry: false,
     });
   });
 
@@ -146,6 +150,24 @@ describe("RequestToAddSection (dialog variant)", () => {
     );
     expect(markup).toContain("Not in your library, but you can request");
     expect(markup).not.toContain("Request to Add");
+  });
+
+  it("does not claim media is absent while the local lookup is unresolved or failed", () => {
+    mocks.useRequestSearch.mockReturnValue({
+      data: { page: 1, total_pages: 1, total_results: 1, results: [missingResult()] },
+      isLoading: false,
+      isError: false,
+    });
+    const markup = render(
+      <RequestToAddSection
+        variant="dialog"
+        query="breaking bad"
+        libraryHadHits={false}
+        libraryResultsKnown={false}
+      />,
+    );
+    expect(markup).toContain("Discovery matches:");
+    expect(markup).not.toContain("Not in your library");
   });
 
   it("filters out results already available in the library", () => {
@@ -233,8 +255,8 @@ describe("RequestToAddSection (dialog variant)", () => {
 
     expect(markup).toContain("Quota Capped Movie");
     expect(markup).not.toContain("bg-amber-400/15");
-    expect(markup).toContain("Limit reached");
-    expect(markup).toContain('title="Limit reached"');
+    expect(markup).toContain("Request limit reached");
+    expect(markup).toContain('title="Request limit reached"');
   });
 
   it("prefers request status over reason when a row is already requested", () => {

--- a/web/src/components/RequestToAddSection.tsx
+++ b/web/src/components/RequestToAddSection.tsx
@@ -29,20 +29,33 @@ function nonRequestableLabel(item: RequestMediaResult): string {
 
 const DIALOG_LIMIT = 4;
 const GRID_LIMIT = 20;
+const INTERACTIVE_SEARCH_GC_TIME_MS = 30_000;
 
 export type RequestToAddSectionProps = {
   variant: "dialog" | "grid";
   query: string;
   /** True when the library search returned at least one hit. Drives header copy. */
   libraryHadHits: boolean;
+  /**
+   * True only after the matching local-library query completed successfully.
+   * Loading and failed searches must not be presented as confirmed absences.
+   */
+  libraryResultsKnown?: boolean;
 };
 
-export function RequestToAddSection({ variant, query, libraryHadHits }: RequestToAddSectionProps) {
+export function RequestToAddSection({
+  variant,
+  query,
+  libraryHadHits,
+  libraryResultsKnown = true,
+}: RequestToAddSectionProps) {
   const { discoveryEnabled } = useCanRequest();
   const search = useRequestSearch("all", query, 1, {
     enabled: discoveryEnabled,
     requireProfile: true,
     staleTime: 5 * 60 * 1000,
+    gcTime: INTERACTIVE_SEARCH_GC_TIME_MS,
+    retry: false,
   });
 
   if (!discoveryEnabled) return null;
@@ -55,12 +68,32 @@ export function RequestToAddSection({ variant, query, libraryHadHits }: RequestT
   const visible = filtered.slice(0, limit);
 
   if (variant === "dialog") {
-    return <DialogVariant items={visible} libraryHadHits={libraryHadHits} />;
+    return (
+      <DialogVariant
+        items={visible}
+        libraryHadHits={libraryHadHits}
+        libraryResultsKnown={libraryResultsKnown}
+      />
+    );
   }
-  return <GridVariant items={visible} libraryHadHits={libraryHadHits} />;
+  return (
+    <GridVariant
+      items={visible}
+      libraryHadHits={libraryHadHits}
+      libraryResultsKnown={libraryResultsKnown}
+    />
+  );
 }
 
-function HeaderCopy({ libraryHadHits, count }: { libraryHadHits: boolean; count: number }) {
+function HeaderCopy({
+  libraryHadHits,
+  libraryResultsKnown,
+  count,
+}: {
+  libraryHadHits: boolean;
+  libraryResultsKnown: boolean;
+  count: number;
+}) {
   if (libraryHadHits) {
     return (
       <div className="text-muted-foreground flex items-center gap-2 px-3 pt-2 pb-1 text-[10px] font-medium tracking-[0.1em] uppercase">
@@ -70,6 +103,10 @@ function HeaderCopy({ libraryHadHits, count }: { libraryHadHits: boolean; count:
         </span>
       </div>
     );
+  }
+
+  if (!libraryResultsKnown) {
+    return <div className="px-3 pt-3 pb-1 text-[12px] text-amber-300/85">Discovery matches:</div>;
   }
 
   return (
@@ -82,13 +119,19 @@ function HeaderCopy({ libraryHadHits, count }: { libraryHadHits: boolean; count:
 function DialogVariant({
   items,
   libraryHadHits,
+  libraryResultsKnown,
 }: {
   items: RequestMediaResult[];
   libraryHadHits: boolean;
+  libraryResultsKnown: boolean;
 }) {
   return (
     <div className="border-t border-white/5 pt-1">
-      <HeaderCopy libraryHadHits={libraryHadHits} count={items.length} />
+      <HeaderCopy
+        libraryHadHits={libraryHadHits}
+        libraryResultsKnown={libraryResultsKnown}
+        count={items.length}
+      />
       <ul className="px-1 py-1">
         {items.map((item) => (
           <li key={`${item.media_type}-${item.tmdb_id}`}>
@@ -151,9 +194,11 @@ function DialogRow({ item }: { item: RequestMediaResult }) {
 function GridVariant({
   items,
   libraryHadHits,
+  libraryResultsKnown,
 }: {
   items: RequestMediaResult[];
   libraryHadHits: boolean;
+  libraryResultsKnown: boolean;
 }) {
   const count = items.length;
   const createRequest = useCreateMediaRequest();
@@ -199,11 +244,19 @@ function GridVariant({
           <div className="flex items-center gap-2 text-amber-200/85">
             <Sparkles className="h-3.5 w-3.5" strokeWidth={2.2} aria-hidden />
             <span className="text-[10px] font-semibold tracking-[0.24em] uppercase">
-              {libraryHadHits ? "Discover · Outside your library" : "Outside your library"}
+              {libraryHadHits
+                ? "Discover · Outside your library"
+                : libraryResultsKnown
+                  ? "Outside your library"
+                  : "Discovery"}
             </span>
           </div>
           <h2 className="font-display text-foreground text-[clamp(1.25rem,1.6vw,1.55rem)] leading-tight font-semibold tracking-tight">
-            {libraryHadHits ? "Request to Add" : "Not in your library, but you can request"}
+            {libraryHadHits
+              ? "Request to Add"
+              : libraryResultsKnown
+                ? "Not in your library, but you can request"
+                : "More search matches"}
           </h2>
         </div>
         <span className="inline-flex items-center gap-1.5 self-end rounded-full border border-amber-400/15 bg-amber-400/[0.06] px-2.5 py-1 text-[11px] font-medium tracking-wide text-amber-100/75 tabular-nums">

--- a/web/src/components/SearchBar.test.tsx
+++ b/web/src/components/SearchBar.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { buildCatalogQueryUpdateHref, parseCatalogSearchParams } from "@/pages/catalogSearchParams";
 
+const mocks = vi.hoisted(() => ({ transitionNavigate: vi.fn() }));
+
+vi.mock("@/hooks/useViewTransition", () => ({
+  useViewTransitionNavigate: () => mocks.transitionNavigate,
+}));
+
 import SearchBar from "./SearchBar";
 
 function LocationProbe() {
@@ -14,6 +20,7 @@ function LocationProbe() {
 describe("SearchBar", () => {
   afterEach(() => {
     vi.useRealTimers();
+    mocks.transitionNavigate.mockReset();
   });
 
   it("keeps All Media selected when live search changes the query", () => {
@@ -45,5 +52,49 @@ describe("SearchBar", () => {
       match: "all",
       rules: [{ field: "genre", op: "contains", value: "Drama" }],
     });
+    expect(mocks.transitionNavigate).not.toHaveBeenCalled();
+  });
+
+  it("settles rapid typing to one final route without a view transition", () => {
+    vi.useFakeTimers();
+
+    render(
+      <MemoryRouter initialEntries={["/catalog?source=query&q=l"]}>
+        <SearchBar prominent initialQuery="l" />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "la" } });
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.change(input, { target: { value: "lan" } });
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.change(input, { target: { value: "lant" } });
+    act(() => vi.advanceTimersByTime(201));
+
+    const location = new URL(`http://example.test${screen.getByLabelText("location").textContent}`);
+    expect(location.searchParams.get("q")).toBe("lant");
+    expect(mocks.transitionNavigate).not.toHaveBeenCalled();
+  });
+
+  it("clears the active result route instead of leaving a stale search mounted", () => {
+    vi.useFakeTimers();
+
+    render(
+      <MemoryRouter initialEntries={["/catalog?source=query&q=lanterns"]}>
+        <SearchBar prominent initialQuery="lanterns" />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    act(() => vi.advanceTimersByTime(201));
+
+    const location = new URL(`http://example.test${screen.getByLabelText("location").textContent}`);
+    expect(location.pathname).toBe("/catalog");
+    expect(location.searchParams.get("source")).toBe("query");
+    expect(location.searchParams.has("q")).toBe(false);
+    expect(mocks.transitionNavigate).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/SearchBar.test.tsx
+++ b/web/src/components/SearchBar.test.tsx
@@ -35,7 +35,7 @@ describe("SearchBar", () => {
 
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "heater" } });
     act(() => {
-      vi.advanceTimersByTime(101);
+      vi.advanceTimersByTime(201);
     });
 
     const location = new URL(`http://example.test${screen.getByLabelText("location").textContent}`);

--- a/web/src/components/SearchBar.test.tsx
+++ b/web/src/components/SearchBar.test.tsx
@@ -89,8 +89,29 @@ describe("SearchBar", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
-    act(() => vi.advanceTimersByTime(201));
 
+    const location = new URL(`http://example.test${screen.getByLabelText("location").textContent}`);
+    expect(location.pathname).toBe("/catalog");
+    expect(location.searchParams.get("source")).toBe("query");
+    expect(location.searchParams.has("q")).toBe(false);
+    expect(mocks.transitionNavigate).not.toHaveBeenCalled();
+  });
+
+  it("keeps a pending non-empty debounce from restoring the route after clear", () => {
+    vi.useFakeTimers();
+
+    render(
+      <MemoryRouter initialEntries={["/catalog?source=query&q=lanterns"]}>
+        <SearchBar prominent initialQuery="lanterns" />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "lantern" } });
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+
+    act(() => vi.advanceTimersByTime(500));
     const location = new URL(`http://example.test${screen.getByLabelText("location").textContent}`);
     expect(location.pathname).toBe("/catalog");
     expect(location.searchParams.get("source")).toBe("query");

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
 import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
 import { useDebounce } from "@/hooks/useDebounce";
 import { Input } from "@/components/ui/input";
@@ -6,7 +7,7 @@ import { buildQueryCatalogHref } from "@/pages/catalogSearchParams";
 import { Search, X } from "lucide-react";
 import type { FormEvent } from "react";
 
-const SEARCH_NAVIGATION_DEBOUNCE_MS = 100;
+const SEARCH_NAVIGATION_DEBOUNCE_MS = 200;
 
 interface SearchBarProps {
   initialQuery?: string;
@@ -23,6 +24,7 @@ export default function SearchBar({
 }: SearchBarProps) {
   const [query, setQuery] = useState(initialQuery);
   const navigate = useViewTransitionNavigate();
+  const navigateWithoutTransition = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
   const isInitialMount = useRef(true);
   const buildSearchHrefRef = useRef(buildSearchHref);
@@ -46,9 +48,14 @@ export default function SearchBar({
       return;
     }
     if (debouncedQuery.trim()) {
-      navigate(buildSearchHrefRef.current(debouncedQuery.trim()), { replace: true });
+      // Updating only the query string is not a page transition. Animating a
+      // full route snapshot for every debounced keystroke makes the search page
+      // visibly wobble and adds compositor work to its hottest interaction.
+      navigateWithoutTransition(buildSearchHrefRef.current(debouncedQuery.trim()), {
+        replace: true,
+      });
     }
-  }, [debouncedQuery, prominent, navigate]);
+  }, [debouncedQuery, prominent, navigateWithoutTransition]);
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -34,6 +34,13 @@ export default function SearchBar({
     buildSearchHrefRef.current = buildSearchHref;
   }, [buildSearchHref]);
 
+  // Browser history, scope changes, and external navigation can update the
+  // canonical query without remounting this component. Keep the input in sync
+  // instead of leaving it attached to a stale request key.
+  useEffect(() => {
+    setQuery(initialQuery);
+  }, [initialQuery]);
+
   useEffect(() => {
     if (autoFocus && inputRef.current) {
       inputRef.current.focus();
@@ -47,20 +54,24 @@ export default function SearchBar({
       isInitialMount.current = false;
       return;
     }
-    if (debouncedQuery.trim()) {
-      // Updating only the query string is not a page transition. Animating a
-      // full route snapshot for every debounced keystroke makes the search page
-      // visibly wobble and adds compositor work to its hottest interaction.
-      navigateWithoutTransition(buildSearchHrefRef.current(debouncedQuery.trim()), {
-        replace: true,
-      });
-    }
+    // Updating only the query string is not a page transition. Animating a
+    // full route snapshot for every debounced keystroke makes the search page
+    // visibly wobble and adds compositor work to its hottest interaction.
+    // Navigate an empty value as well so clearing the field aborts and removes
+    // the previous results instead of leaving an invisible stale search alive.
+    navigateWithoutTransition(buildSearchHrefRef.current(debouncedQuery.trim()), {
+      replace: true,
+    });
   }, [debouncedQuery, prominent, navigateWithoutTransition]);
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (query.trim()) {
-      navigate(buildSearchHref(query.trim()));
+      if (prominent) {
+        navigateWithoutTransition(buildSearchHref(query.trim()));
+      } else {
+        navigate(buildSearchHref(query.trim()));
+      }
     }
   }
 
@@ -73,7 +84,7 @@ export default function SearchBar({
           placeholder="Search movies, series..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className="surface-panel h-14 rounded-[1.4rem] border-0 pr-10 pl-12 text-base shadow-none"
+          className="search-paint-surface h-14 rounded-[1.4rem] border pr-10 pl-12 text-base shadow-none"
         />
         {query && (
           <button

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -28,6 +28,7 @@ export default function SearchBar({
   const inputRef = useRef<HTMLInputElement>(null);
   const isInitialMount = useRef(true);
   const buildSearchHrefRef = useRef(buildSearchHref);
+  const lastNavigatedQueryRef = useRef(initialQuery.trim());
   const debouncedQuery = useDebounce(query, SEARCH_NAVIGATION_DEBOUNCE_MS);
 
   useEffect(() => {
@@ -39,6 +40,7 @@ export default function SearchBar({
   // instead of leaving it attached to a stale request key.
   useEffect(() => {
     setQuery(initialQuery);
+    lastNavigatedQueryRef.current = initialQuery.trim();
   }, [initialQuery]);
 
   useEffect(() => {
@@ -54,25 +56,46 @@ export default function SearchBar({
       isInitialMount.current = false;
       return;
     }
+    const normalizedQuery = query.trim();
+    const normalizedDebouncedQuery = debouncedQuery.trim();
+    // A newer keystroke (including clear) invalidates the previous debounce.
+    // The hook already clears its timer; this comparison also closes the race
+    // where an expired callback and the input update reach React together.
+    if (
+      normalizedDebouncedQuery !== normalizedQuery ||
+      lastNavigatedQueryRef.current === normalizedDebouncedQuery
+    ) {
+      return;
+    }
     // Updating only the query string is not a page transition. Animating a
     // full route snapshot for every debounced keystroke makes the search page
     // visibly wobble and adds compositor work to its hottest interaction.
-    // Navigate an empty value as well so clearing the field aborts and removes
-    // the previous results instead of leaving an invisible stale search alive.
-    navigateWithoutTransition(buildSearchHrefRef.current(debouncedQuery.trim()), {
+    lastNavigatedQueryRef.current = normalizedDebouncedQuery;
+    navigateWithoutTransition(buildSearchHrefRef.current(normalizedDebouncedQuery), {
       replace: true,
     });
-  }, [debouncedQuery, prominent, navigateWithoutTransition]);
+  }, [debouncedQuery, prominent, navigateWithoutTransition, query]);
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (query.trim()) {
       if (prominent) {
+        lastNavigatedQueryRef.current = query.trim();
         navigateWithoutTransition(buildSearchHref(query.trim()));
       } else {
         navigate(buildSearchHref(query.trim()));
       }
     }
+  }
+
+  function handleClear() {
+    setQuery("");
+    if (!prominent) return;
+
+    // Clear is an explicit action, not typeahead. Remove the active route and
+    // abort its request immediately instead of waiting for the debounce.
+    lastNavigatedQueryRef.current = "";
+    navigateWithoutTransition(buildSearchHrefRef.current(""), { replace: true });
   }
 
   if (prominent) {
@@ -89,7 +112,7 @@ export default function SearchBar({
         {query && (
           <button
             type="button"
-            onClick={() => setQuery("")}
+            onClick={handleClear}
             aria-label="Clear search"
             className="text-muted-foreground hover:text-foreground absolute top-1/2 right-4 -translate-y-1/2 p-1"
           >

--- a/web/src/components/catalog/SearchScopeChips.tsx
+++ b/web/src/components/catalog/SearchScopeChips.tsx
@@ -22,7 +22,7 @@ export default function SearchScopeChips({ activeScope, onScopeChange }: SearchS
     <div
       role="radiogroup"
       aria-label="Search scope"
-      className="surface-panel inline-flex items-center gap-1 rounded-full p-1"
+      className="search-paint-surface inline-flex items-center gap-1 rounded-full border p-1"
     >
       {SCOPE_OPTIONS.map((option) => {
         const isActive = option.value === activeScope;

--- a/web/src/hooks/queries/catalog.test.tsx
+++ b/web/src/hooks/queries/catalog.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -146,6 +147,42 @@ describe("useCatalogWindow", () => {
     expect(pageQueries?.every((query) => query.gcTime === 30_000 && query.retry === false)).toBe(
       true,
     );
+  });
+
+  it("surfaces and retries a failed visible follow-on page", async () => {
+    const state = createCatalogSearchState("query", { q: "star" });
+    const limit = 60;
+    const pageError = new Error("search_timeout");
+    const page0Refetch = vi.fn().mockResolvedValue(undefined);
+    const failedPageRefetch = vi.fn().mockResolvedValue(undefined);
+
+    mocks.useQuery.mockReturnValue({
+      data: { ...makePage(0, limit), snapshot: "2026-01-01T00:00:00Z" },
+      isLoading: false,
+      isError: false,
+      isPlaceholderData: false,
+      error: null,
+      refetch: page0Refetch,
+    });
+    mocks.useQueries.mockReturnValue([
+      {
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: pageError,
+        refetch: failedPageRefetch,
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useCatalogWindow(state, { limit, visibleRange: [60, 119] }),
+    );
+    expect(result.current.isError).toBe(true);
+    expect(result.current.error).toBe(pageError);
+
+    await result.current.refetch();
+    expect(page0Refetch).toHaveBeenCalledOnce();
+    expect(failedPageRefetch).toHaveBeenCalledOnce();
   });
 
   it("estimates window size from has_more when total is omitted", () => {

--- a/web/src/hooks/queries/catalog.test.tsx
+++ b/web/src/hooks/queries/catalog.test.tsx
@@ -111,9 +111,13 @@ describe("useCatalogWindow", () => {
     const state = createCatalogSearchState("query", { q: "heater" });
     const limit = 60;
     let page0Query:
-      | { placeholderData?: (previous: CatalogResponse) => CatalogResponse }
+      | {
+          placeholderData?: (previous: CatalogResponse) => CatalogResponse;
+          gcTime?: number;
+          retry?: boolean;
+        }
       | undefined;
-    let pageQueries: Array<{ enabled?: boolean }> | undefined;
+    let pageQueries: Array<{ enabled?: boolean; gcTime?: number; retry?: boolean }> | undefined;
 
     mocks.useQuery.mockImplementation((query) => {
       page0Query = query;
@@ -137,7 +141,11 @@ describe("useCatalogWindow", () => {
 
     const previous = makePage(0, limit);
     expect(page0Query?.placeholderData?.(previous)).toBe(previous);
+    expect(page0Query).toMatchObject({ gcTime: 30_000, retry: false });
     expect(pageQueries?.every((query) => query.enabled === false)).toBe(true);
+    expect(pageQueries?.every((query) => query.gcTime === 30_000 && query.retry === false)).toBe(
+      true,
+    );
   });
 
   it("estimates window size from has_more when total is omitted", () => {

--- a/web/src/hooks/queries/catalog.test.tsx
+++ b/web/src/hooks/queries/catalog.test.tsx
@@ -185,6 +185,42 @@ describe("useCatalogWindow", () => {
     expect(failedPageRefetch).toHaveBeenCalledOnce();
   });
 
+  it("keeps a successful visible page when only its off-screen buffer fails", async () => {
+    const state = createCatalogSearchState("favorites");
+    const limit = 60;
+    const page0Refetch = vi.fn().mockResolvedValue(undefined);
+    const failedBufferRefetch = vi.fn().mockResolvedValue(undefined);
+
+    mocks.useQuery.mockReturnValue({
+      data: { ...makePage(0, limit), snapshot: "2026-01-01T00:00:00Z" },
+      isLoading: false,
+      isError: false,
+      isPlaceholderData: false,
+      error: null,
+      refetch: page0Refetch,
+    });
+    mocks.useQueries.mockReturnValue([
+      {
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        error: new Error("buffer failed"),
+        refetch: failedBufferRefetch,
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useCatalogWindow(state, { limit, visibleRange: [0, limit - 1] }),
+    );
+    expect(result.current.data.pages.get(0)).toHaveLength(limit);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeUndefined();
+
+    await result.current.refetch();
+    expect(page0Refetch).toHaveBeenCalledOnce();
+    expect(failedBufferRefetch).not.toHaveBeenCalled();
+  });
+
   it("estimates window size from has_more when total is omitted", () => {
     const state = createCatalogSearchState("query", { library_id: 7 });
     const limit = 60;

--- a/web/src/hooks/queries/catalog.test.tsx
+++ b/web/src/hooks/queries/catalog.test.tsx
@@ -107,6 +107,39 @@ describe("useCatalogWindow", () => {
     expect(markup).toContain('data-page7="missing"');
   });
 
+  it("keeps the previous search grid mounted while page 0 is replacing", () => {
+    const state = createCatalogSearchState("query", { q: "heater" });
+    const limit = 60;
+    let page0Query:
+      | { placeholderData?: (previous: CatalogResponse) => CatalogResponse }
+      | undefined;
+    let pageQueries: Array<{ enabled?: boolean }> | undefined;
+
+    mocks.useQuery.mockImplementation((query) => {
+      page0Query = query;
+      return {
+        data: makePage(0, limit),
+        isLoading: true,
+        isPlaceholderData: true,
+      };
+    });
+    mocks.useQueries.mockImplementation(({ queries }) => {
+      pageQueries = queries;
+      return queries.map(() => ({ data: undefined, isLoading: false }));
+    });
+
+    function Harness() {
+      useCatalogWindow(state, { limit, visibleRange: [60, 119] });
+      return null;
+    }
+
+    renderToStaticMarkup(<Harness />);
+
+    const previous = makePage(0, limit);
+    expect(page0Query?.placeholderData?.(previous)).toBe(previous);
+    expect(pageQueries?.every((query) => query.enabled === false)).toBe(true);
+  });
+
   it("estimates window size from has_more when total is omitted", () => {
     const state = createCatalogSearchState("query", { library_id: 7 });
     const limit = 60;

--- a/web/src/hooks/queries/catalog.ts
+++ b/web/src/hooks/queries/catalog.ts
@@ -153,8 +153,10 @@ export function useCatalogWindow(
   const remainingPageParams = catalogParamsForKey(state, limit, false);
   const visibleRange = options.visibleRange ?? [0, limit - 1];
   const bufferPages = state.source === "query" && state.q ? 0 : 1;
-  const startPage = Math.max(0, Math.floor(visibleRange[0] / limit) - bufferPages);
-  const endPage = Math.floor(visibleRange[1] / limit) + bufferPages;
+  const visibleStartPage = Math.max(0, Math.floor(visibleRange[0] / limit));
+  const visibleEndPage = Math.floor(visibleRange[1] / limit);
+  const startPage = Math.max(0, visibleStartPage - bufferPages);
+  const endPage = visibleEndPage + bufferPages;
 
   // Fetch page 0 separately so its snapshot timestamp is available
   // synchronously for subsequent page queries, preventing duplicate items
@@ -208,8 +210,16 @@ export function useCatalogWindow(
 
   const title = page0Result.data?.title ?? state.title;
   const isLoading = page0Result.isLoading;
-  const failedRemainingResults = remainingResults.filter((result) => result.isError);
-  const remainingError = failedRemainingResults[0]?.error;
+  const failedVisibleResults = remainingResults.filter((result, queryIndex) => {
+    const pageIndex = remainingPageIndices[queryIndex];
+    return (
+      pageIndex !== undefined &&
+      pageIndex >= visibleStartPage &&
+      pageIndex <= visibleEndPage &&
+      result.isError
+    );
+  });
+  const remainingError = failedVisibleResults[0]?.error;
 
   const pageResults = useMemo(() => {
     const map = new Map<number, CatalogResponse>();
@@ -333,7 +343,7 @@ export function useCatalogWindow(
       effectiveSort: page0Result.data?.effective_sort,
     },
     isLoading,
-    isError: page0Result.isError || failedRemainingResults.length > 0,
+    isError: page0Result.isError || failedVisibleResults.length > 0,
     isPlaceholderData: page0Result.isPlaceholderData,
     error: page0Result.error ?? remainingError,
     refetch: async () => {
@@ -342,7 +352,7 @@ export function useCatalogWindow(
       // missing from the grid and immediately recreates the same partial view.
       await Promise.all([
         page0Result.refetch(),
-        ...failedRemainingResults.map((result) => result.refetch()),
+        ...failedVisibleResults.map((result) => result.refetch()),
       ]);
     },
   };

--- a/web/src/hooks/queries/catalog.ts
+++ b/web/src/hooks/queries/catalog.ts
@@ -12,6 +12,12 @@ import {
   type CatalogSearchState,
 } from "@/pages/catalogSearchParams";
 
+// Search-as-you-type creates a distinct query key for every settled input.
+// Keep enough history for a quick correction/backspace without retaining ten
+// minutes of poster-heavy responses, and never automatically replay a timed
+// out interactive search against PostgreSQL.
+const INTERACTIVE_SEARCH_GC_TIME_MS = 30_000;
+
 function catalogParamsForKey(
   state: CatalogSearchState,
   limit: number,
@@ -142,6 +148,7 @@ export function useCatalogWindow(
   const limit = options.limit ?? 60;
   const includeTotal = options.includeTotal ?? true;
   const enabled = options.enabled ?? true;
+  const isInteractiveSearch = state.source === "query" && Boolean(state.q);
   const page0Params = catalogParamsForKey(state, limit, includeTotal);
   const remainingPageParams = catalogParamsForKey(state, limit, false);
   const visibleRange = options.visibleRange ?? [0, limit - 1];
@@ -157,9 +164,11 @@ export function useCatalogWindow(
     queryFn: ({ signal }: { signal: AbortSignal }) =>
       fetchCatalogPage(state, limit, 0, { signal }, includeTotal),
     staleTime: 10 * 60 * 1000,
+    ...(isInteractiveSearch
+      ? { gcTime: INTERACTIVE_SEARCH_GC_TIME_MS, retry: false as const }
+      : {}),
     enabled,
-    placeholderData:
-      state.source === "query" && state.q ? (previousData) => previousData : undefined,
+    placeholderData: isInteractiveSearch ? (previousData) => previousData : undefined,
   });
 
   const snapshot = page0Result.data?.snapshot;
@@ -189,6 +198,9 @@ export function useCatalogWindow(
         queryFn: ({ signal }: { signal: AbortSignal }) =>
           fetchCatalogPage(state, limit, offset, { signal }, false, snapshot),
         staleTime: 10 * 60 * 1000,
+        ...(isInteractiveSearch
+          ? { gcTime: INTERACTIVE_SEARCH_GC_TIME_MS, retry: false as const }
+          : {}),
         enabled: canFetchRemainingPages,
       };
     }),
@@ -319,6 +331,10 @@ export function useCatalogWindow(
       effectiveSort: page0Result.data?.effective_sort,
     },
     isLoading,
+    isError: page0Result.isError,
+    isPlaceholderData: page0Result.isPlaceholderData,
+    error: page0Result.error,
+    refetch: page0Result.refetch,
   };
 }
 

--- a/web/src/hooks/queries/catalog.ts
+++ b/web/src/hooks/queries/catalog.ts
@@ -208,6 +208,8 @@ export function useCatalogWindow(
 
   const title = page0Result.data?.title ?? state.title;
   const isLoading = page0Result.isLoading;
+  const failedRemainingResults = remainingResults.filter((result) => result.isError);
+  const remainingError = failedRemainingResults[0]?.error;
 
   const pageResults = useMemo(() => {
     const map = new Map<number, CatalogResponse>();
@@ -331,10 +333,18 @@ export function useCatalogWindow(
       effectiveSort: page0Result.data?.effective_sort,
     },
     isLoading,
-    isError: page0Result.isError,
+    isError: page0Result.isError || failedRemainingResults.length > 0,
     isPlaceholderData: page0Result.isPlaceholderData,
-    error: page0Result.error,
-    refetch: page0Result.refetch,
+    error: page0Result.error ?? remainingError,
+    refetch: async () => {
+      // Page 0 owns the snapshot and total, so refresh it together with every
+      // failed visible page. Retrying only page 0 leaves a timed-out later page
+      // missing from the grid and immediately recreates the same partial view.
+      await Promise.all([
+        page0Result.refetch(),
+        ...failedRemainingResults.map((result) => result.refetch()),
+      ]);
+    },
   };
 }
 

--- a/web/src/hooks/queries/catalog.ts
+++ b/web/src/hooks/queries/catalog.ts
@@ -158,10 +158,13 @@ export function useCatalogWindow(
       fetchCatalogPage(state, limit, 0, { signal }, includeTotal),
     staleTime: 10 * 60 * 1000,
     enabled,
+    placeholderData:
+      state.source === "query" && state.q ? (previousData) => previousData : undefined,
   });
 
   const snapshot = page0Result.data?.snapshot;
-  const canFetchRemainingPages = enabled && page0Result.data !== undefined;
+  const canFetchRemainingPages =
+    enabled && page0Result.data !== undefined && !page0Result.isPlaceholderData;
 
   const remainingPageIndices = useMemo(() => {
     const indices = new Set<number>();

--- a/web/src/hooks/queries/useRequests.test.tsx
+++ b/web/src/hooks/queries/useRequests.test.tsx
@@ -84,8 +84,14 @@ describe("useRequestSearch", () => {
     mocks.useCurrentProfile.mockReturnValue({ profile: { id: "p" } });
     render(<CallHook mediaType="all" q="dune" />);
 
-    const options = mocks.useQuery.mock.calls[0]![0] as { staleTime: number };
+    const options = mocks.useQuery.mock.calls[0]![0] as {
+      staleTime: number;
+      gcTime?: number;
+      retry?: boolean | number;
+    };
     expect(options.staleTime).toBe(30 * 1000);
+    expect(options).not.toHaveProperty("gcTime");
+    expect(options).not.toHaveProperty("retry");
   });
 
   it("allows callers to opt into a longer staleTime", () => {
@@ -99,6 +105,22 @@ describe("useRequestSearch", () => {
 
     const options = mocks.useQuery.mock.calls[0]![0] as { staleTime: number };
     expect(options.staleTime).toBe(5 * 60 * 1000);
+  });
+
+  it("allows interactive callers to bound cache retention and disable retries", () => {
+    mocks.useCurrentProfile.mockReturnValue({ profile: { id: "p" } });
+
+    function CallInteractiveSearch() {
+      useRequestSearch("all", "dune", 1, { gcTime: 30_000, retry: false });
+      return null;
+    }
+    render(<CallInteractiveSearch />);
+
+    const options = mocks.useQuery.mock.calls[0]![0] as {
+      gcTime?: number;
+      retry?: boolean;
+    };
+    expect(options).toMatchObject({ gcTime: 30_000, retry: false });
   });
 
   it("respects the enabled option override", () => {

--- a/web/src/hooks/queries/useRequests.ts
+++ b/web/src/hooks/queries/useRequests.ts
@@ -169,6 +169,10 @@ export interface UseRequestSearchOptions {
   requireProfile?: boolean;
   /** Cache freshness window for this search surface. Default: existing Requests page timing. */
   staleTime?: number;
+  /** Inactive cache lifetime for rapidly changing interactive search keys. */
+  gcTime?: number;
+  /** Retry policy; interactive search surfaces should not replay expensive failures. */
+  retry?: boolean | number;
 }
 
 export function useRequestSearch(
@@ -200,6 +204,8 @@ export function useRequestSearch(
     enabled:
       enabledOverride && normalizedQuery.length > 1 && (!requireProfile || Boolean(profile?.id)),
     staleTime: options.staleTime ?? REQUESTS_STALE_TIME,
+    ...(options.gcTime !== undefined ? { gcTime: options.gcTime } : {}),
+    ...(options.retry !== undefined ? { retry: options.retry } : {}),
   });
 }
 

--- a/web/src/lib/mediaRequests.ts
+++ b/web/src/lib/mediaRequests.ts
@@ -98,7 +98,7 @@ export function formatRequestReason(reason?: string): string {
     case "blocked":
       return "Blocked";
     case "quota_exceeded":
-      return "Limit reached";
+      return "Request limit reached";
     default:
       return "Unavailable";
   }

--- a/web/src/pages/Catalog.test.tsx
+++ b/web/src/pages/Catalog.test.tsx
@@ -641,6 +641,26 @@ describe("Catalog page", () => {
     expect(markup).not.toContain("Stale Result");
   });
 
+  it("uses catalog-specific copy for a non-search failure", () => {
+    appInitialEntries = ["/catalog?source=favorites"];
+    mockUseCatalogWindow.mockReturnValue({
+      data: { title: "Favorites", totalItems: 0, pages: new Map() },
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <App />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("Catalog stopped before it could finish.");
+    expect(markup).toContain("Retry catalog");
+    expect(markup).not.toContain("Try a more specific title");
+  });
+
   it("applies the preferred media scope (default: video) when the URL has no type param", () => {
     renderToStaticMarkup(
       <QueryClientProvider client={new QueryClient()}>

--- a/web/src/pages/Catalog.test.tsx
+++ b/web/src/pages/Catalog.test.tsx
@@ -56,13 +56,15 @@ vi.mock("@/components/RequestToAddSection", () => ({
     variant,
     query,
     libraryHadHits,
+    libraryResultsKnown,
   }: {
     variant: string;
     query: string;
     libraryHadHits: boolean;
+    libraryResultsKnown?: boolean;
   }) => (
     <div data-testid="request-section">
-      {`variant="${variant}" query="${query}" libraryHadHits="${String(libraryHadHits)}"`}
+      {`variant="${variant}" query="${query}" libraryHadHits="${String(libraryHadHits)}" libraryResultsKnown="${String(libraryResultsKnown)}"`}
     </div>
   ),
 }));
@@ -207,6 +209,8 @@ describe("Catalog page", () => {
         pages: new Map([[0, [{ content_id: "movie-1", title: "Heat", type: "movie" }]]]),
       },
       isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
     });
     mockUseCatalogFilters.mockReturnValue({
       data: { genres: ["Drama"], content_ratings: ["R"] },
@@ -389,6 +393,7 @@ describe("Catalog page", () => {
     expect(markup).toContain('data-testid="request-section"');
     expect(markup).toContain("variant=&quot;grid&quot;");
     expect(markup).toContain("libraryHadHits=&quot;true&quot;");
+    expect(markup).toContain("libraryResultsKnown=&quot;true&quot;");
   });
 
   it("renders the request grid variant with libraryHadHits=false when library has 0 hits", () => {
@@ -427,6 +432,31 @@ describe("Catalog page", () => {
     );
 
     expect(markup).toContain("libraryHadHits=&quot;false&quot;");
+    expect(markup).toContain("libraryResultsKnown=&quot;true&quot;");
+  });
+
+  it("marks library results unknown when the local search failed", () => {
+    mockUseCanRequest.mockReturnValue({
+      discoveryEnabled: true,
+      isResolving: false,
+      submitDisabledReason: null,
+    });
+    mockUseCatalogWindow.mockReturnValue({
+      data: { title: 'Results for "heat"', totalItems: 0, pages: new Map() },
+      isLoading: false,
+      isError: true,
+      isPlaceholderData: false,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <App />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("libraryHadHits=&quot;false&quot;");
+    expect(markup).toContain("libraryResultsKnown=&quot;false&quot;");
   });
 
   it("does not render the request section when source is not query", () => {
@@ -472,6 +502,8 @@ describe("Catalog page", () => {
       enabled: false,
       requireProfile: true,
       staleTime: 5 * 60 * 1000,
+      gcTime: 30_000,
+      retry: false,
     });
   });
 
@@ -583,6 +615,30 @@ describe("Catalog page", () => {
 
     expect(markup).toContain('data-loading="false"');
     expect(markup).toContain('data-total="0"');
+  });
+
+  it("hides stale results and explains a bounded search failure", () => {
+    mockUseCatalogWindow.mockReturnValue({
+      data: {
+        title: "Old Search",
+        totalItems: 1,
+        pages: new Map([[0, [{ content_id: "old", title: "Stale Result", type: "movie" }]]]),
+      },
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    });
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <App />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("Search stopped before it could finish.");
+    expect(markup).toContain("Retry search");
+    expect(markup).not.toContain('data-kind="item-grid"');
+    expect(markup).not.toContain("Stale Result");
   });
 
   it("applies the preferred media scope (default: video) when the URL has no type param", () => {

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -426,14 +426,19 @@ function CatalogResults({
           className="search-paint-surface flex flex-col items-center justify-center gap-3 rounded-2xl border px-4 py-16 text-center"
           role="alert"
         >
-          <p className="font-medium">Search stopped before it could finish.</p>
+          <p className="font-medium">
+            {isQuerySource
+              ? "Search stopped before it could finish."
+              : "Catalog stopped before it could finish."}
+          </p>
           <p className="text-muted-foreground max-w-md text-sm">
-            The server ended the lookup so it could not keep using CPU in the background. Try a more
-            specific title or retry once.
+            {isQuerySource
+              ? "The server ended the lookup so it could not keep using CPU in the background. Try a more specific title or retry once."
+              : "The server could not load every requested result. Retry the catalog once."}
           </p>
           <Button variant="outline" size="sm" onClick={() => void catalogQuery.refetch()}>
             <RefreshCw className="size-4" />
-            Retry search
+            {isQuerySource ? "Retry search" : "Retry catalog"}
           </Button>
         </div>
       ) : tmdbMayRescueLibrary ? null : (

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
-import { CheckSquare, Search, Trash2, X } from "lucide-react";
+import { CheckSquare, RefreshCw, Search, Trash2, X } from "lucide-react";
 
 import { captureProfileRequestContext } from "@/api/client";
 import type { BrowseItem } from "@/api/types";
@@ -35,6 +35,7 @@ import {
 import type { CatalogSearchState } from "./catalogSearchParams";
 
 const REQUEST_SEARCH_DEBOUNCE_MS = 100;
+const INTERACTIVE_SEARCH_GC_TIME_MS = 30_000;
 
 function defaultCatalogTitle(source: string, searchQuery?: string) {
   if (source === "favorites") return "Favorites";
@@ -232,11 +233,15 @@ function CatalogResults({
     enabled: canRequest.discoveryEnabled && isQuerySource,
     requireProfile: true,
     staleTime: 5 * 60 * 1000,
+    gcTime: INTERACTIVE_SEARCH_GC_TIME_MS,
+    retry: false,
   });
   const tmdbMissingCount =
     tmdbQuery.data?.results?.filter((result) => result.availability !== "available").length ?? 0;
-  const libraryHasResults = (catalogQuery.data?.totalItems ?? 0) > 0;
-  const libraryEmpty = !catalogQuery.isLoading && !libraryHasResults;
+  const libraryResultsKnown =
+    !catalogQuery.isLoading && !catalogQuery.isPlaceholderData && !catalogQuery.isError;
+  const libraryHasResults = libraryResultsKnown && (catalogQuery.data?.totalItems ?? 0) > 0;
+  const libraryEmpty = libraryResultsKnown && !libraryHasResults;
   // When the library is empty and the request section will (or might) render,
   // hide ItemGrid entirely. The previous approach pinned ItemGrid's `loading`
   // prop to true, which renders 24 skeleton tiles forever above the section.
@@ -416,7 +421,22 @@ function CatalogResults({
         </section>
       )}
 
-      {tmdbMayRescueLibrary ? null : (
+      {catalogQuery.isError ? (
+        <div
+          className="search-paint-surface flex flex-col items-center justify-center gap-3 rounded-2xl border px-4 py-16 text-center"
+          role="alert"
+        >
+          <p className="font-medium">Search stopped before it could finish.</p>
+          <p className="text-muted-foreground max-w-md text-sm">
+            The server ended the lookup so it could not keep using CPU in the background. Try a more
+            specific title or retry once.
+          </p>
+          <Button variant="outline" size="sm" onClick={() => void catalogQuery.refetch()}>
+            <RefreshCw className="size-4" />
+            Retry search
+          </Button>
+        </div>
+      ) : tmdbMayRescueLibrary ? null : (
         <ItemGrid
           totalItems={catalogQuery.data?.totalItems ?? 0}
           pages={catalogQuery.data?.pages ?? new Map()}
@@ -435,6 +455,7 @@ function CatalogResults({
           variant="grid"
           query={tmdbDebouncedQ}
           libraryHadHits={libraryHasResults}
+          libraryResultsKnown={libraryResultsKnown}
         />
       ) : null}
 


### PR DESCRIPTION
## Problem

Related issue: #826

Closes #826

I use PostgreSQL FTS because I do not want a separate search daemon or a second copy of the catalogue. On a production-sized library, the existing PostgreSQL path was slow enough that normal title searches took several seconds, broad prefixes timed out, and each settled keypress triggered a full-page View Transition/repaint.

The measured catalogue had 15,826 media items, 141,104 aliases, 385,267 episodes, and 247,842 episode-catalog rows. The old main query averaged 4,659.2 ms and reached 26,187.7 ms max across 41 `pg_stat_statements` calls.

This PR keeps PostgreSQL as the only persistent search index. It does not add Meilisearch, Typesense, Bleve storage, a worker, or an application result cache.

## Approach

### PostgreSQL lookup path

- Score aliases once in a materialized, index-backed CTE instead of running correlated alias subqueries per media candidate.
- Materialize title candidates first. The overview branch runs only when the accessible catalogue has no title/alias hit; PostgreSQL reports it as `never executed` for ordinary title searches.
- Use exact normalized-title B-tree lookup for one-to-three-character titles and leading normalized-title lookup while the final typeahead word is shorter than four characters.
- Store normalized title, title `tsvector`, and overview `tsvector` on the already-maintained `episode_catalog_entries` rows. Existing synchronous refreshes feed one trigger; there is no queue or background indexer.
- Build retry-safe B-tree/GIN indexes concurrently and remove invalid remnants from interrupted concurrent builds before retrying.
- Keep the wide media projection out of the candidate sort; hydrate only the limited page.

### Typo recovery and relevance

This preserves PR #386's separate sparse fallback and pagination model. Fuzzy work remains terminal: page 0 only, fewer than five FTS hits, and at least one token of four characters.

- Exact normalized-title hits suppress fuzzy recovery entirely.
- Canonical-title and alias candidates are independent `pg_trgm` index scans, combined and permission-filtered before hydration. No alias scan is correlated to each media row.
- SQL ranking blends 65% whole-title similarity and 35% strict-word similarity so one matching word cannot dominate a misspelled phrase.
- PostgreSQL contributes at most 50 fuzzy rows.
- The in-process reranker reads at most four matching aliases per item: 50 items / 200 aliases maximum, 16 query tokens, 64 title tokens, and 64 runes per token. It checks cancellation between candidates and retains no state after the request.
- Auto edit distance is 0 for tokens of two characters or less, 1 for three-to-five characters, and 2 for longer tokens. The small ranking policy is inspired by Bleve; Bleve's index/storage engine is not imported.

### Request, memory, and CPU bounds

- The complete PostgreSQL FTS + fuzzy transaction has a three-second deadline.
- A timed-out fuzzy transaction receives a separate one-second rollback-only context so the connection can return to the pool without extending the response deadline.
- Superseded browser requests use `AbortSignal`; cancellation does not emit a false 500.
- Server deadline exhaustion returns retryable `504 search_timeout` after database work has stopped.
- Interactive local and request-provider queries use `retry: false` and a 30-second inactive `gcTime`; normal catalogue/request screens keep their existing cache policy.
- No unbounded server-side result cache, catalogue-sized in-process index, goroutine, or worker is added.

### Web stability and result state

- Prominent typing uses ordinary replace navigation rather than a View Transition for every debounced keypress.
- Clearing the input navigates the empty query immediately, aborting/removing the old result route.
- Page 0 remains stable placeholder data while its replacement loads, but old remaining pages cannot fetch under the new query key.
- Search input, scope chips, and timeout state use an explicit opaque page surface with no backdrop filter.
- `Not in your library` is shown only after the local lookup completes successfully and is empty; loading, placeholder, and failed states use neutral discovery copy.
- Request cards show `Movie` or `Series`, and `quota_exceeded` reads `Request limit reached`, so a same-title external movie is not confused with a local series or a search cap.
- The narrow short-token SQL explicitly types its first bound parameter. This covers `Breaking Bad`, `Who Are You?`, `Up`, and intermediate states such as `the m`; without the guard, PostgreSQL rejected the generated statement with `SQLSTATE 42P18`.

## Benchmarks

All PostgreSQL figures below are from read-only `EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)` against the production-sized catalogue, limit 61, with a hard statement timeout. The final episode schema/index behavior was exercised with a transaction-local copy and rolled back during development.

### Old vs new PostgreSQL plans

| Query | Before planning | Before execution | After planning | After execution | Execution gain |
|---|---:|---:|---:|---:|---:|
| `l` | 29.794 ms | 2,202.980 ms | 32.558 ms | 152.108 ms | 14.5x |
| `la` | — | >3,000 ms timeout | 4.819 ms | 116.628 ms | >25.7x |
| `lan` | 55.548 ms | 1,179.570 ms | 5.462 ms | 6.160 ms | 191.5x |
| `the` | — | >3,000 ms timeout | 2.740 ms | 94.753 ms | >31.7x |
| `lant` | 46.652 ms | 139.911 ms | 13.424 ms | 33.025 ms | 4.2x |
| `star` | 56.214 ms | 1,453.003 ms warm / 2,814.537 ms first | 7.302 ms | 171.635 ms | 8.5x warm / 16.4x first |
| `love` | — | >3,000 ms timeout | 7.996 ms | 189.539 ms | >15.8x |
| `dune` | 29.491 ms | 122.883 ms | 6.162 ms | 12.601 ms | 9.8x |
| `the m` | — | >3,000 ms timeout | 12.735 ms | 162.034 ms | >18.5x |
| `harry p` | 36.410 ms | 197.137 ms | 3.496 ms | 20.416 ms | 9.7x |
| `lanterns` | 91.626 ms | 5,605.681 ms | 8.444 ms | 3.995 ms | 1,403x |

`lanterns` fell from 156,795 shared-buffer hits to 137 shared/local pages. Broad `star` fell from 36,814 shared hits to 3,346 shared/local pages. For title-bearing searches, both overview scans were `never executed`.

### User search examples

The old column is the authenticated live resolver timing captured before this change. The new column is the final PostgreSQL plan time, so I am not presenting these as direct end-to-end ratios.

| Query | Old live local resolver | New DB plan |
|---|---:|---:|
| `Game of Thrones` | 4,466 ms | 11.597 ms |
| `Breaking Bad` | 4,314 ms | 7.467 ms |
| `Fast` | 8,677 ms | 17.409 ms |

The exact-title guard skips fuzzy recovery for the first two. `Fast` returns its title family through indexed FTS/prefix search.

### Typo queries

Same catalogue, three-second statement timeout, and pinned `pg_trgm` threshold:

| Query | Before candidate SQL | Final candidate SQL | First result / result family |
|---|---:|---:|---|
| `Gane of Throns` | >3,000 ms timeout | 287.705 ms | `Game of Thrones` |
| `Breking Bad` | — | 384.193 ms | `Breaking Bad` |
| `Fast and Furios` | — | 111.047 ms | `Fast & Furious`, then related franchise titles |
| `Hary Poter` | — | 181.234 ms | Harry Potter titles |
| `Avengrs Endgme` | — | 117.484 ms | `Avengers: Endgame` |

The previous word-only score placed `Justice League: Throne of Atlantis` above `Game of Thrones`. The blended SQL score plus bounded token/edit rerank corrects that ordering.

### Constant-bounded Go reranker

`BenchmarkRerankFuzzyItemsCappedCandidateSet`, 50 candidates × four aliases, Apple M4, five runs on this upstream port:

| Run | Time | Allocation | Allocations |
|---:|---:|---:|---:|
| 1 | 0.184135 ms/op | 238,891 B/op | 4,662 allocs/op |
| 2 | 0.183537 ms/op | 238,890 B/op | 4,662 allocs/op |
| 3 | 0.181924 ms/op | 238,891 B/op | 4,662 allocs/op |
| 4 | 0.183567 ms/op | 238,890 B/op | 4,662 allocs/op |
| 5 | 0.186646 ms/op | 238,890 B/op | 4,662 allocs/op |

This workload is constant with respect to total library size.

### Browser/server observations

- Authenticated sequence: `Game of Thrones` → clear → `Breaking Bad` → clear → `Fast`, typo queries, and rapid 40 ms/key bursts.
- Input geometry stayed at 456×56 / x=32 / y=196; the result-grid top stayed at y=434 through sampled key entry.
- Computed search-surface style was opaque (`opacity: 1`, `backdrop-filter: none`).
- After read-only SQL/browser stress, `pg_stat_activity` showed zero active FTS/trigram searches and maximum active age zero.
- The same implementation is live on the fork. The local `Breaking Bad` 2008 series now returns correctly; the remaining same-title discovery item is visibly a distinct movie.
- No screenshot is attached because the intended visual design is unchanged; the fix removes motion/repaint and stabilizes state rather than introducing new chrome.

## Validation

Local validation on the complete upstream diff:

```text
go test ./internal/catalog/... ./internal/api/handlers/... ./migrations/...
PASS: catalog, catalog/reattribute, handlers, migrations

go vet ./internal/catalog/... ./internal/api/handlers/... ./migrations/...
PASS

go build ./...
PASS

pnpm exec vitest run [7 changed search test files]
Test Files  7 passed (7)
Tests      86 passed (86)

pnpm run format:check
All matched files use Prettier code style!

pnpm run lint
0 errors; 172 inherited warnings

pnpm run build
PASS: 4,208 modules transformed; built in 11.66s

make verify-settings-bindings + pinned-pnpm web binding comparison
settings bindings are current
web settings binding is current

make verify-playback-fixtures
playback fixtures are current

make verify-local-paths
PASS

git diff --check
PASS
```

Focused coverage includes title/overview gating, independent alias/canonical fuzzy arms, absence of correlated alias rescans, exact and leading short-token paths, data/count parameter typing, permission filters, duplicate prevention, pagination/totals, exact-title fuzzy suppression, typo ordering, cancellation, timeout response semantics, rapid typing, clear navigation, placeholder-page gating, interactive cache/retry options, request-provider state, and Movie/Series labels.

Final upstream GitHub Actions run `33238740125` passed all three jobs on head `0842865f`: Docs hygiene (10s), Web (5m27s), and Go (7m17s). The Go job includes the full build, gofmt, vet, changed-lines `golangci-lint`, generated-contract checks, and `make test-go`; Web includes lint, formatting, production build, `make test-web`, and generated settings bindings.

CodeRabbit reported four correctness edges and one inactive sort key. Each was reproduced against the current code and resolved in `1a9495f9`: grouped timeout mapping, episode-overview refresh, clear/debounce ordering, failed later-page propagation/refetch, and removal of constant `title_rank`. All four review threads are resolved. Post-review reruns passed the affected Go packages, migration suite, all seven search Web files (86 tests), targeted ESLint with zero errors, and the production Web build; the final full CI run above also passed. CodeRabbit's final status is passing, with its additional review skipped by the service's rate limit after the lint-only `0842865f` follow-up.

## Risks

- The migration performs one bounded backfill of existing episode-catalog rows, then builds indexes concurrently. It uses Goose `NO TRANSACTION`; invalid interrupted index remnants are removed on retry.
- Inserts and episode refreshes synchronously maintain three search fields. There is no eventual-consistency queue.
- Pathological PostgreSQL searches now stop at three seconds and return a 504 instead of consuming CPU indefinitely.
- Meilisearch code and configuration are unchanged.
- Native clients receive the existing non-2xx path with a more accurate 504 only when search times out; no success-response schema changes. Jellyfin compatibility benefits from the repository-level query bound but does not receive the native API error body.
- PR #386's stable sparse-result pagination, access-filter parity, pinned trigram threshold, truncation semantics, and cursor-mode safeguards remain covered by the combined tests.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): `gpt-5.6-sol` (ultra reasoning)
- Involvement: Fully AI-generated, human verified
- Human orchestration: @blurbery defined the PostgreSQL-only architecture, performance/reliability bounds, directed the reproduction and edge-case matrix, selected the deployment checks, and validated the live result.
- Adversarial review: A separate full-diff review examined SQL plan shape, access filters, pagination, cancellation, cache lifetime, CPU/memory bounds, migration retry behavior, and UI loading/error state. Live verification exposed an untyped `$1` on narrow-title queries and ambiguous outside-library copy; both were fixed with regression tests. The upstream port was then reviewed against PR #386, and the only merge conflict preserved both upstream's raised settings surface and this PR's opaque search surface. No unresolved finding remains.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved catalog search ranking with typo, alias, and phrase matching.
  - Added clearer Movie and Series labels to request cards.
  - Added distinct search and catalog error panels with appropriate retry actions.
  - Discovery results now indicate when library matching is unavailable.
  - Added improved handling for short and leading-title searches.

- **Bug Fixes**
  - Improved search clearing and rapid-typing behavior.
  - Prevented stale results after search failures.
  - Search timeouts now display an appropriate timeout response.
  - Updated episode descriptions are reflected in search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->