### PR TITLE
fix(jellycompat): negotiate Dolby Vision MKV playback

### DIFF
--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -1182,6 +1182,21 @@ surround, because an in-player track switch does not request a new playlist URL.
 Direct-file and subtitle routes are unchanged because they never execute this
 audio recipe.
 
+Jellyfin HLS remuxes that copy both video and audio use the literal `remux-v1`
+path segment instead (`/Videos/{id}/remux-v1/...`). The segment freezes copy
+semantics for the life of the negotiation: old routers do not match it, current
+handlers reject a copy session on an unversioned or `audio-v2` path and any
+other session on the `remux-v1` path, and an audio switch to a track outside
+the negotiated copy allowlist (same codec, same channel layout, accepted by the
+device profile for fMP4) is rejected before any local, remote, or durable state
+changes — the playlist and `EXT-X-MAP` URLs never change, so a switch that
+alters the copied bytes' shape would require a new PlaybackInfo negotiation.
+Because compat sessions are shared as one durable JSON document that every
+mutation rewrites whole, the compat session structs preserve JSON fields they
+do not declare; a binary that predates that envelope can still erase
+newer-generation fields (such as the remux flags) during the single rolling
+deploy that introduces them.
+
 A remote start carrying source-channel facts is valid only for the exact AAC
 stereo shape and must echo recipe version 2 after FFmpeg reaches readiness. The
 caller stops a job that omits or contradicts that receipt. Shared reconstruction

--- a/internal/jellycompat/audio_selection_test.go
+++ b/internal/jellycompat/audio_selection_test.go
@@ -378,6 +378,112 @@ func TestHandlePlaybackReportRetriesRejectedLocalSurroundSelectionWithoutMutatio
 	}
 }
 
+func TestApplyCompatAudioSelectionRejectsUnsupportedLocalHLSRemuxAudioCopy(t *testing.T) {
+	version := testCompatVersion()
+	version.VideoTracks[0].Codec = "hevc"
+	version.VideoTracks[0].DVProfile = 8
+	version.AudioTracks[0].Codec = "eac3"
+	version.AudioTracks[1].Codec = "dts"
+	defaultStreamIndex := len(version.VideoTracks)
+	unsupportedStreamIndex := defaultStreamIndex + 1
+	source := testCompatSource(NewResourceIDCodec(), version)
+	source.HLSRemux = true
+	source.HLSRemuxAudioStreamIndexes = []int{defaultStreamIndex}
+	source.TranscodeAudio = false
+	source.SelectedAudioStreamIndex = intPtr(defaultStreamIndex)
+	inputPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(inputPath, []byte("video"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := NewPlaybackSessionStore(time.Hour, nil)
+	store.Put(PlaybackSession{
+		ID: "play-1", CompatToken: "token-1", UpstreamSessionID: "upstream-1", UpstreamPlayMethod: "transcode",
+		MediaSources: []PlaybackMediaSource{source},
+	})
+	manager := &testCompatSessionManager{sessions: map[string]*playback.Session{
+		"upstream-1": {ID: "upstream-1", UserID: 7, ProfileID: "profile-1", MediaFileID: version.FileID, PlayMethod: playback.PlayTranscode, BasePlayMethod: playback.PlayTranscode},
+	}}
+	handler := &PlaybackHandler{
+		playbackStore: store,
+		sessionMgr:    manager,
+		fileResolver: testCompatFileResolver{file: &models.MediaFile{
+			ID: version.FileID, FilePath: inputPath,
+			VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8}},
+		}},
+		TranscodeDir: t.TempDir(),
+		FFmpegPath:   writeCompatTestFFmpeg(t),
+		HWAccel:      playback.HWAccelNone,
+		tm:           playback.NewTranscodeManager(),
+	}
+	live, err := handler.ensureTranscodeSession(t.Context(), "play-1", "upstream-1", source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = live.Close() })
+
+	playSession, _ := store.Get("play-1")
+	_, _, restarted, err := handler.applyCompatAudioSelection(t.Context(), playSession, source.ID, unsupportedStreamIndex, 12)
+	if !errors.Is(err, errCompatHLSRemuxAudioUnsupported) || restarted {
+		t.Fatalf("selection = restarted %t error %v, want unsupported remux audio", restarted, err)
+	}
+	persisted, _ := store.Get("play-1")
+	if got := *persisted.MediaSources[0].SelectedAudioStreamIndex; got != defaultStreamIndex {
+		t.Fatalf("persisted stream index = %d, want %d", got, defaultStreamIndex)
+	}
+	if opts := live.Opts(); opts.AudioTrackIndex != 0 || opts.TargetCodecVideo != compatCopyCodec ||
+		opts.TargetCodecAudio != compatCopyCodec || opts.VideoSampleEntry != playback.VideoSampleEntryDVH1 {
+		t.Fatalf("live recipe = track %d video %q audio %q sample entry %q, want original copy/copy/dvh1 recipe",
+			opts.AudioTrackIndex, opts.TargetCodecVideo, opts.TargetCodecAudio, opts.VideoSampleEntry)
+	}
+	if len(manager.audioTrackCalls) != 0 {
+		t.Fatalf("upstream selection calls = %#v, want none", manager.audioTrackCalls)
+	}
+}
+
+func TestApplyCompatAudioSelectionRejectsUnsupportedRemoteHLSRemuxAudioCopy(t *testing.T) {
+	version := testCompatVersion()
+	version.VideoTracks[0].Codec = "hevc"
+	version.AudioTracks[0].Codec = "eac3"
+	version.AudioTracks[1].Codec = "truehd"
+	defaultStreamIndex := len(version.VideoTracks)
+	unsupportedStreamIndex := defaultStreamIndex + 1
+	source := testCompatSource(NewResourceIDCodec(), version)
+	source.HLSRemux = true
+	source.HLSRemuxAudioStreamIndexes = []int{defaultStreamIndex}
+	source.TranscodeAudio = false
+	source.SelectedAudioStreamIndex = intPtr(defaultStreamIndex)
+	store := NewPlaybackSessionStore(time.Hour, nil)
+	store.Put(PlaybackSession{
+		ID: "play-1", CompatToken: "token-1", UpstreamSessionID: "upstream-1", UpstreamPlayMethod: "transcode",
+		MediaSources: []PlaybackMediaSource{source},
+	})
+	manager := &testCompatSessionManager{sessions: map[string]*playback.Session{
+		"upstream-1": {
+			ID: "upstream-1", UserID: 7, ProfileID: "profile-1", MediaFileID: version.FileID,
+			PlayMethod: playback.PlayTranscode, BasePlayMethod: playback.PlayTranscode, TranscodeNodeURL: "http://remote-node.invalid",
+		},
+	}}
+	handler := &PlaybackHandler{
+		playbackStore: store,
+		sessionMgr:    manager,
+		fileResolver:  testCompatFileResolver{file: &models.MediaFile{ID: version.FileID, FilePath: "/media/movie.mkv"}},
+		tm:            playback.NewTranscodeManager(),
+	}
+
+	playSession, _ := store.Get("play-1")
+	_, _, restarted, err := handler.applyCompatAudioSelection(t.Context(), playSession, source.ID, unsupportedStreamIndex, 12)
+	if !errors.Is(err, errCompatHLSRemuxAudioUnsupported) || restarted {
+		t.Fatalf("selection = restarted %t error %v, want unsupported remux audio", restarted, err)
+	}
+	persisted, _ := store.Get("play-1")
+	if got := *persisted.MediaSources[0].SelectedAudioStreamIndex; got != defaultStreamIndex {
+		t.Fatalf("persisted stream index = %d, want %d", got, defaultStreamIndex)
+	}
+	if len(manager.audioTrackCalls) != 0 {
+		t.Fatalf("upstream selection calls = %#v, want none", manager.audioTrackCalls)
+	}
+}
+
 func TestHandlePlaybackReportRollsBackRemoteAttestationFailureAndRetries(t *testing.T) {
 	version := testCompatVersion()
 	version.AudioTracks[0].Channels = 2

--- a/internal/jellycompat/audio_v2_routes_test.go
+++ b/internal/jellycompat/audio_v2_routes_test.go
@@ -1,11 +1,68 @@
 package jellycompat
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/models"
 )
+
+func TestMasterManifestKeepsRemuxV1AndLegacySessionsIsolated(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     PlaybackMediaSource
+		serve      func(*PlaybackHandler, http.ResponseWriter, *http.Request)
+		requestURL string
+	}{
+		{
+			name: "legacy route rejects audio-copy remux",
+			source: PlaybackMediaSource{
+				ID: "source-1", FileID: 42, HLSRemux: true,
+				HLSRemuxAudioStreamIndexes: []int{1},
+				Version:                    testCompatVersion(),
+			},
+			serve:      (*PlaybackHandler).HandleMasterManifest,
+			requestURL: "/Videos/item-1/master.m3u8?PlaySessionId=play-1&MediaSourceId=source-1",
+		},
+		{
+			name: "remux-v1 route rejects legacy transcode",
+			source: func() PlaybackMediaSource {
+				source := testCompatSource(NewResourceIDCodec(), testCompatVersion())
+				source.ID = "source-1"
+				for index := range source.Version.AudioTracks {
+					source.Version.AudioTracks[index].Channels = 2
+				}
+				return source
+			}(),
+			serve:      (*PlaybackHandler).HandleRemuxV1MasterManifest,
+			requestURL: "/Videos/item-1/remux-v1/master.m3u8?PlaySessionId=play-1&MediaSourceId=source-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewPlaybackSessionStore(time.Hour, nil)
+			store.Put(PlaybackSession{
+				ID: "play-1", CompatToken: "token-1", RouteItemID: "item-1",
+				MediaSources: []PlaybackMediaSource{tt.source},
+			})
+			handler := &PlaybackHandler{playbackStore: store}
+			request := httptest.NewRequest(http.MethodGet, tt.requestURL, nil)
+			request = request.WithContext(context.WithValue(request.Context(), compatSessionKey, &Session{Token: "token-1"}))
+			recorder := httptest.NewRecorder()
+
+			tt.serve(handler, recorder, request)
+
+			if recorder.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, body = %s; want route isolation 404", recorder.Code, recorder.Body.String())
+			}
+		})
+	}
+}
 
 func TestMediaSourceDTOEmitsStableAudioV2HLSRoute(t *testing.T) {
 	version := testCompatVersion()

--- a/internal/jellycompat/deviceprofile.go
+++ b/internal/jellycompat/deviceprofile.go
@@ -39,6 +39,8 @@ type TranscodingProfile struct {
 type CodecProfile struct {
 	Type            string             `json:"Type,omitempty"`
 	Codec           string             `json:"Codec,omitempty"`
+	Container       string             `json:"Container,omitempty"`
+	SubContainer    string             `json:"SubContainer,omitempty"`
 	Conditions      []ProfileCondition `json:"Conditions,omitempty"`
 	ApplyConditions []ProfileCondition `json:"ApplyConditions,omitempty"`
 }
@@ -186,6 +188,32 @@ func (p DeviceProfile) SupportsTranscoding(version catalog.FileVersion) bool {
 			continue
 		}
 		return true
+	}
+	return false
+}
+
+// SupportsHLSRemuxForAudioStream reports whether the client accepts the
+// source codecs in an HLS fragmented-MP4 stream. Codec-profile conditions are
+// evaluated against the sample entry Silo will write, not against an unknown
+// source-container tag.
+func (p DeviceProfile) SupportsHLSRemuxForAudioStream(version catalog.FileVersion, audioStreamIndex *int) bool {
+	if len(p.TranscodingProfiles) == 0 {
+		return false
+	}
+	audioCodec := compatAudioCodec(version, audioStreamIndex)
+	for _, profile := range p.TranscodingProfiles {
+		if !matchesVideoType(profile.Type) {
+			continue
+		}
+		if protocol := strings.ToLower(strings.TrimSpace(profile.Protocol)); protocol != "" && protocol != "hls" {
+			continue
+		}
+		if !matchesCSV(profile.Container, "mp4") ||
+			!matchesCSV(profile.VideoCodec, version.CodecVideo) ||
+			!matchesCSV(profile.AudioCodec, audioCodec) {
+			continue
+		}
+		return p.hlsRemuxCodecProfileCompatibility(version, audioStreamIndex).supportsDirectPlay()
 	}
 	return false
 }

--- a/internal/jellycompat/deviceprofile.go
+++ b/internal/jellycompat/deviceprofile.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
 )
 
 // DeviceProfile captures the subset of Jellyfin client capabilities the
@@ -214,6 +215,40 @@ func (p DeviceProfile) SupportsHLSRemuxForAudioStream(version catalog.FileVersio
 			continue
 		}
 		return p.hlsRemuxCodecProfileCompatibility(version, audioStreamIndex).supportsDirectPlay()
+	}
+	return false
+}
+
+func (p DeviceProfile) supportsHLSRemuxWithAudioTranscodeForAudioStream(version catalog.FileVersion, audioStreamIndex *int) bool {
+	if len(p.TranscodingProfiles) == 0 {
+		return false
+	}
+	for _, profile := range p.TranscodingProfiles {
+		if !matchesVideoType(profile.Type) {
+			continue
+		}
+		if protocol := strings.ToLower(strings.TrimSpace(profile.Protocol)); protocol != "" && protocol != "hls" {
+			continue
+		}
+		if !matchesCSV(profile.Container, "mp4") ||
+			!matchesCSV(profile.VideoCodec, version.CodecVideo) ||
+			!matchesCSV(profile.AudioCodec, compatTargetAudioCodec) {
+			continue
+		}
+
+		outputVersion := version
+		outputAudio := compatAudioTrack(version, audioStreamIndex)
+		outputAudio.Codec = compatTargetAudioCodec
+		outputAudio.Profile = ""
+		outputAudio.Bitrate = 192_000
+		if outputAudio.Channels > 0 {
+			outputAudio.Channels = 2
+		}
+		outputAudio.Default = true
+		outputVersion.CodecAudio = compatTargetAudioCodec
+		outputVersion.AudioTracks = []models.AudioTrack{outputAudio}
+		outputAudioStreamIndex := len(outputVersion.VideoTracks)
+		return p.hlsRemuxCodecProfileCompatibility(outputVersion, &outputAudioStreamIndex).supportsDirectPlay()
 	}
 	return false
 }

--- a/internal/jellycompat/deviceprofile_conditions.go
+++ b/internal/jellycompat/deviceprofile_conditions.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/playback"
 )
 
 type codecProfileCompatibility struct {
@@ -77,15 +78,38 @@ func stringifyConditionValue(value any) (string, error) {
 }
 
 func (p DeviceProfile) codecProfileCompatibility(version catalog.FileVersion, audioStreamIndex *int) codecProfileCompatibility {
+	return p.codecProfileCompatibilityWithValues(
+		version,
+		audioStreamIndex,
+		buildConditionValues(version, audioStreamIndex),
+		version.Container,
+		false,
+	)
+}
+
+func (p DeviceProfile) hlsRemuxCodecProfileCompatibility(version catalog.FileVersion, audioStreamIndex *int) codecProfileCompatibility {
+	values := buildConditionValues(version, audioStreamIndex)
+	if tag := playback.VideoSampleEntryForDVCopy(compatDolbyVisionProfile(compatPrimaryVideoTrack(version))); tag != "" {
+		values["videocodectag"] = conditionValue{text: tag}
+	}
+	return p.codecProfileCompatibilityWithValues(version, audioStreamIndex, values, "mp4", true)
+}
+
+func (p DeviceProfile) codecProfileCompatibilityWithValues(
+	version catalog.FileVersion,
+	audioStreamIndex *int,
+	values conditionValues,
+	container string,
+	useSubContainer bool,
+) codecProfileCompatibility {
 	compat := codecProfileCompatibility{VideoSupported: true, AudioSupported: true}
 	if len(p.CodecProfiles) == 0 {
 		return compat
 	}
 
-	values := buildConditionValues(version, audioStreamIndex)
 	for _, profile := range p.CodecProfiles {
 		target := codecProfileTarget(profile)
-		if target == "" || !codecProfileApplies(profile, version, audioStreamIndex) {
+		if target == "" || !codecProfileApplies(profile, version, audioStreamIndex, container, useSubContainer) {
 			continue
 		}
 		if !conditionsMatch(profile.ApplyConditions, values) {
@@ -116,7 +140,20 @@ func codecProfileTarget(profile CodecProfile) string {
 	}
 }
 
-func codecProfileApplies(profile CodecProfile, version catalog.FileVersion, audioStreamIndex *int) bool {
+func codecProfileApplies(
+	profile CodecProfile,
+	version catalog.FileVersion,
+	audioStreamIndex *int,
+	container string,
+	useSubContainer bool,
+) bool {
+	profileContainers := profile.Container
+	if useSubContainer && normalizeCompatToken(profile.Container) == compatHLSPathSegment {
+		profileContainers = profile.SubContainer
+	}
+	if !matchesCodecProfileContainer(profileContainers, container) {
+		return false
+	}
 	if strings.TrimSpace(profile.Codec) == "" {
 		return true
 	}
@@ -128,6 +165,39 @@ func codecProfileApplies(profile CodecProfile, version catalog.FileVersion, audi
 	default:
 		return false
 	}
+}
+
+// matchesCodecProfileContainer mirrors Jellyfin's ContainerHelper semantics:
+// a leading '-' makes the comma-separated list an exclusion list, while an
+// empty list applies to every container.
+func matchesCodecProfileContainer(profileContainers, inputContainers string) bool {
+	profileContainers = strings.TrimSpace(profileContainers)
+	negative := strings.HasPrefix(profileContainers, "-")
+	if negative {
+		profileContainers = strings.TrimSpace(strings.TrimPrefix(profileContainers, "-"))
+	}
+	if profileContainers == "" {
+		return true
+	}
+
+	matched := false
+	for input := range strings.SplitSeq(inputContainers, ",") {
+		for profile := range strings.SplitSeq(profileContainers, ",") {
+			input = strings.TrimSpace(input)
+			profile = strings.TrimSpace(profile)
+			if input != "" && profile != "" && strings.EqualFold(input, profile) {
+				matched = true
+				break
+			}
+		}
+		if matched {
+			break
+		}
+	}
+	if negative {
+		return !matched
+	}
+	return matched
 }
 
 func conditionsOnlyTargetAudio(conditions []ProfileCondition) bool {

--- a/internal/jellycompat/deviceprofile_conditions.go
+++ b/internal/jellycompat/deviceprofile_conditions.go
@@ -89,7 +89,11 @@ func (p DeviceProfile) codecProfileCompatibility(version catalog.FileVersion, au
 
 func (p DeviceProfile) hlsRemuxCodecProfileCompatibility(version catalog.FileVersion, audioStreamIndex *int) codecProfileCompatibility {
 	values := buildConditionValues(version, audioStreamIndex)
-	if tag := playback.VideoSampleEntryForDVCopy(compatDolbyVisionProfile(compatPrimaryVideoTrack(version))); tag != "" {
+	// Derive the promised sample entry from the same value the serve paths use
+	// (PrimaryDVProfile, the probed integer field) — not from
+	// compatDolbyVisionProfile's descriptive-string fallback — so negotiation
+	// can never promise a dvh1 tag the muxer will not write.
+	if tag := playback.VideoSampleEntryForDVCopy(compatPrimaryVideoTrack(version).DVProfile); tag != "" {
 		values["videocodectag"] = conditionValue{text: tag}
 	}
 	return p.codecProfileCompatibilityWithValues(version, audioStreamIndex, values, "mp4", true)
@@ -148,11 +152,10 @@ func codecProfileApplies(
 	useSubContainer bool,
 ) bool {
 	profileContainers := profile.Container
-	profileContainer := strings.TrimSpace(profile.Container)
-	if useSubContainer &&
-		profileContainer != "" &&
-		!strings.HasPrefix(profileContainer, "-") &&
-		matchesCodecProfileContainer(profileContainer, compatHLSPathSegment) {
+	// Jellyfin's CodecProfile substitutes SubContainer only when Container is
+	// exactly "hls" (ordinal, case-insensitive) — a multi-token list such as
+	// "hls,dash" keeps the literal Container list.
+	if useSubContainer && strings.EqualFold(strings.TrimSpace(profile.Container), "hls") {
 		profileContainers = profile.SubContainer
 	}
 	if !matchesCodecProfileContainer(profileContainers, container) {

--- a/internal/jellycompat/deviceprofile_conditions.go
+++ b/internal/jellycompat/deviceprofile_conditions.go
@@ -148,7 +148,11 @@ func codecProfileApplies(
 	useSubContainer bool,
 ) bool {
 	profileContainers := profile.Container
-	if useSubContainer && normalizeCompatToken(profile.Container) == compatHLSPathSegment {
+	profileContainer := strings.TrimSpace(profile.Container)
+	if useSubContainer &&
+		profileContainer != "" &&
+		!strings.HasPrefix(profileContainer, "-") &&
+		matchesCodecProfileContainer(profileContainer, compatHLSPathSegment) {
 		profileContainers = profile.SubContainer
 	}
 	if !matchesCodecProfileContainer(profileContainers, container) {

--- a/internal/jellycompat/deviceprofile_conditions_test.go
+++ b/internal/jellycompat/deviceprofile_conditions_test.go
@@ -44,6 +44,29 @@ func TestDecodeDeviceProfileKeepsCodecProfiles(t *testing.T) {
 	}
 }
 
+func TestMatchesCodecProfileContainerUsesJellyfinLiteralTokens(t *testing.T) {
+	tests := []struct {
+		name              string
+		profileContainers string
+		inputContainers   string
+		want              bool
+	}{
+		{name: "asterisk is a literal", profileContainers: "*", inputContainers: "mkv", want: false},
+		{name: "ts does not alias mpegts", profileContainers: "ts", inputContainers: "mpegts", want: false},
+		{name: "negative ts allows mpegts", profileContainers: "-ts", inputContainers: "mpegts", want: true},
+		{name: "case insensitive literal", profileContainers: "MKV", inputContainers: "mkv", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesCodecProfileContainer(tt.profileContainers, tt.inputContainers); got != tt.want {
+				t.Fatalf("matchesCodecProfileContainer(%q, %q) = %v, want %v",
+					tt.profileContainers, tt.inputContainers, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildPlaybackSourceCodecProfiles(t *testing.T) {
 	h := &PlaybackHandler{codec: NewResourceIDCodec()}
 	baseVersion := catalog.FileVersion{

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -734,7 +734,7 @@ func (h *PlaybackHandler) applyCompatToneMapAvailability(ctx context.Context, so
 }
 
 func applyCompatToneMapAvailabilityWithPolicy(source PlaybackMediaSource, capabilities tonemap.Capabilities, policy tonemap.Policy) PlaybackMediaSource {
-	if !source.SupportsTranscoding || source.TranscodeAudio {
+	if !source.SupportsTranscoding || compatHLSCopiesVideo(source) {
 		return source
 	}
 	file := &models.MediaFile{
@@ -1060,15 +1060,21 @@ func (h *PlaybackHandler) buildProxyRedirectURL(
 	}
 
 	sourceAudioChannels := 0
-	if method == string(playback.PlayTranscode) || (method == string(playback.PlayRemux) && source.TranscodeAudio) {
+	if method == string(playback.PlayTranscode) {
+		sourceAudioChannels = compatHLSRecipeSourceAudioChannels(source)
+	} else if method == string(playback.PlayRemux) && source.TranscodeAudio {
 		sourceAudioChannels = compatSourceAudioChannels(source)
+	}
+	targetAudioCodec := compatTargetAudioCodec
+	if method == string(playback.PlayTranscode) && !compatHLSTranscodesAudio(source) {
+		targetAudioCodec = compatCopyCodec
 	}
 	claims := streamtoken.Claims{
 		SessionID:           upstreamSessionID,
 		MediaPath:           file.FilePath,
 		PlayMethod:          method,
 		TranscodeAudio:      source.TranscodeAudio,
-		TargetCodecAudio:    compatTargetAudioCodec,
+		TargetCodecAudio:    targetAudioCodec,
 		AudioTrackIndex:     audioTrackIndex,
 		SourceAudioChannels: sourceAudioChannels,
 		AudioOnly:           file.IsAudioOnly(),
@@ -1091,7 +1097,7 @@ func (h *PlaybackHandler) buildProxyRedirectURL(
 		// Keep ordinary tokens safe for mixed-generation proxy fleets.
 		claims.SourceAudioChannels = 0
 	}
-	if claims.SourceAudioChannels == 0 && method == string(playback.PlayTranscode) && !source.TranscodeAudio && compatVersionRequiresToneMap(source.Version) {
+	if claims.SourceAudioChannels == 0 && method == string(playback.PlayTranscode) && !compatHLSCopiesVideo(source) && compatVersionRequiresToneMap(source.Version) {
 		// Older binaries do not understand the frozen tone-map claims. Give them
 		// a method they reject rather than let a proxy serve HDR bytes the plan
 		// promised as tone-mapped SDR.
@@ -1210,7 +1216,7 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 		}
 	}
 	if h.playbackStore != nil {
-		expectedSourceAudioChannels := compatSourceAudioChannels(source)
+		expectedSourceAudioChannels := compatHLSRecipeSourceAudioChannels(source)
 		expectedAudioTrackIndex := compatAudioTrackIndexOrDefault(source)
 		if current, ok := h.playbackStore.Get(playSessionID); ok && current.TranscodeStarted && current.Recipe != nil && current.Recipe.TranscodeNodeURL != "" &&
 			current.Recipe.MediaFileID == source.FileID &&
@@ -1222,7 +1228,7 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 			}
 		}
 	}
-	if compatSourceAudioChannels(source) > 0 {
+	if sourceAudioChannels := compatHLSRecipeSourceAudioChannels(source); sourceAudioChannels > 0 {
 		capabilityCtx, cancelCapabilityFetch := context.WithTimeout(ctx, h.toneMapCapabilityTimeout())
 		info, capabilityErr := h.remoteToneMapCapabilityInfo(capabilityCtx, transcodeNodeURL)
 		cancelCapabilityFetch()
@@ -1238,7 +1244,7 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 			return fmt.Errorf("bind transcode node: %w", err)
 		}
 	}
-	if !source.TranscodeAudio && is4KResolution(source.Version.Resolution) && !h.allow4KVideoTranscode(ctx) {
+	if !compatHLSCopiesVideo(source) && is4KResolution(source.Version.Resolution) && !h.allow4KVideoTranscode(ctx) {
 		return errTranscode4KDisallowed
 	}
 	if d := float64(source.Version.Duration); d > 0 && initialSeekSeconds > d {
@@ -1256,7 +1262,7 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 	toneMapRecipe := compatToneMapRecipe{}
 	var toneMapCapabilities tonemap.Capabilities
 	nodeProbeTimeoutMillis := int64(0)
-	if !source.TranscodeAudio {
+	if !compatHLSCopiesVideo(source) {
 		metadata := tonemap.MetadataForFile(file)
 		var requiredPolicy tonemap.Policy
 		if requiredToneMapMode != "" {
@@ -1319,7 +1325,7 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 		SegmentDuration:     segmentDuration,
 		HWAccel:             h.remoteDispatchHWAccel(transcodeNodeURL),
 		AudioTrackIndex:     compatAudioTrackIndexOrDefault(source),
-		SourceAudioChannels: compatSourceAudioChannels(source),
+		SourceAudioChannels: compatHLSRecipeSourceAudioChannels(source),
 		TotalDuration:       float64(source.Version.Duration),
 		RequireReady:        toneMapRecipe.mode != "",
 	}
@@ -1347,9 +1353,12 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 	if autoVideoToolboxBitrate > 0 {
 		reqBody.TargetBitrateKbps = autoVideoToolboxBitrate
 	}
-	if source.TranscodeAudio {
-		reqBody.TargetCodecVideo = "copy"
+	if compatHLSCopiesVideo(source) {
+		reqBody.TargetCodecVideo = compatCopyCodec
 		reqBody.VideoSampleEntry = playback.VideoSampleEntryForDVCopy(file.PrimaryDVProfile())
+	}
+	if !compatHLSTranscodesAudio(source) {
+		reqBody.TargetCodecAudio = compatCopyCodec
 	}
 
 	dispatch := func(request transcodenode.TranscodeStartRequest) (transcodenode.TranscodeStartResponse, int, bool, error) {
@@ -1542,8 +1551,8 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 	toneMapRecipe.apply(&opts)
 	opts.HWAccel = strings.TrimSpace(nodeResponse.HWAccel)
 	opts.ToneMapMode = nodeResponse.ToneMapMode
-	if source.TranscodeAudio {
-		opts.TargetCodecVideo = "copy"
+	if compatHLSCopiesVideo(source) {
+		opts.TargetCodecVideo = compatCopyCodec
 	}
 
 	if err := h.persistTranscodeRecipe(ctx, playSessionID, upstreamSessionID, opts); err != nil {
@@ -1780,7 +1789,7 @@ func (h *PlaybackHandler) HandlePlaybackInfo(w http.ResponseWriter, r *http.Requ
 		if req.MediaSourceID != "" && !mediaSourceIDsEqual(source.ID, req.MediaSourceID) {
 			continue
 		}
-		if source.SupportsTranscoding && !source.TranscodeAudio && compatVersionRequiresToneMap(version) {
+		if source.SupportsTranscoding && !compatHLSCopiesVideo(source) && compatVersionRequiresToneMap(version) {
 			if !toneMapPolicyLoaded {
 				var policyErr error
 				toneMapPolicy, policyErr = h.toneMapPolicyResult(r.Context())
@@ -1963,18 +1972,30 @@ func (h *PlaybackHandler) buildPlaybackSource(
 	supportsDirectPlay := enableDirectPlay && profile.SupportsDirectPlayForAudioStream(version, selectedAudioIndex)
 	audioSupported := profile.SupportsAudioCodecForDirectStreamForAudioStream(version, selectedAudioIndex)
 	videoSupported := profile.SupportsVideoCodecForDirectStreamForAudioStream(version, selectedAudioIndex)
-	transcodeAudio := enableDirectStream && allowVideoCopy && videoSupported && !audioSupported
-	supportsDirectStream := !transcodeAudio &&
+	enableTranscoding := boolDefault(req.EnableTranscoding, true)
+	hlsAudioCopy := enableTranscoding &&
+		enableDirectStream &&
+		allowVideoCopy &&
+		allowAudioCopy &&
+		!supportsDirectPlay &&
+		profile.SupportsHLSRemuxForAudioStream(version, selectedAudioIndex)
+	transcodeAudio := !hlsAudioCopy && enableDirectStream && allowVideoCopy && videoSupported && !audioSupported
+	hlsRemux := hlsAudioCopy || transcodeAudio
+	var hlsRemuxAudioStreamIndexes []int
+	if hlsRemux && !transcodeAudio {
+		hlsRemuxAudioStreamIndexes = supportedHLSRemuxAudioStreamIndexes(version, profile)
+	}
+	supportsDirectStream := !hlsRemux &&
 		enableDirectStream &&
 		allowVideoCopy &&
 		videoSupported &&
 		allowAudioCopy &&
 		audioSupported
-	supportsTranscoding := boolDefault(req.EnableTranscoding, true) && profile.SupportsTranscoding(version)
+	supportsTranscoding := enableTranscoding && (hlsRemux || profile.SupportsTranscoding(version))
 	// Don't offer full video encodes of 4K sources when allow_4k_transcode is
-	// off. Audio-only transcodes (transcodeAudio) stream-copy the video and
-	// stay available.
-	if supportsTranscoding && !transcodeAudio && !allow4KTranscode && is4KResolution(version.Resolution) {
+	// off. HLS remuxes stream-copy the video and stay available regardless of
+	// whether their audio is copied or encoded.
+	if supportsTranscoding && !hlsRemux && !allow4KTranscode && is4KResolution(version.Resolution) {
 		supportsTranscoding = false
 	}
 
@@ -1985,6 +2006,8 @@ func (h *PlaybackHandler) buildPlaybackSource(
 		SupportsDirectPlay:         supportsDirectPlay,
 		SupportsDirectStream:       supportsDirectStream,
 		SupportsTranscoding:        supportsTranscoding,
+		HLSRemux:                   hlsRemux,
+		HLSRemuxAudioStreamIndexes: hlsRemuxAudioStreamIndexes,
 		TranscodeAudio:             transcodeAudio,
 		DefaultAudioStreamIndex:    audioIndex,
 		SelectedAudioStreamIndex:   selectedAudioIndex,
@@ -1993,9 +2016,19 @@ func (h *PlaybackHandler) buildPlaybackSource(
 	}
 }
 
+func supportedHLSRemuxAudioStreamIndexes(version catalog.FileVersion, profile DeviceProfile) []int {
+	indexes := make([]int, 0, len(version.AudioTracks))
+	for audioTrackIndex := range version.AudioTracks {
+		streamIndex := len(version.VideoTracks) + audioTrackIndex
+		if profile.SupportsHLSRemuxForAudioStream(version, &streamIndex) {
+			indexes = append(indexes, streamIndex)
+		}
+	}
+	return indexes
+}
+
 func (h *PlaybackHandler) mediaSourceDTO(routeItemID, playSessionID, compatToken string, source PlaybackMediaSource) mediaSourceDTO {
 	selectedAudioStreamIndex := effectiveCompatAudioStreamIndex(source)
-	hlsAudioV2 := compatHLSRequiresAudioV2(source)
 	dto := mediaSourceDTO{
 		Protocol:                            "File",
 		ID:                                  source.ID,
@@ -2044,8 +2077,12 @@ func (h *PlaybackHandler) mediaSourceDTO(routeItemID, playSessionID, compatToken
 	}
 	dto.TranscodingSubProtocol = "hls"
 	if source.SupportsTranscoding {
-		dto.TranscodingURL = fmt.Sprintf("%s/master.m3u8?PlaySessionId=%s&MediaSourceId=%s", compatVideoPath(routeItemID, hlsAudioV2), playSessionID, source.ID)
-		if source.TranscodeAudio {
+		basePath := compatVideoPath(routeItemID, false)
+		if routePathSegment := compatHLSRoutePathSegment(source); routePathSegment != "" {
+			basePath += "/" + routePathSegment
+		}
+		dto.TranscodingURL = fmt.Sprintf("%s/master.m3u8?PlaySessionId=%s&MediaSourceId=%s", basePath, playSessionID, source.ID)
+		if compatHLSCopiesVideo(source) {
 			dto.TranscodingContainer = "mp4"
 		} else {
 			dto.TranscodingContainer = "ts"

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -1979,9 +1979,10 @@ func (h *PlaybackHandler) buildPlaybackSource(
 		allowAudioCopy &&
 		!supportsDirectPlay &&
 		profile.SupportsHLSRemuxForAudioStream(version, selectedAudioIndex)
-	hlsAudioTranscode := !allowAudioCopy &&
+	hlsAudioTranscode := !hlsAudioCopy &&
 		enableTranscoding &&
 		!supportsDirectPlay &&
+		(!allowAudioCopy || !audioSupported) &&
 		profile.supportsHLSRemuxWithAudioTranscodeForAudioStream(version, selectedAudioIndex)
 	transcodeAudio := !hlsAudioCopy &&
 		enableDirectStream &&
@@ -1991,7 +1992,7 @@ func (h *PlaybackHandler) buildPlaybackSource(
 	hlsRemux := hlsAudioCopy || transcodeAudio
 	var hlsRemuxAudioStreamIndexes []int
 	if hlsRemux && !transcodeAudio {
-		hlsRemuxAudioStreamIndexes = supportedHLSRemuxAudioStreamIndexes(version, profile)
+		hlsRemuxAudioStreamIndexes = supportedHLSRemuxAudioStreamIndexes(version, profile, selectedAudioIndex)
 	}
 	supportsDirectStream := !hlsRemux &&
 		enableDirectStream &&
@@ -1999,7 +2000,12 @@ func (h *PlaybackHandler) buildPlaybackSource(
 		videoSupported &&
 		allowAudioCopy &&
 		audioSupported
-	supportsTranscoding := enableTranscoding && (hlsRemux || profile.SupportsTranscoding(version))
+	// A remux route is only advertised when some transcoding profile vouched
+	// for it: the copy and AAC legs each verified the fMP4 HLS output above,
+	// and the legacy audio-transcode leg keeps the pre-remux SupportsTranscoding
+	// gate rather than minting a TranscodingURL no profile ever matched.
+	supportsTranscoding := enableTranscoding &&
+		(hlsAudioCopy || (transcodeAudio && hlsAudioTranscode) || profile.SupportsTranscoding(version))
 	// Don't offer full video encodes of 4K sources when allow_4k_transcode is
 	// off. HLS remuxes stream-copy the video and stay available regardless of
 	// whether their audio is copied or encoded.
@@ -2024,9 +2030,18 @@ func (h *PlaybackHandler) buildPlaybackSource(
 	}
 }
 
-func supportedHLSRemuxAudioStreamIndexes(version catalog.FileVersion, profile DeviceProfile) []int {
+// supportedHLSRemuxAudioStreamIndexes freezes the copy-safe switch targets. A
+// copy playlist reuses the same playlist and EXT-X-MAP URLs across a track
+// switch, so the client's SourceBuffer keeps the init segment negotiated for
+// the initial track; only tracks whose fMP4 init is interchangeable with it
+// (same codec and channel layout) are safe to switch without renegotiation.
+func supportedHLSRemuxAudioStreamIndexes(version catalog.FileVersion, profile DeviceProfile, selectedAudioIndex *int) []int {
+	selected := compatAudioTrack(version, selectedAudioIndex)
 	indexes := make([]int, 0, len(version.AudioTracks))
-	for audioTrackIndex := range version.AudioTracks {
+	for audioTrackIndex, track := range version.AudioTracks {
+		if !strings.EqualFold(track.Codec, selected.Codec) || track.Channels != selected.Channels {
+			continue
+		}
 		streamIndex := len(version.VideoTracks) + audioTrackIndex
 		if profile.SupportsHLSRemuxForAudioStream(version, &streamIndex) {
 			indexes = append(indexes, streamIndex)

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -1979,7 +1979,15 @@ func (h *PlaybackHandler) buildPlaybackSource(
 		allowAudioCopy &&
 		!supportsDirectPlay &&
 		profile.SupportsHLSRemuxForAudioStream(version, selectedAudioIndex)
-	transcodeAudio := !hlsAudioCopy && enableDirectStream && allowVideoCopy && videoSupported && !audioSupported
+	hlsAudioTranscode := !allowAudioCopy &&
+		enableTranscoding &&
+		!supportsDirectPlay &&
+		profile.supportsHLSRemuxWithAudioTranscodeForAudioStream(version, selectedAudioIndex)
+	transcodeAudio := !hlsAudioCopy &&
+		enableDirectStream &&
+		allowVideoCopy &&
+		videoSupported &&
+		(!audioSupported || hlsAudioTranscode)
 	hlsRemux := hlsAudioCopy || transcodeAudio
 	var hlsRemuxAudioStreamIndexes []int
 	if hlsRemux && !transcodeAudio {

--- a/internal/jellycompat/media_routes.go
+++ b/internal/jellycompat/media_routes.go
@@ -25,6 +25,9 @@ var jellycompatMediaRoutes = []streamtelemetry.MediaRoute{
 	compatRoute(http.MethodGet, "/Videos/{id}/audio-v2/master.m3u8", streamtelemetry.ClassManifest, true),
 	compatRoute(http.MethodGet, "/Videos/{id}/audio-v2/hls/{playlistId}/stream.m3u8", streamtelemetry.ClassManifest, true),
 	compatRoute(http.MethodGet, "/Videos/{id}/audio-v2/hls/{playlistId}/{segmentId}.{segmentContainer}", streamtelemetry.ClassPlayback, true),
+	compatRoute(http.MethodGet, "/Videos/{id}/remux-v1/master.m3u8", streamtelemetry.ClassManifest, true),
+	compatRoute(http.MethodGet, "/Videos/{id}/remux-v1/hls/{playlistId}/stream.m3u8", streamtelemetry.ClassManifest, true),
+	compatRoute(http.MethodGet, "/Videos/{id}/remux-v1/hls/{playlistId}/{segmentId}.{segmentContainer}", streamtelemetry.ClassPlayback, true),
 	compatRoute(http.MethodGet, "/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/stream.{routeFormat}", streamtelemetry.ClassPlayback, true),
 	compatRoute(http.MethodGet, "/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeDeliveryIndex}/stream.{routeFormat}", streamtelemetry.ClassPlayback, true),
 }

--- a/internal/jellycompat/media_routes_test.go
+++ b/internal/jellycompat/media_routes_test.go
@@ -99,6 +99,9 @@ func TestAudioV2PlaybackPathsAreNotCapturedByLegacyRouter(t *testing.T) {
 		{http.MethodGet, "/Videos/item-1/audio-v2/master.m3u8"},
 		{http.MethodGet, "/Videos/item-1/audio-v2/hls/play-v2/stream.m3u8"},
 		{http.MethodGet, "/Videos/item-1/audio-v2/hls/play-v2/seg_00001.ts"},
+		{http.MethodGet, "/Videos/item-1/remux-v1/master.m3u8"},
+		{http.MethodGet, "/Videos/item-1/remux-v1/hls/play-v2/stream.m3u8"},
+		{http.MethodGet, "/Videos/item-1/remux-v1/hls/play-v2/seg_00001.m4s"},
 	}
 	for _, request := range requests {
 		recorder := httptest.NewRecorder()

--- a/internal/jellycompat/playback_hevc_remux_test.go
+++ b/internal/jellycompat/playback_hevc_remux_test.go
@@ -111,6 +111,32 @@ func TestHLSRemuxCodecProfileUsesHLSSubContainer(t *testing.T) {
 	}
 }
 
+func TestHLSRemuxCodecProfileUsesSubContainerForHLSContainerList(t *testing.T) {
+	profile, err := decodeDeviceProfile(strings.NewReader(`{
+		"TranscodingProfiles": [{
+			"Type": "Video", "Protocol": "hls", "Container": "mp4", "VideoCodec": "hevc", "AudioCodec": "eac3"
+		}],
+		"CodecProfiles": [{
+			"Type": "Video", "Container": "hls,dash", "SubContainer": "mp4", "Codec": "hevc",
+			"Conditions": [{
+				"Condition": "EqualsAny", "Property": "VideoRangeType", "Value": "SDR", "IsRequired": false
+			}]
+		}]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := catalog.FileVersion{
+		FileID: 42, Container: "mkv", CodecVideo: "hevc", CodecAudio: "eac3", HDR: true,
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8, VideoRangeType: "DOVIWithHDR10"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	if profile.SupportsHLSRemuxForAudioStream(version, defaultAudioStreamIndex(version)) {
+		t.Fatal("HLS MP4 remux was accepted despite an incompatible codec profile scoped to hls,dash with the MP4 sub-container")
+	}
+}
+
 func TestBuildPlaybackSourceHLSOutputAudioProfilePrefersCopyOverSourceRestriction(t *testing.T) {
 	profile, err := decodeDeviceProfile(strings.NewReader(`{
 		"DirectPlayProfiles": [{
@@ -149,6 +175,48 @@ func TestBuildPlaybackSourceHLSOutputAudioProfilePrefersCopyOverSourceRestrictio
 	}
 	if len(source.HLSRemuxAudioStreamIndexes) != 1 || source.HLSRemuxAudioStreamIndexes[0] != 1 {
 		t.Fatalf("HLSRemuxAudioStreamIndexes = %v, want EAC3 stream 1 copy-compatible", source.HLSRemuxAudioStreamIndexes)
+	}
+}
+
+func TestBuildPlaybackSourceHLSRemuxTranscodesAudioWhenCopyIsDisabled(t *testing.T) {
+	profile := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{{
+			Type: "Video", Container: "mp4", VideoCodec: "hevc", AudioCodec: "eac3",
+		}},
+		TranscodingProfiles: []TranscodingProfile{{
+			Type: "Video", Protocol: "hls", Container: "mp4", VideoCodec: "hevc", AudioCodec: "aac",
+		}},
+	}
+	version := catalog.FileVersion{
+		FileID: 42, Resolution: "2160p", Container: "mkv", CodecVideo: "hevc", CodecAudio: "eac3", HDR: true,
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8, VideoRangeType: "DOVIWithHDR10"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	h := &PlaybackHandler{codec: NewResourceIDCodec()}
+	source := h.buildPlaybackSource(
+		"item",
+		"play",
+		version,
+		profile,
+		playbackInfoRequest{AllowAudioStreamCopy: boolPtr(false)},
+		false,
+	)
+	if source.SupportsDirectPlay || source.SupportsDirectStream {
+		t.Fatalf("source unexpectedly supports direct playback: direct=%v stream=%v", source.SupportsDirectPlay, source.SupportsDirectStream)
+	}
+	if !source.HLSRemux || !source.TranscodeAudio || !source.SupportsTranscoding {
+		t.Fatalf(
+			"source route = remux %v transcode-audio %v supports-transcoding %v, want video-copy HLS with AAC audio transcode",
+			source.HLSRemux,
+			source.TranscodeAudio,
+			source.SupportsTranscoding,
+		)
+	}
+
+	dto := h.mediaSourceDTO("item", "play", "token", source)
+	if dto.TranscodingURL == "" || dto.TranscodingContainer != "mp4" {
+		t.Fatalf("transcoding route = URL %q container %q, want usable MP4 HLS route", dto.TranscodingURL, dto.TranscodingContainer)
 	}
 }
 

--- a/internal/jellycompat/playback_hevc_remux_test.go
+++ b/internal/jellycompat/playback_hevc_remux_test.go
@@ -1,0 +1,350 @@
+package jellycompat
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/playback"
+	"github.com/Silo-Server/silo-server/internal/transcodenode"
+)
+
+func TestBuildPlaybackSourceWebOSDOVIMKVUsesVersionedContainerRules(t *testing.T) {
+	version := catalog.FileVersion{
+		FileID:     42,
+		Resolution: "2160p",
+		Container:  "mkv",
+		CodecVideo: "hevc",
+		CodecAudio: "eac3",
+		HDR:        true,
+		VideoTracks: []models.VideoTrack{{
+			Codec: "hevc", Profile: "Main 10", Width: 3840, Height: 2160, BitDepth: 10,
+			DVProfile: 8, VideoRangeType: "DOVIWithHDR10",
+		}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+	tests := []struct {
+		name                    string
+		restrictedContainers    string
+		wantDirectPlay          bool
+		wantHLSRemux            bool
+		wantSupportsTranscoding bool
+	}{
+		{
+			name:                    "WebOS 25 direct plays Dolby Vision MKV",
+			restrictedContainers:    "-mp4,ts,mkv",
+			wantDirectPlay:          true,
+			wantHLSRemux:            false,
+			wantSupportsTranscoding: false,
+		},
+		{
+			name:                    "WebOS 24 remuxes Dolby Vision MKV",
+			restrictedContainers:    "-mp4,ts",
+			wantDirectPlay:          false,
+			wantHLSRemux:            true,
+			wantSupportsTranscoding: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := decodeDeviceProfile(strings.NewReader(fmt.Sprintf(`{
+				"DirectPlayProfiles": [{
+					"Type": "Video", "Container": "mkv", "VideoCodec": "hevc", "AudioCodec": "eac3"
+				}],
+				"TranscodingProfiles": [{
+					"Type": "Video", "Protocol": "hls", "Container": "mp4", "VideoCodec": "hevc", "AudioCodec": "eac3"
+				}],
+				"CodecProfiles": [{
+					"Type": "Video", "Container": %q, "Codec": "hevc",
+					"Conditions": [{
+						"Condition": "EqualsAny", "Property": "VideoRangeType", "Value": "SDR|HDR10|HDR10Plus|HLG", "IsRequired": false
+					}]
+				}]
+			}`, tt.restrictedContainers)))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			source := (&PlaybackHandler{codec: NewResourceIDCodec()}).buildPlaybackSource(
+				"item", "play", version, profile, playbackInfoRequest{}, false,
+			)
+			if source.SupportsDirectPlay != tt.wantDirectPlay {
+				t.Fatalf("SupportsDirectPlay = %v, want %v", source.SupportsDirectPlay, tt.wantDirectPlay)
+			}
+			if source.HLSRemux != tt.wantHLSRemux {
+				t.Fatalf("HLSRemux = %v, want %v", source.HLSRemux, tt.wantHLSRemux)
+			}
+			if source.SupportsTranscoding != tt.wantSupportsTranscoding {
+				t.Fatalf("SupportsTranscoding = %v, want %v", source.SupportsTranscoding, tt.wantSupportsTranscoding)
+			}
+		})
+	}
+}
+
+func TestHLSRemuxCodecProfileUsesHLSSubContainer(t *testing.T) {
+	profile, err := decodeDeviceProfile(strings.NewReader(`{
+		"TranscodingProfiles": [{
+			"Type": "Video", "Protocol": "hls", "Container": "mp4", "VideoCodec": "hevc", "AudioCodec": "eac3"
+		}],
+		"CodecProfiles": [{
+			"Type": "Video", "Container": "hls", "SubContainer": "ts", "Codec": "hevc",
+			"Conditions": [{
+				"Condition": "EqualsAny", "Property": "VideoRangeType", "Value": "SDR", "IsRequired": false
+			}]
+		}]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := catalog.FileVersion{
+		FileID: 42, Container: "mkv", CodecVideo: "hevc", CodecAudio: "eac3", HDR: true,
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8, VideoRangeType: "DOVIWithHDR10"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	if !profile.SupportsHLSRemuxForAudioStream(version, defaultAudioStreamIndex(version)) {
+		t.Fatal("HLS MP4 remux was rejected by a codec profile scoped only to the HLS TS sub-container")
+	}
+}
+
+func TestBuildPlaybackSourceHLSOutputAudioProfilePrefersCopyOverSourceRestriction(t *testing.T) {
+	profile, err := decodeDeviceProfile(strings.NewReader(`{
+		"DirectPlayProfiles": [{
+			"Type": "Video", "Container": "mkv", "VideoCodec": "hevc", "AudioCodec": "eac3"
+		}],
+		"TranscodingProfiles": [{
+			"Type": "Video", "Protocol": "hls", "Container": "mp4", "VideoCodec": "hevc", "AudioCodec": "eac3"
+		}],
+		"CodecProfiles": [{
+			"Type": "VideoAudio", "Container": "-mp4,ts", "Codec": "eac3",
+			"Conditions": [{
+				"Condition": "LessThanEqual", "Property": "AudioChannels", "Value": "2", "IsRequired": false
+			}]
+		}]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := catalog.FileVersion{
+		FileID: 42, Resolution: "2160p", Container: "mkv", CodecVideo: "hevc", CodecAudio: "eac3", HDR: true,
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8, VideoRangeType: "DOVIWithHDR10"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	source := (&PlaybackHandler{codec: NewResourceIDCodec()}).buildPlaybackSource(
+		"item", "play", version, profile, playbackInfoRequest{}, false,
+	)
+	if source.SupportsDirectPlay {
+		t.Fatal("SupportsDirectPlay = true, want source-scoped 2-channel restriction to block MKV direct play")
+	}
+	if !source.HLSRemux || !source.SupportsTranscoding {
+		t.Fatalf("HLS remux = %v, SupportsTranscoding = %v; want MP4 HLS route", source.HLSRemux, source.SupportsTranscoding)
+	}
+	if source.TranscodeAudio {
+		t.Fatal("TranscodeAudio = true, want output-scoped MP4 profile to preserve EAC3 copy")
+	}
+	if len(source.HLSRemuxAudioStreamIndexes) != 1 || source.HLSRemuxAudioStreamIndexes[0] != 1 {
+		t.Fatalf("HLSRemuxAudioStreamIndexes = %v, want EAC3 stream 1 copy-compatible", source.HLSRemuxAudioStreamIndexes)
+	}
+}
+
+func TestBuildPlaybackSourceSafariHEVCMKVOffersHLSRemux(t *testing.T) {
+	h := &PlaybackHandler{codec: NewResourceIDCodec()}
+	version := catalog.FileVersion{
+		FileID:     42,
+		Resolution: "2160p",
+		Container:  "mkv",
+		CodecVideo: "hevc",
+		CodecAudio: "eac3",
+		HDR:        true,
+		VideoTracks: []models.VideoTrack{{
+			Codec:          "hevc",
+			Profile:        "Main 10",
+			Level:          153,
+			Width:          3840,
+			Height:         1606,
+			BitDepth:       10,
+			DVProfile:      8,
+			HDR10Plus:      true,
+			VideoRangeType: "DOVIWithHDR10Plus",
+		}},
+		AudioTracks: []models.AudioTrack{
+			{Codec: "eac3", Channels: 6, Default: true},
+			{Codec: "truehd", Channels: 8},
+		},
+	}
+	profile := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{{
+			Type:       "Video",
+			Container:  "mp4,m4v",
+			VideoCodec: "hevc,h264",
+			AudioCodec: "aac,mp3,ac3,eac3,flac,alac",
+		}},
+		TranscodingProfiles: []TranscodingProfile{{
+			Type:       "Video",
+			Protocol:   "hls",
+			Container:  "mp4",
+			VideoCodec: "hevc,h264,vp9",
+			AudioCodec: "aac,ac3,eac3,flac,alac",
+		}},
+		CodecProfiles: []CodecProfile{{
+			Type:  "Video",
+			Codec: "hevc",
+			Conditions: []ProfileCondition{{
+				Condition:  "EqualsAny",
+				Property:   "VideoCodecTag",
+				Value:      "hvc1|dvh1",
+				IsRequired: true,
+			}},
+		}},
+	}
+
+	source := h.buildPlaybackSource("item", "play", version, profile, playbackInfoRequest{}, false)
+	if source.SupportsDirectPlay {
+		t.Fatal("SupportsDirectPlay = true, want false for MKV vs MP4")
+	}
+	if source.SupportsDirectStream {
+		t.Fatal("SupportsDirectStream = true, want false because its static URL would serve MKV")
+	}
+	if !source.SupportsTranscoding {
+		t.Fatal("SupportsTranscoding = false, want an HLS remux route")
+	}
+	if source.TranscodeAudio {
+		t.Fatal("TranscodeAudio = true, want EAC3 copied because the HLS profile accepts it")
+	}
+	if len(source.HLSRemuxAudioStreamIndexes) != 1 || source.HLSRemuxAudioStreamIndexes[0] != 1 {
+		t.Fatalf("HLSRemuxAudioStreamIndexes = %v, want only the EAC3 stream frozen as copy-compatible", source.HLSRemuxAudioStreamIndexes)
+	}
+
+	dto := h.mediaSourceDTO("item", "play", "token", source)
+	if dto.TranscodingURL == "" {
+		t.Fatal("TranscodingURL is empty")
+	}
+	if !strings.HasPrefix(dto.TranscodingURL, "/Videos/item/remux-v1/master.m3u8?") {
+		t.Fatalf("TranscodingURL = %q, want rolling-deploy-safe remux-v1 route", dto.TranscodingURL)
+	}
+	if dto.TranscodingContainer != "mp4" {
+		t.Fatalf("TranscodingContainer = %q, want mp4", dto.TranscodingContainer)
+	}
+	if dto.DirectStreamURL != "" {
+		t.Fatalf("DirectStreamURL = %q, want empty", dto.DirectStreamURL)
+	}
+}
+
+func TestStartRemoteSafariHEVCMKVRemuxCopiesAdvertisedCodecs(t *testing.T) {
+	var request transcodenode.TranscodeStartRequest
+	node := fakeTranscodeNode(t, &request)
+	recipeStore := &stubRecipeNodeStore{}
+	handler, _, playbackStore := newRemoteTranscodeHandler(t, node.URL, recipeStore)
+	playbackStore.Put(PlaybackSession{ID: "play-1", UpstreamSessionID: "upstream-1"})
+
+	source := PlaybackMediaSource{
+		ID:       "source-1",
+		FileID:   42,
+		HLSRemux: true,
+		Version: catalog.FileVersion{
+			FileID:     42,
+			Resolution: "2160p",
+			Container:  "mkv",
+			CodecVideo: "hevc",
+			CodecAudio: "eac3",
+			HDR:        true,
+			VideoTracks: []models.VideoTrack{{
+				Codec: "hevc", DVProfile: 8, Width: 3840, Height: 1606, BitDepth: 10,
+			}},
+			AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+		},
+	}
+	file := &models.MediaFile{
+		ID: 42, FilePath: "/media/movie.mkv", CodecVideo: "hevc", CodecAudio: "eac3",
+		Resolution: "2160p", HDR: true,
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8, Width: 3840, Height: 1606, BitDepth: 10}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	if err := handler.startRemoteTranscode(context.Background(), "play-1", "upstream-1", source, file, 0, node.URL); err != nil {
+		t.Fatalf("startRemoteTranscode: %v", err)
+	}
+	if request.TargetCodecVideo != "copy" || request.TargetCodecAudio != "copy" {
+		t.Fatalf("remote codecs = video %q audio %q, want copy/copy", request.TargetCodecVideo, request.TargetCodecAudio)
+	}
+	if request.VideoSampleEntry != playback.VideoSampleEntryDVH1 {
+		t.Fatalf("VideoSampleEntry = %q, want dvh1", request.VideoSampleEntry)
+	}
+	if request.SourceAudioChannels != 0 || request.TargetAudioChannels != 0 || request.AudioRecipeVersion != "" {
+		t.Fatalf("remote request unexpectedly encodes audio: %+v", request)
+	}
+	if request.ToneMapMode != "" {
+		t.Fatalf("ToneMapMode = %q, want no tone map for video copy", request.ToneMapMode)
+	}
+
+	card, ok := recipeStore.Get("upstream-1")
+	if !ok {
+		t.Fatal("remote recipe was not persisted")
+	}
+	if card.TargetCodecVideo != "copy" || card.TargetCodecAudio != "copy" || card.VideoSampleEntry != playback.VideoSampleEntryDVH1 {
+		t.Fatalf("persisted recipe = video %q audio %q sample-entry %q, want copy/copy/dvh1", card.TargetCodecVideo, card.TargetCodecAudio, card.VideoSampleEntry)
+	}
+}
+
+func TestRequiredVideoCodecTagUsesRemuxOutputOnly(t *testing.T) {
+	profile := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{{
+			Type: "Video", Container: "mp4", VideoCodec: "hevc", AudioCodec: "eac3",
+		}},
+		TranscodingProfiles: []TranscodingProfile{{
+			Type: "Video", Protocol: "hls", Container: "mp4", VideoCodec: "hevc", AudioCodec: "eac3",
+		}},
+		CodecProfiles: []CodecProfile{{
+			Type: "Video", Codec: "hevc",
+			Conditions: []ProfileCondition{{
+				Condition: "EqualsAny", Property: "VideoCodecTag", Value: "hvc1|dvh1", IsRequired: true,
+			}},
+		}},
+	}
+	version := catalog.FileVersion{
+		FileID: 1, Resolution: "2160p", Container: "mp4", CodecVideo: "hevc", CodecAudio: "eac3",
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	source := (&PlaybackHandler{codec: NewResourceIDCodec()}).buildPlaybackSource(
+		"item", "play", version, profile, playbackInfoRequest{}, false,
+	)
+	if source.SupportsDirectPlay {
+		t.Fatal("SupportsDirectPlay = true, but the source MP4 sample entry was never probed")
+	}
+	if !source.HLSRemux || !source.SupportsTranscoding {
+		t.Fatalf("HLS remux route = remux %v transcode %v, want remuxed dvh1 output", source.HLSRemux, source.SupportsTranscoding)
+	}
+}
+
+func TestHLSRemuxDoesNotClaimUnwrittenHVC1Tag(t *testing.T) {
+	profile := DeviceProfile{
+		TranscodingProfiles: []TranscodingProfile{{
+			Type: "Video", Protocol: "hls", Container: "mp4", VideoCodec: "hevc", AudioCodec: "eac3",
+		}},
+		CodecProfiles: []CodecProfile{{
+			Type: "Video", Codec: "hevc",
+			Conditions: []ProfileCondition{{
+				Condition: "Equals", Property: "VideoCodecTag", Value: "hvc1", IsRequired: true,
+			}},
+		}},
+	}
+	version := catalog.FileVersion{
+		FileID: 1, Resolution: "2160p", Container: "mkv", CodecVideo: "hevc", CodecAudio: "eac3",
+		VideoTracks: []models.VideoTrack{{Codec: "hevc"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	source := (&PlaybackHandler{codec: NewResourceIDCodec()}).buildPlaybackSource(
+		"item", "play", version, profile, playbackInfoRequest{}, false,
+	)
+	if source.HLSRemux || source.SupportsTranscoding {
+		t.Fatalf("unwritten hvc1 tag produced route: remux %v transcode %v", source.HLSRemux, source.SupportsTranscoding)
+	}
+}

--- a/internal/jellycompat/playback_hevc_remux_test.go
+++ b/internal/jellycompat/playback_hevc_remux_test.go
@@ -3,6 +3,7 @@ package jellycompat
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -111,7 +112,10 @@ func TestHLSRemuxCodecProfileUsesHLSSubContainer(t *testing.T) {
 	}
 }
 
-func TestHLSRemuxCodecProfileUsesSubContainerForHLSContainerList(t *testing.T) {
+func TestHLSRemuxCodecProfileKeepsLiteralContainerListWithHLSToken(t *testing.T) {
+	// Jellyfin substitutes SubContainer only when Container is exactly "hls".
+	// A multi-token list containing hls keeps its literal token list, so this
+	// incompatible profile never applies to the MP4 remux output.
 	profile, err := decodeDeviceProfile(strings.NewReader(`{
 		"TranscodingProfiles": [{
 			"Type": "Video", "Protocol": "hls", "Container": "mp4", "VideoCodec": "hevc", "AudioCodec": "eac3"
@@ -132,8 +136,8 @@ func TestHLSRemuxCodecProfileUsesSubContainerForHLSContainerList(t *testing.T) {
 		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
 	}
 
-	if profile.SupportsHLSRemuxForAudioStream(version, defaultAudioStreamIndex(version)) {
-		t.Fatal("HLS MP4 remux was accepted despite an incompatible codec profile scoped to hls,dash with the MP4 sub-container")
+	if !profile.SupportsHLSRemuxForAudioStream(version, defaultAudioStreamIndex(version)) {
+		t.Fatal("HLS MP4 remux was rejected by an hls,dash-scoped codec profile that Jellyfin would never apply to MP4 output")
 	}
 }
 
@@ -217,6 +221,72 @@ func TestBuildPlaybackSourceHLSRemuxTranscodesAudioWhenCopyIsDisabled(t *testing
 	dto := h.mediaSourceDTO("item", "play", "token", source)
 	if dto.TranscodingURL == "" || dto.TranscodingContainer != "mp4" {
 		t.Fatalf("transcoding route = URL %q container %q, want usable MP4 HLS route", dto.TranscodingURL, dto.TranscodingContainer)
+	}
+}
+
+func TestBuildPlaybackSourceKeepsLegacyTranscodingGateWithoutHLSProfile(t *testing.T) {
+	// The client's DirectPlayProfiles accept the video codec but not the audio
+	// codec, and its only TranscodingProfile is progressive HTTP: no profile
+	// vouches for any HLS output, so no TranscodingURL may be minted.
+	profile := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{{
+			Type: "Video", Container: "mp4", VideoCodec: "hevc", AudioCodec: "aac",
+		}},
+		TranscodingProfiles: []TranscodingProfile{{
+			Type: "Video", Protocol: "http", Container: "mp4", VideoCodec: "hevc", AudioCodec: "aac",
+		}},
+	}
+	version := catalog.FileVersion{
+		FileID: 42, Resolution: "2160p", Container: "mkv", CodecVideo: "hevc", CodecAudio: "eac3", HDR: true,
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8, VideoRangeType: "DOVIWithHDR10"}},
+		AudioTracks: []models.AudioTrack{{Codec: "eac3", Channels: 6, Default: true}},
+	}
+
+	h := &PlaybackHandler{codec: NewResourceIDCodec()}
+	source := h.buildPlaybackSource("item", "play", version, profile, playbackInfoRequest{}, false)
+	if source.SupportsDirectPlay || source.SupportsDirectStream {
+		t.Fatalf("direct methods = play %v stream %v, want none", source.SupportsDirectPlay, source.SupportsDirectStream)
+	}
+	if source.SupportsTranscoding {
+		t.Fatal("SupportsTranscoding = true, want no unverified fMP4 HLS offer for an HTTP-only profile")
+	}
+	if dto := h.mediaSourceDTO("item", "play", "token", source); dto.TranscodingURL != "" {
+		t.Fatalf("TranscodingURL = %q, want empty", dto.TranscodingURL)
+	}
+}
+
+func TestSupportedHLSRemuxAudioStreamIndexesFreezeCodecAndChannelLayout(t *testing.T) {
+	// The copy playlist reuses the same EXT-X-MAP URL across a switch, so only
+	// tracks interchangeable with the selected track's init segment (same
+	// codec, same channel layout) may enter the switch allowlist even when the
+	// device profile accepts the other codecs.
+	profile := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{{
+			Type: "Video", Container: "mp4", VideoCodec: "hevc", AudioCodec: "eac3,ac3",
+		}},
+		TranscodingProfiles: []TranscodingProfile{{
+			Type: "Video", Protocol: "hls", Container: "mp4", VideoCodec: "hevc", AudioCodec: "eac3,ac3",
+		}},
+	}
+	version := catalog.FileVersion{
+		FileID: 42, Resolution: "2160p", Container: "mkv", CodecVideo: "hevc", CodecAudio: "eac3", HDR: true,
+		VideoTracks: []models.VideoTrack{{Codec: "hevc", DVProfile: 8, VideoRangeType: "DOVIWithHDR10"}},
+		AudioTracks: []models.AudioTrack{
+			{Codec: "eac3", Channels: 6, Default: true},
+			{Codec: "ac3", Channels: 6},
+			{Codec: "eac3", Channels: 2},
+			{Codec: "eac3", Channels: 6},
+		},
+	}
+
+	source := (&PlaybackHandler{codec: NewResourceIDCodec()}).buildPlaybackSource(
+		"item", "play", version, profile, playbackInfoRequest{}, false,
+	)
+	if !source.HLSRemux || source.TranscodeAudio {
+		t.Fatalf("route = remux %v transcode-audio %v, want audio-copy remux", source.HLSRemux, source.TranscodeAudio)
+	}
+	if want := []int{1, 4}; !slices.Equal(source.HLSRemuxAudioStreamIndexes, want) {
+		t.Fatalf("HLSRemuxAudioStreamIndexes = %v, want %v (6-channel EAC3 tracks only)", source.HLSRemuxAudioStreamIndexes, want)
 	}
 }
 

--- a/internal/jellycompat/playback_sessions.go
+++ b/internal/jellycompat/playback_sessions.go
@@ -63,12 +63,17 @@ type PlaybackSession struct {
 
 // PlaybackMediaSource stores one negotiated stream source within a compat play session.
 type PlaybackMediaSource struct {
-	ID                          string
-	FileID                      int
-	Version                     catalog.FileVersion
-	SupportsDirectPlay          bool
-	SupportsDirectStream        bool
-	SupportsTranscoding         bool
+	ID                   string
+	FileID               int
+	Version              catalog.FileVersion
+	SupportsDirectPlay   bool
+	SupportsDirectStream bool
+	SupportsTranscoding  bool
+	// HLSRemux selects fragmented MP4 with video copy. TranscodeAudio remains
+	// the independent audio-encode decision, so a compatible audio codec can
+	// stay bit-for-bit copied.
+	HLSRemux                    bool
+	HLSRemuxAudioStreamIndexes  []int
 	TranscodeAudio              bool
 	DefaultAudioStreamIndex     *int
 	SelectedAudioStreamIndex    *int

--- a/internal/jellycompat/playback_sessions.go
+++ b/internal/jellycompat/playback_sessions.go
@@ -2,6 +2,7 @@ package jellycompat
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sort"
 	"sync"
@@ -59,6 +60,10 @@ type PlaybackSession struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ExpiresAt time.Time
+
+	// preservedJSON carries fields written by a newer binary through this
+	// binary's durable read-modify-write cycle. See playback_sessions_json.go.
+	preservedJSON map[string]json.RawMessage
 }
 
 // PlaybackMediaSource stores one negotiated stream source within a compat play session.
@@ -80,6 +85,10 @@ type PlaybackMediaSource struct {
 	DefaultSubtitleStreamIndex  *int
 	SelectedSubtitleStreamIndex *int
 	ETag                        string
+
+	// preservedJSON carries fields written by a newer binary through this
+	// binary's durable read-modify-write cycle. See playback_sessions_json.go.
+	preservedJSON map[string]json.RawMessage
 }
 
 // CompatPlaybackStore persists compat playback negotiation sessions (the

--- a/internal/jellycompat/playback_sessions_json.go
+++ b/internal/jellycompat/playback_sessions_json.go
@@ -1,0 +1,121 @@
+package jellycompat
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// Compat playback sessions are shared across processes as one JSONB document,
+// and every durable mutation is a read-modify-write of that whole document
+// (updateDB / stageTerminalDB). During a rolling deployment the process
+// applying a mutation may be older than the process that negotiated the
+// session, so any field the older binary's struct does not declare would be
+// silently erased on the rewrite — e.g. a route-version flag whose loss makes
+// every URL the client is actively playing 404. The custom JSON round-trip
+// below captures keys this binary does not recognize and re-emits them
+// verbatim, so a document only ever loses fields to a binary that predates
+// this envelope.
+//
+// The envelope covers the jellycompat-owned structs. Fields added to nested
+// foreign types (catalog.FileVersion, playback.RecipeCard) still need their
+// own compatibility story.
+
+type playbackSessionJSON PlaybackSession
+type playbackMediaSourceJSON PlaybackMediaSource
+
+var playbackSessionKnownJSONKeys = sync.OnceValue(func() map[string]struct{} {
+	return knownJSONKeys(reflect.TypeFor[playbackSessionJSON]())
+})
+
+var playbackMediaSourceKnownJSONKeys = sync.OnceValue(func() map[string]struct{} {
+	return knownJSONKeys(reflect.TypeFor[playbackMediaSourceJSON]())
+})
+
+func (s *PlaybackSession) UnmarshalJSON(data []byte) error {
+	var known playbackSessionJSON
+	if err := json.Unmarshal(data, &known); err != nil {
+		return err
+	}
+	*s = PlaybackSession(known)
+	s.preservedJSON = unknownJSONFields(data, playbackSessionKnownJSONKeys())
+	return nil
+}
+
+func (s PlaybackSession) MarshalJSON() ([]byte, error) {
+	return marshalWithPreservedJSON(playbackSessionJSON(s), s.preservedJSON)
+}
+
+func (s *PlaybackMediaSource) UnmarshalJSON(data []byte) error {
+	var known playbackMediaSourceJSON
+	if err := json.Unmarshal(data, &known); err != nil {
+		return err
+	}
+	*s = PlaybackMediaSource(known)
+	s.preservedJSON = unknownJSONFields(data, playbackMediaSourceKnownJSONKeys())
+	return nil
+}
+
+func (s PlaybackMediaSource) MarshalJSON() ([]byte, error) {
+	return marshalWithPreservedJSON(playbackMediaSourceJSON(s), s.preservedJSON)
+}
+
+// knownJSONKeys lists the JSON object keys the given struct type produces, so
+// unknownJSONFields can subtract them. The session structs use field names as
+// keys today; the json-tag parsing keeps the subtraction correct if a tag is
+// ever added.
+func knownJSONKeys(t reflect.Type) map[string]struct{} {
+	keys := make(map[string]struct{}, t.NumField())
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+		name := field.Name
+		if tag, _, _ := strings.Cut(field.Tag.Get("json"), ","); tag == "-" {
+			continue
+		} else if tag != "" {
+			name = tag
+		}
+		keys[name] = struct{}{}
+	}
+	return keys
+}
+
+func unknownJSONFields(data []byte, known map[string]struct{}) map[string]json.RawMessage {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	for key := range raw {
+		if _, ok := known[key]; ok {
+			delete(raw, key)
+		}
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
+}
+
+func marshalWithPreservedJSON(known any, preserved map[string]json.RawMessage) ([]byte, error) {
+	data, err := json.Marshal(known)
+	if err != nil || len(preserved) == 0 {
+		return data, err
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(data, &merged); err != nil {
+		return nil, err
+	}
+	// This binary's fields are authoritative; preserved keys are by
+	// construction unknown here, so a collision can only mean the document was
+	// written by a newer schema this binary also declares — let the declared
+	// field win.
+	for key, value := range preserved {
+		if _, exists := merged[key]; !exists {
+			merged[key] = value
+		}
+	}
+	return json.Marshal(merged)
+}

--- a/internal/jellycompat/playback_sessions_json_test.go
+++ b/internal/jellycompat/playback_sessions_json_test.go
@@ -1,0 +1,78 @@
+package jellycompat
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPlaybackSessionJSONPreservesUnknownFieldsAcrossRewrite(t *testing.T) {
+	// A document written by a newer binary: this binary knows neither the
+	// top-level key nor the per-source key. A read-modify-write must carry
+	// both through verbatim, or a rolling deployment erases the newer
+	// generation's negotiation state.
+	doc := []byte(`{
+		"ID": "play-1",
+		"CompatToken": "token-1",
+		"FutureSessionField": {"nested": true},
+		"MediaSources": [{
+			"ID": "source-1",
+			"FileID": 42,
+			"TranscodeAudio": false,
+			"FutureSourceField": [1, 2, 3]
+		}]
+	}`)
+
+	var session PlaybackSession
+	if err := json.Unmarshal(doc, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session.ID != "play-1" || len(session.MediaSources) != 1 || session.MediaSources[0].FileID != 42 {
+		t.Fatalf("known fields did not decode: %+v", session)
+	}
+
+	// The mutation an older binary would apply mid-deploy.
+	session.MediaSources[0].SelectedAudioStreamIndex = intPtr(2)
+
+	rewritten, err := json.Marshal(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rewritten, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if string(raw["FutureSessionField"]) != `{"nested":true}` {
+		t.Fatalf("top-level unknown field lost or altered: %s", raw["FutureSessionField"])
+	}
+	var sources []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["MediaSources"], &sources); err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 1 || string(sources[0]["FutureSourceField"]) != `[1,2,3]` {
+		t.Fatalf("per-source unknown field lost or altered: %v", sources)
+	}
+	if string(sources[0]["SelectedAudioStreamIndex"]) != `2` {
+		t.Fatalf("mutation not applied: %s", sources[0]["SelectedAudioStreamIndex"])
+	}
+}
+
+func TestPlaybackSessionJSONKnownFieldsShadowStalePreservedCopies(t *testing.T) {
+	doc := []byte(`{"ID": "play-1", "TranscodeStarted": true}`)
+	var session PlaybackSession
+	if err := json.Unmarshal(doc, &session); err != nil {
+		t.Fatal(err)
+	}
+	session.TranscodeStarted = false
+
+	rewritten, err := json.Marshal(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rewritten, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if string(raw["TranscodeStarted"]) != `false` {
+		t.Fatalf("declared field lost to a stale raw copy: %s", raw["TranscodeStarted"])
+	}
+}

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -270,6 +270,9 @@ func NewRouter(deps Dependencies) chi.Router {
 		r.Get("/Videos/{id}/audio-v2/master.m3u8", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{id}/audio-v2/master.m3u8", playbackHandler.HandleAudioV2MasterManifest))
 		r.Get("/Videos/{id}/audio-v2/hls/{playlistId}/stream.m3u8", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{id}/audio-v2/hls/{playlistId}/stream.m3u8", playbackHandler.HandleAudioV2HLSManifest))
 		r.Get("/Videos/{id}/audio-v2/hls/{playlistId}/{segmentId}.{segmentContainer}", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{id}/audio-v2/hls/{playlistId}/{segmentId}.{segmentContainer}", playbackHandler.HandleAudioV2HLSSegment))
+		r.Get("/Videos/{id}/remux-v1/master.m3u8", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{id}/remux-v1/master.m3u8", playbackHandler.HandleRemuxV1MasterManifest))
+		r.Get("/Videos/{id}/remux-v1/hls/{playlistId}/stream.m3u8", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{id}/remux-v1/hls/{playlistId}/stream.m3u8", playbackHandler.HandleRemuxV1HLSManifest))
+		r.Get("/Videos/{id}/remux-v1/hls/{playlistId}/{segmentId}.{segmentContainer}", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{id}/remux-v1/hls/{playlistId}/{segmentId}.{segmentContainer}", playbackHandler.HandleRemuxV1HLSSegment))
 		r.Get("/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/stream.{routeFormat}", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/stream.{routeFormat}", playbackHandler.HandleSubtitleStream))
 		// Infuse probes external subtitles with an extra numeric path component before stream.{format}.
 		r.Get("/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeDeliveryIndex}/stream.{routeFormat}", observeCompat(deps.StreamTelemetry, http.MethodGet, "/Videos/{routeItemId}/{routeMediaSourceId}/Subtitles/{routeIndex}/{routeDeliveryIndex}/stream.{routeFormat}", playbackHandler.HandleSubtitleStream))
@@ -285,7 +288,6 @@ func NewRouter(deps Dependencies) chi.Router {
 func skipCompatMediaCompression(r *http.Request) bool {
 	const (
 		videosSegment = "Videos"
-		hlsSegment    = "hls"
 		hlsManifest   = "stream.m3u8"
 	)
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
@@ -297,9 +299,11 @@ func skipCompatMediaCompression(r *http.Request) bool {
 		return p[2] == "stream" || len(strings.TrimPrefix(p[2], "stream.")) > 0
 	case len(p) == 4 && p[0] == videosSegment && p[1] != "" && p[2] == compatAudioV2PathSegment && (p[3] == "stream" || strings.HasPrefix(p[3], "stream.")):
 		return p[3] == "stream" || len(strings.TrimPrefix(p[3], "stream.")) > 0
-	case len(p) == 5 && p[0] == videosSegment && p[1] != "" && p[2] == hlsSegment && p[3] != "" && p[4] != "":
+	case len(p) == 5 && p[0] == videosSegment && p[1] != "" && p[2] == compatHLSPathSegment && p[3] != "" && p[4] != "":
 		return p[4] != hlsManifest && strings.Contains(p[4], ".")
-	case len(p) == 6 && p[0] == videosSegment && p[1] != "" && p[2] == compatAudioV2PathSegment && p[3] == hlsSegment && p[4] != "" && p[5] != "":
+	case len(p) == 6 && p[0] == videosSegment && p[1] != "" &&
+		(p[2] == compatAudioV2PathSegment || p[2] == compatRemuxV1PathSegment) &&
+		p[3] == compatHLSPathSegment && p[4] != "" && p[5] != "":
 		return p[5] != hlsManifest && strings.Contains(p[5], ".")
 	case len(p) == 3 && p[0] == "Items" && p[1] != "" && p[2] == "Download":
 		return true

--- a/internal/jellycompat/router_compression_test.go
+++ b/internal/jellycompat/router_compression_test.go
@@ -17,6 +17,7 @@ func TestSkipCompatMediaCompression(t *testing.T) {
 		{http.MethodGet, "/Videos/i1/audio-v2/stream", true},
 		{http.MethodHead, "/Videos/i1/audio-v2/stream.mkv", true},
 		{http.MethodGet, "/Videos/i1/audio-v2/hls/p1/000.ts", true},
+		{http.MethodGet, "/Videos/i1/remux-v1/hls/p1/000.m4s", true},
 		{http.MethodGet, "/Items/i1/Download", true},
 		{http.MethodGet, "/Videos/i1/master.m3u8", false},
 		{http.MethodGet, "/Videos/i1/hls/p1/stream.m3u8", false},

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -34,10 +34,13 @@ import (
 // the near-head follow-up segments arrive quickly enough for browser playback.
 const (
 	compatSegmentDuration    = 2
+	compatHLSPathSegment     = "hls"
 	compatAudioV2PathSegment = "audio-v2"
+	compatRemuxV1PathSegment = "remux-v1"
 )
 
 type compatAudioV2RouteContextKey struct{}
+type compatRemuxV1RouteContextKey struct{}
 
 func withCompatAudioV2Route(r *http.Request) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), compatAudioV2RouteContextKey{}, true))
@@ -48,8 +51,25 @@ func isCompatAudioV2Route(r *http.Request) bool {
 	return marked
 }
 
+func withCompatRemuxV1Route(r *http.Request) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), compatRemuxV1RouteContextKey{}, true))
+}
+
+func isCompatRemuxV1Route(r *http.Request) bool {
+	marked, _ := r.Context().Value(compatRemuxV1RouteContextKey{}).(bool)
+	return marked
+}
+
 func validateCompatAudioV2Route(w http.ResponseWriter, r *http.Request, required bool) bool {
 	if isCompatAudioV2Route(r) == required {
+		return true
+	}
+	writeError(w, http.StatusNotFound, "NotFound", "Playback route not found")
+	return false
+}
+
+func validateCompatRemuxV1Route(w http.ResponseWriter, r *http.Request, required bool) bool {
+	if isCompatRemuxV1Route(r) == required {
 		return true
 	}
 	writeError(w, http.StatusNotFound, "NotFound", "Playback route not found")
@@ -80,12 +100,47 @@ func compatProgressiveRequiresAudioV2(source PlaybackMediaSource, method string)
 }
 
 func compatHLSRequiresAudioV2(source PlaybackMediaSource) bool {
-	// Every compatibility HLS recipe targets AAC, including a full video
-	// transcode where TranscodeAudio is false. Version the fixed URL when any
-	// selectable track can need v2: audio selection changes do not mint a new
-	// playlist URL, so selected-track-only routing would permit a later switch
-	// to cross back onto an old API pod.
-	return compatSourceHasSurroundAudio(source)
+	// Every compatibility HLS encode targets AAC, including a full video
+	// transcode where TranscodeAudio is false. Audio-copy remuxes use their own
+	// route version. Version AAC recipes when any selectable track can need v2:
+	// audio selection changes do not mint a new playlist URL, so selected-track-
+	// only routing would permit a later switch to cross back onto an old API pod.
+	return compatHLSTranscodesAudio(source) && compatSourceHasSurroundAudio(source)
+}
+
+func compatHLSUsesAudioCopyV1(source PlaybackMediaSource) bool {
+	return source.HLSRemux && !source.TranscodeAudio
+}
+
+func compatHLSRoutePathSegment(source PlaybackMediaSource) string {
+	if compatHLSUsesAudioCopyV1(source) {
+		return compatRemuxV1PathSegment
+	}
+	if compatHLSRequiresAudioV2(source) {
+		return compatAudioV2PathSegment
+	}
+	return ""
+}
+
+func compatHLSCopiesVideo(source PlaybackMediaSource) bool {
+	// TranscodeAudio implied the legacy fMP4/video-copy route before HLSRemux
+	// was stored explicitly. Keep that interpretation for durable sessions
+	// negotiated by an older process during a rolling deployment.
+	return source.HLSRemux || source.TranscodeAudio
+}
+
+func compatHLSTranscodesAudio(source PlaybackMediaSource) bool {
+	if compatHLSCopiesVideo(source) {
+		return source.TranscodeAudio
+	}
+	return true
+}
+
+func compatHLSRecipeSourceAudioChannels(source PlaybackMediaSource) int {
+	if !compatHLSTranscodesAudio(source) {
+		return 0
+	}
+	return compatSourceAudioChannels(source)
 }
 
 func compatSourceHasSurroundAudio(source PlaybackMediaSource) bool {
@@ -101,7 +156,7 @@ func compatRecipeMatchesSource(recipe *playback.RecipeCard, source PlaybackMedia
 	return recipe != nil &&
 		recipe.MediaFileID == source.FileID &&
 		recipe.AudioTrackIndex == compatAudioTrackIndexOrDefault(source) &&
-		recipe.SourceAudioChannels == compatSourceAudioChannels(source)
+		recipe.SourceAudioChannels == compatHLSRecipeSourceAudioChannels(source)
 }
 
 // Versioned wrappers put a literal path segment in every byte URL whose
@@ -124,6 +179,18 @@ func (h *PlaybackHandler) HandleAudioV2HLSSegment(w http.ResponseWriter, r *http
 	h.HandleHLSSegment(w, withCompatAudioV2Route(r))
 }
 
+func (h *PlaybackHandler) HandleRemuxV1MasterManifest(w http.ResponseWriter, r *http.Request) {
+	h.HandleMasterManifest(w, withCompatRemuxV1Route(r))
+}
+
+func (h *PlaybackHandler) HandleRemuxV1HLSManifest(w http.ResponseWriter, r *http.Request) {
+	h.HandleHLSManifest(w, withCompatRemuxV1Route(r))
+}
+
+func (h *PlaybackHandler) HandleRemuxV1HLSSegment(w http.ResponseWriter, r *http.Request) {
+	h.HandleHLSSegment(w, withCompatRemuxV1Route(r))
+}
+
 // errUpstreamReplaced signals that a concurrent request attached a different
 // upstream session to the play session while this one was being created.
 var errUpstreamReplaced = errors.New("upstream session replaced concurrently")
@@ -139,6 +206,12 @@ var errAudioDownmixCapabilityUnavailable = errors.New("audio downmix capability 
 // moved on. The client may retry through the master route, which builds and
 // persists a fresh recipe from the frozen source.
 var errCompatRecipeSourceMismatch = errors.New("transcode recipe does not match the selected media source")
+
+// errCompatHLSRemuxAudioUnsupported prevents an audio-copy playlist from
+// switching to a track the negotiated device profile cannot carry in fMP4.
+// The playlist route freezes copy semantics, so changing to AAC encoding would
+// require a new PlaybackInfo negotiation and a differently versioned URL.
+var errCompatHLSRemuxAudioUnsupported = errors.New("selected audio stream is not supported by the negotiated HLS remux")
 
 // requireLocalAudioDownmixCapability gates only recipes whose bytes use the
 // versioned surround-to-stereo boost. Zero is the normalized legacy value for
@@ -400,6 +473,9 @@ func (h *PlaybackHandler) HandleMasterManifest(w http.ResponseWriter, r *http.Re
 	if !validateCompatAudioV2Route(w, r, compatHLSRequiresAudioV2(*source)) {
 		return
 	}
+	if !validateCompatRemuxV1Route(w, r, compatHLSUsesAudioCopyV1(*source)) {
+		return
+	}
 	// Attach BEFORE ensureUpstreamPlayback below: this route can start a
 	// transcode before it writes a byte, which is the whole reason §4.2 enrolls
 	// manifest routes. A cut has to be able to act here, not after the side
@@ -437,7 +513,7 @@ func (h *PlaybackHandler) HandleMasterManifest(w http.ResponseWriter, r *http.Re
 				writeError(w, http.StatusNotFound, "NotFound", "Media file not found")
 				return
 			}
-			plan, planErr := h.planCompatTranscodeSession(r.Context(), upstreamSession, file, source.Version.Bitrate, !source.TranscodeAudio, compatSourceAudioChannels(*source))
+			plan, planErr := h.planCompatTranscodeSession(r.Context(), upstreamSession, file, source.Version.Bitrate, !compatHLSCopiesVideo(*source), compatHLSRecipeSourceAudioChannels(*source))
 			if planErr != nil {
 				failRemoteStart()
 				if errors.Is(planErr, errToneMapCapabilityUnavailable) {
@@ -561,12 +637,12 @@ func (h *PlaybackHandler) HandleMasterManifest(w http.ResponseWriter, r *http.Re
 	segDuration := h.compatSegmentDuration()
 
 	if manifest == nil {
-		manifest = generateFullManifest(source.Version.Duration, segDuration, source.TranscodeAudio, playSession.InitialSeekSeconds)
+		manifest = generateFullManifest(source.Version.Duration, segDuration, compatHLSCopiesVideo(*source), playSession.InitialSeekSeconds)
 	}
 
 	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(rewriteManifest(manifest, playSession.RouteItemID, playSession.ID, source.ID, compatHLSRequiresAudioV2(*source)))
+	_, _ = w.Write(rewriteManifest(manifest, playSession.RouteItemID, playSession.ID, source.ID, compatHLSRoutePathSegment(*source)))
 }
 
 func writeCompatTranscodeError(w http.ResponseWriter, err error) {
@@ -630,6 +706,9 @@ func (h *PlaybackHandler) HandleHLSManifest(w http.ResponseWriter, r *http.Reque
 	if !validateCompatAudioV2Route(w, r, compatHLSRequiresAudioV2(*source)) {
 		return
 	}
+	if !validateCompatRemuxV1Route(w, r, compatHLSUsesAudioCopyV1(*source)) {
+		return
+	}
 	// Before ensureTranscodeManifest, for the same reason as the master manifest.
 	attachCompatStream(r.Context(), session, playSession, source.FileID)
 
@@ -650,11 +729,11 @@ func (h *PlaybackHandler) HandleHLSManifest(w http.ResponseWriter, r *http.Reque
 	segDuration := h.compatSegmentDuration()
 
 	if manifest == nil {
-		manifest = generateFullManifest(source.Version.Duration, segDuration, source.TranscodeAudio, playSession.InitialSeekSeconds)
+		manifest = generateFullManifest(source.Version.Duration, segDuration, compatHLSCopiesVideo(*source), playSession.InitialSeekSeconds)
 	}
 	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(rewriteManifest(manifest, playSession.RouteItemID, playSession.ID, source.ID, compatHLSRequiresAudioV2(*source)))
+	_, _ = w.Write(rewriteManifest(manifest, playSession.RouteItemID, playSession.ID, source.ID, compatHLSRoutePathSegment(*source)))
 }
 
 // HandleHLSSegment proxies HLS segment requests through compat-owned routes.
@@ -685,6 +764,9 @@ func (h *PlaybackHandler) HandleHLSSegment(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if !validateCompatAudioV2Route(w, r, compatHLSRequiresAudioV2(*source)) {
+		return
+	}
+	if !validateCompatRemuxV1Route(w, r, compatHLSUsesAudioCopyV1(*source)) {
 		return
 	}
 	segmentSourceFileID := source.FileID
@@ -901,7 +983,7 @@ func (h *PlaybackHandler) prepareCompatSegmentRecipe(
 		}
 	}
 	if playSession.Recipe.TranscodeNodeURL == "" {
-		if err := h.requireLocalAudioDownmixCapability(ctx, compatSourceAudioChannels(source)); err != nil {
+		if err := h.requireLocalAudioDownmixCapability(ctx, compatHLSRecipeSourceAudioChannels(source)); err != nil {
 			return nil, err
 		}
 	}
@@ -1303,6 +1385,7 @@ func (h *PlaybackHandler) cleanupPlaySession(
 const (
 	compatTargetVideoCodec = "h264"
 	compatTargetAudioCodec = "aac"
+	compatCopyCodec        = "copy"
 )
 
 const (
@@ -2029,7 +2112,7 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	source PlaybackMediaSource,
 	requiredToneMapMode tonemap.Mode,
 ) (*playback.TranscodeSession, error) {
-	sourceAudioChannels := compatSourceAudioChannels(source)
+	sourceAudioChannels := compatHLSRecipeSourceAudioChannels(source)
 	audioTrackIndex := compatAudioTrackIndexOrDefault(source)
 	if existing := h.tm.GetTranscodeSession(upstreamSessionID); existing != nil && compatTranscodeSessionUsesToneMapMode(existing, requiredToneMapMode) {
 		if compatLiveTranscodeMatchesAudioSource(existing, source) {
@@ -2066,7 +2149,7 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 			}
 		}
 	}
-	if !source.TranscodeAudio && is4KResolution(source.Version.Resolution) && !h.allow4KVideoTranscode(ctx) {
+	if !compatHLSCopiesVideo(source) && is4KResolution(source.Version.Resolution) && !h.allow4KVideoTranscode(ctx) {
 		return nil, errTranscode4KDisallowed
 	}
 	if h.fileResolver == nil {
@@ -2113,13 +2196,16 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	if sourceAudioChannels > 0 {
 		opts.TargetAudioChannels = 2
 	}
-	if source.TranscodeAudio {
-		opts.TargetCodecVideo = "copy"
+	if compatHLSCopiesVideo(source) {
+		opts.TargetCodecVideo = compatCopyCodec
 		opts.VideoSampleEntry = playback.VideoSampleEntryForDVCopy(file.PrimaryDVProfile())
+	}
+	if !compatHLSTranscodesAudio(source) {
+		opts.TargetCodecAudio = compatCopyCodec
 	}
 	var toneMapCapabilities tonemap.Capabilities
 	autoVideoToolboxBitrate := 0
-	if !source.TranscodeAudio {
+	if !compatHLSCopiesVideo(source) {
 		metadata := tonemap.MetadataForFile(file)
 		if metadata.DynamicRange != "" && metadata.DynamicRange != playback.DynamicRangeSDRV3 {
 			var capabilityErr error
@@ -2283,7 +2369,7 @@ func compatLiveTranscodeMatchesAudioSource(transcodeSession *playback.TranscodeS
 	}
 	opts := transcodeSession.Opts()
 	return opts.AudioTrackIndex == compatAudioTrackIndexOrDefault(source) &&
-		opts.SourceAudioChannels == compatSourceAudioChannels(source)
+		opts.SourceAudioChannels == compatHLSRecipeSourceAudioChannels(source)
 }
 
 func shouldGenerateCompatFullManifest(source PlaybackMediaSource, segmentDuration int) bool {
@@ -2360,8 +2446,23 @@ func selectedCompatAudioSource(session *PlaybackSession, mediaSourceID string, a
 	if !isValidCompatAudioStreamIndex(source.Version, audioStreamIndex) {
 		return nil, fmt.Errorf("invalid compat audio stream index")
 	}
+	if !compatHLSRemuxSupportsAudioStream(*source, audioStreamIndex) {
+		return nil, errCompatHLSRemuxAudioUnsupported
+	}
 	source.SelectedAudioStreamIndex = intPtr(audioStreamIndex)
 	return source, nil
+}
+
+func compatHLSRemuxSupportsAudioStream(source PlaybackMediaSource, audioStreamIndex int) bool {
+	if !compatHLSUsesAudioCopyV1(source) {
+		return true
+	}
+	for _, supportedStreamIndex := range source.HLSRemuxAudioStreamIndexes {
+		if supportedStreamIndex == audioStreamIndex {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *PlaybackHandler) preflightCompatAudioSelection(ctx context.Context, playSession *PlaybackSession, source PlaybackMediaSource) error {
@@ -2373,7 +2474,7 @@ func (h *PlaybackHandler) preflightCompatAudioSelection(ctx context.Context, pla
 		// recipe. The API-local capability only governs an integrated process.
 		return nil
 	}
-	return h.requireLocalAudioDownmixCapability(ctx, compatSourceAudioChannels(source))
+	return h.requireLocalAudioDownmixCapability(ctx, compatHLSRecipeSourceAudioChannels(source))
 }
 
 func (h *PlaybackHandler) applyCompatAudioSelection(
@@ -2536,7 +2637,7 @@ func (h *PlaybackHandler) restartCompatTranscodeForAudioSelection(
 	}
 
 	if transcodeSession := h.tm.GetTranscodeSession(playSession.UpstreamSessionID); transcodeSession != nil {
-		sourceAudioChannels := compatSourceAudioChannels(source)
+		sourceAudioChannels := compatHLSRecipeSourceAudioChannels(source)
 		if err := h.requireLocalAudioDownmixCapability(ctx, sourceAudioChannels); err != nil {
 			return false, err
 		}
@@ -2735,7 +2836,7 @@ func compatPlayMethod(method string) playback.PlayMethod {
 	}
 }
 
-func rewriteManifest(manifest []byte, routeItemID, playlistID, mediaSourceID string, audioV2 bool) []byte {
+func rewriteManifest(manifest []byte, routeItemID, playlistID, mediaSourceID, routePathSegment string) []byte {
 	var out strings.Builder
 	scanner := bufio.NewScanner(strings.NewReader(string(manifest)))
 	for scanner.Scan() {
@@ -2744,9 +2845,9 @@ func rewriteManifest(manifest []byte, routeItemID, playlistID, mediaSourceID str
 		case strings.HasPrefix(line, "#EXT-X-MAP:URI=\""):
 			prefix := "#EXT-X-MAP:URI=\""
 			uri := strings.TrimSuffix(strings.TrimPrefix(line, prefix), "\"")
-			line = prefix + buildSegmentProxyPath(routeItemID, playlistID, mediaSourceID, uri, audioV2) + "\""
+			line = prefix + buildSegmentProxyPath(routeItemID, playlistID, mediaSourceID, uri, routePathSegment) + "\""
 		case line != "" && !strings.HasPrefix(line, "#"):
-			line = buildSegmentProxyPath(routeItemID, playlistID, mediaSourceID, line, audioV2)
+			line = buildSegmentProxyPath(routeItemID, playlistID, mediaSourceID, line, routePathSegment)
 		}
 		out.WriteString(line)
 		out.WriteByte('\n')
@@ -2754,7 +2855,7 @@ func rewriteManifest(manifest []byte, routeItemID, playlistID, mediaSourceID str
 	return []byte(out.String())
 }
 
-func buildSegmentProxyPath(routeItemID, playlistID, mediaSourceID, current string, audioV2 bool) string {
+func buildSegmentProxyPath(routeItemID, playlistID, mediaSourceID, current, routePathSegment string) string {
 	base := path.Base(current)
 	query := url.Values{}
 	if parsed, err := url.Parse(current); err == nil {
@@ -2767,8 +2868,8 @@ func buildSegmentProxyPath(routeItemID, playlistID, mediaSourceID, current strin
 	}
 	qs := "?" + query.Encode()
 	basePath := fmt.Sprintf("/Videos/%s", routeItemID)
-	if audioV2 {
-		basePath += "/" + compatAudioV2PathSegment
+	if routePathSegment != "" {
+		basePath += "/" + routePathSegment
 	}
 	if base == "stream.m3u8" {
 		return fmt.Sprintf("%s/hls/%s/stream.m3u8%s", basePath, playlistID, qs)

--- a/internal/jellycompat/streams_test.go
+++ b/internal/jellycompat/streams_test.go
@@ -864,7 +864,7 @@ func TestRewriteManifest_PreservesPlaybackAndMediaSourceIDs(t *testing.T) {
 		"",
 	}, "\n")
 
-	got := string(rewriteManifest([]byte(manifest), "item-1", "play-1", "source-1", false))
+	got := string(rewriteManifest([]byte(manifest), "item-1", "play-1", "source-1", ""))
 
 	if !strings.Contains(got, "#EXT-X-MAP:URI=\"/Videos/item-1/hls/play-1/init.mp4?MediaSourceId=source-1&PlaySessionId=play-1\"") {
 		t.Fatalf("expected init segment to include media and playback session ids, got:\n%s", got)
@@ -876,7 +876,7 @@ func TestRewriteManifest_PreservesPlaybackAndMediaSourceIDs(t *testing.T) {
 		t.Fatalf("expected nested manifest to include media and playback session ids, got:\n%s", got)
 	}
 
-	audioV2 := string(rewriteManifest([]byte(manifest), "item-1", "play-1", "source-1", true))
+	audioV2 := string(rewriteManifest([]byte(manifest), "item-1", "play-1", "source-1", compatAudioV2PathSegment))
 	for _, want := range []string{
 		`#EXT-X-MAP:URI="/Videos/item-1/audio-v2/hls/play-1/init.mp4?MediaSourceId=source-1&PlaySessionId=play-1"`,
 		"/Videos/item-1/audio-v2/hls/play-1/seg_00000.m4s?MediaSourceId=source-1&PlaySessionId=play-1",
@@ -884,6 +884,16 @@ func TestRewriteManifest_PreservesPlaybackAndMediaSourceIDs(t *testing.T) {
 	} {
 		if !strings.Contains(audioV2, want) {
 			t.Fatalf("v2 manifest missing %q:\n%s", want, audioV2)
+		}
+	}
+
+	remuxV1 := string(rewriteManifest([]byte(manifest), "item-1", "play-1", "source-1", compatRemuxV1PathSegment))
+	for _, want := range []string{
+		`#EXT-X-MAP:URI="/Videos/item-1/remux-v1/hls/play-1/init.mp4?MediaSourceId=source-1&PlaySessionId=play-1"`,
+		"/Videos/item-1/remux-v1/hls/play-1/seg_00000.m4s?MediaSourceId=source-1&PlaySessionId=play-1",
+	} {
+		if !strings.Contains(remuxV1, want) {
+			t.Fatalf("remux-v1 manifest missing %q:\n%s", want, remuxV1)
 		}
 	}
 }

--- a/internal/jellycompat/testdata/media_routes.txt
+++ b/internal/jellycompat/testdata/media_routes.txt
@@ -101,6 +101,9 @@ HEAD /Videos/{id}/audio-v2/stream.{container}	media	playback	viewer_egress	true	
 GET /Videos/{id}/hls/{playlistId}/stream.m3u8	media	manifest	viewer_egress	true	true
 GET /Videos/{id}/hls/{playlistId}/{segmentId}.{segmentContainer}	media	playback	viewer_egress	true	true
 GET /Videos/{id}/master.m3u8	media	manifest	viewer_egress	true	true
+GET /Videos/{id}/remux-v1/hls/{playlistId}/stream.m3u8	media	manifest	viewer_egress	true	true
+GET /Videos/{id}/remux-v1/hls/{playlistId}/{segmentId}.{segmentContainer}	media	playback	viewer_egress	true	true
+GET /Videos/{id}/remux-v1/master.m3u8	media	manifest	viewer_egress	true	true
 GET /Videos/{id}/stream	media	playback	viewer_egress	true	true
 HEAD /Videos/{id}/stream	media	playback	viewer_egress	true	true
 GET /Videos/{id}/stream.{container}	media	playback	viewer_egress	true	true
@@ -221,6 +224,9 @@ HEAD /Videos/{id}/audio-v2/stream.{container}	media	playback	viewer_egress	true	
 GET /Videos/{id}/hls/{playlistId}/stream.m3u8	media	manifest	viewer_egress	true	true
 GET /Videos/{id}/hls/{playlistId}/{segmentId}.{segmentContainer}	media	playback	viewer_egress	true	true
 GET /Videos/{id}/master.m3u8	media	manifest	viewer_egress	true	true
+GET /Videos/{id}/remux-v1/hls/{playlistId}/stream.m3u8	media	manifest	viewer_egress	true	true
+GET /Videos/{id}/remux-v1/hls/{playlistId}/{segmentId}.{segmentContainer}	media	playback	viewer_egress	true	true
+GET /Videos/{id}/remux-v1/master.m3u8	media	manifest	viewer_egress	true	true
 GET /Videos/{id}/stream	media	playback	viewer_egress	true	true
 HEAD /Videos/{id}/stream	media	playback	viewer_egress	true	true
 GET /Videos/{id}/stream.{container}	media	playback	viewer_egress	true	true


### PR DESCRIPTION
## Problem

Related issue: #756

Fixes #756.

Jellyfin WebOS and Safari clients could receive a successful `PlaybackInfo` response with no usable playback method for Dolby Vision HEVC MKV files. Silo rejected direct play for MKV, did not model the client's fMP4 HLS remux capability, and then applied the 4K transcode policy even though video could be copied.

The separate `SQLSTATE 22021` session-persistence defect reported in the issue is not changed here.

## Approach

- Preserve Jellyfin codec-profile `Container` and `SubContainer` fields and apply Jellyfin's literal, case-insensitive positive/negative container matching.
- Evaluate direct play against the source container. WebOS 25 can therefore direct play compatible Dolby Vision MKV, while older WebOS profiles that exclude MKV fall back to fMP4 HLS remux.
- Evaluate HLS remux compatibility against the MP4 output and prefer profile-approved audio copy before AAC fallback.
- Produce copy/copy fMP4 HLS with the Dolby Vision `dvh1` video tag, and apply the 4K transcode policy only when video is actually encoded.
- Use versioned `/remux-v1/` routes so mixed-version deployments cannot interpret new remux sessions through the legacy route.
- Persist the audio stream indexes approved for copy and reject incompatible track switches before mutating local or remote playback state.

## Validation

Passed:

```text
make embed-stub
go build ./...
gofmt -l .
  (no output)
go vet ./...
golangci-lint run --new-from-merge-base=origin/main ./...
  0 issues.
go test ./internal/jellycompat -count=1 -timeout 240s
  ok github.com/Silo-Server/silo-server/internal/jellycompat 53.072s
git diff --check
CI=true pnpm install --frozen-lockfile
cd web && pnpm run lint
  0 errors, 172 inherited warnings
cd web && pnpm run format:check
  All matched files use Prettier code style!
cd web && pnpm run build
  built successfully
make test-web
  Test Files 350 passed (350)
  Tests 2935 passed (2935)
make verify-settings-bindings-all
  settings bindings are current
  web settings binding is current
make verify-playback-fixtures
  playback fixtures are current
make verify-local-paths
```

Not passing locally:

```text
make test-go
```

The full Go suite was run twice. It fails in existing timing-sensitive hardware-probe tests under `internal/playback`: fake FFmpeg subprocesses hit their approximately 200 ms deadlines and report `signal: killed`. One existing `internal/transcodenode` timing test also fails: `TestHandleDownloadPrepareTrackingDoesNotBlockAndRemovesAfterTrack`. The changed `internal/jellycompat` suite passes independently, as shown above.

The first literal `pnpm install --frozen-lockfile` invocation stopped because pnpm would not recreate `node_modules` without a TTY. It was rerun successfully as `CI=true pnpm install --frozen-lockfile` using the unchanged lockfile.

Manual playback on physical WebOS 24/25 hardware and Safari was not run from this development host.

## Risks

Container-scoped profile evaluation affects Jellyfin compatibility negotiation beyond this specific file. Regression tests cover positive and negative container lists, WebOS 24/25 behavior, Safari fMP4 remux, Dolby Vision tagging, audio-copy selection and switching, 4K policy behavior, and route-version isolation. There are no schema or native v1 API changes.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: Two independent read-only reviews inspected the complete `origin/main..HEAD` Jellyfin compatibility diff. One found that source-container AAC fallback could be chosen before validating output-container audio copy; the implementation now evaluates fMP4 output compatibility first and includes a 5.1 EAC3 regression test. Another found that post-negotiation audio switches could select tracks outside the copy-safe set; the negotiated allowlist is now persisted and enforced before local, remote, or stored state changes. Follow-up reviews found no remaining Critical or Important issues.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved HLS remux playback with video copy and independently managed audio streams.
  * Added dedicated remux-v1 HLS playlist and segment routes.
  * Improved HEVC and Dolby Vision compatibility across supported playback scenarios.
  * Preserved playback session settings across compatibility updates.

* **Bug Fixes**
  * Prevented unsupported audio selections from restarting playback or changing saved preferences.
  * Isolated legacy, audio-v2, and remux-v1 playback sessions to prevent route conflicts.
  * Improved codec and container profile matching for HLS playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->