### PR TITLE
fix(web): show platform-aware search shortcuts

### DIFF
--- a/web/src/components/AdminLayout.test.tsx
+++ b/web/src/components/AdminLayout.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   useAdminServerStatus: vi.fn(),
+  shortcutLabel: "Ctrl K",
 }));
 
 vi.mock("@/hooks/queries/admin/settings", () => ({
@@ -26,6 +27,11 @@ vi.mock("@/playback/watchPlaybackContext", () => ({
 }));
 vi.mock("@/pages/audiobooks/player/audiobookPlaybackContext", () => ({
   useAudiobookPlaybackController: () => null,
+}));
+vi.mock("@/lib/keyboardShortcut", () => ({
+  get SEARCH_SHORTCUT_LABEL() {
+    return mocks.shortcutLabel;
+  },
 }));
 
 import AdminLayout from "./AdminLayout";
@@ -53,6 +59,7 @@ function renderAdmin(initialPath = "/admin") {
 
 beforeEach(() => {
   mocks.useAdminServerStatus.mockReturnValue({ data: { restart_required: true } });
+  mocks.shortcutLabel = "Ctrl K";
   vi.stubGlobal("matchMedia", (query: string) => ({
     matches: query === "(min-width: 64rem)",
     media: query,
@@ -67,15 +74,10 @@ afterEach(() => {
 });
 
 describe("AdminLayout search shortcut hint", () => {
-  function stubUserAgent(value: string) {
-    vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(value);
-  }
-
   // The dialog opens on Cmd or Ctrl, so the advertised hint has to name the key
   // this keyboard actually has — a hardcoded ⌘ is a dead instruction on Windows
   // and Linux, which is most self-hosters.
   it("names Ctrl off Apple platforms", () => {
-    stubUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
     renderAdmin();
 
     const [search] = screen.getAllByRole("button", { name: "Search admin sections" });
@@ -85,7 +87,7 @@ describe("AdminLayout search shortcut hint", () => {
   });
 
   it("names the command glyph on Apple platforms", () => {
-    stubUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15");
+    mocks.shortcutLabel = "⌘ K";
     renderAdmin();
 
     const [search] = screen.getAllByRole("button", { name: "Search admin sections" });

--- a/web/src/components/AdminLayout.tsx
+++ b/web/src/components/AdminLayout.tsx
@@ -18,7 +18,7 @@ import { usePolicyCapability } from "@/hooks/queries/admin/policy";
 import { useAdminServerStatus } from "@/hooks/queries/admin/settings";
 import { buildAdminCommandNavSections } from "@/lib/adminNavigation";
 import { resolveAdminDocumentTitle } from "@/lib/documentTitle";
-import { searchShortcutLabel } from "@/lib/keyboardShortcut";
+import { SEARCH_SHORTCUT_LABEL } from "@/lib/keyboardShortcut";
 import { cn } from "@/lib/utils";
 import { Menu, Search, X } from "lucide-react";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
@@ -187,16 +187,12 @@ function AdminSearchButton({
   className?: string;
   showShortcut?: boolean;
 }) {
-  // Advertised, not hardcoded: the dialog opens on either modifier, so the hint
-  // has to name the one this keyboard actually has.
-  const shortcut = searchShortcutLabel();
-
   return (
     <button
       type="button"
       onClick={onClick}
       aria-label="Search admin sections"
-      title={`Search admin sections (${shortcut})`}
+      title={`Search admin sections (${SEARCH_SHORTCUT_LABEL})`}
       className={cn(
         "text-muted-foreground hover:text-foreground hover:bg-accent/60 focus-visible:ring-ring/60 border-border/70 bg-surface/70 flex h-9 items-center justify-center gap-2 rounded-xl border px-2.5 transition-colors focus-visible:ring-[3px] focus-visible:outline-none",
         className,
@@ -207,7 +203,7 @@ function AdminSearchButton({
         <>
           <span className="hidden text-[13px] font-medium xl:inline">Search</span>
           <kbd className="border-border/70 pointer-events-none rounded border px-1.5 py-0.5 font-mono text-[10px] whitespace-nowrap select-none">
-            {shortcut}
+            {SEARCH_SHORTCUT_LABEL}
           </kbd>
         </>
       ) : null}

--- a/web/src/components/AdminSectionCommandDialog.test.tsx
+++ b/web/src/components/AdminSectionCommandDialog.test.tsx
@@ -56,6 +56,16 @@ describe("AdminSectionCommandDialog", () => {
     expect(screen.getByRole("option", { name: /Dashboard/ })).toBeInTheDocument();
   });
 
+  it("opens and focuses admin search with Ctrl+K", async () => {
+    renderDialog();
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    const searchBox = await screen.findByRole("searchbox", { name: "Search admin sections" });
+
+    await waitFor(() => expect(searchBox).toHaveFocus());
+    expect(screen.getByRole("option", { name: /Dashboard/ })).toBeInTheDocument();
+  });
+
   it("searches all admin section groups", async () => {
     renderDialog();
 

--- a/web/src/components/AppSidebar.test.tsx
+++ b/web/src/components/AppSidebar.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PluginSettingsSummary } from "@/api/types";
+import { SEARCH_SHORTCUT_LABEL } from "@/lib/keyboardShortcut";
 
 import AppSidebar from "./AppSidebar";
 import {
@@ -197,6 +198,12 @@ describe("AppSidebar", () => {
 
     expect(markup).toContain("text-sidebar-accent-foreground bg-sidebar-accent");
     expect(markup).not.toContain("text-sidebar-primary-foreground bg-sidebar-accent");
+  });
+
+  it("uses the shared platform-aware label for the search shortcut", () => {
+    const markup = renderSidebar("/");
+
+    expect(markup).toContain(`>${SEARCH_SHORTCUT_LABEL}</kbd>`);
   });
 
   it("renders the Silo brand mark instead of the old play glyph", () => {

--- a/web/src/components/AppSidebar.tsx
+++ b/web/src/components/AppSidebar.tsx
@@ -23,6 +23,7 @@ import { usePluginSettingsList } from "@/hooks/queries/pluginSettings";
 import { useRequestFeatureStatus } from "@/hooks/queries/useRequests";
 import { useSidebarPins, useToggleSidebarPin } from "@/hooks/queries/sidebarPins";
 import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
+import { SEARCH_SHORTCUT_LABEL } from "@/lib/keyboardShortcut";
 import { pluginRouteHref } from "@/lib/pluginRouteHref";
 import {
   buildLibraryCollectionCatalogHref,
@@ -741,7 +742,7 @@ export default function AppSidebar({ onNavigate, collapsed = false }: AppSidebar
                       showLabels ? "opacity-100" : "opacity-0"
                     }`}
                   >
-                    {"\u2318"}K
+                    {SEARCH_SHORTCUT_LABEL}
                   </kbd>
                 </ViewTransitionLink>
               </li>

--- a/web/src/components/GlobalSearch.test.tsx
+++ b/web/src/components/GlobalSearch.test.tsx
@@ -219,6 +219,23 @@ describe("GlobalSearch", () => {
     expect(lastCall.enabled).toBe(false);
   });
 
+  it("opens global search with Ctrl+K", () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter>
+          <GlobalSearch />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByTestId("dialog")).toBeNull();
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+    expect(screen.getByTestId("dialog")).toBeInTheDocument();
+  });
+
   it("encodes picked item IDs before navigating", async () => {
     mocks.useQuery.mockReturnValue({
       data: {

--- a/web/src/components/settings/SettingsSearchInput.tsx
+++ b/web/src/components/settings/SettingsSearchInput.tsx
@@ -2,7 +2,7 @@ import { useEffect, useId, useRef } from "react";
 import { Search, X } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
-import { searchShortcutLabel } from "@/lib/keyboardShortcut";
+import { SEARCH_SHORTCUT_LABEL } from "@/lib/keyboardShortcut";
 import { cn } from "@/lib/utils";
 
 interface SettingsSearchInputProps {
@@ -35,7 +35,6 @@ export function SettingsSearchInput({
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const hasQuery = value.trim().length > 0;
-  const shortcutHint = searchShortcutLabel();
   // Idle shows nothing: a "12 settings pages" style count under an untouched
   // box is noise. The line only speaks while a query is filtering.
   const status = hasQuery
@@ -100,7 +99,7 @@ export function SettingsSearchInput({
             aria-hidden="true"
             className="border-border/80 bg-surface text-muted-foreground pointer-events-none absolute top-1/2 right-2 hidden h-6 -translate-y-1/2 items-center rounded-md border px-1.5 font-sans text-[10px] font-medium sm:inline-flex"
           >
-            {shortcutHint}
+            {SEARCH_SHORTCUT_LABEL}
           </kbd>
         ) : null}
       </div>

--- a/web/src/lib/keyboardShortcut.test.ts
+++ b/web/src/lib/keyboardShortcut.test.ts
@@ -1,32 +1,33 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { searchShortcutLabel } from "./keyboardShortcut";
-
 function stubUserAgent(value: string) {
   vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(value);
+}
+
+async function loadShortcutLabel(userAgent: string) {
+  vi.resetModules();
+  stubUserAgent(userAgent);
+  const { SEARCH_SHORTCUT_LABEL } = await import("./keyboardShortcut");
+  return SEARCH_SHORTCUT_LABEL;
 }
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("searchShortcutLabel", () => {
-  it("uses the command glyph on Apple keyboards", () => {
-    stubUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15");
-    expect(searchShortcutLabel()).toBe("⌘ K");
-
-    stubUserAgent("Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15");
-    expect(searchShortcutLabel()).toBe("⌘ K");
+describe("SEARCH_SHORTCUT_LABEL", () => {
+  it.each([
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+    "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+  ])("uses the command glyph on Apple keyboards", async (userAgent) => {
+    expect(await loadShortcutLabel(userAgent)).toBe("⌘ K");
   });
 
-  it("spells out Ctrl everywhere else", () => {
-    stubUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-    expect(searchShortcutLabel()).toBe("Ctrl K");
-
-    stubUserAgent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36");
-    expect(searchShortcutLabel()).toBe("Ctrl K");
-
-    stubUserAgent("Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36");
-    expect(searchShortcutLabel()).toBe("Ctrl K");
+  it.each([
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36",
+  ])("spells out Ctrl everywhere else", async (userAgent) => {
+    expect(await loadShortcutLabel(userAgent)).toBe("Ctrl K");
   });
 });

--- a/web/src/lib/keyboardShortcut.ts
+++ b/web/src/lib/keyboardShortcut.ts
@@ -1,14 +1,12 @@
 /**
  * How the search shortcut is spelled on this machine: the ⌘ glyph on Apple
- * keyboards, "Ctrl" everywhere else. Every surface that advertises the
- * ⌘K / Ctrl-K search shortcut reads it from here, so a Windows or Linux admin
- * is never told to press a key their keyboard does not have.
+ * keyboards, "Ctrl" everywhere else. This is resolved once when the module
+ * loads; rendering a shortcut hint does no platform detection or extra work.
  *
  * The handlers themselves accept either modifier — this is a label, not the
  * binding.
  */
-export function searchShortcutLabel(): string {
-  const isApple =
-    typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
-  return isApple ? "⌘ K" : "Ctrl K";
-}
+export const SEARCH_SHORTCUT_LABEL =
+  typeof navigator !== "undefined" && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent)
+    ? "⌘ K"
+    : "Ctrl K";

--- a/web/src/pages/AdminDevices.tsx
+++ b/web/src/pages/AdminDevices.tsx
@@ -39,6 +39,7 @@ import {
 } from "@/components/admin/deviceOverrides";
 import { ALL_DEVICE_SETTING_KEYS } from "@/lib/settingsDisplay";
 import { SETTING_KEYS } from "@/lib/settingsContract";
+import { SEARCH_SHORTCUT_LABEL } from "@/lib/keyboardShortcut";
 import { AdminSubtitleAppearanceDialog } from "@/components/admin/AdminSubtitleAppearanceDialog";
 import { cn } from "@/lib/utils";
 
@@ -357,7 +358,7 @@ export default function AdminDevices() {
             Inspect, tune, and reset per-profile playback overrides across the fleet. Filter by
             user, platform, or override pattern. Press{" "}
             <kbd className="bg-surface/70 border-border/70 text-foreground/80 inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-[10.5px]">
-              ⌘K
+              {SEARCH_SHORTCUT_LABEL}
             </kbd>{" "}
             to jump to another admin page.
           </p>

--- a/web/src/pages/SettingsLayout.test.tsx
+++ b/web/src/pages/SettingsLayout.test.tsx
@@ -224,6 +224,19 @@ describe("SettingsLayout", () => {
     expect(searchBox).toHaveFocus();
   });
 
+  it("focuses personal settings search with Ctrl+K", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings"]}>
+        <SettingsLayout />
+      </MemoryRouter>,
+    );
+
+    const searchBox = screen.getByRole("searchbox", { name: "Search settings" });
+    fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+
+    expect(searchBox).toHaveFocus();
+  });
+
   it("does not consume Cmd+K when the detail search is hidden", () => {
     vi.stubGlobal(
       "matchMedia",


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow cross-platform fix

The search UI advertises `⌘ K` in a few places even on Windows and Linux. The actual handlers already accept either Meta or Ctrl, so search works, but the hint tells non-Apple users to press a key their keyboard does not have.

I see this as a small operating-system compatibility fix rather than a new search feature.

## Approach

Resolve the display label once when the keyboard-shortcut module loads:

- Apple user agents show `⌘ K`.
- Windows, Linux, Android, and other user agents show `Ctrl K`.

The sidebar, admin search button/title, settings search input, and admin devices copy all reuse that value. The existing keyboard handlers are unchanged.

This stays deliberately lightweight: no new hooks, state, effects, event listeners, requests, or search-path work. Platform detection runs once per page load rather than during each render.

I also added explicit Ctrl+K interaction coverage for global search, admin search, and settings search.

## Comparison

High-resolution, domain-free captures of the shortcut hint:

### macOS

![macOS search shortcut showing Command K](https://raw.githubusercontent.com/blurbery/silo-server/c901c9d2ee71152367c501d54eacb18318583e91/platform-shortcut-macos.png)

### Windows 10 browser emulation

![Windows search shortcut showing Ctrl K](https://raw.githubusercontent.com/blurbery/silo-server/c901c9d2ee71152367c501d54eacb18318583e91/platform-shortcut-windows.png)

## Validation

- `cd web && corepack pnpm exec vitest run src/lib/keyboardShortcut.test.ts src/components/AppSidebar.test.tsx src/components/AdminLayout.test.tsx src/components/AdminSectionCommandDialog.test.tsx src/components/GlobalSearch.test.tsx src/pages/SettingsLayout.test.tsx --reporter=verbose` — 6 files passed, 86 tests passed on the current upstream base.
- Windows 10 user-agent emulation resolved the label to `Ctrl K`; Ctrl+K opened global search and admin search, and focused settings search.
- The same implementation was also tested on my deployed fork before porting upstream: 6 files passed, 87 tests passed.
- Manual macOS verification on the deployed fork confirmed `⌘ K` remains visible and the shortcut works.
- Changed-file Prettier check — passed.
- Changed-file ESLint — passed.
- `cd web && corepack pnpm run build` — passed. Vite only reported the existing font-resolution and large-chunk warnings.
- Full Go/backend validation was not run locally because this is a frontend-only label and test change; GitHub Actions is expected to run the repository-wide matrix.

## Risks

Low. User-agent detection only changes the displayed hint; it does not change shortcut handling or search behavior. Non-Apple and unknown user agents fall back to `Ctrl K`.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): GPT-5 (the model family reported to this task; Codex did not expose a more specific model slug)
- Involvement: AI-assisted — I supplied the original UX requirement, macOS reference and manual verification, performance constraint, and privacy requirement for the screenshots. Codex ported the focused change, added the Windows interaction tests, produced the comparison captures, and drafted this PR.
- Adversarial review: I reviewed the complete upstream diff for platform-detection mistakes, stale hard-coded Apple hints, shortcut conflicts, render-time work, search-path changes, and unrelated fork code. The review found that the original tests proved the label but did not explicitly dispatch Ctrl+K across every search surface, so focused global, admin, and settings interaction tests were added. A source-wide scan found no remaining visible hard-coded Apple-only search hint; no new listeners, hooks, state, requests, or search work were introduced.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Search shortcut hints now automatically display the appropriate key combination for Apple and non-Apple devices across the admin and settings interfaces.
  * Added support for opening and focusing search with **Ctrl+K** on non-Apple devices.

* **Bug Fixes**
  * Standardized shortcut labels across search buttons, sidebars, settings, and device pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
