### PR TITLE
feat(ratings): add server-local community cards

### DIFF
--- a/docs/ratings-api.md
+++ b/docs/ratings-api.md
@@ -1,0 +1,65 @@
+# Ratings API
+
+Silo ratings have two deliberately separate uses:
+
+- A personal rating belongs to one account profile and remains an input to that profile's recommendation taste.
+- A community rating surface shows how profiles on the same Silo server rated an item. Its average and reactions are display-only and never affect recommendations.
+
+All documented data and mutation routes require an authenticated, selected profile. Existing personal-rating routes and behavior are unchanged.
+
+## Capability discovery
+
+`GET /api/v1/ratings/capabilities`
+
+```json
+{
+  "community_ratings": true,
+  "community_rating_reactions": true
+}
+```
+
+Clients should check this endpoint before presenting the optional community surface. The web client supports it on movie and main series detail pages. Apple, Android, and Jellyfin-compatible clients do not currently expose this Silo-specific surface.
+
+## List community ratings
+
+`GET /api/v1/ratings/{item_id}/community?limit=100`
+
+Every explicit profile rating for the requested item is included, whether or not that profile has watch progress. The card list is capped at 100 rows per request; the average and vote count cover every explicit rating for the item.
+
+```json
+{
+  "average_rating": 4.5,
+  "vote_count": 2,
+  "ratings": [
+    {
+      "key": "opaque-rating-key",
+      "display_name": "S*******",
+      "avatar_url": "/profile-avatars/avatar-1.svg",
+      "rating": 5,
+      "rated_at": "2026-08-29T08:00:00Z",
+      "up_count": 3,
+      "down_count": 1,
+      "viewer_reaction": "up",
+      "is_viewer": false
+    }
+  ]
+}
+```
+
+`average_rating` is `null` when there are no votes. The existing `user_ratings` primary key keeps one rating per account/profile/item: changing the stars updates that row and clearing the personal rating removes its community card. Profile and account IDs are never returned. `display_name` contains the first Unicode character followed by one `*` for every hidden character. `is_viewer` lets clients distinguish the selected profile when protected display names happen to match. Avatar URLs are resolved from the profile's current avatar when the response is created, so later profile changes are reflected on refresh. Uploaded avatars use a short-lived opaque proxy URL; private storage keys are not sent to other profiles.
+
+## React to a rating
+
+Set or change the selected profile's one reaction to any rating, including its own:
+
+`PUT /api/v1/ratings/{item_id}/community/{rating_key}/reaction`
+
+```json
+{ "reaction": "up" }
+```
+
+`reaction` is `up` or `down`. Sending the other value changes the existing reaction rather than adding a second one. Remove the selected profile's reaction, including when the same button is selected again, with:
+
+`DELETE /api/v1/ratings/{item_id}/community/{rating_key}/reaction`
+
+Both successful mutations return `204 No Content`. Ratings and reactions are stored in PostgreSQL and survive normal server and container restarts.

--- a/docs/ratings-api.md
+++ b/docs/ratings-api.md
@@ -24,7 +24,7 @@ Clients should check this endpoint before presenting the optional community surf
 
 `GET /api/v1/ratings/{item_id}/community?limit=100`
 
-Every explicit profile rating for the requested item is included, whether or not that profile has watch progress. The card list is capped at 100 rows per request; the average and vote count cover every explicit rating for the item.
+Every explicit profile rating is eligible for inclusion, whether or not that profile has watch progress. The response returns up to the requested card-list limit (maximum 100); the average and vote count cover every explicit rating for the item.
 
 ```json
 {

--- a/internal/api/handlers/profile_avatars.go
+++ b/internal/api/handlers/profile_avatars.go
@@ -42,6 +42,7 @@ var supportedDiceBearAvatarStyles = map[string]struct{}{
 }
 
 type profileAvatarStore interface {
+	GetObject(ctx context.Context, bucket, key string) ([]byte, error)
 	PutObject(ctx context.Context, bucket, key string, data []byte) error
 	DeleteObject(ctx context.Context, bucket, key string) error
 	ListObjects(ctx context.Context, bucket, prefix string) ([]string, error)

--- a/internal/api/handlers/profiles.go
+++ b/internal/api/handlers/profiles.go
@@ -628,6 +628,21 @@ func (h *ProfileHandler) HandleDeleteProfile(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Shared rating data lives in PostgreSQL even when the profile itself lives
+	// in per-user SQLite. Purge it first so a database failure leaves the
+	// profile intact and retryable instead of returning success with an orphaned
+	// community card.
+	if h.RatingProfilePurger != nil {
+		purgeCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
+		purgeErr := h.RatingProfilePurger.PurgeProfile(purgeCtx, userID, profileID)
+		cancel()
+		if purgeErr != nil {
+			slog.ErrorContext(r.Context(), "profile rating purge failed before delete", "component", "api", "user_id", userID, "profile_id", profileID, "error", purgeErr)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to remove profile rating data")
+			return
+		}
+	}
+
 	if err := store.DeleteProfile(r.Context(), profileID); err != nil {
 		writeError(w, http.StatusNotFound, "not_found", "Profile not found")
 		return
@@ -644,14 +659,6 @@ func (h *ProfileHandler) HandleDeleteProfile(w http.ResponseWriter, r *http.Requ
 			slog.WarnContext(r.Context(), "profile device-library purge failed after delete", "component", "api", "user_id", userID, "profile_id", profileID, "error", purgeErr)
 		}
 	}
-	if h.RatingProfilePurger != nil {
-		purgeCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
-		defer cancel()
-		if purgeErr := h.RatingProfilePurger.PurgeProfile(purgeCtx, userID, profileID); purgeErr != nil {
-			slog.WarnContext(r.Context(), "profile rating purge failed after delete", "component", "api", "user_id", userID, "profile_id", profileID, "error", purgeErr)
-		}
-	}
-
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/api/handlers/profiles.go
+++ b/internal/api/handlers/profiles.go
@@ -36,6 +36,11 @@ type ProfileHandler struct {
 	DeviceLibraryPurger interface {
 		PurgeProfileDevices(ctx context.Context, userID int, profileID string) error
 	}
+	// RatingProfilePurger removes shared PostgreSQL ratings and reactions for
+	// profiles stored outside PostgreSQL.
+	RatingProfilePurger interface {
+		PurgeProfile(ctx context.Context, userID int, profileID string) error
+	}
 	// EventsHub, when set, receives a user_settings.changed event for every
 	// canonical setting row a profile mutation syncs (see
 	// profiles_settings_sync.go). Nil (as in tests) simply skips publishing.
@@ -637,6 +642,13 @@ func (h *ProfileHandler) HandleDeleteProfile(w http.ResponseWriter, r *http.Requ
 		defer cancel()
 		if purgeErr := h.DeviceLibraryPurger.PurgeProfileDevices(purgeCtx, userID, profileID); purgeErr != nil {
 			slog.WarnContext(r.Context(), "profile device-library purge failed after delete", "component", "api", "user_id", userID, "profile_id", profileID, "error", purgeErr)
+		}
+	}
+	if h.RatingProfilePurger != nil {
+		purgeCtx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 30*time.Second)
+		defer cancel()
+		if purgeErr := h.RatingProfilePurger.PurgeProfile(purgeCtx, userID, profileID); purgeErr != nil {
+			slog.WarnContext(r.Context(), "profile rating purge failed after delete", "component", "api", "user_id", userID, "profile_id", profileID, "error", purgeErr)
 		}
 	}
 

--- a/internal/api/handlers/profiles_test.go
+++ b/internal/api/handlers/profiles_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -28,12 +29,13 @@ type testProfileUserRepo struct {
 type ratingProfilePurgerStub struct {
 	userID    int
 	profileID string
+	err       error
 }
 
 func (s *ratingProfilePurgerStub) PurgeProfile(_ context.Context, userID int, profileID string) error {
 	s.userID = userID
 	s.profileID = profileID
-	return nil
+	return s.err
 }
 
 func (r testProfileUserRepo) GetByID(context.Context, int) (*models.User, error) {
@@ -692,6 +694,33 @@ func TestHandleDeleteProfile_AllowsPrimaryToDeleteOther(t *testing.T) {
 	}
 	if purger.userID != 1 || purger.profileID != "profile-2" {
 		t.Fatalf("rating purge target = (%d, %q), want (1, profile-2)", purger.userID, purger.profileID)
+	}
+}
+
+func TestHandleDeleteProfile_PreservesProfileWhenRatingPurgeFails(t *testing.T) {
+	store := newProfileTestStore(t)
+	if err := store.CreateProfile(context.Background(), userstore.Profile{ID: "profile-2", Name: "Kids"}); err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	handler := NewProfileHandler(testUserStoreProvider{store: store})
+	handler.RatingProfilePurger = &ratingProfilePurgerStub{err: errors.New("database unavailable")}
+	req := newAuthorizedProfileRequestWithRole(
+		http.MethodDelete,
+		"/profiles/profile-2",
+		"",
+		"user",
+		"profile-1",
+	)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleDeleteProfile(recorder, withProfileRouteParam(req, "id", "profile-2"))
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	profile, err := store.GetProfile(context.Background(), "profile-2")
+	if err != nil || profile == nil {
+		t.Fatalf("profile was removed after rating purge failure: %v", err)
 	}
 }
 

--- a/internal/api/handlers/profiles_test.go
+++ b/internal/api/handlers/profiles_test.go
@@ -25,6 +25,17 @@ type testProfileUserRepo struct {
 	err  error
 }
 
+type ratingProfilePurgerStub struct {
+	userID    int
+	profileID string
+}
+
+func (s *ratingProfilePurgerStub) PurgeProfile(_ context.Context, userID int, profileID string) error {
+	s.userID = userID
+	s.profileID = profileID
+	return nil
+}
+
 func (r testProfileUserRepo) GetByID(context.Context, int) (*models.User, error) {
 	return r.user, r.err
 }
@@ -657,6 +668,8 @@ func TestHandleDeleteProfile_AllowsPrimaryToDeleteOther(t *testing.T) {
 		t.Fatalf("create profile: %v", err)
 	}
 	handler := NewProfileHandler(testUserStoreProvider{store: store})
+	purger := &ratingProfilePurgerStub{}
+	handler.RatingProfilePurger = purger
 
 	req := newAuthorizedProfileRequestWithRole(
 		http.MethodDelete,
@@ -676,6 +689,9 @@ func TestHandleDeleteProfile_AllowsPrimaryToDeleteOther(t *testing.T) {
 	profile, err := store.GetProfile(context.Background(), "profile-2")
 	if err == nil && profile != nil {
 		t.Fatal("expected profile to be deleted")
+	}
+	if purger.userID != 1 || purger.profileID != "profile-2" {
+		t.Fatalf("rating purge target = (%d, %q), want (1, profile-2)", purger.userID, purger.profileID)
 	}
 }
 

--- a/internal/api/handlers/ratings.go
+++ b/internal/api/handlers/ratings.go
@@ -2,8 +2,16 @@ package handlers
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -17,6 +25,9 @@ type ratingsRepository interface {
 	Get(ctx context.Context, userID int, profileID, mediaItemID string) (*catalog.UserRating, error)
 	Delete(ctx context.Context, userID int, profileID, mediaItemID string) error
 	List(ctx context.Context, userID int, profileID string, limit, offset int) ([]catalog.UserRating, error)
+	ListCommunity(ctx context.Context, viewerUserID int, viewerProfileID, mediaItemID string, limit, offset int) ([]catalog.CommunityRating, error)
+	SetCommunityReaction(ctx context.Context, viewerUserID int, viewerProfileID, mediaItemID string, targetUserID int, targetProfileID string, reaction int) (bool, error)
+	DeleteCommunityReaction(ctx context.Context, viewerUserID int, viewerProfileID, mediaItemID string, targetUserID int, targetProfileID string) error
 }
 
 // RatingsHandler handles user rating operations.
@@ -25,6 +36,9 @@ type RatingsHandler struct {
 	itemRepo                personalDataItemRepository
 	profileStaler           ProfileStaler
 	profileRefreshRequester ProfileRefreshRequester
+	AvatarStore             profileAvatarStore
+	AvatarTTL               time.Duration
+	AvatarTokenSecret       []byte
 }
 
 // NewRatingsHandler creates a new RatingsHandler.
@@ -63,10 +77,38 @@ type ratingListResponse struct {
 	Ratings []ratingListItem `json:"ratings"`
 }
 
+type communityRatingListItem struct {
+	Key            string `json:"key"`
+	DisplayName    string `json:"display_name"`
+	AvatarURL      string `json:"avatar_url,omitempty"`
+	Rating         int    `json:"rating"`
+	RatedAt        string `json:"rated_at"`
+	UpCount        int    `json:"up_count"`
+	DownCount      int    `json:"down_count"`
+	ViewerReaction string `json:"viewer_reaction,omitempty"`
+	IsViewer       bool   `json:"is_viewer"`
+}
+
+type communityRatingsResponse struct {
+	AverageRating *float64                  `json:"average_rating"`
+	VoteCount     int                       `json:"vote_count"`
+	Ratings       []communityRatingListItem `json:"ratings"`
+}
+
 // --- Request types ---
 
 type setRatingRequest struct {
 	Rating int `json:"rating"`
+}
+
+type setCommunityRatingReactionRequest struct {
+	Reaction string `json:"reaction"`
+}
+
+type communityAvatarTokenPayload struct {
+	ObjectKey string `json:"o"`
+	Version   int64  `json:"v"`
+	ExpiresAt int64  `json:"e"`
 }
 
 // HandleSetRating handles PUT /ratings/{item_id}.
@@ -180,4 +222,302 @@ func (h *RatingsHandler) HandleListRatings(w http.ResponseWriter, r *http.Reques
 	}
 
 	writeJSON(w, http.StatusOK, ratingListResponse{Ratings: items})
+}
+
+// HandleCapabilities advertises the optional server-local rating surface without
+// changing the existing personal-rating contract used by older clients.
+func (h *RatingsHandler) HandleCapabilities(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]bool{
+		"community_ratings":          true,
+		"community_rating_reactions": true,
+	})
+}
+
+// HandleListCommunityRatings handles GET /ratings/{item_id}/community.
+func (h *RatingsHandler) HandleListCommunityRatings(w http.ResponseWriter, r *http.Request) {
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	itemID := chi.URLParam(r, "item_id")
+	if itemID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Item ID is required")
+		return
+	}
+	if err := h.itemRepo.EnsureAccessible(r.Context(), itemID, requestAccessFilter(r)); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	limit, _ := parsePagination(r)
+	if limit > 100 {
+		limit = 100
+	}
+	ratings, err := h.ratingsRepo.ListCommunity(r.Context(), userID, profileID, itemID, limit, 0)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list community ratings")
+		return
+	}
+
+	items := make([]communityRatingListItem, 0, len(ratings))
+	for _, rating := range ratings {
+		avatarURL := h.communityAvatarURL(r.Context(), rating)
+		items = append(items, communityRatingListItem{
+			Key:            communityRatingKey(itemID, rating),
+			DisplayName:    abbreviateProfileName(rating.ProfileName),
+			AvatarURL:      avatarURL,
+			Rating:         rating.Rating,
+			RatedAt:        rating.RatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+			UpCount:        rating.UpCount,
+			DownCount:      rating.DownCount,
+			ViewerReaction: communityReactionName(rating.ViewerReaction),
+			IsViewer:       rating.UserID == userID && rating.ProfileID == profileID,
+		})
+	}
+
+	var average *float64
+	voteCount := 0
+	if len(ratings) > 0 {
+		value := ratings[0].AverageRating
+		average = &value
+		voteCount = ratings[0].TotalVoteCount
+	}
+	writeJSON(w, http.StatusOK, communityRatingsResponse{
+		AverageRating: average,
+		VoteCount:     voteCount,
+		Ratings:       items,
+	})
+}
+
+// HandleCommunityRatingAvatar serves an uploaded avatar through a short-lived,
+// opaque capability. It keeps storage keys (which contain account/profile IDs)
+// out of community API responses while still allowing an ordinary <img> tag to
+// load the asset without copying account credentials into a URL.
+func (h *RatingsHandler) HandleCommunityRatingAvatar(w http.ResponseWriter, r *http.Request) {
+	payload, ok := h.parseCommunityAvatarToken(chi.URLParam(r, "token"))
+	if !ok || h.AvatarStore == nil {
+		http.NotFound(w, r)
+		return
+	}
+	data, err := h.AvatarStore.GetObject(r.Context(), h.AvatarStore.Bucket(), payload.ObjectKey)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "private, max-age=900")
+	w.Header().Set("Content-Type", "image/webp")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+// HandleSetCommunityRatingReaction handles
+// PUT /ratings/{item_id}/community/{rating_key}/reaction.
+func (h *RatingsHandler) HandleSetCommunityRatingReaction(w http.ResponseWriter, r *http.Request) {
+	var req setCommunityRatingReactionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	var reaction int
+	switch strings.ToLower(strings.TrimSpace(req.Reaction)) {
+	case "up":
+		reaction = 1
+	case "down":
+		reaction = -1
+	default:
+		writeError(w, http.StatusBadRequest, "bad_request", "Reaction must be up or down")
+		return
+	}
+
+	target, ok := h.communityReactionTarget(w, r)
+	if !ok {
+		return
+	}
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+
+	inserted, err := h.ratingsRepo.SetCommunityReaction(
+		r.Context(),
+		userID,
+		profileID,
+		chi.URLParam(r, "item_id"),
+		target.UserID,
+		target.ProfileID,
+		reaction,
+	)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to set rating reaction")
+		return
+	}
+	if !inserted {
+		writeError(w, http.StatusNotFound, "not_found", "Rating not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleDeleteCommunityRatingReaction handles
+// DELETE /ratings/{item_id}/community/{rating_key}/reaction.
+func (h *RatingsHandler) HandleDeleteCommunityRatingReaction(w http.ResponseWriter, r *http.Request) {
+	target, ok := h.communityReactionTarget(w, r)
+	if !ok {
+		return
+	}
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	if err := h.ratingsRepo.DeleteCommunityReaction(
+		r.Context(),
+		userID,
+		profileID,
+		chi.URLParam(r, "item_id"),
+		target.UserID,
+		target.ProfileID,
+	); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to delete rating reaction")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *RatingsHandler) communityReactionTarget(w http.ResponseWriter, r *http.Request) (catalog.CommunityRating, bool) {
+	itemID := chi.URLParam(r, "item_id")
+	ratingKey := chi.URLParam(r, "rating_key")
+	if itemID == "" || ratingKey == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Item ID and rating key are required")
+		return catalog.CommunityRating{}, false
+	}
+	if err := h.itemRepo.EnsureAccessible(r.Context(), itemID, requestAccessFilter(r)); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return catalog.CommunityRating{}, false
+	}
+
+	userID := apimw.GetUserID(r.Context())
+	profileID := apimw.GetProfileID(r.Context())
+	ratings, err := h.ratingsRepo.ListCommunity(r.Context(), userID, profileID, itemID, 100, 0)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to find rating")
+		return catalog.CommunityRating{}, false
+	}
+	for _, rating := range ratings {
+		if communityRatingKey(itemID, rating) == ratingKey || legacyCommunityRatingKey(rating) == ratingKey {
+			return rating, true
+		}
+	}
+	writeError(w, http.StatusNotFound, "not_found", "Rating not found")
+	return catalog.CommunityRating{}, false
+}
+
+func communityRatingKey(mediaItemID string, rating catalog.CommunityRating) string {
+	// A card represents one profile's rating of one item. Keep its opaque key
+	// stable when the stars or rated_at value change so clients update the
+	// existing card instead of treating an edit as a new card.
+	raw := mediaItemID + "\x00" + strconv.Itoa(rating.UserID) + "\x00" + rating.ProfileID
+	digest := sha256.Sum256([]byte(raw))
+	return base64.RawURLEncoding.EncodeToString(digest[:16])
+}
+
+// legacyCommunityRatingKey keeps reactions from an already-open page working
+// during a rolling deployment from the timestamp-scoped key format.
+func legacyCommunityRatingKey(rating catalog.CommunityRating) string {
+	raw := strconv.Itoa(rating.UserID) + "\x00" + rating.ProfileID + "\x00" + rating.RatedAt.UTC().Format(time.RFC3339Nano)
+	digest := sha256.Sum256([]byte(raw))
+	return base64.RawURLEncoding.EncodeToString(digest[:16])
+}
+
+func abbreviateProfileName(name string) string {
+	runes := []rune(strings.TrimSpace(name))
+	if len(runes) == 0 {
+		return "User***"
+	}
+	return string(runes[0]) + strings.Repeat("*", len(runes)-1)
+}
+
+func communityReactionName(reaction int) string {
+	switch reaction {
+	case 1:
+		return "up"
+	case -1:
+		return "down"
+	default:
+		return ""
+	}
+}
+
+func (h *RatingsHandler) communityAvatarURL(ctx context.Context, rating catalog.CommunityRating) string {
+	if !isUploadedAvatarRef(rating.Avatar) {
+		_, avatarURL := resolveProfileAvatar(ctx, h.AvatarStore, h.AvatarTTL, rating.Avatar)
+		return avatarURL
+	}
+	if h.AvatarStore == nil || len(h.AvatarTokenSecret) == 0 {
+		return ""
+	}
+	ttl := h.AvatarTTL
+	if ttl <= 0 {
+		ttl = 15 * time.Minute
+	}
+	payload := communityAvatarTokenPayload{
+		ObjectKey: uploadedAvatarDisplayKey(strings.TrimPrefix(rating.Avatar, profileAvatarUploadPrefix)),
+		Version:   rating.ProfileUpdatedAt.UnixNano(),
+		ExpiresAt: time.Now().Add(ttl).Truncate(5 * time.Minute).Unix(),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	block, err := aes.NewCipher(communityAvatarEncryptionKey(h.AvatarTokenSecret))
+	if err != nil {
+		return ""
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return ""
+	}
+	nonceMAC := hmac.New(sha256.New, communityAvatarNonceKey(h.AvatarTokenSecret))
+	_, _ = nonceMAC.Write(raw)
+	nonce := nonceMAC.Sum(nil)[:gcm.NonceSize()]
+	sealed := gcm.Seal(nil, nonce, raw, nil)
+	token := append(append([]byte(nil), nonce...), sealed...)
+	return "/api/v1/ratings/community-avatar/" + base64.RawURLEncoding.EncodeToString(token)
+}
+
+func (h *RatingsHandler) parseCommunityAvatarToken(token string) (communityAvatarTokenPayload, bool) {
+	var payload communityAvatarTokenPayload
+	if token == "" || len(token) > 2048 || len(h.AvatarTokenSecret) == 0 {
+		return payload, false
+	}
+	sealed, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return payload, false
+	}
+	block, err := aes.NewCipher(communityAvatarEncryptionKey(h.AvatarTokenSecret))
+	if err != nil {
+		return payload, false
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil || len(sealed) <= gcm.NonceSize() {
+		return payload, false
+	}
+	raw, err := gcm.Open(nil, sealed[:gcm.NonceSize()], sealed[gcm.NonceSize():], nil)
+	if err != nil || json.Unmarshal(raw, &payload) != nil {
+		return communityAvatarTokenPayload{}, false
+	}
+	if !strings.HasPrefix(payload.ObjectKey, "profile-avatars/") ||
+		!strings.HasSuffix(payload.ObjectKey, "/w256.webp") ||
+		strings.Contains(payload.ObjectKey, "..") ||
+		payload.ExpiresAt < time.Now().Unix() {
+		return communityAvatarTokenPayload{}, false
+	}
+	return payload, true
+}
+
+func communityAvatarEncryptionKey(secret []byte) []byte {
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte("silo-community-avatar-encryption-v1"))
+	return mac.Sum(nil)
+}
+
+func communityAvatarNonceKey(secret []byte) []byte {
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte("silo-community-avatar-nonce-v1"))
+	return mac.Sum(nil)
 }

--- a/internal/api/handlers/ratings.go
+++ b/internal/api/handlers/ratings.go
@@ -8,16 +8,22 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"golang.org/x/sync/errgroup"
 )
+
+const communityProfileHydrationConcurrency = 8
 
 // ratingsRepository defines the data access interface for user ratings.
 type ratingsRepository interface {
@@ -39,6 +45,7 @@ type RatingsHandler struct {
 	AvatarStore             profileAvatarStore
 	AvatarTTL               time.Duration
 	AvatarTokenSecret       []byte
+	StoreProvider           userstore.UserStoreProvider
 }
 
 // NewRatingsHandler creates a new RatingsHandler.
@@ -247,15 +254,16 @@ func (h *RatingsHandler) HandleListCommunityRatings(w http.ResponseWriter, r *ht
 		return
 	}
 
-	limit, _ := parsePagination(r)
+	limit, offset := parsePagination(r)
 	if limit > 100 {
 		limit = 100
 	}
-	ratings, err := h.ratingsRepo.ListCommunity(r.Context(), userID, profileID, itemID, limit, 0)
+	ratings, err := h.ratingsRepo.ListCommunity(r.Context(), userID, profileID, itemID, limit, offset)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to list community ratings")
 		return
 	}
+	h.hydrateCommunityProfiles(r.Context(), ratings)
 
 	items := make([]communityRatingListItem, 0, len(ratings))
 	for _, rating := range ratings {
@@ -285,6 +293,71 @@ func (h *RatingsHandler) HandleListCommunityRatings(w http.ResponseWriter, r *ht
 		VoteCount:     voteCount,
 		Ratings:       items,
 	})
+}
+
+// hydrateCommunityProfiles fills metadata for profiles stored in per-user
+// SQLite. PostgreSQL-backed profiles are resolved by ListCommunity's join, so
+// this fallback adds no store reads on that path. Each unresolved account is
+// loaded once, with bounded concurrency and a hard maximum of 100 cards.
+func (h *RatingsHandler) hydrateCommunityProfiles(ctx context.Context, ratings []catalog.CommunityRating) {
+	if h.StoreProvider == nil {
+		return
+	}
+
+	unresolvedUsers := make(map[int]struct{})
+	for _, rating := range ratings {
+		if !rating.ProfileResolved {
+			unresolvedUsers[rating.UserID] = struct{}{}
+		}
+	}
+	if len(unresolvedUsers) == 0 {
+		return
+	}
+
+	profilesByUser := make(map[int]map[string]userstore.Profile, len(unresolvedUsers))
+	var profilesMu sync.Mutex
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(communityProfileHydrationConcurrency)
+	for userID := range unresolvedUsers {
+		userID := userID
+		group.Go(func() error {
+			store, err := h.StoreProvider.ForUser(groupCtx, userID)
+			if err != nil || store == nil {
+				slog.WarnContext(groupCtx, "community rating profile store unavailable", "component", "api", "user_id", userID, "error", err)
+				return nil
+			}
+			profiles, err := store.ListProfiles(groupCtx)
+			if err != nil {
+				slog.WarnContext(groupCtx, "community rating profiles unavailable", "component", "api", "user_id", userID, "error", err)
+				return nil
+			}
+			byID := make(map[string]userstore.Profile, len(profiles))
+			for _, profile := range profiles {
+				byID[profile.ID] = profile
+			}
+			profilesMu.Lock()
+			profilesByUser[userID] = byID
+			profilesMu.Unlock()
+			return nil
+		})
+	}
+	_ = group.Wait()
+
+	for i := range ratings {
+		if ratings[i].ProfileResolved {
+			continue
+		}
+		profile, ok := profilesByUser[ratings[i].UserID][ratings[i].ProfileID]
+		if !ok {
+			continue
+		}
+		ratings[i].ProfileName = profile.Name
+		ratings[i].Avatar = profile.Avatar
+		if updatedAt, err := time.Parse(time.RFC3339Nano, profile.UpdatedAt); err == nil {
+			ratings[i].ProfileUpdatedAt = updatedAt
+		}
+		ratings[i].ProfileResolved = true
+	}
 }
 
 // HandleCommunityRatingAvatar serves an uploaded avatar through a short-lived,

--- a/internal/api/handlers/ratings_community_test.go
+++ b/internal/api/handlers/ratings_community_test.go
@@ -1,0 +1,354 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type communityRatingsRepoStub struct {
+	community      []catalog.CommunityRating
+	setReaction    int
+	setTargetUser  int
+	setTargetID    string
+	setReactionOK  bool
+	deleteReaction bool
+}
+
+func (*communityRatingsRepoStub) Set(context.Context, int, string, string, int) error { return nil }
+func (*communityRatingsRepoStub) Get(context.Context, int, string, string) (*catalog.UserRating, error) {
+	return nil, nil
+}
+func (*communityRatingsRepoStub) Delete(context.Context, int, string, string) error { return nil }
+func (*communityRatingsRepoStub) List(context.Context, int, string, int, int) ([]catalog.UserRating, error) {
+	return nil, nil
+}
+func (s *communityRatingsRepoStub) ListCommunity(context.Context, int, string, string, int, int) ([]catalog.CommunityRating, error) {
+	return s.community, nil
+}
+func (s *communityRatingsRepoStub) SetCommunityReaction(_ context.Context, _ int, _ string, _ string, targetUserID int, targetProfileID string, reaction int) (bool, error) {
+	s.setTargetUser = targetUserID
+	s.setTargetID = targetProfileID
+	s.setReaction = reaction
+	return s.setReactionOK, nil
+}
+func (s *communityRatingsRepoStub) DeleteCommunityReaction(context.Context, int, string, string, int, string) error {
+	s.deleteReaction = true
+	return nil
+}
+
+type communityRatingsItemRepoStub struct{}
+
+func (communityRatingsItemRepoStub) GetByID(context.Context, string) (*models.MediaItem, error) {
+	return nil, nil
+}
+func (communityRatingsItemRepoStub) GetByIDs(context.Context, []string) ([]*models.MediaItem, error) {
+	return nil, nil
+}
+func (communityRatingsItemRepoStub) EnsureAccessible(context.Context, string, catalog.AccessFilter) error {
+	return nil
+}
+
+type communityAvatarStoreStub struct {
+	data   []byte
+	getKey string
+}
+
+func (s *communityAvatarStoreStub) GetObject(_ context.Context, _, key string) ([]byte, error) {
+	s.getKey = key
+	return s.data, nil
+}
+func (*communityAvatarStoreStub) PutObject(context.Context, string, string, []byte) error {
+	return nil
+}
+func (*communityAvatarStoreStub) DeleteObject(context.Context, string, string) error { return nil }
+func (*communityAvatarStoreStub) ListObjects(context.Context, string, string) ([]string, error) {
+	return nil, nil
+}
+func (*communityAvatarStoreStub) PresignGetURL(context.Context, string, string, time.Duration) (string, error) {
+	return "https://storage.invalid/private-key", nil
+}
+func (*communityAvatarStoreStub) Bucket() string { return "private" }
+
+func TestCommunityRatingsResponseMasksIdentityAndUsesCurrentAvatar(t *testing.T) {
+	ratedAt := time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC)
+	repo := &communityRatingsRepoStub{community: []catalog.CommunityRating{
+		{
+			UserID:         9,
+			ProfileID:      "profile-secret",
+			ProfileName:    "Samantha",
+			Avatar:         "preset:avatar-1",
+			Rating:         5,
+			RatedAt:        ratedAt,
+			UpCount:        7,
+			DownCount:      2,
+			ViewerReaction: 1,
+			AverageRating:  4.5,
+			TotalVoteCount: 2,
+		},
+	}}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	req := communityRatingsRequest(http.MethodGet, "/ratings/movie-1/community", "movie-1", "", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleListCommunityRatings(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	if strings.Contains(body, "profile-secret") || strings.Contains(body, "Samantha") {
+		t.Fatalf("response leaked profile identity: %s", body)
+	}
+	for _, want := range []string{
+		`"display_name":"S*******"`,
+		`"avatar_url":"/profile-avatars/avatar-1.svg"`,
+		`"rated_at":"2026-08-29T08:00:00Z"`,
+		`"viewer_reaction":"up"`,
+		`"average_rating":4.5`,
+		`"vote_count":2`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("response %q does not contain %q", body, want)
+		}
+	}
+}
+
+func TestSetCommunityRatingReactionResolvesOpaqueCardKey(t *testing.T) {
+	target := catalog.CommunityRating{
+		UserID:      9,
+		ProfileID:   "profile-secret",
+		ProfileName: "Samantha",
+		Rating:      5,
+		RatedAt:     time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC),
+	}
+	repo := &communityRatingsRepoStub{
+		community:     []catalog.CommunityRating{target},
+		setReactionOK: true,
+	}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	req := communityRatingsRequest(
+		http.MethodPut,
+		"/ratings/movie-1/community/key/reaction",
+		"movie-1",
+		communityRatingKey("movie-1", target),
+		strings.NewReader(`{"reaction":"down"}`),
+	)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleSetCommunityRatingReaction(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.setTargetUser != target.UserID || repo.setTargetID != target.ProfileID || repo.setReaction != -1 {
+		t.Fatalf("set target = (%d, %q, %d)", repo.setTargetUser, repo.setTargetID, repo.setReaction)
+	}
+}
+
+func TestSetCommunityRatingReactionAcceptsLegacyKeyDuringRollingDeploy(t *testing.T) {
+	target := catalog.CommunityRating{
+		UserID:      9,
+		ProfileID:   "profile-secret",
+		ProfileName: "Samantha",
+		Rating:      5,
+		RatedAt:     time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC),
+	}
+	repo := &communityRatingsRepoStub{
+		community:     []catalog.CommunityRating{target},
+		setReactionOK: true,
+	}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	req := communityRatingsRequest(
+		http.MethodPut,
+		"/ratings/movie-1/community/key/reaction",
+		"movie-1",
+		legacyCommunityRatingKey(target),
+		strings.NewReader(`{"reaction":"up"}`),
+	)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleSetCommunityRatingReaction(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestCommunityUploadedAvatarUsesOpaqueProxyCapability(t *testing.T) {
+	rating := catalog.CommunityRating{
+		UserID:           9,
+		ProfileID:        "profile-secret",
+		ProfileName:      "Samantha",
+		Avatar:           "upload:profile-avatars/9/profile-secret/original.webp",
+		ProfileUpdatedAt: time.Date(2026, 8, 29, 8, 5, 0, 0, time.UTC),
+		Rating:           5,
+		RatedAt:          time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC),
+	}
+	repo := &communityRatingsRepoStub{community: []catalog.CommunityRating{rating}}
+	store := &communityAvatarStoreStub{data: []byte("webp-data")}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	handler.AvatarStore = store
+	handler.AvatarTokenSecret = []byte("test-avatar-signing-secret")
+
+	avatarURL := handler.communityAvatarURL(context.Background(), rating)
+	if strings.Contains(avatarURL, "profile-secret") || strings.Contains(avatarURL, "profile-avatars/9") {
+		t.Fatalf("avatar URL leaked storage identity: %s", avatarURL)
+	}
+	const prefix = "/api/v1/ratings/community-avatar/"
+	if !strings.HasPrefix(avatarURL, prefix) {
+		t.Fatalf("avatar URL = %q", avatarURL)
+	}
+
+	req := communityRatingsRequest(
+		http.MethodGet,
+		avatarURL,
+		"",
+		"",
+		nil,
+	)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("token", strings.TrimPrefix(avatarURL, prefix))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+	recorder := httptest.NewRecorder()
+	handler.HandleCommunityRatingAvatar(recorder, req)
+
+	if recorder.Code != http.StatusOK || recorder.Body.String() != "webp-data" {
+		t.Fatalf("avatar response = %d %q", recorder.Code, recorder.Body.String())
+	}
+	if store.getKey != "profile-avatars/9/profile-secret/w256.webp" {
+		t.Fatalf("avatar object key = %q", store.getKey)
+	}
+}
+
+func TestCommunityAvatarTokenRejectsOversizedInput(t *testing.T) {
+	handler := NewRatingsHandler(&communityRatingsRepoStub{}, communityRatingsItemRepoStub{})
+	handler.AvatarTokenSecret = []byte("test-avatar-signing-secret")
+
+	if _, ok := handler.parseCommunityAvatarToken(strings.Repeat("a", 2049)); ok {
+		t.Fatal("oversized avatar token was accepted")
+	}
+}
+
+func TestSetCommunityRatingReactionAllowsOwnCard(t *testing.T) {
+	target := catalog.CommunityRating{
+		UserID:      7,
+		ProfileID:   "viewer-profile",
+		ProfileName: "Viewer",
+		Rating:      4,
+		RatedAt:     time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC),
+	}
+	repo := &communityRatingsRepoStub{
+		community:     []catalog.CommunityRating{target},
+		setReactionOK: true,
+	}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	req := communityRatingsRequest(
+		http.MethodPut,
+		"/ratings/movie-1/community/key/reaction",
+		"movie-1",
+		communityRatingKey("movie-1", target),
+		strings.NewReader(`{"reaction":"up"}`),
+	)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleSetCommunityRatingReaction(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.setTargetUser != target.UserID || repo.setTargetID != target.ProfileID || repo.setReaction != 1 {
+		t.Fatalf("set target = (%d, %q, %d)", repo.setTargetUser, repo.setTargetID, repo.setReaction)
+	}
+}
+
+func TestDeleteCommunityRatingReactionAllowsOwnCard(t *testing.T) {
+	target := catalog.CommunityRating{
+		UserID:      7,
+		ProfileID:   "viewer-profile",
+		ProfileName: "Viewer",
+		Rating:      4,
+		RatedAt:     time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC),
+	}
+	repo := &communityRatingsRepoStub{community: []catalog.CommunityRating{target}}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	req := communityRatingsRequest(
+		http.MethodDelete,
+		"/ratings/movie-1/community/key/reaction",
+		"movie-1",
+		communityRatingKey("movie-1", target),
+		nil,
+	)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleDeleteCommunityRatingReaction(recorder, req)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if !repo.deleteReaction {
+		t.Fatal("own-card reaction delete did not reach repository")
+	}
+}
+
+func TestAbbreviateProfileNameUsesRunes(t *testing.T) {
+	if got := abbreviateProfileName("Åsa-Marie"); got != "Å********" {
+		t.Fatalf("abbreviated name = %q", got)
+	}
+	if got := abbreviateProfileName("Mohommad"); got != "M*******" {
+		t.Fatalf("abbreviated name = %q", got)
+	}
+}
+
+func TestCommunityRatingKeyIsStableAcrossEditsAndScopedToOneCard(t *testing.T) {
+	rating := catalog.CommunityRating{
+		UserID:    7,
+		ProfileID: "viewer-profile",
+		Rating:    2,
+		RatedAt:   time.Date(2026, 8, 13, 8, 0, 0, 0, time.UTC),
+	}
+	original := communityRatingKey("movie-1", rating)
+
+	rating.Rating = 5
+	rating.RatedAt = time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC)
+	if edited := communityRatingKey("movie-1", rating); edited != original {
+		t.Fatalf("edited rating key = %q, want stable key %q", edited, original)
+	}
+
+	otherAccount := rating
+	otherAccount.UserID = 8
+	if got := communityRatingKey("movie-1", otherAccount); got == original {
+		t.Fatal("different account produced the same card key")
+	}
+	if got := communityRatingKey("movie-2", rating); got == original {
+		t.Fatal("different item produced the same card key")
+	}
+}
+
+func communityRatingsRequest(method, target, itemID, ratingKey string, body *strings.Reader) *http.Request {
+	var req *http.Request
+	if body == nil {
+		req = httptest.NewRequest(method, target, nil)
+	} else {
+		req = httptest.NewRequest(method, target, body)
+	}
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("item_id", itemID)
+	if ratingKey != "" {
+		routeContext.URLParams.Add("rating_key", ratingKey)
+	}
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeContext)
+	ctx = apimw.SetClaims(ctx, &auth.Claims{UserID: 7})
+	ctx = apimw.SetProfileID(ctx, "viewer-profile")
+	return req.WithContext(ctx)
+}

--- a/internal/api/handlers/ratings_community_test.go
+++ b/internal/api/handlers/ratings_community_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userstore"
 )
 
 type communityRatingsRepoStub struct {
@@ -23,6 +24,8 @@ type communityRatingsRepoStub struct {
 	setTargetID    string
 	setReactionOK  bool
 	deleteReaction bool
+	listLimit      int
+	listOffset     int
 }
 
 func (*communityRatingsRepoStub) Set(context.Context, int, string, string, int) error { return nil }
@@ -33,7 +36,9 @@ func (*communityRatingsRepoStub) Delete(context.Context, int, string, string) er
 func (*communityRatingsRepoStub) List(context.Context, int, string, int, int) ([]catalog.UserRating, error) {
 	return nil, nil
 }
-func (s *communityRatingsRepoStub) ListCommunity(context.Context, int, string, string, int, int) ([]catalog.CommunityRating, error) {
+func (s *communityRatingsRepoStub) ListCommunity(_ context.Context, _ int, _ string, _ string, limit, offset int) ([]catalog.CommunityRating, error) {
+	s.listLimit = limit
+	s.listOffset = offset
 	return s.community, nil
 }
 func (s *communityRatingsRepoStub) SetCommunityReaction(_ context.Context, _ int, _ string, _ string, targetUserID int, targetProfileID string, reaction int) (bool, error) {
@@ -84,17 +89,18 @@ func TestCommunityRatingsResponseMasksIdentityAndUsesCurrentAvatar(t *testing.T)
 	ratedAt := time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC)
 	repo := &communityRatingsRepoStub{community: []catalog.CommunityRating{
 		{
-			UserID:         9,
-			ProfileID:      "profile-secret",
-			ProfileName:    "Samantha",
-			Avatar:         "preset:avatar-1",
-			Rating:         5,
-			RatedAt:        ratedAt,
-			UpCount:        7,
-			DownCount:      2,
-			ViewerReaction: 1,
-			AverageRating:  4.5,
-			TotalVoteCount: 2,
+			UserID:          9,
+			ProfileID:       "profile-secret",
+			ProfileName:     "Samantha",
+			Avatar:          "preset:avatar-1",
+			ProfileResolved: true,
+			Rating:          5,
+			RatedAt:         ratedAt,
+			UpCount:         7,
+			DownCount:       2,
+			ViewerReaction:  1,
+			AverageRating:   4.5,
+			TotalVoteCount:  2,
 		},
 	}}
 	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
@@ -121,6 +127,62 @@ func TestCommunityRatingsResponseMasksIdentityAndUsesCurrentAvatar(t *testing.T)
 		if !strings.Contains(body, want) {
 			t.Errorf("response %q does not contain %q", body, want)
 		}
+	}
+}
+
+func TestCommunityRatingsHydratesSQLiteProfileMetadata(t *testing.T) {
+	ratedAt := time.Date(2026, 8, 29, 8, 0, 0, 0, time.UTC)
+	store := newEmptyProfileTestStore(t)
+	if err := store.CreateProfile(context.Background(), userstore.Profile{
+		ID:        "profile-secret",
+		Name:      "Samantha",
+		Avatar:    "preset:avatar-1",
+		UpdatedAt: ratedAt.Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatalf("create SQLite profile: %v", err)
+	}
+	repo := &communityRatingsRepoStub{community: []catalog.CommunityRating{
+		{
+			UserID:          9,
+			ProfileID:       "profile-secret",
+			ProfileResolved: false,
+			Rating:          5,
+			RatedAt:         ratedAt,
+			AverageRating:   5,
+			TotalVoteCount:  1,
+		},
+	}}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	handler.StoreProvider = mappedTestUserStoreProvider{stores: map[int]userstore.UserStore{9: store}}
+	req := communityRatingsRequest(http.MethodGet, "/ratings/movie-1/community", "movie-1", "", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleListCommunityRatings(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	for _, want := range []string{`"display_name":"S*******"`, `"avatar_url":"/profile-avatars/avatar-1.svg"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("response %q does not contain %q", body, want)
+		}
+	}
+}
+
+func TestCommunityRatingsPassesPaginationOffset(t *testing.T) {
+	repo := &communityRatingsRepoStub{}
+	handler := NewRatingsHandler(repo, communityRatingsItemRepoStub{})
+	req := communityRatingsRequest(http.MethodGet, "/ratings/movie-1/community?limit=17&offset=23", "movie-1", "", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.HandleListCommunityRatings(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.listLimit != 17 || repo.listOffset != 23 {
+		t.Fatalf("pagination = limit %d offset %d, want 17 and 23", repo.listLimit, repo.listOffset)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -949,6 +949,10 @@ func NewRouter(deps Dependencies) chi.Router {
 	var recsRepoForStale *recommendations.Repo
 	if ratingsRepo != nil && itemRepo != nil {
 		ratingsHandler = handlers.NewRatingsHandler(ratingsRepo, itemRepo)
+		ratingsHandler.AvatarStore = deps.S3Private
+		if deps.Config != nil {
+			ratingsHandler.AvatarTokenSecret = []byte(deps.Config.Auth.JWTSecret)
+		}
 		if deps.DB != nil {
 			recsRepoForStale = recommendations.NewRepo(deps.DB)
 			ratingsHandler.SetProfileStaler(recsRepoForStale)
@@ -2120,6 +2124,18 @@ func NewRouter(deps Dependencies) chi.Router {
 			})
 		}
 
+		// Uploaded community avatars use a short-lived signed capability because
+		// browser image requests cannot attach the selected profile's auth header.
+		// The handler proxies the object so storage keys containing private IDs
+		// never reach another household user's browser.
+		if ratingsHandler != nil && deps.S3Private != nil {
+			if deps.RateLimitMW != nil {
+				r.With(deps.RateLimitMW.Handler).Get("/ratings/community-avatar/{token}", ratingsHandler.HandleCommunityRatingAvatar)
+			} else {
+				r.Get("/ratings/community-avatar/{token}", ratingsHandler.HandleCommunityRatingAvatar)
+			}
+		}
+
 		// All remaining routes require auth.
 		if authMiddleware != nil {
 			r.Group(func(r chi.Router) {
@@ -2372,6 +2388,10 @@ func NewRouter(deps Dependencies) chi.Router {
 						r.Route("/ratings", func(r chi.Router) {
 							r.Use(apimw.RequireProfile)
 							r.Get("/", ratingsHandler.HandleListRatings)
+							r.Get("/capabilities", ratingsHandler.HandleCapabilities)
+							r.Get("/{item_id}/community", ratingsHandler.HandleListCommunityRatings)
+							r.Put("/{item_id}/community/{rating_key}/reaction", ratingsHandler.HandleSetCommunityRatingReaction)
+							r.Delete("/{item_id}/community/{rating_key}/reaction", ratingsHandler.HandleDeleteCommunityRatingReaction)
 							r.Get("/{item_id}", ratingsHandler.HandleGetRating)
 							r.Put("/{item_id}", ratingsHandler.HandleSetRating)
 							r.Delete("/{item_id}", ratingsHandler.HandleDeleteRating)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -861,7 +861,12 @@ func NewRouter(deps Dependencies) chi.Router {
 		profileHandler.UserRepo = userRepo
 		profileHandler.EventsHub = deps.EventsHub
 		profileHandler.ProfileTokens = profileTokenService
-		profileHandler.AvatarStore = deps.S3Private
+		if deps.S3Private != nil {
+			profileHandler.AvatarStore = deps.S3Private
+		}
+		if ratingsRepo != nil {
+			profileHandler.RatingProfilePurger = ratingsRepo
+		}
 		profileHandler.SessionsReader = playbackSessionsLoader
 		personalDataHandler = handlers.NewPersonalDataHandler(deps.UserStoreProvider, itemRepo)
 		if detailSvc != nil {
@@ -949,7 +954,12 @@ func NewRouter(deps Dependencies) chi.Router {
 	var recsRepoForStale *recommendations.Repo
 	if ratingsRepo != nil && itemRepo != nil {
 		ratingsHandler = handlers.NewRatingsHandler(ratingsRepo, itemRepo)
-		ratingsHandler.AvatarStore = deps.S3Private
+		if deps.S3Private != nil {
+			ratingsHandler.AvatarStore = deps.S3Private
+		}
+		if deps.UserStoreProvider != nil {
+			ratingsHandler.StoreProvider = deps.UserStoreProvider
+		}
 		if deps.Config != nil {
 			ratingsHandler.AvatarTokenSecret = []byte(deps.Config.Auth.JWTSecret)
 		}

--- a/internal/catalog/ratings_repo.go
+++ b/internal/catalog/ratings_repo.go
@@ -28,6 +28,7 @@ type CommunityRating struct {
 	ProfileName      string
 	Avatar           string
 	ProfileUpdatedAt time.Time
+	ProfileResolved  bool
 	Rating           int
 	RatedAt          time.Time
 	UpCount          int
@@ -89,6 +90,37 @@ func (r *RatingsRepo) Delete(ctx context.Context, userID int, profileID, mediaIt
 	)
 	if err != nil {
 		return fmt.Errorf("delete rating: %w", err)
+	}
+	return nil
+}
+
+// PurgeProfile removes ratings owned by a deleted profile and reactions made
+// by it. Profile records may live in per-user SQLite, so PostgreSQL cannot
+// enforce the reactor-side cleanup with a foreign key.
+func (r *RatingsRepo) PurgeProfile(ctx context.Context, userID int, profileID string) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin profile rating purge: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM household_rating_reactions
+		WHERE (target_user_id = $1 AND target_profile_id = $2)
+		   OR (reactor_user_id = $1 AND reactor_profile_id = $2)`,
+		userID, profileID,
+	); err != nil {
+		return fmt.Errorf("purge profile rating reactions: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM user_ratings
+		WHERE user_id = $1 AND profile_id = $2`,
+		userID, profileID,
+	); err != nil {
+		return fmt.Errorf("purge profile ratings: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit profile rating purge: %w", err)
 	}
 	return nil
 }
@@ -172,9 +204,10 @@ func (r *RatingsRepo) ListCommunity(
 		)
 		SELECT ur.user_id,
 		       ur.profile_id,
-		       up.name AS profile_name,
-		       up.avatar,
-		       up.updated_at AS profile_updated_at,
+		       COALESCE(up.name, '') AS profile_name,
+		       COALESCE(up.avatar, '') AS avatar,
+		       COALESCE(up.updated_at, to_timestamp(0)) AS profile_updated_at,
+		       (up.id IS NOT NULL) AS profile_resolved,
 		       ur.rating,
 		       ur.rated_at,
 		       COALESCE(rc.up_count, 0),
@@ -183,7 +216,7 @@ func (r *RatingsRepo) ListCommunity(
 		       AVG(ur.rating) OVER ()::double precision AS average_rating,
 		       COUNT(*) OVER ()::integer AS total_vote_count
 		FROM user_ratings ur
-		JOIN user_profiles up
+		LEFT JOIN user_profiles up
 		  ON up.user_id = ur.user_id
 		 AND up.id = ur.profile_id
 		LEFT JOIN reaction_counts rc
@@ -211,6 +244,7 @@ func (r *RatingsRepo) ListCommunity(
 			&rating.ProfileName,
 			&rating.Avatar,
 			&rating.ProfileUpdatedAt,
+			&rating.ProfileResolved,
 			&rating.Rating,
 			&rating.RatedAt,
 			&rating.UpCount,

--- a/internal/catalog/ratings_repo.go
+++ b/internal/catalog/ratings_repo.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,6 +17,24 @@ type UserRating struct {
 	MediaItemID string    `json:"media_item_id"`
 	Rating      int       `json:"rating"`
 	RatedAt     time.Time `json:"rated_at"`
+}
+
+// CommunityRating is a profile's explicit rating plus its server-local reaction
+// totals. User and profile IDs stay internal; handlers expose only an opaque
+// per-rating key and an abbreviated display name.
+type CommunityRating struct {
+	UserID           int
+	ProfileID        string
+	ProfileName      string
+	Avatar           string
+	ProfileUpdatedAt time.Time
+	Rating           int
+	RatedAt          time.Time
+	UpCount          int
+	DownCount        int
+	ViewerReaction   int
+	AverageRating    float64
+	TotalVoteCount   int
 }
 
 // RatingsRepo provides access to the user_ratings table.
@@ -33,7 +52,7 @@ func (r *RatingsRepo) Set(ctx context.Context, userID int, profileID, mediaItemI
 	_, err := r.pool.Exec(ctx, `
 		INSERT INTO user_ratings (user_id, profile_id, media_item_id, rating, rated_at)
 		VALUES ($1, $2, $3, $4, NOW())
-		ON CONFLICT (user_id, profile_id, media_item_id)
+		ON CONFLICT ON CONSTRAINT user_ratings_pkey
 		DO UPDATE SET rating = EXCLUDED.rating, rated_at = EXCLUDED.rated_at`,
 		userID, profileID, mediaItemID, rating,
 	)
@@ -52,7 +71,7 @@ func (r *RatingsRepo) Get(ctx context.Context, userID int, profileID, mediaItemI
 		WHERE user_id = $1 AND profile_id = $2 AND media_item_id = $3`,
 		userID, profileID, mediaItemID,
 	).Scan(&ur.UserID, &ur.ProfileID, &ur.MediaItemID, &ur.Rating, &ur.RatedAt)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -123,4 +142,171 @@ func (r *RatingsRepo) ListForItems(ctx context.Context, userID int, profileID st
 		result[itemID] = rating
 	}
 	return result, rows.Err()
+}
+
+// ListCommunity returns explicit profile ratings for an item. The returned
+// average is display-only and never feeds personal recommendation signals.
+func (r *RatingsRepo) ListCommunity(
+	ctx context.Context,
+	viewerUserID int,
+	viewerProfileID string,
+	mediaItemID string,
+	limit int,
+	offset int,
+) ([]CommunityRating, error) {
+	rows, err := r.pool.Query(ctx, `
+		WITH reaction_counts AS (
+			SELECT target_user_id,
+			       target_profile_id,
+			       COUNT(*) FILTER (WHERE reaction = 1)::integer AS up_count,
+			       COUNT(*) FILTER (WHERE reaction = -1)::integer AS down_count,
+			       COALESCE(
+				MAX(reaction) FILTER (
+					WHERE reactor_user_id = $2 AND reactor_profile_id = $3
+				),
+				0
+			   )::integer AS viewer_reaction
+			FROM household_rating_reactions
+			WHERE media_item_id = $1
+			GROUP BY target_user_id, target_profile_id
+		)
+		SELECT ur.user_id,
+		       ur.profile_id,
+		       up.name AS profile_name,
+		       up.avatar,
+		       up.updated_at AS profile_updated_at,
+		       ur.rating,
+		       ur.rated_at,
+		       COALESCE(rc.up_count, 0),
+		       COALESCE(rc.down_count, 0),
+		       COALESCE(rc.viewer_reaction, 0),
+		       AVG(ur.rating) OVER ()::double precision AS average_rating,
+		       COUNT(*) OVER ()::integer AS total_vote_count
+		FROM user_ratings ur
+		JOIN user_profiles up
+		  ON up.user_id = ur.user_id
+		 AND up.id = ur.profile_id
+		LEFT JOIN reaction_counts rc
+		  ON rc.target_user_id = ur.user_id
+		 AND rc.target_profile_id = ur.profile_id
+		WHERE ur.media_item_id = $1
+		ORDER BY (ur.user_id = $2 AND ur.profile_id = $3) DESC,
+		         ur.rated_at DESC,
+		         ur.user_id,
+		         ur.profile_id
+		LIMIT $4 OFFSET $5`,
+		mediaItemID, viewerUserID, viewerProfileID, limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list community ratings: %w", err)
+	}
+	defer rows.Close()
+
+	ratings := make([]CommunityRating, 0, limit)
+	for rows.Next() {
+		var rating CommunityRating
+		if err := rows.Scan(
+			&rating.UserID,
+			&rating.ProfileID,
+			&rating.ProfileName,
+			&rating.Avatar,
+			&rating.ProfileUpdatedAt,
+			&rating.Rating,
+			&rating.RatedAt,
+			&rating.UpCount,
+			&rating.DownCount,
+			&rating.ViewerReaction,
+			&rating.AverageRating,
+			&rating.TotalVoteCount,
+		); err != nil {
+			return nil, fmt.Errorf("scan community rating: %w", err)
+		}
+		ratings = append(ratings, rating)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate community ratings: %w", err)
+	}
+	return ratings, nil
+}
+
+// SetCommunityReaction records one profile-scoped reaction for an existing
+// rating. Selecting from user_ratings keeps a delete racing the request from
+// leaving an orphaned reaction.
+func (r *RatingsRepo) SetCommunityReaction(
+	ctx context.Context,
+	viewerUserID int,
+	viewerProfileID string,
+	mediaItemID string,
+	targetUserID int,
+	targetProfileID string,
+	reaction int,
+) (bool, error) {
+	var inserted int
+	err := r.pool.QueryRow(ctx, `
+		INSERT INTO household_rating_reactions (
+			media_item_id,
+			target_user_id,
+			target_profile_id,
+			reactor_user_id,
+			reactor_profile_id,
+			reaction,
+			reacted_at
+		)
+		SELECT ur.media_item_id, ur.user_id, ur.profile_id, $4, $5, $6, NOW()
+		FROM user_ratings ur
+		WHERE ur.media_item_id = $1
+		  AND ur.user_id = $2
+		  AND ur.profile_id = $3
+		ON CONFLICT (
+			media_item_id,
+			target_user_id,
+			target_profile_id,
+			reactor_user_id,
+			reactor_profile_id
+		) DO UPDATE
+		SET reaction = EXCLUDED.reaction,
+		    reacted_at = EXCLUDED.reacted_at
+		RETURNING 1`,
+		mediaItemID,
+		targetUserID,
+		targetProfileID,
+		viewerUserID,
+		viewerProfileID,
+		reaction,
+	).Scan(&inserted)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("set community rating reaction: %w", err)
+	}
+	return inserted == 1, nil
+}
+
+// DeleteCommunityReaction removes the current profile's reaction to a rating.
+func (r *RatingsRepo) DeleteCommunityReaction(
+	ctx context.Context,
+	viewerUserID int,
+	viewerProfileID string,
+	mediaItemID string,
+	targetUserID int,
+	targetProfileID string,
+) error {
+	_, err := r.pool.Exec(ctx, `
+		DELETE FROM household_rating_reactions
+		WHERE media_item_id = $1
+		  AND target_user_id = $2
+		  AND target_profile_id = $3
+		  AND reactor_user_id = $4
+		  AND reactor_profile_id = $5`,
+		mediaItemID,
+		targetUserID,
+		targetProfileID,
+		viewerUserID,
+		viewerProfileID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete community rating reaction: %w", err)
+	}
+	return nil
 }

--- a/internal/catalog/ratings_repo_test.go
+++ b/internal/catalog/ratings_repo_test.go
@@ -1,0 +1,95 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestRatingsRepoSupportsSQLiteProfilesAndProfilePurge(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	suffix := time.Now().UnixNano()
+	var sqliteUserID, targetUserID int
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`,
+		fmt.Sprintf("ratings-sqlite-%d", suffix),
+	).Scan(&sqliteUserID); err != nil {
+		t.Fatalf("seed SQLite-profile user: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`,
+		fmt.Sprintf("ratings-target-%d", suffix),
+	).Scan(&targetUserID); err != nil {
+		t.Fatalf("seed target user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = ANY($1)`, []int{sqliteUserID, targetUserID})
+	})
+
+	profileID := fmt.Sprintf("sqlite-profile-%d", suffix)
+	targetProfileID := fmt.Sprintf("target-profile-%d", suffix)
+	ownedItemID := fmt.Sprintf("ratings-owned-%d", suffix)
+	targetItemID := fmt.Sprintf("ratings-target-item-%d", suffix)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO user_ratings (user_id, profile_id, media_item_id, rating, rated_at)
+		VALUES ($1, $2, $3, 5, now()),
+		       ($4, $5, $6, 4, now())`,
+		sqliteUserID, profileID, ownedItemID,
+		targetUserID, targetProfileID, targetItemID,
+	); err != nil {
+		t.Fatalf("seed ratings: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO household_rating_reactions (
+			media_item_id,
+			target_user_id,
+			target_profile_id,
+			reactor_user_id,
+			reactor_profile_id,
+			reaction
+		) VALUES ($1, $2, $3, $4, $5, 1)`,
+		targetItemID, targetUserID, targetProfileID, sqliteUserID, profileID,
+	); err != nil {
+		t.Fatalf("seed SQLite-profile reaction: %v", err)
+	}
+
+	repo := NewRatingsRepo(pool)
+	ratings, err := repo.ListCommunity(ctx, sqliteUserID, profileID, ownedItemID, 100, 0)
+	if err != nil {
+		t.Fatalf("list community ratings: %v", err)
+	}
+	if len(ratings) != 1 || ratings[0].ProfileResolved {
+		t.Fatalf("community ratings = %+v, want one unresolved SQLite-profile card", ratings)
+	}
+
+	if err := repo.PurgeProfile(ctx, sqliteUserID, profileID); err != nil {
+		t.Fatalf("purge profile ratings: %v", err)
+	}
+	var ownedCount, reactionCount, targetCount int
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			(SELECT count(*) FROM user_ratings WHERE user_id = $1 AND profile_id = $2),
+			(SELECT count(*) FROM household_rating_reactions WHERE reactor_user_id = $1 AND reactor_profile_id = $2),
+			(SELECT count(*) FROM user_ratings WHERE user_id = $3 AND profile_id = $4)`,
+		sqliteUserID, profileID, targetUserID, targetProfileID,
+	).Scan(&ownedCount, &reactionCount, &targetCount); err != nil {
+		t.Fatalf("count purged rating data: %v", err)
+	}
+	if ownedCount != 0 || reactionCount != 0 || targetCount != 1 {
+		t.Fatalf("post-purge counts = owned %d reactions %d target %d, want 0, 0, 1", ownedCount, reactionCount, targetCount)
+	}
+}

--- a/internal/catalog/reattribute/reattribute.go
+++ b/internal/catalog/reattribute/reattribute.go
@@ -270,6 +270,35 @@ func movePairs(ctx context.Context, tx pgx.Tx, pairs []IDPair, report *Report) (
 // its destination before that delete cascades.
 func mergeRatingReactionCollisions(ctx context.Context, tx pgx.Tx, fromIDs, toIDs []string) error {
 	_, err := tx.Exec(ctx, `
+		WITH reaction_candidates AS (
+			SELECT p.to_id AS media_item_id,
+			       source_reaction.target_user_id,
+			       source_reaction.target_profile_id,
+			       source_reaction.reactor_user_id,
+			       source_reaction.reactor_profile_id,
+			       source_reaction.reaction,
+			       source_reaction.reacted_at,
+			       ROW_NUMBER() OVER (
+				       PARTITION BY p.to_id,
+				                    source_reaction.target_user_id,
+				                    source_reaction.target_profile_id,
+				                    source_reaction.reactor_user_id,
+				                    source_reaction.reactor_profile_id
+				       ORDER BY source_reaction.reacted_at DESC,
+				                p.from_id,
+				                source_reaction.reaction DESC
+			       ) AS candidate_rank
+			FROM (
+				SELECT DISTINCT p.from_id, p.to_id
+				FROM `+pairsCTE+`
+			) p
+			JOIN household_rating_reactions source_reaction
+			  ON source_reaction.media_item_id = p.from_id
+			JOIN user_ratings destination_rating
+			  ON destination_rating.media_item_id = p.to_id
+			 AND destination_rating.user_id = source_reaction.target_user_id
+			 AND destination_rating.profile_id = source_reaction.target_profile_id
+		)
 		INSERT INTO household_rating_reactions (
 			media_item_id,
 			target_user_id,
@@ -279,20 +308,15 @@ func mergeRatingReactionCollisions(ctx context.Context, tx pgx.Tx, fromIDs, toID
 			reaction,
 			reacted_at
 		)
-		SELECT p.to_id,
-		       source_reaction.target_user_id,
-		       source_reaction.target_profile_id,
-		       source_reaction.reactor_user_id,
-		       source_reaction.reactor_profile_id,
-		       source_reaction.reaction,
-		       source_reaction.reacted_at
-		FROM `+pairsCTE+`
-		JOIN household_rating_reactions source_reaction
-		  ON source_reaction.media_item_id = p.from_id
-		JOIN user_ratings destination_rating
-		  ON destination_rating.media_item_id = p.to_id
-		 AND destination_rating.user_id = source_reaction.target_user_id
-		 AND destination_rating.profile_id = source_reaction.target_profile_id
+		SELECT media_item_id,
+		       target_user_id,
+		       target_profile_id,
+		       reactor_user_id,
+		       reactor_profile_id,
+		       reaction,
+		       reacted_at
+		FROM reaction_candidates
+		WHERE candidate_rank = 1
 		ON CONFLICT (
 			media_item_id,
 			target_user_id,

--- a/internal/catalog/reattribute/reattribute.go
+++ b/internal/catalog/reattribute/reattribute.go
@@ -251,12 +251,64 @@ func movePairs(ctx context.Context, tx pgx.Tx, pairs []IDPair, report *Report) (
 	report.ProgressMoved += moved
 	report.ProgressConflicts += conflicts
 
+	if err := mergeRatingReactionCollisions(ctx, tx, fromIDs, toIDs); err != nil {
+		return err
+	}
 	for _, intent := range intentTables {
 		movedRows, err := moveIntentPairs(ctx, tx, intent.table, intent.idColumn, intent.keyCols, fromIDs, toIDs)
 		if err != nil {
 			return err
 		}
 		report.IntentMoved += movedRows
+	}
+	return nil
+}
+
+// mergeRatingReactionCollisions preserves reactions when both the source and
+// destination already have a rating from the same profile. The generic intent
+// mover deletes the duplicate source rating, so reactions must be copied onto
+// its destination before that delete cascades.
+func mergeRatingReactionCollisions(ctx context.Context, tx pgx.Tx, fromIDs, toIDs []string) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO household_rating_reactions (
+			media_item_id,
+			target_user_id,
+			target_profile_id,
+			reactor_user_id,
+			reactor_profile_id,
+			reaction,
+			reacted_at
+		)
+		SELECT p.to_id,
+		       source_reaction.target_user_id,
+		       source_reaction.target_profile_id,
+		       source_reaction.reactor_user_id,
+		       source_reaction.reactor_profile_id,
+		       source_reaction.reaction,
+		       source_reaction.reacted_at
+		FROM `+pairsCTE+`
+		JOIN household_rating_reactions source_reaction
+		  ON source_reaction.media_item_id = p.from_id
+		JOIN user_ratings destination_rating
+		  ON destination_rating.media_item_id = p.to_id
+		 AND destination_rating.user_id = source_reaction.target_user_id
+		 AND destination_rating.profile_id = source_reaction.target_profile_id
+		ON CONFLICT (
+			media_item_id,
+			target_user_id,
+			target_profile_id,
+			reactor_user_id,
+			reactor_profile_id
+		) DO UPDATE
+		SET reaction = CASE
+				WHEN EXCLUDED.reacted_at >= household_rating_reactions.reacted_at
+				THEN EXCLUDED.reaction
+				ELSE household_rating_reactions.reaction
+			END,
+		    reacted_at = GREATEST(household_rating_reactions.reacted_at, EXCLUDED.reacted_at)
+	`, fromIDs, toIDs)
+	if err != nil {
+		return fmt.Errorf("reattribute: rating reaction collisions: %w", err)
 	}
 	return nil
 }

--- a/internal/catalog/reattribute/reattribute_db_test.go
+++ b/internal/catalog/reattribute/reattribute_db_test.go
@@ -402,3 +402,72 @@ func TestRun_PreviewRollsBack(t *testing.T) {
 		t.Fatalf("after rollback progress item = %q, want untouched %q", got, from)
 	}
 }
+
+func TestMergeRatingReactionCollisionsDeduplicatesManySourcesToOneDestination(t *testing.T) {
+	env := newTestEnv(t)
+	ctx := context.Background()
+	sourceOne := fmt.Sprintf("rating-source-one-%d", env.suffix)
+	sourceTwo := fmt.Sprintf("rating-source-two-%d", env.suffix)
+	destination := fmt.Sprintf("rating-destination-%d", env.suffix)
+	reactorProfileID := fmt.Sprintf("reactor-%d", env.suffix)
+
+	if _, err := env.pool.Exec(ctx, `
+		INSERT INTO user_ratings (user_id, profile_id, media_item_id, rating, rated_at)
+		VALUES ($1, $2, $3, 3, now() - interval '3 hours'),
+		       ($1, $2, $4, 4, now() - interval '2 hours'),
+		       ($1, $2, $5, 5, now() - interval '1 hour')`,
+		env.userID, env.profileID, sourceOne, sourceTwo, destination,
+	); err != nil {
+		t.Fatalf("seed ratings: %v", err)
+	}
+	if _, err := env.pool.Exec(ctx, `
+		INSERT INTO household_rating_reactions (
+			media_item_id,
+			target_user_id,
+			target_profile_id,
+			reactor_user_id,
+			reactor_profile_id,
+			reaction,
+			reacted_at
+		)
+		VALUES ($1, $3, $4, $3, $5, 1, now() - interval '2 hours'),
+		       ($2, $3, $4, $3, $5, -1, now() - interval '1 hour')`,
+		sourceOne, sourceTwo, env.userID, env.profileID, reactorProfileID,
+	); err != nil {
+		t.Fatalf("seed rating reactions: %v", err)
+	}
+
+	tx, err := env.pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := mergeRatingReactionCollisions(
+		ctx,
+		tx,
+		[]string{sourceOne, sourceTwo},
+		[]string{destination, destination},
+	); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("merge reactions: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var count, reaction int
+	if err := env.pool.QueryRow(ctx, `
+		SELECT count(*), max(reaction)
+		FROM household_rating_reactions
+		WHERE media_item_id = $1
+		  AND target_user_id = $2
+		  AND target_profile_id = $3
+		  AND reactor_user_id = $2
+		  AND reactor_profile_id = $4`,
+		destination, env.userID, env.profileID, reactorProfileID,
+	).Scan(&count, &reaction); err != nil {
+		t.Fatalf("load destination reaction: %v", err)
+	}
+	if count != 1 || reaction != -1 {
+		t.Fatalf("destination reaction = count %d value %d, want one newest reaction (-1)", count, reaction)
+	}
+}

--- a/internal/metadata/provider_id_integrity.go
+++ b/internal/metadata/provider_id_integrity.go
@@ -709,6 +709,38 @@ var mediaItemMergeSteps = []mediaItemMergeStep{
 			ON CONFLICT (user_id, profile_id, media_item_id) DO UPDATE
 			SET rating = CASE WHEN EXCLUDED.rated_at >= user_ratings.rated_at THEN EXCLUDED.rating ELSE user_ratings.rating END,
 			    rated_at = GREATEST(user_ratings.rated_at, EXCLUDED.rated_at)`},
+	{"merge rating reactions", `
+			INSERT INTO household_rating_reactions (
+				media_item_id,
+				target_user_id,
+				target_profile_id,
+				reactor_user_id,
+				reactor_profile_id,
+				reaction,
+				reacted_at
+			)
+			SELECT $2,
+			       target_user_id,
+			       target_profile_id,
+			       reactor_user_id,
+			       reactor_profile_id,
+			       reaction,
+			       reacted_at
+			FROM household_rating_reactions
+			WHERE media_item_id = $1
+			ON CONFLICT (
+				media_item_id,
+				target_user_id,
+				target_profile_id,
+				reactor_user_id,
+				reactor_profile_id
+			) DO UPDATE
+			SET reaction = CASE
+					WHEN EXCLUDED.reacted_at >= household_rating_reactions.reacted_at
+					THEN EXCLUDED.reaction
+					ELSE household_rating_reactions.reaction
+				END,
+			    reacted_at = GREATEST(household_rating_reactions.reacted_at, EXCLUDED.reacted_at)`},
 	{"delete source ratings", `DELETE FROM user_ratings WHERE media_item_id = $1`},
 	{"merge progress", `
 			INSERT INTO user_watch_progress (

--- a/internal/userstore/pgstore/profiles.go
+++ b/internal/userstore/pgstore/profiles.go
@@ -301,6 +301,16 @@ func (s *PostgresUserStore) DeleteProfile(ctx context.Context, id string) error 
 		return fmt.Errorf("deleting collection items for profile %s: %w", id, err)
 	}
 
+	// The reactor profile may live outside PostgreSQL, so community reactions
+	// deliberately have no reactor-side profile FK. Remove both ratings owned
+	// by this profile and reactions it made while the profile delete is atomic.
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM household_rating_reactions
+		WHERE (target_user_id = $1 AND target_profile_id = $2)
+		   OR (reactor_user_id = $1 AND reactor_profile_id = $2)`, s.userID, id); err != nil {
+		return fmt.Errorf("deleting rating reactions for profile %s: %w", id, err)
+	}
+
 	// user_setting_values is listed rather than left to its composite profile
 	// FK so both backends delete identically: the per-user SQLite store has no
 	// foreign keys at all. Account-scope rows carry a NULL profile_id and are

--- a/internal/userstore/pgstore/profiles.go
+++ b/internal/userstore/pgstore/profiles.go
@@ -309,6 +309,7 @@ func (s *PostgresUserStore) DeleteProfile(ctx context.Context, id string) error 
 		"user_favorites",
 		"user_watchlist",
 		"user_watch_progress",
+		"user_ratings",
 		"user_collection_sort_preferences",
 		"user_personal_collections",
 		"user_series_playback_preferences",

--- a/migrations/sql/20260829083235_add_household_rating_reactions.sql
+++ b/migrations/sql/20260829083235_add_household_rating_reactions.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+CREATE INDEX IF NOT EXISTS idx_user_ratings_media_item_rated
+    ON user_ratings (media_item_id, rated_at DESC);
+
+CREATE TABLE household_rating_reactions (
+    media_item_id text NOT NULL,
+    target_user_id integer NOT NULL,
+    target_profile_id text NOT NULL,
+    reactor_user_id integer NOT NULL,
+    reactor_profile_id text NOT NULL,
+    reaction smallint NOT NULL,
+    reacted_at timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT household_rating_reactions_pkey PRIMARY KEY (
+        media_item_id,
+        target_user_id,
+        target_profile_id,
+        reactor_user_id,
+        reactor_profile_id
+    ),
+    CONSTRAINT household_rating_reactions_value_check CHECK (reaction IN (-1, 1)),
+    CONSTRAINT household_rating_reactions_no_self_check CHECK (
+        target_user_id <> reactor_user_id OR target_profile_id <> reactor_profile_id
+    ),
+    CONSTRAINT household_rating_reactions_target_fkey FOREIGN KEY (
+        target_user_id,
+        target_profile_id,
+        media_item_id
+    ) REFERENCES user_ratings (user_id, profile_id, media_item_id)
+      ON UPDATE CASCADE
+      ON DELETE CASCADE,
+    CONSTRAINT household_rating_reactions_reactor_profile_fkey FOREIGN KEY (
+        reactor_user_id,
+        reactor_profile_id
+    ) REFERENCES user_profiles (user_id, id)
+      ON DELETE CASCADE
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS household_rating_reactions;
+DROP INDEX IF EXISTS idx_user_ratings_media_item_rated;

--- a/migrations/sql/20260829083235_add_household_rating_reactions.sql
+++ b/migrations/sql/20260829083235_add_household_rating_reactions.sql
@@ -27,11 +27,6 @@ CREATE TABLE household_rating_reactions (
         media_item_id
     ) REFERENCES user_ratings (user_id, profile_id, media_item_id)
       ON UPDATE CASCADE
-      ON DELETE CASCADE,
-    CONSTRAINT household_rating_reactions_reactor_profile_fkey FOREIGN KEY (
-        reactor_user_id,
-        reactor_profile_id
-    ) REFERENCES user_profiles (user_id, id)
       ON DELETE CASCADE
 );
 

--- a/migrations/sql/20260829094500_allow_self_household_rating_reactions.sql
+++ b/migrations/sql/20260829094500_allow_self_household_rating_reactions.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE household_rating_reactions
+    DROP CONSTRAINT IF EXISTS household_rating_reactions_no_self_check;
+
+-- +goose Down
+DELETE FROM household_rating_reactions
+WHERE target_user_id = reactor_user_id
+  AND target_profile_id = reactor_profile_id;
+
+ALTER TABLE household_rating_reactions
+    ADD CONSTRAINT household_rating_reactions_no_self_check CHECK (
+        target_user_id <> reactor_user_id OR target_profile_id <> reactor_profile_id
+    );

--- a/migrations/sql/20260829120149_support_sqlite_community_profiles.sql
+++ b/migrations/sql/20260829120149_support_sqlite_community_profiles.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+ALTER TABLE household_rating_reactions
+    DROP CONSTRAINT IF EXISTS household_rating_reactions_reactor_profile_fkey;
+
+ALTER TABLE household_rating_reactions
+    ADD CONSTRAINT household_rating_reactions_reactor_user_fkey FOREIGN KEY (
+        reactor_user_id
+    ) REFERENCES users (id)
+      ON DELETE CASCADE;
+
+-- +goose Down
+ALTER TABLE household_rating_reactions
+    DROP CONSTRAINT IF EXISTS household_rating_reactions_reactor_user_fkey;
+
+DELETE FROM household_rating_reactions reaction
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM user_profiles profile
+    WHERE profile.user_id = reaction.reactor_user_id
+      AND profile.id = reaction.reactor_profile_id
+);
+
+ALTER TABLE household_rating_reactions
+    ADD CONSTRAINT household_rating_reactions_reactor_profile_fkey FOREIGN KEY (
+        reactor_user_id,
+        reactor_profile_id
+    ) REFERENCES user_profiles (user_id, id)
+      ON DELETE CASCADE;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1137,6 +1137,26 @@ export interface ItemExtra {
   file_id?: number;
 }
 
+export type CommunityRatingReaction = "up" | "down";
+
+export interface CommunityRatingEntry {
+  key: string;
+  display_name: string;
+  avatar_url?: string;
+  rating: number;
+  rated_at: string;
+  up_count: number;
+  down_count: number;
+  viewer_reaction?: CommunityRatingReaction;
+  is_viewer: boolean;
+}
+
+export interface CommunityRatingsResponse {
+  average_rating: number | null;
+  vote_count: number;
+  ratings: CommunityRatingEntry[];
+}
+
 export interface ItemDetail {
   content_id: string;
   play_content_id?: string;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1139,6 +1139,11 @@ export interface ItemExtra {
 
 export type CommunityRatingReaction = "up" | "down";
 
+export interface RatingsCapabilities {
+  community_ratings: boolean;
+  community_rating_reactions: boolean;
+}
+
 export interface CommunityRatingEntry {
   key: string;
   display_name: string;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1255,6 +1255,10 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
   }
 
+  .star-rating-community-fill {
+    color: rgb(250 204 21 / 0.38);
+  }
+
   /* The stored rating is the resting state, so it survives a pointer that is
      inside the pill but not over a star (its padding, the gaps between stars)
      and it still renders where :has() is unsupported. */
@@ -1262,7 +1266,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     color: rgb(250 204 21);
   }
 
-  .star-rating-star[data-filled="true"] svg {
+  .star-rating-star[data-filled="true"] .star-rating-personal {
     fill: currentcolor;
   }
 
@@ -1272,8 +1276,12 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     color: color-mix(in srgb, var(--muted-foreground) 50%, transparent);
   }
 
-  .star-rating:has(.star-rating-star:hover) .star-rating-star svg {
+  .star-rating:has(.star-rating-star:hover) .star-rating-personal {
     fill: none;
+  }
+
+  .star-rating:has(.star-rating-star:hover) .star-rating-community-fill {
+    opacity: 0;
   }
 
   .star-rating:has(.star-rating-star:nth-of-type(1):hover) .star-rating-star:nth-of-type(-n + 1),
@@ -1286,20 +1294,30 @@ html[data-navigation-direction]::view-transition-new(main-content) {
 
   .star-rating:has(.star-rating-star:nth-of-type(1):hover)
     .star-rating-star:nth-of-type(-n + 1)
-    svg,
+    .star-rating-personal,
   .star-rating:has(.star-rating-star:nth-of-type(2):hover)
     .star-rating-star:nth-of-type(-n + 2)
-    svg,
+    .star-rating-personal,
   .star-rating:has(.star-rating-star:nth-of-type(3):hover)
     .star-rating-star:nth-of-type(-n + 3)
-    svg,
+    .star-rating-personal,
   .star-rating:has(.star-rating-star:nth-of-type(4):hover)
     .star-rating-star:nth-of-type(-n + 4)
-    svg,
+    .star-rating-personal,
   .star-rating:has(.star-rating-star:nth-of-type(5):hover)
     .star-rating-star:nth-of-type(-n + 5)
-    svg {
+    .star-rating-personal {
     fill: currentcolor;
+  }
+
+  /* Community rating cards are deliberately opaque and isolated from the
+     backdrop. Scrolling or reacting never asks the browser to resample a live
+     blur surface. */
+  .household-rating-card {
+    contain: layout paint;
+    background: color-mix(in srgb, var(--surface) 88%, var(--background));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
 
   /* Less-transparent glass for small chips that sit over busy cover art

--- a/web/src/components/StarRating.test.tsx
+++ b/web/src/components/StarRating.test.tsx
@@ -33,4 +33,22 @@ describe("StarRating", () => {
     fireEvent.click(stars[2]!);
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
+
+  it("layers the watched-profile average beneath the personal rating", () => {
+    render(
+      <StarRating value={2} communityAverage={3.5} communityVoteCount={4} onChange={() => {}} />,
+    );
+
+    const group = screen.getByRole("radiogroup", {
+      name: "Rating. Server average 3.5 from 4 ratings.",
+    });
+    const stars = screen.getAllByRole("radio");
+
+    expect(group).toBeInTheDocument();
+    expect(stars[2]).toHaveAttribute("data-community-fill", "1.00");
+    expect(stars[3]).toHaveAttribute("data-community-fill", "0.50");
+    expect(stars[4]).toHaveAttribute("data-community-fill", "0.00");
+    expect(stars[1]).toHaveAttribute("data-filled", "true");
+    expect(stars[2]).toHaveAttribute("data-filled", "false");
+  });
 });

--- a/web/src/components/StarRating.tsx
+++ b/web/src/components/StarRating.tsx
@@ -5,11 +5,19 @@ interface StarRatingProps {
   value: number | null;
   onChange: (rating: number | null) => void;
   size?: number;
+  communityAverage?: number | null;
+  communityVoteCount?: number;
 }
 
 const STAR_COUNT = 5;
 
-function StarRating({ value, onChange, size = 20 }: StarRatingProps) {
+function StarRating({
+  value,
+  onChange,
+  size = 20,
+  communityAverage = null,
+  communityVoteCount = 0,
+}: StarRatingProps) {
   function handleClick(star: number) {
     if (star === value) {
       onChange(null);
@@ -39,17 +47,23 @@ function StarRating({ value, onChange, size = 20 }: StarRatingProps) {
   );
 
   const tabbableStar = value ?? 1;
+  const groupLabel =
+    communityAverage !== null && communityVoteCount > 0
+      ? `Rating. Server average ${communityAverage.toFixed(1)} from ${communityVoteCount} ${communityVoteCount === 1 ? "rating" : "ratings"}.`
+      : "Rating";
 
   return (
     <div
       role="radiogroup"
-      aria-label="Rating"
+      aria-label={groupLabel}
       className="star-rating flex items-center gap-0.5 rounded-full px-2.5 py-2"
       onKeyDown={handleKeyDown}
     >
       {Array.from({ length: STAR_COUNT }, (_, i) => {
         const star = i + 1;
         const filled = value !== null && star <= value;
+        const communityFill =
+          communityAverage === null ? 0 : Math.max(0, Math.min(1, communityAverage - i));
         return (
           <button
             key={star}
@@ -60,10 +74,35 @@ function StarRating({ value, onChange, size = 20 }: StarRatingProps) {
             tabIndex={star === tabbableStar ? 0 : -1}
             data-filled={filled}
             data-rating={star}
+            data-community-fill={communityFill.toFixed(2)}
             className="star-rating-star focus-visible:ring-ring cursor-pointer rounded-sm border-none bg-transparent p-0.5 leading-none outline-none focus-visible:ring-2"
             onClick={() => handleClick(star)}
           >
-            <Star size={size} fill="none" strokeWidth={1.5} />
+            <span
+              className="star-rating-glyph relative block"
+              style={{ width: size, height: size }}
+            >
+              {communityFill > 0 && (
+                <span
+                  aria-hidden="true"
+                  className="star-rating-community-fill absolute inset-y-0 left-0 overflow-hidden"
+                  style={{ width: `${communityFill * 100}%` }}
+                >
+                  <Star
+                    className="absolute top-0 left-0 fill-current"
+                    size={size}
+                    strokeWidth={1.5}
+                  />
+                </span>
+              )}
+              <Star
+                aria-hidden="true"
+                className="star-rating-personal relative"
+                size={size}
+                fill="none"
+                strokeWidth={1.5}
+              />
+            </span>
           </button>
         );
       })}

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -291,6 +291,7 @@ export const mediaSurfaceKeys = {
 export const ratingKeys = {
   all: ["ratings"] as const,
   item: (itemId: string) => ["ratings", itemId] as const,
+  community: (itemId: string) => ["ratings", itemId, "community"] as const,
   list: () => ["ratings", "list"] as const,
 };
 

--- a/web/src/hooks/queries/keys.ts
+++ b/web/src/hooks/queries/keys.ts
@@ -290,6 +290,7 @@ export const mediaSurfaceKeys = {
 
 export const ratingKeys = {
   all: ["ratings"] as const,
+  capabilities: () => ["ratings", "capabilities"] as const,
   item: (itemId: string) => ["ratings", itemId] as const,
   community: (itemId: string) => ["ratings", itemId, "community"] as const,
   list: () => ["ratings", "list"] as const,

--- a/web/src/hooks/queries/profiles.ts
+++ b/web/src/hooks/queries/profiles.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import type { AdminSession, Profile, CreateProfileRequest, ProfileListResponse } from "@/api/types";
-import { profileKeys } from "./keys";
+import { profileKeys, ratingKeys } from "./keys";
 import { toast } from "sonner";
 
 function replaceProfileInList(profiles: Profile[] | undefined, updatedProfile: Profile) {
@@ -84,6 +84,7 @@ export function useUpdateProfile() {
       });
       toast.success("Profile updated");
       queryClient.invalidateQueries({ queryKey: profileKeys.list() });
+      queryClient.invalidateQueries({ queryKey: ratingKeys.all });
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to save profile");
@@ -109,6 +110,7 @@ export function useUploadProfileAvatar() {
       }));
       toast.success("Avatar updated");
       queryClient.invalidateQueries({ queryKey: profileKeys.list() });
+      queryClient.invalidateQueries({ queryKey: ratingKeys.all });
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to upload avatar");
@@ -130,6 +132,7 @@ export function useDeleteProfileAvatar() {
       }));
       toast.success("Avatar removed");
       queryClient.invalidateQueries({ queryKey: profileKeys.list() });
+      queryClient.invalidateQueries({ queryKey: ratingKeys.all });
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to remove avatar");
@@ -144,6 +147,7 @@ export function useDeleteProfile() {
     onSuccess: () => {
       toast.success("Profile deleted");
       queryClient.invalidateQueries({ queryKey: profileKeys.list() });
+      queryClient.invalidateQueries({ queryKey: ratingKeys.all });
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to delete");

--- a/web/src/hooks/queries/ratings.test.ts
+++ b/web/src/hooks/queries/ratings.test.ts
@@ -1,9 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { catalogKeys, itemKeys } from "./keys";
+import { catalogKeys, itemKeys, ratingKeys } from "./keys";
 
 const mocks = vi.hoisted(() => ({
   cancelItemDetailQueries: vi.fn(),
+  cancelQueries: vi.fn(),
   getQueriesData: vi.fn(),
+  getQueryData: vi.fn(),
+  setQueryData: vi.fn(),
+  invalidateQueries: vi.fn(),
   useMutation: vi.fn(),
 }));
 
@@ -13,7 +17,13 @@ vi.mock("@tanstack/react-query", async () => {
   return {
     ...actual,
     useMutation: (...args: unknown[]) => mocks.useMutation(...args),
-    useQueryClient: () => ({ getQueriesData: mocks.getQueriesData }),
+    useQueryClient: () => ({
+      cancelQueries: mocks.cancelQueries,
+      getQueriesData: mocks.getQueriesData,
+      getQueryData: mocks.getQueryData,
+      setQueryData: mocks.setQueryData,
+      invalidateQueries: mocks.invalidateQueries,
+    }),
   };
 });
 
@@ -31,14 +41,19 @@ vi.mock("./ratingsSurfaceRefresh", () => ({
   invalidateRatingSurfaceQueries: vi.fn(),
 }));
 
-import { useDeleteRating, useSetRating } from "./ratings";
+import { useDeleteRating, useSetCommunityRatingReaction, useSetRating } from "./ratings";
 
 describe("rating mutations", () => {
   beforeEach(() => {
     mocks.cancelItemDetailQueries.mockReset();
     mocks.cancelItemDetailQueries.mockResolvedValue(undefined);
+    mocks.cancelQueries.mockReset();
+    mocks.cancelQueries.mockResolvedValue(undefined);
     mocks.getQueriesData.mockReset();
     mocks.getQueriesData.mockReturnValue([]);
+    mocks.getQueryData.mockReset();
+    mocks.setQueryData.mockReset();
+    mocks.invalidateQueries.mockReset();
     mocks.useMutation.mockReset();
     mocks.useMutation.mockImplementation((options: unknown) => options);
   });
@@ -51,15 +66,197 @@ describe("rating mutations", () => {
     async (_label, useRating, value) => {
       useRating();
       const options = mocks.useMutation.mock.calls[0]?.[0] as {
+        scope: { id: string };
         onMutate: (rating?: number) => Promise<unknown>;
       };
 
       await options.onMutate(value);
 
+      expect(options.scope).toEqual({ id: "rating:item-1" });
       const filters = mocks.getQueriesData.mock.calls[0]?.[0];
       expect(filters.predicate({ queryKey: catalogKeys.itemDetail("item-1") })).toBe(true);
       expect(filters.predicate({ queryKey: itemKeys.detail("item-1") })).toBe(true);
       expect(filters.predicate({ queryKey: catalogKeys.itemDetail("item-2") })).toBe(false);
     },
   );
+
+  it("optimistically edits the viewer's existing card without changing its identity", async () => {
+    let cached = {
+      average_rating: 4.5,
+      vote_count: 2,
+      ratings: [
+        {
+          key: "stable-viewer-card",
+          display_name: "b***",
+          rating: 5,
+          rated_at: "2026-08-13T08:00:00Z",
+          up_count: 1,
+          down_count: 0,
+          is_viewer: true,
+        },
+        {
+          key: "other-card",
+          display_name: "b***",
+          rating: 4,
+          rated_at: "2026-08-12T08:00:00Z",
+          up_count: 0,
+          down_count: 0,
+          is_viewer: false,
+        },
+      ],
+    };
+    mocks.getQueryData.mockReturnValue(cached);
+    mocks.setQueryData.mockImplementation((_key: unknown, update: unknown) => {
+      if (typeof update === "function") {
+        cached = update(cached);
+      }
+    });
+
+    useSetRating("item-1");
+    const options = mocks.useMutation.mock.calls[0]?.[0] as {
+      onMutate: (rating: number) => Promise<unknown>;
+    };
+
+    await options.onMutate(2);
+
+    expect(mocks.cancelQueries).toHaveBeenCalledWith({
+      queryKey: ratingKeys.community("item-1"),
+    });
+    expect(cached.average_rating).toBe(3);
+    expect(cached.vote_count).toBe(2);
+    expect(cached.ratings[0]).toMatchObject({
+      key: "stable-viewer-card",
+      rating: 2,
+      is_viewer: true,
+    });
+    expect(cached.ratings[1]).toMatchObject({ key: "other-card", rating: 4 });
+  });
+
+  it("optimistically removes only the viewer's card when their rating is cleared", async () => {
+    let cached = {
+      average_rating: 4.5,
+      vote_count: 2,
+      ratings: [
+        {
+          key: "stable-viewer-card",
+          display_name: "b***",
+          rating: 5,
+          rated_at: "2026-08-13T08:00:00Z",
+          up_count: 1,
+          down_count: 0,
+          is_viewer: true,
+        },
+        {
+          key: "other-card",
+          display_name: "b***",
+          rating: 4,
+          rated_at: "2026-08-12T08:00:00Z",
+          up_count: 0,
+          down_count: 0,
+          is_viewer: false,
+        },
+      ],
+    };
+    mocks.getQueryData.mockReturnValue(cached);
+    mocks.setQueryData.mockImplementation((_key: unknown, update: unknown) => {
+      if (typeof update === "function") {
+        cached = update(cached);
+      }
+    });
+
+    useDeleteRating("item-1");
+    const options = mocks.useMutation.mock.calls[0]?.[0] as {
+      onMutate: () => Promise<unknown>;
+    };
+
+    await options.onMutate();
+
+    expect(cached).toMatchObject({
+      average_rating: 4,
+      vote_count: 1,
+      ratings: [{ key: "other-card", rating: 4, is_viewer: false }],
+    });
+  });
+
+  it("optimistically moves a community reaction between separate tallies", async () => {
+    let cached = {
+      average_rating: 4,
+      vote_count: 1,
+      ratings: [
+        {
+          key: "rating-1",
+          display_name: "Sam***",
+          rating: 4,
+          up_count: 2,
+          down_count: 5,
+          viewer_reaction: "up" as const,
+          is_viewer: false,
+        },
+      ],
+    };
+    mocks.getQueryData.mockReturnValue(cached);
+    mocks.setQueryData.mockImplementation((_key: unknown, update: unknown) => {
+      if (typeof update === "function") {
+        cached = update(cached);
+      }
+    });
+
+    useSetCommunityRatingReaction("item-1");
+    const options = mocks.useMutation.mock.calls[0]?.[0] as {
+      onMutate: (variables: {
+        ratingKey: string;
+        reaction: "up" | "down" | null;
+      }) => Promise<unknown>;
+    };
+
+    await options.onMutate({ ratingKey: "rating-1", reaction: "down" });
+
+    expect(cached.ratings[0]).toMatchObject({
+      up_count: 1,
+      down_count: 6,
+      viewer_reaction: "down",
+    });
+  });
+
+  it("optimistically removes the viewer's selected reaction from their own card", async () => {
+    let cached = {
+      average_rating: 5,
+      vote_count: 1,
+      ratings: [
+        {
+          key: "rating-viewer",
+          display_name: "B***",
+          rated_at: "2026-08-29T08:00:00Z",
+          rating: 5,
+          up_count: 1,
+          down_count: 0,
+          viewer_reaction: "up" as const,
+          is_viewer: true,
+        },
+      ],
+    };
+    mocks.getQueryData.mockReturnValue(cached);
+    mocks.setQueryData.mockImplementation((_key: unknown, update: unknown) => {
+      if (typeof update === "function") {
+        cached = update(cached);
+      }
+    });
+
+    useSetCommunityRatingReaction("item-1");
+    const options = mocks.useMutation.mock.calls[0]?.[0] as {
+      onMutate: (variables: {
+        ratingKey: string;
+        reaction: "up" | "down" | null;
+      }) => Promise<unknown>;
+    };
+
+    await options.onMutate({ ratingKey: "rating-viewer", reaction: null });
+
+    expect(cached.ratings[0]).toMatchObject({
+      up_count: 0,
+      down_count: 0,
+      viewer_reaction: undefined,
+      is_viewer: true,
+    });
+  });
 });

--- a/web/src/hooks/queries/ratings.test.ts
+++ b/web/src/hooks/queries/ratings.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   setQueryData: vi.fn(),
   invalidateQueries: vi.fn(),
   useMutation: vi.fn(),
+  useQuery: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", async () => {
@@ -17,6 +18,7 @@ vi.mock("@tanstack/react-query", async () => {
   return {
     ...actual,
     useMutation: (...args: unknown[]) => mocks.useMutation(...args),
+    useQuery: (...args: unknown[]) => mocks.useQuery(...args),
     useQueryClient: () => ({
       cancelQueries: mocks.cancelQueries,
       getQueriesData: mocks.getQueriesData,
@@ -41,7 +43,12 @@ vi.mock("./ratingsSurfaceRefresh", () => ({
   invalidateRatingSurfaceQueries: vi.fn(),
 }));
 
-import { useDeleteRating, useSetCommunityRatingReaction, useSetRating } from "./ratings";
+import {
+  useCommunityRatings,
+  useDeleteRating,
+  useSetCommunityRatingReaction,
+  useSetRating,
+} from "./ratings";
 
 describe("rating mutations", () => {
   beforeEach(() => {
@@ -56,6 +63,37 @@ describe("rating mutations", () => {
     mocks.invalidateQueries.mockReset();
     mocks.useMutation.mockReset();
     mocks.useMutation.mockImplementation((options: unknown) => options);
+    mocks.useQuery.mockReset();
+    mocks.useQuery.mockImplementation((options: unknown) => options);
+  });
+
+  it("loads community ratings only after capability discovery enables them", () => {
+    useCommunityRatings("item-1");
+    expect(mocks.useQuery.mock.calls[0]?.[0]).toMatchObject({
+      queryKey: ratingKeys.capabilities(),
+      staleTime: Infinity,
+      gcTime: Infinity,
+    });
+    expect(mocks.useQuery.mock.calls[1]?.[0]).toMatchObject({
+      queryKey: ratingKeys.community("item-1"),
+      enabled: false,
+    });
+
+    mocks.useQuery.mockReset();
+    mocks.useQuery
+      .mockImplementationOnce((options: unknown) => ({
+        ...(options as object),
+        data: { community_ratings: true, community_rating_reactions: true },
+        isError: false,
+        isLoading: false,
+      }))
+      .mockImplementationOnce((options: unknown) => options);
+
+    useCommunityRatings("item-1");
+    expect(mocks.useQuery.mock.calls[1]?.[0]).toMatchObject({
+      queryKey: ratingKeys.community("item-1"),
+      enabled: true,
+    });
   });
 
   it.each([

--- a/web/src/hooks/queries/ratings.ts
+++ b/web/src/hooks/queries/ratings.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { CommunityRatingReaction, CommunityRatingsResponse, ItemDetail } from "@/api/types";
+import type {
+  CommunityRatingReaction,
+  CommunityRatingsResponse,
+  ItemDetail,
+  RatingsCapabilities,
+} from "@/api/types";
 import { invalidateRatingSurfaceQueries } from "./ratingsSurfaceRefresh";
 import { ratingKeys } from "./keys";
 import {
@@ -91,13 +96,29 @@ export function useDeleteRating(itemId: string) {
   });
 }
 
-export function useCommunityRatings(itemId: string) {
+export function useRatingsCapabilities() {
   return useQuery({
+    queryKey: ratingKeys.capabilities(),
+    queryFn: () => api<RatingsCapabilities>("/ratings/capabilities"),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+}
+
+export function useCommunityRatings(itemId: string) {
+  const capabilitiesQuery = useRatingsCapabilities();
+  const communityQuery = useQuery({
     queryKey: ratingKeys.community(itemId),
     queryFn: () => api<CommunityRatingsResponse>(`/ratings/${itemId}/community?limit=100`),
-    enabled: itemId.length > 0,
+    enabled: itemId.length > 0 && capabilitiesQuery.data?.community_ratings === true,
     staleTime: 30_000,
   });
+  return {
+    ...communityQuery,
+    capabilities: capabilitiesQuery.data,
+    isError: capabilitiesQuery.isError || communityQuery.isError,
+    isLoading: capabilitiesQuery.isLoading || communityQuery.isLoading,
+  };
 }
 
 interface CommunityReactionMutation {

--- a/web/src/hooks/queries/ratings.ts
+++ b/web/src/hooks/queries/ratings.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { ItemDetail } from "@/api/types";
+import type { CommunityRatingReaction, CommunityRatingsResponse, ItemDetail } from "@/api/types";
 import { invalidateRatingSurfaceQueries } from "./ratingsSurfaceRefresh";
+import { ratingKeys } from "./keys";
 import {
   cancelItemDetailQueries,
   isItemDetailQueryKey,
@@ -10,26 +11,39 @@ import {
 
 export function useSetRating(itemId: string) {
   const queryClient = useQueryClient();
+  const communityQueryKey = ratingKeys.community(itemId);
   return useMutation({
+    scope: { id: `rating:${itemId}` },
     mutationFn: (rating: number) =>
       api(`/ratings/${itemId}`, {
         method: "PUT",
         body: JSON.stringify({ rating }),
       }),
     onMutate: async (rating: number) => {
-      await cancelItemDetailQueries(queryClient, itemId);
+      await Promise.all([
+        cancelItemDetailQueries(queryClient, itemId),
+        queryClient.cancelQueries({ queryKey: communityQueryKey }),
+      ]);
       const previous = queryClient.getQueriesData<ItemDetail>({
         predicate: (query) => isItemDetailQueryKey(query.queryKey, itemId),
       });
+      const previousCommunity =
+        queryClient.getQueryData<CommunityRatingsResponse>(communityQueryKey);
       updateCatalogItemDetail(queryClient, itemId, (detail) => ({
         ...detail,
         user_rating: rating,
       }));
-      return { previous };
+      queryClient.setQueryData<CommunityRatingsResponse>(communityQueryKey, (current) =>
+        updateViewerCommunityRating(current, rating, new Date().toISOString()),
+      );
+      return { previous, previousCommunity };
     },
     onError: (_err, _vars, context) => {
       for (const [queryKey, value] of context?.previous ?? []) {
         queryClient.setQueryData(queryKey, value);
+      }
+      if (context) {
+        queryClient.setQueryData(communityQueryKey, context.previousCommunity);
       }
     },
     onSettled: () => {
@@ -40,26 +54,147 @@ export function useSetRating(itemId: string) {
 
 export function useDeleteRating(itemId: string) {
   const queryClient = useQueryClient();
+  const communityQueryKey = ratingKeys.community(itemId);
   return useMutation({
+    scope: { id: `rating:${itemId}` },
     mutationFn: () => api(`/ratings/${itemId}`, { method: "DELETE" }),
     onMutate: async () => {
-      await cancelItemDetailQueries(queryClient, itemId);
+      await Promise.all([
+        cancelItemDetailQueries(queryClient, itemId),
+        queryClient.cancelQueries({ queryKey: communityQueryKey }),
+      ]);
       const previous = queryClient.getQueriesData<ItemDetail>({
         predicate: (query) => isItemDetailQueryKey(query.queryKey, itemId),
       });
+      const previousCommunity =
+        queryClient.getQueryData<CommunityRatingsResponse>(communityQueryKey);
       updateCatalogItemDetail(queryClient, itemId, (detail) => ({
         ...detail,
         user_rating: null,
       }));
-      return { previous };
+      queryClient.setQueryData<CommunityRatingsResponse>(communityQueryKey, (current) =>
+        removeViewerCommunityRating(current),
+      );
+      return { previous, previousCommunity };
     },
     onError: (_err, _vars, context) => {
       for (const [queryKey, value] of context?.previous ?? []) {
         queryClient.setQueryData(queryKey, value);
       }
+      if (context) {
+        queryClient.setQueryData(communityQueryKey, context.previousCommunity);
+      }
     },
     onSettled: () => {
       return invalidateRatingSurfaceQueries(queryClient, itemId);
     },
+  });
+}
+
+export function useCommunityRatings(itemId: string) {
+  return useQuery({
+    queryKey: ratingKeys.community(itemId),
+    queryFn: () => api<CommunityRatingsResponse>(`/ratings/${itemId}/community?limit=100`),
+    enabled: itemId.length > 0,
+    staleTime: 30_000,
+  });
+}
+
+interface CommunityReactionMutation {
+  ratingKey: string;
+  reaction: CommunityRatingReaction | null;
+}
+
+function updateViewerCommunityRating(
+  current: CommunityRatingsResponse | undefined,
+  rating: number,
+  ratedAt: string,
+) {
+  if (!current) return current;
+  const viewer = current.ratings.find((entry) => entry.is_viewer);
+  if (!viewer) return current;
+
+  const average =
+    current.average_rating == null || current.vote_count === 0
+      ? current.average_rating
+      : (current.average_rating * current.vote_count - viewer.rating + rating) / current.vote_count;
+  return {
+    ...current,
+    average_rating: average,
+    ratings: current.ratings.map((entry) =>
+      entry.is_viewer ? { ...entry, rating, rated_at: ratedAt } : entry,
+    ),
+  };
+}
+
+function removeViewerCommunityRating(current: CommunityRatingsResponse | undefined) {
+  if (!current) return current;
+  const viewer = current.ratings.find((entry) => entry.is_viewer);
+  if (!viewer) return current;
+
+  const voteCount = Math.max(0, current.vote_count - 1);
+  const average =
+    voteCount === 0 || current.average_rating == null
+      ? null
+      : (current.average_rating * current.vote_count - viewer.rating) / voteCount;
+  return {
+    ...current,
+    average_rating: average,
+    vote_count: voteCount,
+    ratings: current.ratings.filter((entry) => !entry.is_viewer),
+  };
+}
+
+export function useSetCommunityRatingReaction(itemId: string) {
+  const queryClient = useQueryClient();
+  const queryKey = ratingKeys.community(itemId);
+
+  return useMutation({
+    mutationFn: ({ ratingKey, reaction }: CommunityReactionMutation) => {
+      const path = `/ratings/${itemId}/community/${encodeURIComponent(ratingKey)}/reaction`;
+      if (reaction === null) {
+        return api<void>(path, { method: "DELETE" });
+      }
+      return api<void>(path, {
+        method: "PUT",
+        body: JSON.stringify({ reaction }),
+      });
+    },
+    onMutate: async ({ ratingKey, reaction }: CommunityReactionMutation) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<CommunityRatingsResponse>(queryKey);
+      queryClient.setQueryData<CommunityRatingsResponse>(queryKey, (current) => {
+        if (!current) return current;
+        return {
+          ...current,
+          ratings: current.ratings.map((entry) => {
+            if (entry.key !== ratingKey) return entry;
+            return {
+              ...entry,
+              up_count: Math.max(
+                0,
+                entry.up_count -
+                  (entry.viewer_reaction === "up" ? 1 : 0) +
+                  (reaction === "up" ? 1 : 0),
+              ),
+              down_count: Math.max(
+                0,
+                entry.down_count -
+                  (entry.viewer_reaction === "down" ? 1 : 0) +
+                  (reaction === "down" ? 1 : 0),
+              ),
+              viewer_reaction: reaction ?? undefined,
+            };
+          }),
+        };
+      });
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey }),
   });
 }

--- a/web/src/hooks/queries/ratingsSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/ratingsSurfaceRefresh.test.ts
@@ -11,6 +11,11 @@ describe("invalidateRatingSurfaceQueries", () => {
       rating: 4,
       rated_at: "2026-03-23T00:00:00.000Z",
     });
+    queryClient.setQueryData(ratingKeys.community("item-1"), {
+      average_rating: null,
+      vote_count: 0,
+      ratings: [],
+    });
     queryClient.setQueryData(recKeys.forYouMain(), { row: null });
     queryClient.setQueryData(recKeys.forYouRows(), { rows: [] });
     queryClient.setQueryData(recKeys.tasteProfile(), {
@@ -29,6 +34,7 @@ describe("invalidateRatingSurfaceQueries", () => {
     await invalidateRatingSurfaceQueries(queryClient, "item-1");
 
     expect(queryClient.getQueryState(ratingKeys.item("item-1"))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(ratingKeys.community("item-1"))?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(recKeys.forYouMain())?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(recKeys.forYouRows())?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(recKeys.tasteProfile())?.isInvalidated).toBe(true);

--- a/web/src/pages/ItemDetail/MovieContent.test.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.test.tsx
@@ -45,6 +45,7 @@ const mocks = vi.hoisted(() => {
     useRating: vi.fn(),
     useSetRating: vi.fn(),
     useDeleteRating: vi.fn(),
+    useCommunityRatings: vi.fn(),
     useSimilarItems: vi.fn(),
     useAuth: vi.fn(),
     useCurrentProfile: vi.fn(),
@@ -75,6 +76,7 @@ vi.mock("@/hooks/queries/ratings", () => ({
   useRating: mocks.useRating,
   useSetRating: mocks.useSetRating,
   useDeleteRating: mocks.useDeleteRating,
+  useCommunityRatings: mocks.useCommunityRatings,
 }));
 
 vi.mock("@/hooks/queries/recommendations", () => ({
@@ -173,6 +175,10 @@ vi.mock("./components/ActionBar", () => ({
   },
 }));
 
+vi.mock("./components/RatingsSection", () => ({
+  default: () => <div />,
+}));
+
 function makeFileVersion(overrides: Partial<FileVersion> = {}): FileVersion {
   return {
     file_id: overrides.file_id ?? 1,
@@ -250,6 +256,7 @@ describe("MovieContent", () => {
     mocks.useRating.mockReturnValue({ data: { rating: 4, rated_at: "2026-03-22T00:00:00Z" } });
     mocks.useSetRating.mockReturnValue({ mutate: vi.fn() });
     mocks.useDeleteRating.mockReturnValue({ mutate: vi.fn() });
+    mocks.useCommunityRatings.mockReturnValue({ data: undefined });
     mocks.useSimilarItems.mockReturnValue({ data: { items: [] }, isLoading: false });
     mocks.useAuth.mockReturnValue({ user: null });
     mocks.useCurrentProfile.mockReturnValue({ profile: null });

--- a/web/src/pages/ItemDetail/MovieContent.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.tsx
@@ -27,6 +27,7 @@ import QualityBadges from "./components/QualityBadges";
 import ScoreRow from "./components/ScoreRow";
 import HeroCrewLine from "./components/HeroCrewLine";
 import MediaUserActionBar from "./components/MediaUserActionBar";
+import RatingsSection from "./components/RatingsSection";
 import MediaInfoDialog from "./components/MediaInfoDialog";
 import SubtitleSearchDialog from "./components/SubtitleSearchDialog";
 import { sortByResolution } from "./components/VersionFlyout";
@@ -350,6 +351,8 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
             </div>
           )
         )}
+
+        <RatingsSection itemId={item.content_id} />
       </div>
       {canCurateMetadata && (
         <EditMetadataDialog item={item} open={editOpen} onOpenChange={setEditOpen} />

--- a/web/src/pages/ItemDetail/SeriesContent.test.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => {
     useSimilarItems: vi.fn(),
     useSetRating: vi.fn(),
     useDeleteRating: vi.fn(),
+    useCommunityRatings: vi.fn(),
     setRatingMutate: vi.fn(),
     deleteRatingMutate: vi.fn(),
   };
@@ -80,6 +81,7 @@ vi.mock("@/playback/watchPlaybackContext", () => ({
 vi.mock("@/hooks/queries/ratings", () => ({
   useSetRating: mocks.useSetRating,
   useDeleteRating: mocks.useDeleteRating,
+  useCommunityRatings: mocks.useCommunityRatings,
 }));
 
 vi.mock("@/components/CastCarousel", () => ({
@@ -115,6 +117,10 @@ vi.mock("./components/ActionBar", () => ({
     mocks.capturedActionBarProps.value = props;
     return <div />;
   },
+}));
+
+vi.mock("./components/RatingsSection", () => ({
+  default: () => <div />,
 }));
 
 function makeSeason(overrides: Partial<Season> = {}): Season {
@@ -199,6 +205,7 @@ describe("SeriesContent", () => {
     mocks.useSimilarItems.mockReturnValue({ data: undefined, isLoading: false });
     mocks.useSetRating.mockReturnValue({ mutate: mocks.setRatingMutate });
     mocks.useDeleteRating.mockReturnValue({ mutate: mocks.deleteRatingMutate });
+    mocks.useCommunityRatings.mockReturnValue({ data: undefined });
   });
 
   it("passes rating state and change handler to ActionBar", () => {

--- a/web/src/pages/ItemDetail/SeriesContent.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.tsx
@@ -26,6 +26,7 @@ import ExtrasSection from "./components/ExtrasSection";
 import ScoreRow from "./components/ScoreRow";
 import HeroCrewLine from "./components/HeroCrewLine";
 import MediaUserActionBar from "./components/MediaUserActionBar";
+import RatingsSection from "./components/RatingsSection";
 import { SeasonCarouselSkeleton, RecommendationGridSkeleton } from "./components/SectionSkeletons";
 import { getSeasonDisplayTitle, resolveSeriesPrimaryAction } from "./itemDetailLayout";
 import { canCurateMetadata as canCurateMetadataForUser } from "@/lib/permissions";
@@ -210,6 +211,8 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
             </div>
           )
         )}
+
+        <RatingsSection itemId={item.content_id} />
       </div>
       {canCurateMetadata && (
         <EditMetadataDialog item={item} open={editOpen} onOpenChange={setEditOpen} />

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -123,6 +123,8 @@ export interface ActionBarProps {
   onSearchSubtitles?: () => void;
   rating?: number | null;
   onRatingChange?: (rating: number | null) => void;
+  communityRatingAverage?: number | null;
+  communityRatingVoteCount?: number;
   qualityPreference?: string | null;
   audioSelectionMode?: "auto" | "explicit";
   explicitAudioTrackIndex?: number | null;
@@ -175,6 +177,8 @@ export default function ActionBar({
   onSearchSubtitles,
   rating,
   onRatingChange,
+  communityRatingAverage,
+  communityRatingVoteCount,
   audioSelectionMode = "auto",
   explicitAudioTrackIndex = null,
   onSelectAudioTrack,
@@ -549,7 +553,13 @@ export default function ActionBar({
         )}
 
         {onRatingChange && (
-          <StarRating value={rating ?? null} onChange={onRatingChange} size={18} />
+          <StarRating
+            value={rating ?? null}
+            onChange={onRatingChange}
+            size={18}
+            communityAverage={communityRatingAverage}
+            communityVoteCount={communityRatingVoteCount}
+          />
         )}
 
         {hasOverflowMenuItems && (

--- a/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import type { ItemDetail } from "@/api/types";
 import { useToggleFavorite } from "@/hooks/queries/favorites";
 import { useWatchedStateMutation } from "@/hooks/queries/items";
-import { useDeleteRating, useSetRating } from "@/hooks/queries/ratings";
+import { useCommunityRatings, useDeleteRating, useSetRating } from "@/hooks/queries/ratings";
 import { useToggleWatchlist } from "@/hooks/queries/watchlist";
 import { getWatchedActionLabel } from "../watchedState";
 import ActionBar, { type ActionBarProps } from "./ActionBar";
@@ -16,7 +16,9 @@ type UserActionProps =
   | "onToggleWatchlist"
   | "inWatchlist"
   | "rating"
-  | "onRatingChange";
+  | "onRatingChange"
+  | "communityRatingAverage"
+  | "communityRatingVoteCount";
 
 interface MediaUserActionBarProps extends Omit<ActionBarProps, UserActionProps> {
   item: ItemDetail;
@@ -35,6 +37,7 @@ export default function MediaUserActionBar({ item, ...props }: MediaUserActionBa
   const { mutate: toggleWatchlist } = useToggleWatchlist(item.content_id);
   const { mutate: setRating } = useSetRating(item.content_id);
   const { mutate: deleteRating } = useDeleteRating(item.content_id);
+  const { data: communityRatings } = useCommunityRatings(item.content_id);
 
   const handleToggleWatched = useCallback(
     () => toggleWatched(!(item.user_data?.played ?? false)),
@@ -71,6 +74,8 @@ export default function MediaUserActionBar({ item, ...props }: MediaUserActionBa
       inWatchlist={inWatchlist}
       rating={item.user_rating ?? null}
       onRatingChange={handleRatingChange}
+      communityRatingAverage={communityRatings?.average_rating}
+      communityRatingVoteCount={communityRatings?.vote_count}
     />
   );
 }

--- a/web/src/pages/ItemDetail/components/RatingsSection.test.tsx
+++ b/web/src/pages/ItemDetail/components/RatingsSection.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RatingsSection from "./RatingsSection";
+
+const mocks = vi.hoisted(() => ({
+  useCommunityRatings: vi.fn(),
+  mutate: vi.fn(),
+}));
+
+vi.mock("@/hooks/queries/ratings", () => ({
+  useCommunityRatings: mocks.useCommunityRatings,
+  useSetCommunityRatingReaction: () => ({
+    mutate: mocks.mutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/useCarouselEmbla", () => ({
+  useCarouselEmbla: () => ({
+    emblaRef: () => {},
+    canScrollPrev: false,
+    canScrollNext: false,
+    scrollPrev: vi.fn(),
+    scrollNext: vi.fn(),
+  }),
+}));
+
+describe("RatingsSection", () => {
+  beforeEach(() => {
+    mocks.mutate.mockReset();
+    mocks.useCommunityRatings.mockReturnValue({
+      data: {
+        average_rating: 4.5,
+        vote_count: 2,
+        ratings: [
+          {
+            key: "rating-other",
+            display_name: "S*******",
+            avatar_url: "/profile-avatars/avatar-1.svg",
+            rating: 5,
+            rated_at: "2026-08-29T08:00:00Z",
+            up_count: 3,
+            down_count: 1,
+            is_viewer: false,
+          },
+          {
+            key: "rating-viewer",
+            display_name: "B***",
+            rating: 4,
+            rated_at: "2026-07-22T08:00:00Z",
+            up_count: 1,
+            down_count: 0,
+            viewer_reaction: "up",
+            is_viewer: true,
+          },
+        ],
+      },
+    });
+  });
+
+  it("renders opaque-style cards with stars and separate reaction tallies", () => {
+    render(<RatingsSection itemId="movie-1" />);
+
+    expect(screen.getByRole("heading", { name: "Ratings" })).toBeInTheDocument();
+    expect(screen.getByText("4.5 average from 2 ratings")).toBeInTheDocument();
+    expect(screen.getByText("S*******")).toBeInTheDocument();
+    expect(screen.getByText("You")).toBeInTheDocument();
+    expect(screen.getByText("August 29, 2026")).toBeInTheDocument();
+    expect(screen.getByLabelText("5 out of 5 stars")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Helpful: 3" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Not helpful: 1" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Helpful: 3" })).toHaveClass(
+      "enabled:cursor-pointer",
+    );
+    expect(screen.getByRole("list")).not.toHaveClass("cursor-grab");
+    expect(screen.getByLabelText("Ratings carousel")).toBeInTheDocument();
+    expect(screen.getAllByRole("article")[0]).toHaveClass("household-rating-card");
+  });
+
+  it("toggles reactions on other and own cards, including removing a selected reaction", () => {
+    render(<RatingsSection itemId="movie-1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Helpful: 3" }));
+    expect(mocks.mutate).toHaveBeenCalledWith({ ratingKey: "rating-other", reaction: "up" });
+
+    const ownHelpful = screen.getByRole("button", { name: "Helpful: 1" });
+    expect(ownHelpful).toBeEnabled();
+    fireEvent.click(ownHelpful);
+    expect(mocks.mutate).toHaveBeenLastCalledWith({
+      ratingKey: "rating-viewer",
+      reaction: null,
+    });
+  });
+
+  it("keeps the section visible when no one has rated the item", () => {
+    mocks.useCommunityRatings.mockReturnValue({
+      data: { average_rating: null, vote_count: 0, ratings: [] },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<RatingsSection itemId="movie-1" />);
+
+    expect(screen.getByRole("heading", { name: "Ratings" })).toBeInTheDocument();
+    expect(screen.getByText("No ratings yet")).toBeInTheDocument();
+    expect(screen.queryByRole("article")).not.toBeInTheDocument();
+  });
+
+  it("distinguishes the viewer when two private display names look identical", () => {
+    mocks.useCommunityRatings.mockReturnValue({
+      data: {
+        average_rating: 5,
+        vote_count: 2,
+        ratings: [
+          {
+            key: "rating-viewer",
+            display_name: "b***",
+            avatar_url: "/viewer.webp",
+            rating: 5,
+            rated_at: "2026-08-29T08:00:00Z",
+            up_count: 1,
+            down_count: 0,
+            is_viewer: true,
+          },
+          {
+            key: "rating-other",
+            display_name: "b***",
+            rating: 5,
+            rated_at: "2026-08-13T08:00:00Z",
+            up_count: 1,
+            down_count: 0,
+            is_viewer: false,
+          },
+        ],
+      },
+    });
+
+    render(<RatingsSection itemId="movie-1" />);
+
+    expect(screen.getAllByText("b***")).toHaveLength(2);
+    expect(screen.getByText("You")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/ItemDetail/components/RatingsSection.test.tsx
+++ b/web/src/pages/ItemDetail/components/RatingsSection.test.tsx
@@ -66,7 +66,7 @@ describe("RatingsSection", () => {
     expect(screen.getByText("S*******")).toBeInTheDocument();
     expect(screen.getByText("You")).toBeInTheDocument();
     expect(screen.getByText("August 29, 2026")).toBeInTheDocument();
-    expect(screen.getByLabelText("5 out of 5 stars")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "5 out of 5 stars" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Helpful: 3" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Not helpful: 1" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Helpful: 3" })).toHaveClass(
@@ -90,6 +90,22 @@ describe("RatingsSection", () => {
       ratingKey: "rating-viewer",
       reaction: null,
     });
+  });
+
+  it("disables reaction controls when the server capability is unavailable", () => {
+    const current = mocks.useCommunityRatings();
+    mocks.useCommunityRatings.mockReturnValue({
+      ...current,
+      capabilities: {
+        community_ratings: true,
+        community_rating_reactions: false,
+      },
+    });
+
+    render(<RatingsSection itemId="movie-1" />);
+
+    expect(screen.getByRole("button", { name: "Helpful: 3" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Not helpful: 1" })).toBeDisabled();
   });
 
   it("keeps the section visible when no one has rated the item", () => {

--- a/web/src/pages/ItemDetail/components/RatingsSection.tsx
+++ b/web/src/pages/ItemDetail/components/RatingsSection.tsx
@@ -1,0 +1,224 @@
+import { ChevronLeft, ChevronRight, Star, ThumbsDown, ThumbsUp } from "lucide-react";
+import type { ReactNode } from "react";
+import type { CommunityRatingEntry, CommunityRatingReaction } from "@/api/types";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useCommunityRatings, useSetCommunityRatingReaction } from "@/hooks/queries/ratings";
+import { useCarouselEmbla } from "@/hooks/useCarouselEmbla";
+
+const ratingDateFormatter = new Intl.DateTimeFormat(undefined, {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
+
+export default function RatingsSection({ itemId }: { itemId: string }) {
+  const { data, isLoading, isError } = useCommunityRatings(itemId);
+  const reactionMutation = useSetCommunityRatingReaction(itemId);
+  const { emblaRef, canScrollPrev, canScrollNext, scrollPrev, scrollNext } = useCarouselEmbla();
+
+  const setReaction = (entry: CommunityRatingEntry, reaction: CommunityRatingReaction) => {
+    if (reactionMutation.isPending) return;
+    reactionMutation.mutate({
+      ratingKey: entry.key,
+      reaction: entry.viewer_reaction === reaction ? null : reaction,
+    });
+  };
+
+  const ratings = data?.ratings ?? [];
+
+  return (
+    <section aria-labelledby="household-ratings-heading">
+      <div className="mb-5 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 id="household-ratings-heading" className="text-xl font-semibold tracking-tight">
+          Ratings
+        </h2>
+        {data?.average_rating != null && (
+          <p className="text-muted-foreground text-xs tabular-nums">
+            {data.average_rating.toFixed(1)} average from {data.vote_count}{" "}
+            {data.vote_count === 1 ? "rating" : "ratings"}
+          </p>
+        )}
+      </div>
+
+      {ratings.length === 0 ? (
+        <div className="household-rating-card border-border/55 text-muted-foreground flex h-24 items-center justify-center rounded-xl border px-5 text-sm">
+          {isLoading ? "Loading ratings…" : isError ? "Ratings unavailable" : "No ratings yet"}
+        </div>
+      ) : (
+        <div className="group/carousel relative">
+          {canScrollPrev && (
+            <button
+              type="button"
+              onClick={scrollPrev}
+              className="from-background/95 absolute top-0 bottom-0 left-0 z-10 flex h-11 w-11 cursor-default items-center justify-center self-center bg-gradient-to-r to-transparent opacity-0 transition-opacity duration-200 group-hover/carousel:opacity-100 focus-visible:opacity-100"
+              aria-label="Scroll ratings left"
+            >
+              <ChevronLeft className="text-foreground h-6 w-6" />
+            </button>
+          )}
+
+          <div
+            ref={emblaRef}
+            className="embla__viewport -mt-1 overflow-hidden pt-1"
+            tabIndex={0}
+            aria-label="Ratings carousel"
+            onKeyDown={(event) => {
+              if (event.key === "ArrowLeft") {
+                scrollPrev();
+              } else if (event.key === "ArrowRight") {
+                scrollNext();
+              }
+            }}
+          >
+            <ul role="list" className="embla__container flex list-none gap-3">
+              {ratings.map((entry) => (
+                <li key={entry.key} className="embla__slide shrink-0">
+                  <RatingCard
+                    entry={entry}
+                    disabled={reactionMutation.isPending}
+                    onReact={(reaction) => setReaction(entry, reaction)}
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {canScrollNext && (
+            <button
+              type="button"
+              onClick={scrollNext}
+              className="from-background/95 absolute top-0 right-0 bottom-0 z-10 flex h-11 w-11 cursor-default items-center justify-center self-center bg-gradient-to-l to-transparent opacity-0 transition-opacity duration-200 group-hover/carousel:opacity-100 focus-visible:opacity-100"
+              aria-label="Scroll ratings right"
+            >
+              <ChevronRight className="text-foreground h-6 w-6" />
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RatingCard({
+  entry,
+  disabled,
+  onReact,
+}: {
+  entry: CommunityRatingEntry;
+  disabled: boolean;
+  onReact: (reaction: CommunityRatingReaction) => void;
+}) {
+  const fallback = Array.from(entry.display_name)[0]?.toUpperCase() ?? "?";
+
+  return (
+    <article className="household-rating-card border-border/55 flex h-[210px] w-[240px] flex-col rounded-xl border px-5 py-5 shadow-sm sm:w-[280px]">
+      <div className="flex min-h-0 flex-1 flex-col items-center text-center">
+        <Avatar className="ring-border/50 mb-2 size-12 ring-1">
+          {entry.avatar_url ? <AvatarImage src={entry.avatar_url} alt="" loading="lazy" /> : null}
+          <AvatarFallback className="bg-primary/15 text-primary font-bold">
+            {fallback}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex max-w-full items-center justify-center gap-1.5">
+          <span className="text-foreground min-w-0 truncate text-sm font-semibold">
+            {entry.display_name}
+          </span>
+          {entry.is_viewer ? (
+            <span className="border-primary/35 bg-primary/12 text-primary shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] leading-none font-semibold">
+              You
+            </span>
+          ) : null}
+        </div>
+        <time className="text-muted-foreground mt-0.5 text-xs" dateTime={entry.rated_at}>
+          {formatRatingDate(entry.rated_at)}
+        </time>
+        <RatingStars rating={entry.rating} />
+      </div>
+
+      <div className="mt-3 flex items-center justify-start gap-1.5">
+        <ReactionButton
+          label="Helpful"
+          count={entry.up_count}
+          selected={entry.viewer_reaction === "up"}
+          disabled={disabled}
+          onClick={() => onReact("up")}
+        >
+          <ThumbsUp aria-hidden="true" className="size-4" />
+        </ReactionButton>
+        <ReactionButton
+          label="Not helpful"
+          count={entry.down_count}
+          selected={entry.viewer_reaction === "down"}
+          disabled={disabled}
+          onClick={() => onReact("down")}
+        >
+          <ThumbsDown aria-hidden="true" className="size-4" />
+        </ReactionButton>
+      </div>
+    </article>
+  );
+}
+
+function RatingStars({ rating }: { rating: number }) {
+  return (
+    <div
+      className="mt-3 flex items-center justify-center gap-1"
+      aria-label={`${rating} out of 5 stars`}
+    >
+      {Array.from({ length: 5 }, (_, index) => {
+        const filled = index < rating;
+        return (
+          <Star
+            key={index}
+            aria-hidden="true"
+            className={
+              filled ? "size-5 fill-yellow-400 text-yellow-400" : "text-muted-foreground/45 size-5"
+            }
+            strokeWidth={1.5}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ReactionButton({
+  label,
+  count,
+  selected,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  count: number;
+  selected: boolean;
+  disabled: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`${label}: ${count}`}
+      aria-pressed={selected}
+      disabled={disabled}
+      onClick={onClick}
+      onPointerDown={(event) => event.stopPropagation()}
+      className={`focus-visible:ring-ring inline-flex h-8 min-w-11 items-center justify-center gap-1.5 rounded-full border px-2.5 text-xs font-medium tabular-nums outline-none focus-visible:ring-2 enabled:cursor-pointer disabled:cursor-default ${
+        selected
+          ? "border-primary/45 bg-primary/15 text-primary"
+          : "border-border/55 bg-background/75 text-muted-foreground enabled:hover:border-border enabled:hover:text-foreground"
+      }`}
+    >
+      {children}
+      <span>{count}</span>
+    </button>
+  );
+}
+
+function formatRatingDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return ratingDateFormatter.format(date);
+}

--- a/web/src/pages/ItemDetail/components/RatingsSection.tsx
+++ b/web/src/pages/ItemDetail/components/RatingsSection.tsx
@@ -12,7 +12,7 @@ const ratingDateFormatter = new Intl.DateTimeFormat(undefined, {
 });
 
 export default function RatingsSection({ itemId }: { itemId: string }) {
-  const { data, isLoading, isError } = useCommunityRatings(itemId);
+  const { data, capabilities, isLoading, isError } = useCommunityRatings(itemId);
   const reactionMutation = useSetCommunityRatingReaction(itemId);
   const { emblaRef, canScrollPrev, canScrollNext, scrollPrev, scrollNext } = useCarouselEmbla();
 
@@ -75,7 +75,10 @@ export default function RatingsSection({ itemId }: { itemId: string }) {
                 <li key={entry.key} className="embla__slide shrink-0">
                   <RatingCard
                     entry={entry}
-                    disabled={reactionMutation.isPending}
+                    disabled={
+                      reactionMutation.isPending ||
+                      capabilities?.community_rating_reactions === false
+                    }
                     onReact={(reaction) => setReaction(entry, reaction)}
                   />
                 </li>
@@ -163,6 +166,7 @@ function RatingStars({ rating }: { rating: number }) {
   return (
     <div
       className="mt-3 flex items-center justify-center gap-1"
+      role="img"
       aria-label={`${rating} out of 5 stars`}
     >
       {Array.from({ length: 5 }, (_, index) => {


### PR DESCRIPTION
## Problem

Related issue: #828

Closes #828

The existing 1–5 star rating is useful for a profile's recommendations, but it is invisible to everyone else on the same Silo server. I wanted to give that control a little more functionality and make it a nice bit of fun for households and shared servers, without changing what it already does.

This adds a separate server-local community view. A profile's own stars still affect only that profile's recommendation taste. The average, cards, and reactions are display-only; other users' ratings never feed somebody else's recommendations.

## Approach

- Layer the server average as faint yellow SVG fill underneath the existing personal star control. Personal selection and same-star removal behave exactly as before.
- Add an always-present Ratings carousel at the bottom of movie and main TV-series pages. It shows `No ratings yet` until the first rating arrives, then uses the shared Embla wheel rail with opaque, rounded cards.
- Show the current avatar, rating date and year, centred stars, and separate up/down tallies. A profile can react to any card, including its own, and selecting the same reaction again removes it.
- Protect usernames as the first Unicode character plus one `*` for every hidden character (`Mohommad` becomes `M*******`). Account/profile IDs never leave the API, and the current card gets a `You` marker so identical protected names do not look like duplicates.
- Keep one durable rating per account/profile/item through the existing `user_ratings_pkey`. A change updates the same row and stable card key; clearing the rating removes the card and cascades its reactions. Rapid set/delete actions are serialized per item and update the existing cache optimistically.
- Store reactions in PostgreSQL with one up/down choice per reacting profile and preserve them through profile deletion, content reattribution, and provider-ID merges. Follow-up migrations preserve the history already shipped by the production fork while allowing self-reactions and profiles stored in per-user SQLite.
- Proxy uploaded avatars through short-lived encrypted capabilities. Other profiles never receive private object keys, and capability input is length-bounded before decoding.
- Advertise the optional surface through `GET /api/v1/ratings/capabilities`. The web client implements it now; Apple, Android, and Jellyfin compatibility are unchanged and can opt in later.

The detail path stays deliberately small. The web client makes one capability request cached for the app session, then the star overlay and carousel share one item request cached for 30 seconds, with no polling. The server uses a direct indexed PostgreSQL read and returns at most 100 cards. PostgreSQL-backed profile metadata is resolved in that same query; the per-user SQLite fallback loads each unresolved account once with concurrency capped at eight. Reactions and rating edits do bounded optimistic work over the existing cards. Avatars are lazy-loaded, icons are SVG, and cards use paint containment with no backdrop blur. This adds no synchronous work to the existing item-detail response, and I have not seen any noticeable UI slowdown in live use, including hard refreshes and rapid rating changes.

## Validation

Fresh local checks on review-fix commit `11d2c7f0`:

- `make migrate-validate` — passed.
- Focused community-rating and profile-deletion handler tests — passed, including preserving the profile and returning an error when shared rating cleanup fails.
- New SQLite-profile hydration and pagination tests — passed. PostgreSQL purge and many-to-one reattribution regression tests compiled locally and remain enabled for CI through `SILO_TEST_DATABASE_URL`; they skipped locally because no test database URL is configured.
- `internal/catalog/reattribute` and `internal/userstore/pgstore` package tests — passed.
- Compile-only checks for `internal/api`, `internal/catalog`, and the affected repository packages — passed.
- Go vet on the affected API, catalog, reattribution, and user-store packages — passed.
- Six affected Vitest files — 23 tests passed.
- TypeScript project build — passed.
- ESLint and Prettier on every changed TypeScript/TSX file — passed.
- Go formatting and `git diff --check` — passed.

Fresh GitHub Actions on final review-fix commit `11d2c7f0` passed: Go in 7m09s, Web in 7m30s, and Docs hygiene in 13s. CodeRabbit's review threads are all resolved. Its final follow-up check passed under the service's review-rate limit after the last two-file fix; the new durable-cleanup failure-path test and the complete Go/Web workflows are green on that exact commit.

The same feature sequence previously passed the Go, Web, and Docs hygiene jobs on all three fork PRs: [initial feature](https://github.com/blurbery/silo-server/pull/69), [interaction fixes](https://github.com/blurbery/silo-server/pull/70), and [card-integrity fixes](https://github.com/blurbery/silo-server/pull/71). This upstream port also corrects the final API documentation, bounds oversized avatar tokens, gates the optional web request through capability discovery, supports SQLite-backed profile metadata and cleanup, and de-duplicates many-to-one reaction reattribution.

I have not attached the live screenshot publicly because it contains a real profile avatar from a private server. The visible empty, populated, date, reaction, protected-name, identical-mask, and `You` states are covered by component tests and were exercised on the deployed fork.

## Risks

- Adds an indexed lookup and a durable reaction table. Both migrations have Goose down paths; normal restarts do not remove ratings or reactions.
- Community reads enforce the current profile's ordinary item access. Cards show ratings from this Silo server only and expose no internal account/profile identifiers.
- Uploaded-avatar capabilities are intentionally usable by an ordinary `<img>` request until their short expiry; their encrypted payload is scoped to the derived display object and does not reveal its storage key.
- Responses cap the card list at 100 while calculating the average/count over all explicit votes. A reaction can only target a card returned in that bounded list.
- The surface is web-only in this PR. Native clients can feature-detect it later without changing the existing personal rating contract.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): GPT-5 (Codex)
- Involvement: AI-assisted. I led the feature design and implementation decisions, supplied the privacy, interaction, and performance requirements, iterated the behavior against the deployed fork, found the hard-refresh and duplicate-looking-card problems, and carried out live production QA. I did a substantial amount of the work through those implementation iterations. Codex assisted with code changes, tests, the focused upstream port, and review.
- Adversarial review: The complete combined diff was reviewed across item authorization, profile/account identity, username and avatar privacy, reaction ownership, self-reaction toggling, primary-key uniqueness, stable card identity, rapid mutation ordering, rollback behavior, migration durability, profile deletion, content/provider merges, query/index bounds, cache invalidation, render churn, accessibility, and backdrop paint. The earlier reviews resolved the watch-gate refresh bug, self-reaction constraint, row-wide pointer cursor, unstable timestamp key, identical masked-name ambiguity, and optimistic edit/remove behavior. The upstream review additionally found and resolved pagination, SQLite-profile compatibility and cleanup, durable cleanup ordering before profile deletion, many-to-one reaction reattribution, capability gating, star semantics, API wording, and a typed-nil avatar-store edge case. No unresolved feature-specific finding remains.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.
