### PR TITLE
fix(web): keep more-like-this in a bounded carousel

### DIFF
--- a/web/src/components/RecommendationGrid.test.tsx
+++ b/web/src/components/RecommendationGrid.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { UICustomizationContext } from "@/contexts/uiCustomizationContext";
 import RecommendationGrid from "./RecommendationGrid";
 
@@ -19,6 +19,10 @@ vi.mock("@/components/CardPlayOverlay", () => ({
 }));
 
 describe("RecommendationGrid", () => {
+  beforeEach(() => {
+    mocks.useCatalogItemDetail.mockReset();
+  });
+
   it("encodes item IDs in detail links", () => {
     mocks.useCatalogItemDetail.mockReturnValue({
       data: {
@@ -38,7 +42,7 @@ describe("RecommendationGrid", () => {
     expect(mocks.useCatalogItemDetail).toHaveBeenCalledWith("ebook 1");
   });
 
-  it("uses the selected density and omits artwork-only caption rows", () => {
+  it("uses the shared Embla carousel at the selected density and omits artwork-only captions", () => {
     mocks.useCatalogItemDetail.mockReturnValue({
       data: {
         content_id: "ebook 1",
@@ -67,8 +71,27 @@ describe("RecommendationGrid", () => {
       </MemoryRouter>,
     );
 
-    expect(markup).toContain("grid-cols-3 sm:grid-cols-5");
-    expect(markup).not.toContain(">A Reader</p>");
+    expect(markup).toContain("embla__viewport");
+    expect(markup).toContain("w-[120px] shrink-0 sm:w-[140px] lg:w-[160px]");
+    expect(markup).not.toContain("mt-1.5 block truncate");
+  });
+
+  it("renders at most 12 recommendation cards", () => {
+    mocks.useCatalogItemDetail.mockImplementation((itemId: string) => ({
+      data: { content_id: itemId, title: itemId, poster_url: "" },
+    }));
+    const items = Array.from({ length: 14 }, (_, index) => ({
+      media_item_id: `item-${index + 1}`,
+    }));
+
+    renderToStaticMarkup(
+      <MemoryRouter>
+        <RecommendationGrid items={items} maxItems={50} />
+      </MemoryRouter>,
+    );
+
+    expect(mocks.useCatalogItemDetail).toHaveBeenCalledTimes(12);
+    expect(mocks.useCatalogItemDetail).not.toHaveBeenCalledWith("item-13");
   });
 
   it("keeps recommendation details and playback as independent links", () => {

--- a/web/src/components/RecommendationGrid.tsx
+++ b/web/src/components/RecommendationGrid.tsx
@@ -1,8 +1,11 @@
 import ViewTransitionLink from "@/components/ViewTransitionLink";
+import MediaCarousel from "@/components/MediaCarousel";
 import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
 import { useUICustomization } from "@/hooks/useUICustomization";
-import { cardGridClasses } from "@/lib/uiCustomization";
+import { carouselCardWidthClasses } from "@/lib/uiCustomization";
 import CardPlayOverlay from "@/components/CardPlayOverlay";
+
+const MAX_MORE_LIKE_THIS_ITEMS = 12;
 
 interface RecommendationGridProps {
   items: Array<{ media_item_id: string }>;
@@ -11,11 +14,11 @@ interface RecommendationGridProps {
 
 interface RecommendationItemCardProps {
   itemId: string;
+  showCaption: boolean;
 }
 
-function RecommendationItemCard({ itemId }: RecommendationItemCardProps) {
+function RecommendationItemCard({ itemId, showCaption }: RecommendationItemCardProps) {
   const { data: item } = useCatalogItemDetail(itemId);
-  const { cardPresentation } = useUICustomization();
   if (!item) {
     return <div className="bg-surface aspect-[2/3] animate-pulse rounded-lg" />;
   }
@@ -47,7 +50,7 @@ function RecommendationItemCard({ itemId }: RecommendationItemCardProps) {
           />
         ) : null}
       </div>
-      {cardPresentation.caption !== "artwork" ? (
+      {showCaption ? (
         <ViewTransitionLink
           to={`/item/${encodeURIComponent(itemId)}`}
           className="mt-1.5 block truncate text-sm font-medium hover:underline"
@@ -61,11 +64,19 @@ function RecommendationItemCard({ itemId }: RecommendationItemCardProps) {
 
 export default function RecommendationGrid({ items, maxItems = 12 }: RecommendationGridProps) {
   const { cardPresentation } = useUICustomization();
+  const itemLimit = Math.max(0, Math.min(maxItems, MAX_MORE_LIKE_THIS_ITEMS));
+  const posterWidthClasses = carouselCardWidthClasses(cardPresentation.poster_size);
+
   return (
-    <div className={cardGridClasses(cardPresentation.poster_size)}>
-      {items.slice(0, maxItems).map((si) => (
-        <RecommendationItemCard key={si.media_item_id} itemId={si.media_item_id} />
+    <MediaCarousel title="More Like This" edgePadding={false}>
+      {items.slice(0, itemLimit).map((si) => (
+        <div key={si.media_item_id} className={posterWidthClasses}>
+          <RecommendationItemCard
+            itemId={si.media_item_id}
+            showCaption={cardPresentation.caption !== "artwork"}
+          />
+        </div>
       ))}
-    </div>
+    </MediaCarousel>
   );
 }

--- a/web/src/hooks/queries/recommendations.ts
+++ b/web/src/hooks/queries/recommendations.ts
@@ -13,6 +13,8 @@ interface RecommendationResponse {
   items: ScoredItem[];
 }
 
+const SIMILAR_ITEMS_LIMIT = 12;
+
 interface ForYouRow {
   type: string;
   label: string;
@@ -40,7 +42,10 @@ export type { ScoredItem, ForYouRow, ForYouResponse };
 export function useSimilarItems(itemId: string) {
   return useQuery({
     queryKey: recKeys.similar(itemId),
-    queryFn: () => api<RecommendationResponse>(`/recommendations/similar/${itemId}`),
+    queryFn: () =>
+      api<RecommendationResponse>(
+        `/recommendations/similar/${encodeURIComponent(itemId)}?limit=${SIMILAR_ITEMS_LIMIT}`,
+      ),
     staleTime: 3600_000,
     enabled: !!itemId,
   });

--- a/web/src/pages/ItemDetail/MovieContent.tsx
+++ b/web/src/pages/ItemDetail/MovieContent.tsx
@@ -343,12 +343,7 @@ export default function MovieContent({ item }: { item: ItemDetail & { type: "mov
           <RecommendationGridSkeleton />
         ) : (
           similarData?.items &&
-          similarData.items.length > 0 && (
-            <div>
-              <h2 className="mb-5 text-xl font-semibold tracking-tight">More Like This</h2>
-              <RecommendationGrid items={similarData.items} />
-            </div>
-          )
+          similarData.items.length > 0 && <RecommendationGrid items={similarData.items} />
         )}
       </div>
       {canCurateMetadata && (

--- a/web/src/pages/ItemDetail/SeriesContent.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.tsx
@@ -203,12 +203,7 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
           <RecommendationGridSkeleton />
         ) : (
           similarData?.items &&
-          similarData.items.length > 0 && (
-            <div>
-              <h2 className="mb-5 text-xl font-semibold tracking-tight">More Like This</h2>
-              <RecommendationGrid items={similarData.items} />
-            </div>
-          )
+          similarData.items.length > 0 && <RecommendationGrid items={similarData.items} />
         )}
       </div>
       {canCurateMetadata && (

--- a/web/src/pages/ItemDetail/components/SectionSkeletons.test.tsx
+++ b/web/src/pages/ItemDetail/components/SectionSkeletons.test.tsx
@@ -24,7 +24,8 @@ describe("RecommendationGridSkeleton", () => {
       </UICustomizationContext.Provider>,
     );
 
-    expect(markup).toContain("grid-cols-3 sm:grid-cols-5");
+    expect(markup).toContain("flex gap-4 overflow-hidden");
+    expect(markup).toContain("w-[120px] shrink-0 sm:w-[140px] lg:w-[160px]");
     expect(markup).not.toContain("mt-1.5 h-4 w-3/4");
   });
 });

--- a/web/src/pages/ItemDetail/components/SectionSkeletons.tsx
+++ b/web/src/pages/ItemDetail/components/SectionSkeletons.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUICustomization } from "@/hooks/useUICustomization";
-import { cardGridClasses } from "@/lib/uiCustomization";
+import { carouselCardWidthClasses } from "@/lib/uiCustomization";
 
 /** Skeleton for a horizontal cast carousel (portrait cards + name/role text) */
 export function CastSkeleton({ count = 8 }: { count?: number }) {
@@ -64,15 +64,16 @@ export function SeasonCarouselSkeleton({ count = 6 }: { count?: number }) {
   );
 }
 
-/** Skeleton for a poster grid (e.g. "More Like This" recommendations) */
+/** Skeleton for the "More Like This" poster carousel. */
 export function RecommendationGridSkeleton({ count = 6 }: { count?: number }) {
   const { cardPresentation } = useUICustomization();
+  const posterWidthClasses = carouselCardWidthClasses(cardPresentation.poster_size);
   return (
     <div>
       <Skeleton className="mb-5 h-6 w-36" />
-      <div className={cardGridClasses(cardPresentation.poster_size)}>
+      <div className="flex gap-4 overflow-hidden lg:gap-5">
         {Array.from({ length: count }, (_, i) => (
-          <div key={i}>
+          <div key={i} className={posterWidthClasses}>
             <Skeleton className="aspect-[2/3] w-full rounded-lg" />
             {cardPresentation.caption !== "artwork" ? (
               <Skeleton className="mt-1.5 h-4 w-3/4" />


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

The More Like This section can turn into a large poster grid and push the rest of the detail page further down. I wanted it to stay compact and consistent with Silo's other horizontal media rows.

## Approach

I changed More Like This to a single-row carousel using the existing `MediaCarousel`/Embla path. Similar recommendations now request and render at most 12 items, which reduces page congestion and stops the carousel becoming an endless horizontal scroll.

This keeps the shared carousel resize and wheel handling, the existing card density settings, and lazy poster loading. It also avoids adding a second carousel implementation.

## Validation

- `pnpm exec vitest run src/components/RecommendationGrid.test.tsx src/pages/ItemDetail/components/SectionSkeletons.test.tsx src/pages/ItemDetail/MovieContent.test.tsx src/pages/ItemDetail/SeriesContent.test.tsx` — 4 files and 12 tests passed
- ESLint on all seven changed files — passed
- Prettier check on all seven changed files — passed
- `pnpm run build` — passed
- Full repository CI: https://github.com/blurbery/silo-server/actions/runs/33252242683 — Web and docs passed; Go was still running when I opened this PR
- I deployed the same focused change on my Silo server and confirmed the carousel works in the live UI

## Risks

Low. This changes the web layout and recommendation request limit only. There are no migrations or API contract changes, and the server already supports the `limit` parameter.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted. I set the requirements, supplied the before screenshot, asked to reuse the existing Embla carousel without undoing the performance work, reviewed the deployed result, and confirmed it works. Codex implemented the change and ran the checks.
- Adversarial review: I had Codex review the upstream-based diff for the request and render caps, duplicate headings, Embla lifecycle, card density, lazy image behavior, and unrelated changes. It found no unresolved issues; the final diff is limited to seven web files.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “More Like This” recommendations now appear in a responsive horizontal carousel.
  * Recommendation results are limited to 12 items.
  * Artwork-only cards no longer display empty captions.
* **Bug Fixes**
  * Item identifiers are safely encoded when loading similar recommendations.
* **UI Improvements**
  * Updated loading placeholders to match the new carousel layout.
  * Simplified the recommendation section presentation on movie and series detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->