### PR TITLE
fix(web): defer resume refresh during playback

### DIFF
--- a/web/src/components/RealtimeEventsProvider.test.tsx
+++ b/web/src/components/RealtimeEventsProvider.test.tsx
@@ -22,6 +22,7 @@ const mockState = vi.hoisted(() => ({
     canPollDashboard: true,
     canApplyRealtimeUpdates: true,
   },
+  pathname: "/",
 }));
 
 vi.mock("@/hooks/useAuth", () => {
@@ -37,7 +38,7 @@ vi.mock("@/hooks/usePageActivity", () => ({
 }));
 
 vi.mock("react-router", () => ({
-  useLocation: () => ({ pathname: "/" }),
+  useLocation: () => ({ pathname: mockState.pathname }),
 }));
 
 class FakeWebSocket {
@@ -182,6 +183,7 @@ describe("RealtimeEventsProvider", () => {
       canPollDashboard: true,
       canApplyRealtimeUpdates: true,
     };
+    mockState.pathname = "/";
   });
 
   afterEach(() => {
@@ -244,6 +246,57 @@ describe("RealtimeEventsProvider", () => {
     });
 
     expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it("defers broad catch-up refetches until foreground playback exits", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const refetchQueries = vi.spyOn(queryClient, "refetchQueries").mockResolvedValue(undefined);
+    mockState.pathname = "/watch/movie-1";
+    const provider = () => (
+      <QueryClientProvider client={queryClient}>
+        <RealtimeEventsProvider>
+          <div />
+        </RealtimeEventsProvider>
+      </QueryClientProvider>
+    );
+
+    const view = render(provider());
+
+    act(() => {
+      mockState.pageActivity = {
+        ...mockState.pageActivity,
+        isVisible: false,
+        canApplyRealtimeUpdates: false,
+      };
+      view.rerender(provider());
+    });
+
+    act(() => {
+      mockState.pageActivity = {
+        ...mockState.pageActivity,
+        isVisible: true,
+        canApplyRealtimeUpdates: true,
+      };
+      view.rerender(provider());
+    });
+
+    expect(refetchQueries).not.toHaveBeenCalled();
+
+    act(() => {
+      mockState.pathname = "/item/movie-1";
+      view.rerender(provider());
+    });
+
+    expect(refetchQueries).toHaveBeenCalledTimes(1);
+    expect(refetchQueries).toHaveBeenCalledWith({
+      type: "active",
+      predicate: expect.any(Function),
+    });
   });
 
   it("preserves cached watched state when a favorite-only event arrives", () => {

--- a/web/src/components/RealtimeEventsProvider.tsx
+++ b/web/src/components/RealtimeEventsProvider.tsx
@@ -486,6 +486,7 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
   const pageActivity = usePageActivity();
   const location = useLocation();
   const authenticatedUserID = user?.id ?? null;
+  const isForegroundPlaybackRoute = location.pathname.startsWith("/watch/");
   const isDashboardRoute = location.pathname === "/admin" || location.pathname === "/admin/";
   const allowDashboardRealtimeUpdates = !isDashboardRoute || pageActivity.canPollDashboard;
   const [connectionState, setConnectionState] = useState<RealtimeConnectionState>("connecting");
@@ -770,13 +771,27 @@ export function RealtimeEventsProvider({ children }: { children: ReactNode }) {
     if (!shouldCatchUpOnFocusRef.current) {
       return;
     }
+    // The foreground player covers the routed app and owns everything it
+    // needs for uninterrupted playback. Refetching every active query here
+    // used to reload profiles, capabilities, theme/settings, branding, and
+    // watch detail together whenever a hidden playback tab became visible.
+    // Keep the catch-up pending until the watch route exits; the underlying
+    // screen will then refresh before it becomes useful again.
+    if (isForegroundPlaybackRoute) {
+      return;
+    }
 
     shouldCatchUpOnFocusRef.current = false;
     void queryClient.refetchQueries({
       type: "active",
       predicate: (query) => !isDashboardQueryKey(query.queryKey),
     });
-  }, [authenticatedUserID, pageActivity.canApplyRealtimeUpdates, queryClient]);
+  }, [
+    authenticatedUserID,
+    isForegroundPlaybackRoute,
+    pageActivity.canApplyRealtimeUpdates,
+    queryClient,
+  ]);
 
   useEffect(() => {
     if (!authenticatedUserID || !pageActivity.canApplyRealtimeUpdates) {


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

When a hidden playback tab became visible again, `RealtimeEventsProvider` ran its broad active-query catch-up immediately. That refreshed unrelated profiles, capabilities, settings, branding, and item-detail data while video was playing.

## Approach

Defer the broad visibility catch-up while the current route is `/watch/*`. The pending flag stays set, so leaving the player runs the same catch-up before the underlying app data is useful again.

The regression test covers the full transition: hide and resume on a watch route causes no broad refetch, then leaving the watch route causes exactly one.

This is limited to the web query lifecycle. It does not change the v1 API, playback protocol, jellycompat, or the Apple and Android clients.

## Validation

Full repository gate on commit `032b4fb6e`:

- `make embed-stub` — passed
- `go build ./...` — passed
- `gofmt -l .` — no output
- `go vet ./...` — passed
- `golangci-lint run --new-from-merge-base="origin/main" ./...` — 0 issues; the linter emitted one stale generated-file cache warning for a deleted local worktree
- `make test-go` — passed
- `cd web && pnpm install --frozen-lockfile` — passed
- `cd web && pnpm run lint` — passed with the repository's existing warning baseline
- `cd web && pnpm run format:check` — all matched files use Prettier style
- `cd web && pnpm run build` — passed with the existing unresolved runtime font and large-chunk warnings
- `make test-web` — 350 test files passed, 2,954 tests passed
- `make verify-settings-bindings-all` — passed
- `make verify-playback-fixtures` — passed
- `make verify-local-paths` — passed

Manual browser validation against a development backend:

- On `/watch/*`, a synthetic background-to-foreground transition produced only the WebSocket ticket request and normal playback progress traffic. It did not produce the broad profile, settings, branding, capabilities, or item-detail request burst.
- Leaving `/watch/*` performed the deferred catch-up, confirming that refresh work is delayed rather than lost.

No screenshot is included because the change affects network behavior and has no visible UI change.

## Risks

The broad catch-up is intentionally delayed until playback exits. Player-owned requests and normal progress updates continue during playback. No migration, API compatibility, security, or cross-client impact was identified.

## AI Disclosure

- Tool(s): Codex in T3 Code; Claude Code through CLIProxy
- Model(s): `gpt-5.6-sol`; `fable`
- Involvement: AI-assisted
- Adversarial review: Fable reviewed the exact base-to-head diff with read-only repository access, focusing on visibility and route lifecycles, effect dependencies, pending catch-up loss or duplication, route matching, query freshness, and regression coverage. It found no blocking defects. Its optional suggestions were broader lifecycle test cases and avoiding a possible duplicate mount fetch on route exit; both were left out because they do not affect the fix's correctness and would broaden this narrow change. Codex verified the findings against the code and reran the complete repository gate after the final rebase.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime updates during video playback by deferring broad content refreshes while watching.
  * Pending updates are automatically applied when playback ends or the viewer leaves the watch screen.
  * Added coverage to verify refresh behavior across playback and non-playback routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->