### PR TITLE
perf(web): smooth Home item navigation across browser engines

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -96,6 +96,8 @@
   --duration-drift: 2000ms;
   /* Sidebar immersion collapse — see `.sidebar-surface`. */
   --duration-sidebar-collapse: 300ms;
+  --duration-sidebar-entry: 340ms;
+  --duration-sidebar-return: 340ms;
 
   /* ── Motion: Easing ────────────────────────────────────────── */
   --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
@@ -320,6 +322,36 @@ html[data-navigation-direction="forward"] {
 html[data-navigation-direction="back"] {
   --nav-slide-shift: 24px;
 }
+
+/* Home entry and return share one perceived speed. Only this exact boundary
+   gets the extra beat; every other route keeps the base 300 ms token. */
+html[data-home-item-entry="true"] {
+  --duration-sidebar-collapse: var(--duration-sidebar-entry);
+}
+html[data-navigation-direction="back"][data-home-route="true"] {
+  --duration-sidebar-collapse: var(--duration-sidebar-return);
+}
+
+@keyframes home-item-detail-reveal {
+  from {
+    opacity: 0.35;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* Home item entry uses a handful of fixed, solid boxes while the sidebar moves.
+   They never pulse or request artwork, and disappear before the real hero's
+   bounded poster/copy group settles. The page surface itself stays opaque. */
+.home-item-transition-block {
+  background: var(--surface);
+  border-color: var(--border);
+}
+
+html[data-home-item-entry="true"] .detail-hero-primary-content {
+  animation: var(--duration-normal) var(--ease-out) both home-item-detail-reveal;
+}
 html[data-navigation-direction]::view-transition-old(main-content) {
   animation: var(--duration-sidebar-collapse) var(--ease-sidebar-collapse) both nav-slide-out;
 }
@@ -346,11 +378,16 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --duration-glacial: 0ms;
     --duration-slow: 150ms;
     --duration-sidebar-collapse: 0ms;
+    --duration-sidebar-entry: 0ms;
+    --duration-sidebar-return: 0ms;
     --animate-ken-burns-a: none;
     --animate-ken-burns-b: none;
   }
   .ambient-glow {
     transition: none;
+  }
+  .detail-hero-primary-content {
+    animation: none !important;
   }
   /* Collapsing the sidebar becomes an instant state change: the frame, the
      content under it, and everything cross-fading inside all stop animating. */

--- a/web/src/components/HeroBanner.test.tsx
+++ b/web/src/components/HeroBanner.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from "react-router";
 import { renderToStaticMarkup } from "react-dom/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { SectionItem } from "@/api/types";
@@ -168,7 +168,14 @@ describe("HeroBanner", () => {
   beforeEach(() => {
     playbackMocks.controller = null;
     playbackMocks.toggleActivePlayback.mockClear();
+    vi.stubGlobal("matchMedia", () => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
   });
+
+  afterEach(() => vi.unstubAllGlobals());
 
   it("names the ken burns tokens literally so tailwind keeps them", () => {
     // Tailwind drops a theme variable it cannot find referenced by name in the
@@ -184,6 +191,32 @@ describe("HeroBanner", () => {
 
     expect(markup).toContain('src="/backdrop.jpg"');
     expect(markup).toContain("var(--animate-ken-burns-a)");
+  });
+
+  it("runs backdrop motion only on the visible slide", async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={[
+            movieSlide({ content_id: "movie-1", backdrop_url: "/first.jpg" }),
+            movieSlide({ content_id: "movie-2", title: "Second", backdrop_url: "/second.jpg" }),
+          ]}
+        />
+      </MemoryRouter>,
+    );
+    const images = Array.from(container.querySelectorAll("img"));
+
+    expect(images[0]?.style.animation).toBe("var(--animate-ken-burns-a)");
+    expect(images[0]).toHaveClass("will-change-transform");
+    expect(images[1]?.style.animation).toBe("none");
+    expect(images[1]).not.toHaveClass("will-change-transform");
+
+    await userEvent.click(screen.getByRole("button", { name: "Next slide" }));
+
+    expect(images[0]?.style.animation).toBe("none");
+    expect(images[0]).not.toHaveClass("will-change-transform");
+    expect(images[1]?.style.animation).toBe("var(--animate-ken-burns-b)");
+    expect(images[1]).toHaveClass("will-change-transform");
   });
 
   it("does not render the desktop spotlighting card", () => {

--- a/web/src/components/HeroBanner.tsx
+++ b/web/src/components/HeroBanner.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, type MouseEvent } from "react";
+import { memo, useState, useEffect, useCallback, useMemo, type MouseEvent } from "react";
 import { Link } from "react-router";
 import { Info, ChevronLeft, ChevronRight, Play, Pause, BookOpen } from "lucide-react";
 import { decodeThumbhash } from "@/lib/thumbhash";
@@ -49,6 +49,55 @@ interface HeroBannerProps {
  */
 const KEN_BURNS_ANIMATIONS = ["var(--animate-ken-burns-a)", "var(--animate-ken-burns-b)"] as const;
 
+const HeroBackdropSlide = memo(function HeroBackdropSlide({
+  slide,
+  index,
+  isActive,
+}: {
+  slide: SectionItem;
+  index: number;
+  isActive: boolean;
+}) {
+  const [loaded, setLoaded] = useState(false);
+  const thumbhash = slide.backdrop_thumbhash ? decodeThumbhash(slide.backdrop_thumbhash) : "";
+
+  return (
+    <div
+      aria-roledescription="slide"
+      className={`bg-muted absolute inset-0 transition-opacity duration-1000 ease-in-out ${isActive ? "opacity-100" : "opacity-0"}`}
+      style={
+        thumbhash
+          ? {
+              backgroundImage: `url(${thumbhash})`,
+              backgroundSize: "cover",
+              backgroundPosition: "center 20%",
+            }
+          : undefined
+      }
+    >
+      {slide.backdrop_url && (
+        <img
+          src={slide.backdrop_url}
+          alt=""
+          className={cn(
+            "h-full w-full object-cover object-[center_20%] transition-opacity duration-(--duration-slow)",
+            isActive && "will-change-transform",
+            loaded ? "opacity-100" : "opacity-0",
+          )}
+          style={{
+            animation: isActive
+              ? KEN_BURNS_ANIMATIONS[index % KEN_BURNS_ANIMATIONS.length]
+              : "none",
+            filter:
+              "brightness(var(--hero-backdrop-brightness, 0.78)) saturate(var(--hero-backdrop-saturate, 0.95))",
+          }}
+          onLoad={() => setLoaded(true)}
+        />
+      )}
+    </div>
+  );
+});
+
 function heroPlayLabel(item: SectionItem, activeAudiobookPlaying?: boolean | null): string {
   if (item.type === "ebook") {
     return "Read";
@@ -83,7 +132,6 @@ export default function HeroBanner({
 }: HeroBannerProps) {
   const slides = useMemo(() => items.slice(0, maxSlides), [items, maxSlides]);
   const [activeIndex, setActiveIndex] = useState(0);
-  const [loaded, setLoaded] = useState<Record<number, boolean>>({});
   const [paused, setPaused] = useState(false);
   const audiobookPlayback = useAudiobookPlaybackController();
   // Bumped whenever auto-advance restarts a fresh 8s cycle — after the slide
@@ -175,39 +223,14 @@ export default function HeroBanner({
       }}
     >
       {/* Backdrop layers – all stacked, crossfade via opacity */}
-      {slides.map((slide, i) => {
-        const thumbhash = slide.backdrop_thumbhash ? decodeThumbhash(slide.backdrop_thumbhash) : "";
-        const isActive = i === activeIndex;
-        return (
-          <div
-            key={slide.content_id ?? i}
-            aria-roledescription="slide"
-            className={`bg-muted absolute inset-0 transition-opacity duration-1000 ease-in-out ${isActive ? "opacity-100" : "opacity-0"}`}
-            style={
-              thumbhash
-                ? {
-                    backgroundImage: `url(${thumbhash})`,
-                    backgroundSize: "cover",
-                    backgroundPosition: "center 20%",
-                  }
-                : undefined
-            }
-          >
-            {slide.backdrop_url && (
-              <img
-                src={slide.backdrop_url}
-                alt=""
-                className={`h-full w-full object-cover object-[center_20%] transition-opacity duration-(--duration-slow) will-change-transform ${loaded[i] ? "opacity-100" : "opacity-0"}`}
-                style={{
-                  animation: KEN_BURNS_ANIMATIONS[i % KEN_BURNS_ANIMATIONS.length],
-                  filter: `brightness(var(--hero-backdrop-brightness, 0.78)) saturate(var(--hero-backdrop-saturate, 0.95))`,
-                }}
-                onLoad={() => setLoaded((prev) => ({ ...prev, [i]: true }))}
-              />
-            )}
-          </div>
-        );
-      })}
+      {slides.map((slide, i) => (
+        <HeroBackdropSlide
+          key={slide.content_id ?? i}
+          slide={slide}
+          index={i}
+          isActive={i === activeIndex}
+        />
+      ))}
 
       {/* Gradient overlays */}
       {bleed && <div className="hero-top-scrim" />}

--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -18,6 +18,9 @@ const mocks = vi.hoisted(() => ({
   } as { name: string; avatar_url?: string },
 }));
 
+let browserUserAgent =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36";
+
 vi.mock("react-router", async () => {
   const actual = await vi.importActual<typeof import("react-router")>("react-router");
   return {
@@ -142,6 +145,9 @@ beforeEach(() => {
     name: "Admin",
     avatar_url: "https://example.com/admin-avatar.webp",
   };
+  browserUserAgent =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36";
+  vi.spyOn(window.navigator, "userAgent", "get").mockImplementation(() => browserUserAgent);
   vi.stubGlobal("matchMedia", (query: string) => ({
     matches: query === "(min-width: 64rem)",
     media: query,
@@ -170,6 +176,22 @@ describe("Layout mobile profile", () => {
 
     expect(settingsLink).toContainElement(avatar);
     expect(avatar).toHaveAttribute("src", "https://example.com/admin-avatar.webp");
+  });
+
+  it("marks only Home as the balanced sidebar return destination", () => {
+    const view = renderLayout();
+    expect(document.documentElement).toHaveAttribute("data-home-route", "true");
+
+    setRoute("/library/1", "library");
+    view.rerender(
+      <MemoryRouter>
+        <Layout>
+          <Harness />
+        </Layout>
+      </MemoryRouter>,
+    );
+
+    expect(document.documentElement).not.toHaveAttribute("data-home-route");
   });
 });
 
@@ -233,10 +255,13 @@ describe("Layout item navigation", () => {
     expect(mocks.prefetchQuery).toHaveBeenCalledWith(
       expect.objectContaining({ queryKey: catalogKeys.itemDetail("movie-1", 2) }),
     );
+    expect(mocks.prefetchQuery.mock.invocationCallOrder[0]!).toBeLessThan(
+      mocks.navigate.mock.invocationCallOrder[0]!,
+    );
     expect(mocks.navigate).toHaveBeenCalledWith("/item/movie-1?libraryId=2", {
       replace: true,
       state: { source: "home" },
-      viewTransition: true,
+      viewTransition: false,
     });
   });
 });
@@ -260,15 +285,26 @@ describe("Layout detail reveal", () => {
     expect(screen.getByRole("status", { name: "details-ready" })).toHaveTextContent("true");
   });
 
-  it("reveals immediately when the item detail is already cached", () => {
+  it("reveals cached details immediately when the item entry is not from Home", () => {
     mocks.getQueryData.mockImplementation((queryKey: unknown) =>
       JSON.stringify(queryKey) === JSON.stringify(catalogKeys.itemDetail("movie-1", undefined))
         ? { content_id: "movie-1" }
         : undefined,
     );
     const view = renderLayout();
-    setRoute("/item/movie-1", "item");
 
+    setRoute("/library/1", "library");
+    act(() =>
+      view.rerender(
+        <MemoryRouter>
+          <Layout>
+            <Harness />
+          </Layout>
+        </MemoryRouter>,
+      ),
+    );
+
+    setRoute("/item/movie-1", "item");
     act(() =>
       view.rerender(
         <MemoryRouter>
@@ -281,6 +317,59 @@ describe("Layout detail reveal", () => {
 
     expect(screen.getByRole("status", { name: "details-ready" })).toHaveTextContent("true");
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps cached Home item re-entry light until the sidebar carry settles", () => {
+    mocks.getQueryData.mockImplementation((queryKey: unknown) =>
+      JSON.stringify(queryKey) === JSON.stringify(catalogKeys.itemDetail("movie-1", undefined))
+        ? { content_id: "movie-1" }
+        : undefined,
+    );
+    const view = renderLayout();
+
+    const enterCachedItem = (key: string) => {
+      setRoute("/item/movie-1", key);
+      act(() =>
+        view.rerender(
+          <MemoryRouter>
+            <Layout>
+              <Harness />
+            </Layout>
+          </MemoryRouter>,
+        ),
+      );
+    };
+
+    enterCachedItem("item-first");
+    expect(screen.getByRole("status", { name: "details-ready" })).toHaveTextContent("false");
+    expect(document.documentElement).toHaveAttribute("data-home-item-entry", "true");
+
+    const surface = screen.getByTestId("sidebar-surface");
+    surface.setAttribute("data-collapsed", "true");
+    fireEvent.transitionEnd(surface, { propertyName: "transform" });
+    expect(screen.getByRole("status", { name: "details-ready" })).toHaveTextContent("true");
+    expect(document.documentElement).toHaveAttribute("data-home-item-entry", "true");
+    surface.removeAttribute("data-collapsed");
+
+    setRoute("/", "home-again");
+    act(() =>
+      view.rerender(
+        <MemoryRouter>
+          <Layout>
+            <Harness />
+          </Layout>
+        </MemoryRouter>,
+      ),
+    );
+
+    enterCachedItem("item-repeat");
+    expect(screen.getByRole("status", { name: "details-ready" })).toHaveTextContent("false");
+
+    screen.getByTestId("sidebar-surface").setAttribute("data-collapsed", "true");
+    fireEvent.transitionEnd(screen.getByTestId("sidebar-surface"), {
+      propertyName: "transform",
+    });
+    expect(screen.getByRole("status", { name: "details-ready" })).toHaveTextContent("true");
   });
 
   it("reveals as soon as the surface settles", () => {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { startTransition, useCallback, useEffect, useLayoutEffect, useState } from "react";
 import { Link, useLocation } from "react-router";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { Menu, Search } from "lucide-react";
@@ -79,7 +79,7 @@ export default function Layout({ children }: LayoutProps) {
     isCalendarRoute;
 
   // The item route commits its lightweight shell immediately. The following
-  // frame starts the sidebar/main compositor transition; prefetched details
+  // paint handoff starts the sidebar/main compositor transition; prefetched details
   // and artwork are revealed only after that motion completes.
   const isDetailImmersion = isItemRoute;
   const targetDetailImmersion = isDetailImmersion;
@@ -87,8 +87,24 @@ export default function Layout({ children }: LayoutProps) {
   const {
     itemDetailsReady,
     pendingLocationKey,
+    enteredItemFromHome,
     reveal: revealItemDetails,
-  } = useSidebarItemDetailsGate(location.key, isItemRoute && hasDesktopSidebar);
+  } = useSidebarItemDetailsGate(location.key, location.pathname, isItemRoute && hasDesktopSidebar);
+
+  const revealPreparedItemDetails = useCallback(
+    (expectedLocationKey: string) => {
+      if (!enteredItemFromHome) {
+        revealItemDetails(expectedLocationKey);
+        return;
+      }
+
+      // A cached detail tree is substantially heavier than the handoff shell.
+      // Keep the shell committed while React prepares that tree concurrently,
+      // then swap it in atomically instead of blocking the last sidebar frame.
+      startTransition(() => revealItemDetails(expectedLocationKey));
+    },
+    [enteredItemFromHome, revealItemDetails],
+  );
 
   const beginItemNavigation = useCallback(
     (request: SidebarItemNavigationRequest) => {
@@ -116,11 +132,11 @@ export default function Layout({ children }: LayoutProps) {
   useEffect(() => {
     if (!isItemRoute || !pendingLocationKey) return;
 
-    // The gate stages the collapse so the detail skeleton is not what animates
-    // into view. A prefetched detail has no skeleton to hide, so waiting for
-    // the sidebar would only delay a page that is already ready to paint.
-    if (hasCachedItemDetail(queryClient, itemRouteLocation)) {
-      revealItemDetails(pendingLocationKey);
+    // Cached details can normally paint immediately. Home entries are the
+    // exception: mounting that heavier tree inside the sidebar compositor
+    // motion makes repeat visits rougher than the first uncached visit.
+    if (!enteredItemFromHome && hasCachedItemDetail(queryClient, itemRouteLocation)) {
+      revealPreparedItemDetails(pendingLocationKey);
       return;
     }
 
@@ -142,7 +158,7 @@ export default function Layout({ children }: LayoutProps) {
         timer = window.setTimeout(revealWhenSettled, Math.min(50, Math.max(0, remaining)));
         return;
       }
-      revealItemDetails(pendingLocationKey);
+      revealPreparedItemDetails(pendingLocationKey);
     };
 
     revealWhenSettled();
@@ -150,21 +166,28 @@ export default function Layout({ children }: LayoutProps) {
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, [isItemRoute, itemRouteLocation, pendingLocationKey, queryClient, revealItemDetails]);
+  }, [
+    enteredItemFromHome,
+    isItemRoute,
+    itemRouteLocation,
+    pendingLocationKey,
+    queryClient,
+    revealPreparedItemDetails,
+  ]);
 
   const handleSidebarTransitionEnd = useCallback(
     (event: ReactTransitionEvent<HTMLDivElement>) => {
       if (event.propertyName === "transform" && isCollapsedSidebarSurface(event.target)) {
-        if (pendingLocationKey) revealItemDetails(pendingLocationKey);
+        if (pendingLocationKey) revealPreparedItemDetails(pendingLocationKey);
       }
     },
-    [pendingLocationKey, revealItemDetails],
+    [pendingLocationKey, revealPreparedItemDetails],
   );
 
   // Publish both sidebar states on the document root so out-of-tree chrome
   // (notably ImpersonationBanner, which renders above all routes) can align
   // with the sidebar. The target drives the snapped `--app-sidebar-offset`;
-  // the visual state is the same one-frame handoff `.sidebar-main-stage` uses
+  // the visual state is the same paint handoff `.sidebar-main-stage` uses
   // in-tree, letting that chrome animate its edge instead of jumping.
   //
   // Layout effect, not effect: the sidebar receives `data-collapsed` during
@@ -178,6 +201,16 @@ export default function Layout({ children }: LayoutProps) {
     // collapse — and the routes rendered outside this shell keep the default
     // root transition, which is the only thing they have to animate.
     root.dataset.appShell = "true";
+    if (isHomePath) {
+      root.dataset.homeRoute = "true";
+    } else {
+      delete root.dataset.homeRoute;
+    }
+    if (enteredItemFromHome) {
+      root.dataset.homeItemEntry = "true";
+    } else {
+      delete root.dataset.homeItemEntry;
+    }
     if (targetDetailImmersion) {
       root.dataset.sidebarCollapsed = "true";
     } else {
@@ -190,10 +223,12 @@ export default function Layout({ children }: LayoutProps) {
     }
     return () => {
       delete root.dataset.appShell;
+      delete root.dataset.homeRoute;
+      delete root.dataset.homeItemEntry;
       delete root.dataset.sidebarCollapsed;
       delete root.dataset.sidebarVisualCollapsed;
     };
-  }, [targetDetailImmersion, visualDetailImmersion]);
+  }, [enteredItemFromHome, isHomePath, targetDetailImmersion, visualDetailImmersion]);
 
   // Auto-hide the mobile header on scroll-down for the Calendar route only.
   // Direction-based (not threshold-based) so a small scroll-up reveals the
@@ -239,7 +274,11 @@ export default function Layout({ children }: LayoutProps) {
   }, [mobileHeaderHidden]);
 
   return (
-    <SidebarItemNavigationProvider begin={beginItemNavigation} itemDetailsReady={itemDetailsReady}>
+    <SidebarItemNavigationProvider
+      begin={beginItemNavigation}
+      itemDetailsReady={itemDetailsReady}
+      enteredItemFromHome={enteredItemFromHome}
+    >
       <div className="bg-background relative min-h-[100dvh] overflow-x-clip">
         <a
           href="#main-content"

--- a/web/src/components/PageBack.test.tsx
+++ b/web/src/components/PageBack.test.tsx
@@ -30,6 +30,7 @@ describe("PageBack", () => {
     resetNavigationHistory();
     window.history.replaceState(null, "");
     delete document.documentElement.dataset.navigationDirection;
+    vi.unstubAllGlobals();
   });
 
   it("renders a button with the default 'Go back' aria-label", () => {
@@ -63,6 +64,24 @@ describe("PageBack", () => {
 
     expect(mocks.navigate).toHaveBeenCalledTimes(1);
     expect(mocks.navigate).toHaveBeenCalledWith("/", { replace: false, viewTransition: true });
+  });
+
+  it("uses the snapshot-free fallback when leaving an item on desktop", async () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(min-width: 64rem)",
+    }));
+    render(
+      <MemoryRouter initialEntries={["/item/movie-1"]}>
+        <PageBack />
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Go back" }));
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/", {
+      replace: false,
+      viewTransition: false,
+    });
   });
 
   it("uses browser history when a router history entry is available", async () => {

--- a/web/src/components/SidebarItemNavigationProvider.tsx
+++ b/web/src/components/SidebarItemNavigationProvider.tsx
@@ -2,22 +2,27 @@ import type { ReactNode } from "react";
 import {
   SidebarItemNavigationContext,
   SidebarItemDetailsReadyContext,
+  SidebarItemEnteredFromHomeContext,
   type BeginSidebarItemNavigation,
 } from "@/components/sidebarItemNavigationContext";
 
 export default function SidebarItemNavigationProvider({
   begin,
   itemDetailsReady,
+  enteredItemFromHome = false,
   children,
 }: {
   begin: BeginSidebarItemNavigation;
   itemDetailsReady: boolean;
+  enteredItemFromHome?: boolean;
   children: ReactNode;
 }) {
   return (
     <SidebarItemNavigationContext.Provider value={begin}>
       <SidebarItemDetailsReadyContext.Provider value={itemDetailsReady}>
-        {children}
+        <SidebarItemEnteredFromHomeContext.Provider value={enteredItemFromHome}>
+          {children}
+        </SidebarItemEnteredFromHomeContext.Provider>
       </SidebarItemDetailsReadyContext.Provider>
     </SidebarItemNavigationContext.Provider>
   );

--- a/web/src/components/ViewTransitionLink.test.tsx
+++ b/web/src/components/ViewTransitionLink.test.tsx
@@ -23,6 +23,7 @@ afterEach(() => {
   resetNavigationHistory();
   window.history.replaceState(null, "");
   delete document.documentElement.dataset.navigationDirection;
+  vi.unstubAllGlobals();
 });
 
 describe("ViewTransitionLink sidebar navigation", () => {
@@ -150,6 +151,24 @@ describe("ViewTransitionLink sidebar navigation", () => {
 
     fireEvent.click(screen.getByRole("link", { name: "Movie" }));
 
+    expect(screen.getByRole("status", { name: "location" })).toHaveTextContent("/item/movie-1");
+  });
+
+  it("routes a desktop item boundary through the snapshot-free chokepoint", () => {
+    const matchMedia = vi.fn((query: string) => ({
+      matches: query === "(min-width: 64rem)",
+    }));
+    vi.stubGlobal("matchMedia", matchMedia);
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <ViewTransitionLink to="/item/movie-1">Movie</ViewTransitionLink>
+        <LocationOutput />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Movie" }));
+
+    expect(matchMedia).toHaveBeenCalledWith("(min-width: 64rem)");
     expect(screen.getByRole("status", { name: "location" })).toHaveTextContent("/item/movie-1");
   });
 });

--- a/web/src/components/ViewTransitionLink.tsx
+++ b/web/src/components/ViewTransitionLink.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react";
-import { createPath, Link, useResolvedPath } from "react-router";
+import { createPath, Link, useLocation, useResolvedPath } from "react-router";
 import type { LinkProps } from "react-router";
 import { useSidebarItemNavigation } from "@/components/sidebarItemNavigationContext";
-import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
+import { shouldUseRouteViewTransition, useViewTransitionNavigate } from "@/hooks/useViewTransition";
 import { markNavigationDirection } from "@/lib/navigationHistory";
 
 type ViewTransitionLinkProps = LinkProps &
@@ -24,6 +24,7 @@ const ViewTransitionLink = forwardRef<HTMLAnchorElement, ViewTransitionLinkProps
   function ViewTransitionLink({ to, replace, state, up = false, onClick, children, ...rest }, ref) {
     const beginSidebarItemNavigation = useSidebarItemNavigation();
     const navigate = useViewTransitionNavigate();
+    const location = useLocation();
     const resolvedPath = useResolvedPath(to);
 
     return (
@@ -63,7 +64,18 @@ const ViewTransitionLink = forwardRef<HTMLAnchorElement, ViewTransitionLinkProps
             replace,
             state,
           });
-          if (intercepted) event.preventDefault();
+          if (intercepted) {
+            event.preventDefault();
+            return;
+          }
+
+          // React Router's <Link> needs the decision before its own click
+          // handler runs. Route the small set of snapshot-free navigations
+          // through the same imperative chokepoint used everywhere else.
+          if (!shouldUseRouteViewTransition(location.pathname, resolvedPath.pathname)) {
+            event.preventDefault();
+            navigate(resolvedPath, { replace, state, viewTransition: false });
+          }
         }}
         viewTransition
         {...rest}

--- a/web/src/components/sidebarItemNavigationContext.ts
+++ b/web/src/components/sidebarItemNavigationContext.ts
@@ -5,6 +5,7 @@ export type BeginSidebarItemNavigation = (request: SidebarItemNavigationRequest)
 
 export const SidebarItemNavigationContext = createContext<BeginSidebarItemNavigation | null>(null);
 export const SidebarItemDetailsReadyContext = createContext(true);
+export const SidebarItemEnteredFromHomeContext = createContext(false);
 
 export function useSidebarItemNavigation(): BeginSidebarItemNavigation | null {
   return useContext(SidebarItemNavigationContext);
@@ -12,4 +13,8 @@ export function useSidebarItemNavigation(): BeginSidebarItemNavigation | null {
 
 export function useSidebarItemDetailsReady(): boolean {
   return useContext(SidebarItemDetailsReadyContext);
+}
+
+export function useSidebarItemEnteredFromHome(): boolean {
+  return useContext(SidebarItemEnteredFromHomeContext);
 }

--- a/web/src/hooks/useImmediateSidebarCollapse.test.tsx
+++ b/web/src/hooks/useImmediateSidebarCollapse.test.tsx
@@ -1,23 +1,48 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { useImmediateSidebarCollapse } from "./useImmediateSidebarCollapse";
+import {
+  isFirefoxEngine,
+  isWebKitEngine,
+  useImmediateSidebarCollapse,
+} from "./useImmediateSidebarCollapse";
+
+const SAFARI_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.6 Safari/605.1.15";
+const ORION_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.5 Safari/605.1.15 Orion/0.99.135";
+const WEBKIT_GTK_USER_AGENT =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 Version/18.0 Safari/605.1.15";
+const CHROME_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36";
+const EDGE_USER_AGENT = `${CHROME_USER_AGENT} Edg/151.0.0.0`;
+const FIREFOX_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0";
+const FIREFOX_IOS_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/149.0 Mobile/15E148 Safari/605.1.15";
+
+function stubUserAgent(userAgent: string) {
+  vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent);
+}
 
 function stubFrames() {
-  const queue: FrameRequestCallback[] = [];
+  let nextId = 1;
+  const queue: Array<{ callback: FrameRequestCallback; id: number }> = [];
+  const cancelled = new Set<number>();
   vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
-    queue.push(callback);
-    return queue.length;
+    const id = nextId++;
+    queue.push({ callback, id });
+    return id;
   });
-  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => cancelled.add(id));
   return {
     get pending() {
-      return queue.length;
+      return queue.filter(({ id }) => !cancelled.has(id)).length;
     },
     async frame() {
-      const callback = queue.shift();
-      expect(callback, "no frame was requested").toBeTypeOf("function");
-      await act(async () => callback!(performance.now()));
+      let entry = queue.shift();
+      while (entry && cancelled.has(entry.id)) entry = queue.shift();
+      expect(entry?.callback, "no frame was requested").toBeTypeOf("function");
+      await act(async () => entry!.callback(performance.now()));
     },
   };
 }
@@ -69,9 +94,10 @@ describe("useImmediateSidebarCollapse", () => {
     expect(renderHook(() => useImmediateSidebarCollapse(true)).result.current).toBe(true);
   });
 
-  it("starts the visual collapse on the next frame", async () => {
+  it("keeps Chromium on the established one-frame handoff", async () => {
     const frames = stubFrames();
     stubReducedMotion(false);
+    stubUserAgent(CHROME_USER_AGENT);
     const { result, rerender } = renderHook(
       ({ collapsed }) => useImmediateSidebarCollapse(collapsed),
       {
@@ -85,6 +111,141 @@ describe("useImmediateSidebarCollapse", () => {
 
     await frames.frame();
     expect(result.current).toBe(true);
+  });
+
+  it("keeps Firefox on the established one-frame handoff", async () => {
+    const frames = stubFrames();
+    stubReducedMotion(false);
+    stubUserAgent(FIREFOX_USER_AGENT);
+    const { result, rerender } = renderHook(
+      ({ collapsed }) => useImmediateSidebarCollapse(collapsed),
+      {
+        initialProps: { collapsed: false },
+      },
+    );
+
+    rerender({ collapsed: true });
+    await frames.frame();
+    expect(result.current).toBe(true);
+    expect(frames.pending).toBe(0);
+  });
+
+  it.each([
+    ["Safari", SAFARI_USER_AGENT],
+    ["Orion", ORION_USER_AGENT],
+    ["WebKitGTK", WEBKIT_GTK_USER_AGENT],
+  ])("keeps the two-frame opening handoff in %s", async (_browser, userAgent) => {
+    const frames = stubFrames();
+    stubReducedMotion(false);
+    stubUserAgent(userAgent);
+    const { result, rerender } = renderHook(
+      ({ collapsed }) => useImmediateSidebarCollapse(collapsed),
+      {
+        initialProps: { collapsed: false },
+      },
+    );
+
+    rerender({ collapsed: true });
+    expect(result.current).toBe(false);
+
+    await frames.frame();
+    expect(result.current).toBe(false);
+    expect(frames.pending).toBe(1);
+
+    await frames.frame();
+    expect(result.current).toBe(true);
+    expect(frames.pending).toBe(0);
+  });
+
+  it.each([
+    ["Safari", SAFARI_USER_AGENT],
+    ["Orion", ORION_USER_AGENT],
+    ["WebKitGTK", WEBKIT_GTK_USER_AGENT],
+  ])("uses the same two-frame Back handoff in %s", async (_browser, userAgent) => {
+    const frames = stubFrames();
+    stubReducedMotion(false);
+    stubUserAgent(userAgent);
+    const { result, rerender } = renderHook(
+      ({ collapsed }) => useImmediateSidebarCollapse(collapsed),
+      {
+        initialProps: { collapsed: true },
+      },
+    );
+
+    rerender({ collapsed: false });
+    expect(result.current).toBe(true);
+
+    await frames.frame();
+    expect(result.current).toBe(true);
+    expect(frames.pending).toBe(1);
+
+    await frames.frame();
+    expect(result.current).toBe(false);
+    expect(frames.pending).toBe(0);
+  });
+
+  it.each([
+    ["Chrome", CHROME_USER_AGENT],
+    ["Edge", EDGE_USER_AGENT],
+    ["Firefox", FIREFOX_USER_AGENT],
+  ])("keeps the one-frame Back handoff in %s", async (_browser, userAgent) => {
+    const frames = stubFrames();
+    stubReducedMotion(false);
+    stubUserAgent(userAgent);
+    const { result, rerender } = renderHook(
+      ({ collapsed }) => useImmediateSidebarCollapse(collapsed),
+      {
+        initialProps: { collapsed: true },
+      },
+    );
+
+    rerender({ collapsed: false });
+    expect(result.current).toBe(true);
+
+    await frames.frame();
+    expect(result.current).toBe(false);
+    expect(frames.pending).toBe(0);
+  });
+
+  it("cancels WebKit's paint-boundary frame when navigation reverses", async () => {
+    const frames = stubFrames();
+    stubReducedMotion(false);
+    stubUserAgent(SAFARI_USER_AGENT);
+    const { result, rerender } = renderHook(
+      ({ collapsed }) => useImmediateSidebarCollapse(collapsed),
+      {
+        initialProps: { collapsed: false },
+      },
+    );
+
+    rerender({ collapsed: true });
+    await frames.frame();
+    expect(frames.pending).toBe(1);
+
+    rerender({ collapsed: false });
+    expect(result.current).toBe(false);
+    expect(frames.pending).toBe(0);
+  });
+
+  it("cancels WebKit's Back paint frame when navigation reverses", async () => {
+    const frames = stubFrames();
+    stubReducedMotion(false);
+    stubUserAgent(ORION_USER_AGENT);
+    const { result, rerender } = renderHook(
+      ({ collapsed }) => useImmediateSidebarCollapse(collapsed),
+      {
+        initialProps: { collapsed: true },
+      },
+    );
+
+    rerender({ collapsed: false });
+    await frames.frame();
+    expect(result.current).toBe(true);
+    expect(frames.pending).toBe(1);
+
+    rerender({ collapsed: true });
+    expect(result.current).toBe(true);
+    expect(frames.pending).toBe(0);
   });
 
   it("applies reduced motion without scheduling a frame", () => {
@@ -119,4 +280,33 @@ describe("useImmediateSidebarCollapse", () => {
     expect(result.current).toBe(true);
     expect(frames.pending).toBe(0);
   });
+});
+
+describe("isWebKitEngine", () => {
+  it.each([SAFARI_USER_AGENT, ORION_USER_AGENT, WEBKIT_GTK_USER_AGENT, FIREFOX_IOS_USER_AGENT])(
+    "detects WebKit engine user agents",
+    (userAgent) => expect(isWebKitEngine(userAgent)).toBe(true),
+  );
+
+  it.each([CHROME_USER_AGENT, EDGE_USER_AGENT, FIREFOX_USER_AGENT])(
+    "does not classify Blink or Gecko as WebKit",
+    (userAgent) => expect(isWebKitEngine(userAgent)).toBe(false),
+  );
+});
+
+describe("isFirefoxEngine", () => {
+  it("detects desktop Firefox", () => {
+    expect(isFirefoxEngine(FIREFOX_USER_AGENT)).toBe(true);
+  });
+
+  it.each([
+    SAFARI_USER_AGENT,
+    ORION_USER_AGENT,
+    WEBKIT_GTK_USER_AGENT,
+    FIREFOX_IOS_USER_AGENT,
+    CHROME_USER_AGENT,
+    EDGE_USER_AGENT,
+  ])("does not classify other engines as desktop Firefox", (userAgent) =>
+    expect(isFirefoxEngine(userAgent)).toBe(false),
+  );
 });

--- a/web/src/hooks/useImmediateSidebarCollapse.ts
+++ b/web/src/hooks/useImmediateSidebarCollapse.ts
@@ -9,10 +9,34 @@ export function prefersReducedMotion(): boolean {
 }
 
 /**
- * Separates the layout snap from the visible compositor transition by one
- * animation frame. This is the minimum handoff needed for the inverse main
- * transform to take effect before the sidebar starts moving; it never waits on
- * item metadata, poster decoding, backdrop loading, or frame-rate heuristics.
+ * Chromium user agents also contain "AppleWebKit", so exclude the Blink
+ * product tokens rather than treating that substring alone as an engine
+ * check. iOS variants intentionally remain WebKit because they use the same
+ * layout engine even when the browser is branded Chrome, Edge, or Firefox.
+ */
+export function isWebKitEngine(userAgent: string): boolean {
+  return (
+    /AppleWebKit/i.test(userAgent) &&
+    !/(?:Chrome|Chromium|HeadlessChrome|Edg|OPR|SamsungBrowser|Vivaldi|YaBrowser)\//i.test(
+      userAgent,
+    )
+  );
+}
+
+/**
+ * Firefox desktop identifies both its Gecko engine and Firefox product token.
+ * Firefox on iOS remains covered by the WebKit check above.
+ */
+export function isFirefoxEngine(userAgent: string): boolean {
+  return /Gecko\/\d+/i.test(userAgent) && /Firefox\/\d+/i.test(userAgent);
+}
+
+/**
+ * Separates the layout snap from the visible compositor transition. Chromium
+ * and Firefox keep the established one-frame handoff. WebKit gets one paint
+ * boundary before the visual state changes because it can otherwise coalesce
+ * the committed compensation transform and its removal into the same paint.
+ * The handoff never waits on item metadata, artwork, or frame-rate heuristics.
  */
 export function useImmediateSidebarCollapse(collapsed: boolean): boolean {
   const [visualCollapsed, setVisualCollapsed] = useState(collapsed);
@@ -40,7 +64,17 @@ export function useImmediateSidebarCollapse(collapsed: boolean): boolean {
       return () => window.clearTimeout(timer);
     }
 
-    frameRef.current = requestAnimationFrame(() => setVisualCollapsed(collapsed));
+    const waitForWebKitPaint =
+      typeof navigator !== "undefined" && isWebKitEngine(navigator.userAgent);
+
+    frameRef.current = requestAnimationFrame(() => {
+      if (!waitForWebKitPaint) {
+        setVisualCollapsed(collapsed);
+        return;
+      }
+
+      frameRef.current = requestAnimationFrame(() => setVisualCollapsed(collapsed));
+    });
     return () => cancelAnimationFrame(frameRef.current);
   }, [collapsed, reduceMotion, visualCollapsed]);
 

--- a/web/src/hooks/useSidebarItemDetailsGate.test.tsx
+++ b/web/src/hooks/useSidebarItemDetailsGate.test.tsx
@@ -5,43 +5,104 @@ import { useSidebarItemDetailsGate } from "./useSidebarItemDetailsGate";
 describe("useSidebarItemDetailsGate", () => {
   it("gates every non-item to item entry, including re-entering a history entry", () => {
     const { result, rerender } = renderHook(
-      ({ locationKey, isItem }: { locationKey: string; isItem: boolean }) =>
-        useSidebarItemDetailsGate(locationKey, isItem),
-      { initialProps: { locationKey: "catalog", isItem: false } },
+      ({
+        locationKey,
+        pathname,
+        isItem,
+      }: {
+        locationKey: string;
+        pathname: string;
+        isItem: boolean;
+      }) => useSidebarItemDetailsGate(locationKey, pathname, isItem),
+      { initialProps: { locationKey: "catalog", pathname: "/catalog", isItem: false } },
     );
 
-    rerender({ locationKey: "movie", isItem: true });
+    rerender({ locationKey: "movie", pathname: "/item/movie", isItem: true });
     expect(result.current.itemDetailsReady).toBe(false);
 
     act(() => result.current.reveal("movie"));
     expect(result.current.itemDetailsReady).toBe(true);
 
-    rerender({ locationKey: "catalog", isItem: false });
-    rerender({ locationKey: "movie", isItem: true });
+    rerender({ locationKey: "catalog", pathname: "/catalog", isItem: false });
+    rerender({ locationKey: "movie", pathname: "/item/movie", isItem: true });
     expect(result.current.itemDetailsReady).toBe(false);
   });
 
   it("does not gate a direct initial item render", () => {
-    const { result } = renderHook(() => useSidebarItemDetailsGate("movie", true));
+    const { result } = renderHook(() => useSidebarItemDetailsGate("movie", "/item/movie", true));
 
     expect(result.current.itemDetailsReady).toBe(true);
     expect(result.current.pendingLocationKey).toBeNull();
+    expect(result.current.enteredItemFromHome).toBe(false);
+  });
+
+  it("remembers a Home item entry after its detail gate settles", () => {
+    const { result, rerender } = renderHook(
+      ({
+        locationKey,
+        pathname,
+        isItem,
+      }: {
+        locationKey: string;
+        pathname: string;
+        isItem: boolean;
+      }) => useSidebarItemDetailsGate(locationKey, pathname, isItem),
+      { initialProps: { locationKey: "home", pathname: "/", isItem: false } },
+    );
+
+    rerender({ locationKey: "movie", pathname: "/item/movie", isItem: true });
+    expect(result.current.enteredItemFromHome).toBe(true);
+
+    rerender({ locationKey: "movie", pathname: "/item/movie", isItem: true });
+    expect(result.current.enteredItemFromHome).toBe(true);
+
+    act(() => result.current.reveal("movie"));
+    expect(result.current.enteredItemFromHome).toBe(true);
+
+    rerender({ locationKey: "home-again", pathname: "/", isItem: false });
+    expect(result.current.enteredItemFromHome).toBe(false);
+  });
+
+  it("does not hold cached details for non-Home item entries", () => {
+    const { result, rerender } = renderHook(
+      ({
+        locationKey,
+        pathname,
+        isItem,
+      }: {
+        locationKey: string;
+        pathname: string;
+        isItem: boolean;
+      }) => useSidebarItemDetailsGate(locationKey, pathname, isItem),
+      { initialProps: { locationKey: "library", pathname: "/library/1", isItem: false } },
+    );
+
+    rerender({ locationKey: "movie", pathname: "/item/movie", isItem: true });
+
+    expect(result.current.enteredItemFromHome).toBe(false);
   });
 
   it("discards an abandoned gate and allows the next item entry", () => {
     const { result, rerender } = renderHook(
-      ({ locationKey, isItem }: { locationKey: string; isItem: boolean }) =>
-        useSidebarItemDetailsGate(locationKey, isItem),
-      { initialProps: { locationKey: "catalog", isItem: false } },
+      ({
+        locationKey,
+        pathname,
+        isItem,
+      }: {
+        locationKey: string;
+        pathname: string;
+        isItem: boolean;
+      }) => useSidebarItemDetailsGate(locationKey, pathname, isItem),
+      { initialProps: { locationKey: "catalog", pathname: "/catalog", isItem: false } },
     );
 
-    rerender({ locationKey: "abandoned-movie", isItem: true });
+    rerender({ locationKey: "abandoned-movie", pathname: "/item/abandoned", isItem: true });
     expect(result.current.itemDetailsReady).toBe(false);
 
-    rerender({ locationKey: "search", isItem: false });
+    rerender({ locationKey: "search", pathname: "/catalog", isItem: false });
     expect(result.current.itemDetailsReady).toBe(true);
 
-    rerender({ locationKey: "next-movie", isItem: true });
+    rerender({ locationKey: "next-movie", pathname: "/item/next", isItem: true });
     expect(result.current.itemDetailsReady).toBe(false);
 
     act(() => result.current.reveal("abandoned-movie"));

--- a/web/src/hooks/useSidebarItemDetailsGate.ts
+++ b/web/src/hooks/useSidebarItemDetailsGate.ts
@@ -2,8 +2,10 @@ import { useCallback, useState } from "react";
 
 interface ItemDetailsGateState {
   locationKey: string;
+  pathname: string;
   gatesItemDetails: boolean;
   pendingLocationKey: string | null;
+  enteredItemFromHome: boolean;
 }
 
 /**
@@ -12,19 +14,32 @@ interface ItemDetailsGateState {
  * click handlers, so POP and programmatic navigation receive the same
  * treatment and abandoned navigation cannot leave a stale global lock.
  */
-export function useSidebarItemDetailsGate(locationKey: string, gatesItemDetails: boolean) {
+export function useSidebarItemDetailsGate(
+  locationKey: string,
+  pathname: string,
+  gatesItemDetails: boolean,
+) {
   const [state, setState] = useState<ItemDetailsGateState>({
     locationKey,
+    pathname,
     gatesItemDetails,
     pendingLocationKey: null,
+    enteredItemFromHome: false,
   });
 
   let currentState = state;
-  if (state.locationKey !== locationKey || state.gatesItemDetails !== gatesItemDetails) {
+  if (
+    state.locationKey !== locationKey ||
+    state.pathname !== pathname ||
+    state.gatesItemDetails !== gatesItemDetails
+  ) {
+    const enteringItem = gatesItemDetails && !state.gatesItemDetails;
     currentState = {
       locationKey,
+      pathname,
       gatesItemDetails,
-      pendingLocationKey: gatesItemDetails && !state.gatesItemDetails ? locationKey : null,
+      pendingLocationKey: enteringItem ? locationKey : null,
+      enteredItemFromHome: enteringItem && state.pathname === "/",
     };
     // React discards this render and retries before rendering children, so the
     // item route never briefly receives `itemDetailsReady=true` on entry.
@@ -42,6 +57,7 @@ export function useSidebarItemDetailsGate(locationKey: string, gatesItemDetails:
   return {
     itemDetailsReady: !gatesItemDetails || currentState.pendingLocationKey === null,
     pendingLocationKey: currentState.pendingLocationKey,
+    enteredItemFromHome: currentState.enteredItemFromHome,
     reveal,
   };
 }

--- a/web/src/hooks/useViewTransition.test.tsx
+++ b/web/src/hooks/useViewTransition.test.tsx
@@ -59,6 +59,7 @@ afterEach(() => {
   resetNavigationHistory();
   window.history.replaceState(null, "");
   delete document.documentElement.dataset.navigationDirection;
+  vi.unstubAllGlobals();
 });
 
 describe("useViewTransitionNavigate", () => {
@@ -135,6 +136,50 @@ describe("useViewTransitionNavigate", () => {
 
     expect(mocks.navigate).toHaveBeenCalledWith("/item/series", {
       state: { from: "crumb" },
+      replace: false,
+      viewTransition: true,
+    });
+  });
+
+  it.each([
+    ["enters", "/", "/item/movie-1"],
+    ["leaves", "/item/movie-1", "/"],
+  ])("skips the root snapshot when desktop navigation %s an item route", async (_label, at, to) => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(min-width: 64rem)",
+    }));
+    render(<Harness to={to} at={at} />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith(to, {
+      replace: false,
+      viewTransition: false,
+    });
+  });
+
+  it("keeps mobile item navigation on the viewport transition", async () => {
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    render(<Harness to="/item/movie-1" at="/" />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith("/item/movie-1", {
+      replace: false,
+      viewTransition: true,
+    });
+  });
+
+  it.each([
+    ["item to item", "/item/series-1", "/item/episode-1"],
+    ["library to item", "/library/1", "/item/movie-1"],
+    ["item to library", "/item/movie-1", "/library/1"],
+  ])("keeps %s navigation on its existing transition", async (_label, at, to) => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(min-width: 64rem)",
+    }));
+    render(<Harness to={to} at={at} />);
+    await go();
+
+    expect(mocks.navigate).toHaveBeenCalledWith(to, {
       replace: false,
       viewTransition: true,
     });

--- a/web/src/hooks/useViewTransition.ts
+++ b/web/src/hooks/useViewTransition.ts
@@ -4,6 +4,34 @@ import type { NavigateOptions, To } from "react-router";
 
 import { markNavigationDirection } from "@/lib/navigationHistory";
 
+const DESKTOP_SIDEBAR_QUERY = "(min-width: 64rem)";
+
+function isItemRoute(pathname: string): boolean {
+  return pathname.startsWith("/item/");
+}
+
+function isHomeItemBoundary(currentPathname: string, targetPathname: string): boolean {
+  return (
+    (currentPathname === "/" && isItemRoute(targetPathname)) ||
+    (isItemRoute(currentPathname) && targetPathname === "/")
+  );
+}
+
+/**
+ * Home and item detail have very different scroll heights. On desktop only,
+ * their existing live sidebar/main transforms carry the boundary without also
+ * rasterizing and scaling a full-height page snapshot. Every other route keeps
+ * its existing View Transition behavior unchanged.
+ */
+export function shouldUseRouteViewTransition(
+  currentPathname: string,
+  targetPathname: string,
+): boolean {
+  if (!isHomeItemBoundary(currentPathname, targetPathname)) return true;
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return true;
+  return !window.matchMedia(DESKTOP_SIDEBAR_QUERY).matches;
+}
+
 export interface ViewTransitionNavigateOptions extends NavigateOptions {
   /**
    * The destination is an ancestor of where we are now, not a new place: play
@@ -17,7 +45,7 @@ export interface ViewTransitionNavigateOptions extends NavigateOptions {
 }
 
 /**
- * The app's imperative navigation chokepoint: opts every navigation into React
+ * The app's imperative navigation chokepoint: opts navigations into React
  * Router's view transitions and stamps the direction `main-content` should move
  * in before the router opens the transition.
  *
@@ -51,13 +79,18 @@ export function useViewTransitionNavigate() {
         return;
       }
 
-      const { up = false, ...navigateOptions } = options ?? {};
+      const {
+        up = false,
+        viewTransition: requestedViewTransition = true,
+        ...navigateOptions
+      } = options ?? {};
       const current = locationRef.current;
       // React Router resolves a relative `to` against the matched route rather
       // than the raw pathname. Every href this app navigates with is absolute,
       // where the two agree; a relative `to` could disagree and turn a push
       // into a replace, so callers pass absolute paths.
-      const target = createPath(resolvePath(to, current.pathname));
+      const resolvedTarget = resolvePath(to, current.pathname);
+      const target = createPath(resolvedTarget);
       // React Router gives `<Link>` the same-URL guard for free; the imperative
       // path gets nothing, and a second identical entry makes the browser's
       // back button look broken.
@@ -67,7 +100,10 @@ export function useViewTransitionNavigate() {
       // normal push either way, so every caller keeps its own entry semantics
       // and every NavigateOptions field is forwarded on both paths.
       markNavigationDirection(up ? "back" : "forward");
-      navigate(to, { ...navigateOptions, replace, viewTransition: true });
+      const viewTransition =
+        requestedViewTransition &&
+        shouldUseRouteViewTransition(current.pathname, resolvedTarget.pathname);
+      navigate(to, { ...navigateOptions, replace, viewTransition });
     },
     [navigate],
   );

--- a/web/src/navigationTransitionCss.test.ts
+++ b/web/src/navigationTransitionCss.test.ts
@@ -56,6 +56,35 @@ describe("navigation view-transition CSS", () => {
     expect(css).toContain("transform: translateX(calc(-1 * var(--nav-slide-shift)))");
   });
 
+  it("matches Home item entry and return timing without changing other routes", () => {
+    expect(css).toMatch(/--duration-sidebar-collapse:\s*300ms;/);
+    expect(css).toMatch(/--duration-sidebar-entry:\s*340ms;/);
+    expect(css).toMatch(/--duration-sidebar-return:\s*340ms;/);
+    expect(css).toMatch(
+      /html\[data-home-item-entry="true"\] \{\s*--duration-sidebar-collapse: var\(--duration-sidebar-entry\);/,
+    );
+    expect(css).toMatch(
+      /html\[data-navigation-direction="back"\]\[data-home-route="true"\] \{\s*--duration-sidebar-collapse: var\(--duration-sidebar-return\);/,
+    );
+    expect(reducedMotionBlock()).toMatch(/--duration-sidebar-entry:\s*0ms;/);
+    expect(reducedMotionBlock()).toMatch(/--duration-sidebar-return:\s*0ms;/);
+  });
+
+  it("uses solid Home item landmarks and settles only the bounded hero content", () => {
+    expect(css).toMatch(
+      /\.home-item-transition-block \{\s*background: var\(--surface\);\s*border-color: var\(--border\);/,
+    );
+    expect(css).toMatch(
+      /html\[data-home-item-entry="true"\] \.detail-hero-primary-content \{\s*animation: var\(--duration-normal\) var\(--ease-out\) both home-item-detail-reveal;/,
+    );
+    expect(css).not.toMatch(
+      /html\[data-home-item-entry="true"\] \.detail-hero-primary-content[^}]*blur/,
+    );
+    expect(reducedMotionBlock()).toMatch(
+      /\.detail-hero-primary-content \{\s*animation: none !important;/,
+    );
+  });
+
   it("runs both halves of the cross-fade on identical timing", () => {
     // The pseudo-elements default to `mix-blend-mode: plus-lighter`, which only
     // cross-fades cleanly while the two opacities sum to 1. Different easing

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -168,7 +168,7 @@ describe("Home", () => {
     ["WebKit", SAFARI_USER_AGENT],
     ["Firefox", FIREFOX_USER_AGENT],
   ])(
-    "keeps %s Home rows deferred until the sidebar return finishes",
+    "restores above-fold %s Home rows during the sidebar return and gates only lower rows",
     async (_browser, userAgent) => {
       vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent);
       vi.stubGlobal("matchMedia", (query: string) => ({
@@ -178,7 +178,7 @@ describe("Home", () => {
         removeEventListener: vi.fn(),
       }));
       document.documentElement.dataset.sidebarVisualCollapsed = "true";
-      const layout = [homeLayout("row-1"), homeLayout("row-2")];
+      const layout = [homeLayout("row-1"), homeLayout("row-2"), homeLayout("row-3")];
       mockUseHomeLayout.mockReturnValue({
         data: { sections: layout },
         isLoading: false,
@@ -201,8 +201,8 @@ describe("Home", () => {
         await Promise.resolve();
       });
 
-      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
-      expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(2);
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
+      expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(1);
 
       const stage = container.querySelector(".sidebar-main-stage");
       const unrelatedTransition = new TransitionEvent("transitionend", { propertyName: "opacity" });
@@ -210,7 +210,7 @@ describe("Home", () => {
         stage?.dispatchEvent(unrelatedTransition);
         await Promise.resolve();
       });
-      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
 
       const transformTransition = new TransitionEvent("transitionend", {
         propertyName: "transform",
@@ -220,7 +220,7 @@ describe("Home", () => {
         await Promise.resolve();
       });
 
-      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(3);
       expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(0);
     },
   );
@@ -240,7 +240,7 @@ describe("Home", () => {
         removeEventListener: vi.fn(),
       }));
       document.documentElement.dataset.sidebarVisualCollapsed = "true";
-      const layout = [homeLayout("row-1")];
+      const layout = [homeLayout("row-1"), homeLayout("row-2"), homeLayout("row-3")];
       mockUseHomeLayout.mockReturnValue({
         data: { sections: layout },
         isLoading: false,
@@ -248,7 +248,9 @@ describe("Home", () => {
         refetch: vi.fn(),
       });
       const queryClient = new QueryClient();
-      queryClient.setQueryData(sectionKeys.homeItems("row-1"), homeSection("row-1"));
+      layout.forEach((section) => {
+        queryClient.setQueryData(sectionKeys.homeItems(section.id), homeSection(section.id));
+      });
 
       await act(async () => {
         root.render(
@@ -261,19 +263,21 @@ describe("Home", () => {
         await Promise.resolve();
       });
 
-      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
+      expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(1);
 
       await act(async () => {
         vi.advanceTimersByTime(SIDEBAR_DETAILS_REVEAL_DEADLINE_MS - 1);
         await Promise.resolve();
       });
-      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
 
       await act(async () => {
         vi.advanceTimersByTime(1);
         await Promise.resolve();
       });
-      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(1);
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(3);
+      expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(0);
     },
   );
 

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -3,10 +3,12 @@
 import { act } from "react";
 import type { ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import Home from "./Home";
+import { SIDEBAR_DETAILS_REVEAL_DEADLINE_MS } from "@/components/sidebarItemNavigation";
 import { sectionKeys } from "@/hooks/queries/keys";
 
 (
@@ -15,6 +17,12 @@ import { sectionKeys } from "@/hooks/queries/keys";
 
 const mockUseHomeLayout = vi.fn();
 const mockFetchHomeSectionItems = vi.fn();
+const SAFARI_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/18.6 Safari/605.1.15";
+const FIREFOX_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:154.0) Gecko/20100101 Firefox/154.0";
+const CHROME_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36";
 
 vi.mock("@/hooks/queries/sections", () => ({
   useHomeLayout: (...args: unknown[]) => mockUseHomeLayout(...args),
@@ -40,7 +48,9 @@ vi.mock("@/components/HeroBanner", () => ({
 }));
 
 vi.mock("@/components/SectionRow", () => ({
-  default: () => <div data-kind="section-row" />,
+  default: ({ section }: { section: { id: string } }) => (
+    <div data-kind="section-row" data-section-id={section.id} />
+  ),
 }));
 
 describe("Home", () => {
@@ -66,6 +76,10 @@ describe("Home", () => {
       root.unmount();
     });
     container.remove();
+    delete document.documentElement.dataset.sidebarVisualCollapsed;
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("does not invalidate cached home sections on mount", async () => {
@@ -126,4 +140,478 @@ describe("Home", () => {
     expect(sectionQuery).toBeDefined();
     expect(sectionQuery?.gcTime).toBe(60 * 60 * 1000);
   });
+
+  it("keeps cached card trees out of the first Home commit", () => {
+    const layout = Array.from({ length: 5 }, (_, index) => homeLayout(`row-${index + 1}`));
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const queryClient = new QueryClient();
+    layout.forEach((section) => {
+      queryClient.setQueryData(sectionKeys.homeItems(section.id), homeSection(section.id));
+    });
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <Home />
+      </QueryClientProvider>,
+    );
+
+    expect(markup.match(/data-home-section-placeholder=/g)).toHaveLength(5);
+    expect(markup).not.toContain('data-kind="section-row"');
+  });
+
+  it.each([
+    ["WebKit", SAFARI_USER_AGENT],
+    ["Firefox", FIREFOX_USER_AGENT],
+  ])(
+    "keeps %s Home rows deferred until the sidebar return finishes",
+    async (_browser, userAgent) => {
+      vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent);
+      vi.stubGlobal("matchMedia", (query: string) => ({
+        matches: query === "(min-width: 64rem)",
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }));
+      document.documentElement.dataset.sidebarVisualCollapsed = "true";
+      const layout = [homeLayout("row-1"), homeLayout("row-2")];
+      mockUseHomeLayout.mockReturnValue({
+        data: { sections: layout },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+      const queryClient = new QueryClient();
+      layout.forEach((section) => {
+        queryClient.setQueryData(sectionKeys.homeItems(section.id), homeSection(section.id));
+      });
+
+      await act(async () => {
+        root.render(
+          <div className="sidebar-main-stage">
+            <QueryClientProvider client={queryClient}>
+              <Home />
+            </QueryClientProvider>
+          </div>,
+        );
+        await Promise.resolve();
+      });
+
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
+      expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(2);
+
+      const stage = container.querySelector(".sidebar-main-stage");
+      const unrelatedTransition = new TransitionEvent("transitionend", { propertyName: "opacity" });
+      await act(async () => {
+        stage?.dispatchEvent(unrelatedTransition);
+        await Promise.resolve();
+      });
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
+
+      const transformTransition = new TransitionEvent("transitionend", {
+        propertyName: "transform",
+      });
+      await act(async () => {
+        stage?.dispatchEvent(transformTransition);
+        await Promise.resolve();
+      });
+
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
+      expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    ["WebKit", SAFARI_USER_AGENT],
+    ["Firefox", FIREFOX_USER_AGENT],
+  ])(
+    "restores %s Home rows at the deadline if the transition is interrupted",
+    async (_browser, userAgent) => {
+      vi.useFakeTimers();
+      vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent);
+      vi.stubGlobal("matchMedia", (query: string) => ({
+        matches: query === "(min-width: 64rem)",
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      }));
+      document.documentElement.dataset.sidebarVisualCollapsed = "true";
+      const layout = [homeLayout("row-1")];
+      mockUseHomeLayout.mockReturnValue({
+        data: { sections: layout },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      });
+      const queryClient = new QueryClient();
+      queryClient.setQueryData(sectionKeys.homeItems("row-1"), homeSection("row-1"));
+
+      await act(async () => {
+        root.render(
+          <div className="sidebar-main-stage">
+            <QueryClientProvider client={queryClient}>
+              <Home />
+            </QueryClientProvider>
+          </div>,
+        );
+        await Promise.resolve();
+      });
+
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
+
+      await act(async () => {
+        vi.advanceTimersByTime(SIDEBAR_DETAILS_REVEAL_DEADLINE_MS - 1);
+        await Promise.resolve();
+      });
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(0);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+        await Promise.resolve();
+      });
+      expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(1);
+    },
+  );
+
+  it("does not gate Chromium Home rows during the sidebar return", async () => {
+    vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(CHROME_USER_AGENT);
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(min-width: 64rem)",
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    document.documentElement.dataset.sidebarVisualCollapsed = "true";
+    const layout = [homeLayout("row-1")];
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(sectionKeys.homeItems("row-1"), homeSection("row-1"));
+
+    await act(async () => {
+      root.render(
+        <div className="sidebar-main-stage">
+          <QueryClientProvider client={queryClient}>
+            <Home />
+          </QueryClientProvider>
+        </div>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(1);
+    expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(0);
+  });
+
+  it("mounts only nearby cached rows until lower Home sections approach the viewport", async () => {
+    const observers: Array<{
+      callback: IntersectionObserverCallback;
+      targets: Set<Element>;
+      disconnect: () => void;
+      rootMargin?: string;
+    }> = [];
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        readonly root = null;
+        readonly thresholds = [0];
+        readonly rootMargin: string;
+        private readonly record: (typeof observers)[number];
+
+        constructor(callback: IntersectionObserverCallback, options?: IntersectionObserverInit) {
+          this.rootMargin = options?.rootMargin ?? "0px";
+          this.record = {
+            callback,
+            targets: new Set<Element>(),
+            disconnect: vi.fn(),
+            rootMargin: options?.rootMargin,
+          };
+          observers.push(this.record);
+        }
+
+        observe = (target: Element) => this.record.targets.add(target);
+        unobserve = (target: Element) => this.record.targets.delete(target);
+        disconnect = () => {
+          this.record.disconnect();
+          this.record.targets.clear();
+        };
+        takeRecords = () => [];
+      },
+    );
+
+    const layout = Array.from({ length: 5 }, (_, index) => homeLayout(`row-${index + 1}`));
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const queryClient = new QueryClient();
+    layout.forEach((section) => {
+      queryClient.setQueryData(sectionKeys.homeItems(section.id), homeSection(section.id));
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Home />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
+    expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(3);
+    expect(mockFetchHomeSectionItems).not.toHaveBeenCalled();
+    expect(observers).toHaveLength(3);
+    expect(observers.every((observer) => observer.rootMargin === "100% 0px")).toBe(true);
+
+    const nextPlaceholder = container.querySelector('[data-home-section-placeholder="row-3"]');
+    const nextObserver = observers.find(
+      (observer) => nextPlaceholder && observer.targets.has(nextPlaceholder),
+    );
+    expect(nextObserver).toBeDefined();
+
+    await act(async () => {
+      nextObserver!.callback(
+        [{ isIntersecting: true, target: nextPlaceholder } as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(3);
+    expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(2);
+    expect(nextObserver!.disconnect).toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+    expect(
+      observers.every((observer) => vi.mocked(observer.disconnect).mock.calls.length > 0),
+    ).toBe(true);
+    root = createRoot(container);
+  });
+
+  it("counts only ready media rows toward the eager paint budget", async () => {
+    const layout = [
+      homeLayout("empty-1"),
+      homeLayout("empty-2"),
+      homeLayout("ready-1"),
+      homeLayout("ready-2"),
+    ];
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const queryClient = new QueryClient();
+    for (const section of layout) {
+      queryClient.setQueryData(
+        sectionKeys.homeItems(section.id),
+        section.id.startsWith("empty")
+          ? { section: { ...section, total_count: 0, items: [] } }
+          : homeSection(section.id),
+      );
+    }
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Home />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
+    expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(0);
+  });
+
+  it("restores every deferred Home row after the sidebar handoff", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        readonly root = null;
+        readonly thresholds = [0];
+        readonly rootMargin = "100% 0px";
+        constructor(_callback: IntersectionObserverCallback) {}
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+        takeRecords = () => [];
+      },
+    );
+
+    const layout = Array.from({ length: 5 }, (_, index) => homeLayout(`row-${index + 1}`));
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const queryClient = new QueryClient();
+    layout.forEach((section) => {
+      queryClient.setQueryData(sectionKeys.homeItems(section.id), homeSection(section.id));
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Home />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(5);
+    expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(0);
+  });
+
+  it("renders every Home row in browsers without IntersectionObserver", async () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const layout = Array.from({ length: 5 }, (_, index) => homeLayout(`row-${index + 1}`));
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const queryClient = new QueryClient();
+    layout.forEach((section) => {
+      queryClient.setQueryData(sectionKeys.homeItems(section.id), homeSection(section.id));
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Home />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll('[data-kind="section-row"]')).toHaveLength(5);
+    expect(container.querySelectorAll("[data-home-section-placeholder]")).toHaveLength(0);
+  });
+
+  it.each([
+    ["WebKit", SAFARI_USER_AGENT],
+    ["Firefox", FIREFOX_USER_AGENT],
+  ])("renders every Home row immediately for reduced motion in %s", (_browser, userAgent) => {
+    vi.spyOn(window.navigator, "userAgent", "get").mockReturnValue(userAgent);
+    document.documentElement.dataset.sidebarVisualCollapsed = "true";
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    const layout = Array.from({ length: 5 }, (_, index) => homeLayout(`row-${index + 1}`));
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    const queryClient = new QueryClient();
+    layout.forEach((section) => {
+      queryClient.setQueryData(sectionKeys.homeItems(section.id), homeSection(section.id));
+    });
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <Home />
+      </QueryClientProvider>,
+    );
+
+    expect(markup.match(/data-kind="section-row"/g)).toHaveLength(5);
+    expect(markup).not.toContain("data-home-section-placeholder");
+  });
+
+  it("renders stale cached rows immediately while refreshing them in the background", async () => {
+    const layout = [homeLayout("stale")];
+    const cached = homeSection("stale");
+    const refreshed = homeSection("stale");
+    mockUseHomeLayout.mockReturnValue({
+      data: { sections: layout },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    mockFetchHomeSectionItems.mockResolvedValue(refreshed);
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(sectionKeys.homeItems("stale"), cached, {
+      updatedAt: Date.now() - 11 * 60 * 1000,
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Home />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-section-id="stale"]')).not.toBeNull();
+    expect(mockFetchHomeSectionItems).toHaveBeenCalledWith(
+      "stale",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
 });
+
+function homeLayout(id: string) {
+  return {
+    id,
+    section_type: "recently_added",
+    title: id,
+    featured: false,
+    item_limit: 18,
+    is_custom: false,
+    customized: false,
+  };
+}
+
+function homeSection(id: string) {
+  return {
+    section: {
+      ...homeLayout(id),
+      total_count: 1,
+      items: [
+        {
+          content_id: `${id}-item`,
+          type: "movie",
+          title: `${id} item`,
+          year: 2026,
+          genres: [],
+          status: "matched",
+          rating_imdb: null,
+          overview: "",
+          poster_url: "",
+          poster_thumbhash: "",
+          backdrop_url: "",
+          backdrop_thumbhash: "",
+          logo_url: "",
+        },
+      ],
+    },
+  };
+}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -327,7 +327,11 @@ function DeferredHomeSection({
   const placeholderRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (rendered || !restorationReady) return;
+    // Restore the bounded above-fold budget as soon as the lightweight Home
+    // commit has painted. WebKit and Firefox keep lower rows behind the sidebar
+    // return gate, but the visible Home surface must travel with that motion
+    // instead of waiting for transitionend (or its 760 ms safety deadline).
+    if (rendered || (!eager && !restorationReady)) return;
     if (eager) {
       startTransition(() => setRendered(true));
       return;

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable react-hooks/set-state-in-effect */
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { startTransition, useEffect, useMemo, useRef, useState } from "react";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { Link } from "react-router";
 import { LayoutDashboard } from "lucide-react";
 import HeroBanner from "@/components/HeroBanner";
 import SectionRow from "@/components/SectionRow";
 import TasteSeedBanner from "@/components/TasteSeedBanner";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { HomeSectionItemsResponse, ResolvedSection } from "@/api/types";
+import type { HomeSectionItemsResponse, ResolvedSection, ResolvedSectionLayout } from "@/api/types";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { HERO_BANNER_SIZE } from "@/lib/design-system";
 import { sectionKeys } from "@/hooks/queries/keys";
@@ -21,19 +21,31 @@ import { planNextHomeSectionBatch } from "./homeSectionQueue";
 import { buildHomeSectionViewModel, type HomeSectionSlot } from "./homeSectionState";
 import { collectCachedHomeSections } from "./homeSectionCache";
 import { useSectionRefreshSignal } from "./homeSurfaceRefresh";
+import { useUICustomization } from "@/hooks/useUICustomization";
+import { carouselIntrinsicHeight } from "@/lib/uiCustomization";
+import {
+  isFirefoxEngine,
+  isWebKitEngine,
+  prefersReducedMotion,
+} from "@/hooks/useImmediateSidebarCollapse";
+import { SIDEBAR_DETAILS_REVEAL_DEADLINE_MS } from "@/components/sidebarItemNavigation";
 
 const MAX_CONCURRENT_SECTION_REQUESTS = 5;
 const SKELETON_CARD_COUNT = 7;
+const EAGER_HOME_ROW_COUNT = 2;
+const HOME_ROW_RENDER_MARGIN = "100% 0px";
+const HOME_ROW_RESTORE_DELAY_MS = 360;
+const HOME_ROW_RESTORE_STAGGER_MS = 70;
+const DESKTOP_SIDEBAR_QUERY = "(min-width: 64rem)";
 
 export default function Home() {
   const queryClient = useQueryClient();
   const { data, isLoading, isError, refetch } = useHomeLayout();
   const { data: homeRefreshSignal = 0 } = useSectionRefreshSignal();
-  const [loadedSections, setLoadedSections] = useState<Map<string, ResolvedSection>>(new Map());
-  const [failedIds, setFailedIds] = useState<Set<string>>(new Set());
-  const [inFlightIds, setInFlightIds] = useState<Set<string>>(new Set());
-  const [completedIds, setCompletedIds] = useState<Set<string>>(new Set());
-  const activeSectionIdsRef = useRef<Set<string>>(new Set());
+  const { cardPresentation } = useUICustomization();
+  const [rowRestorationReady, setRowRestorationReady] = useState(
+    () => !shouldWaitForSidebarReturn(),
+  );
 
   useDocumentTitle("Home");
 
@@ -44,18 +56,70 @@ export default function Home() {
         `${section.id}:${section.section_type}:${section.title}:${section.featured ? "featured" : "row"}:${section.item_limit}:${section.is_custom ? "custom" : "default"}:${section.customized ? "customized" : "clean"}`,
     )
     .join("|");
+  const cacheResetKey = `${homeRefreshSignal}:${layoutResetKey}`;
+  const [initialCachedSections] = useState(() => readCachedHomeSections(queryClient, layout));
+  const cacheResetKeyRef = useRef(cacheResetKey);
+
+  const [loadedSections, setLoadedSections] = useState(initialCachedSections);
+  const [failedIds, setFailedIds] = useState<Set<string>>(new Set());
+  const [inFlightIds, setInFlightIds] = useState<Set<string>>(new Set());
+  const [completedIds, setCompletedIds] = useState<Set<string>>(() =>
+    freshCachedHomeSectionIds(queryClient, layout),
+  );
+  const activeSectionIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (rowRestorationReady) return;
+    const stage = document.querySelector<HTMLElement>(".sidebar-main-stage");
+    if (!stage) {
+      setRowRestorationReady(true);
+      return;
+    }
+
+    let revealed = false;
+    const reveal = (event?: Event) => {
+      if (revealed) return;
+      if (
+        event instanceof TransitionEvent &&
+        (event.target !== stage || event.propertyName !== "transform")
+      ) {
+        return;
+      }
+      revealed = true;
+      stage.removeEventListener("transitionend", reveal);
+      stage.removeEventListener("transitioncancel", reveal);
+      window.clearTimeout(deadline);
+      startTransition(() => setRowRestorationReady(true));
+    };
+
+    stage.addEventListener("transitionend", reveal);
+    stage.addEventListener("transitioncancel", reveal);
+    const deadline = window.setTimeout(reveal, SIDEBAR_DETAILS_REVEAL_DEADLINE_MS);
+    return () => {
+      revealed = true;
+      stage.removeEventListener("transitionend", reveal);
+      stage.removeEventListener("transitioncancel", reveal);
+      window.clearTimeout(deadline);
+    };
+  }, [rowRestorationReady]);
 
   useEffect(() => {
     const activeIds = layout.map((section) => section.id);
+    const cachedSections = readCachedHomeSections(queryClient, layout);
+    const cacheReset = cacheResetKeyRef.current !== cacheResetKey;
+    cacheResetKeyRef.current = cacheResetKey;
     activeSectionIdsRef.current = new Set(activeIds);
-    setLoadedSections(
-      collectCachedHomeSections(layout, (sectionId) =>
-        queryClient.getQueryData<HomeSectionItemsResponse>(sectionKeys.homeItems(sectionId)),
-      ),
+    setLoadedSections((current) =>
+      mapsHaveSameEntries(current, cachedSections) ? current : cachedSections,
     );
-    setFailedIds(new Set());
-    setInFlightIds(new Set());
-    setCompletedIds(new Set());
+    setFailedIds((current) => (current.size === 0 ? current : new Set()));
+    setInFlightIds((current) => (current.size === 0 ? current : new Set()));
+    const nextCompletedIds = cacheReset
+      ? new Set<string>()
+      : freshCachedHomeSectionIds(queryClient, layout);
+    setCompletedIds((current) =>
+      setsHaveSameEntries(current, nextCompletedIds) ? current : nextCompletedIds,
+    );
 
     return () => {
       activeSectionIdsRef.current = new Set();
@@ -63,7 +127,7 @@ export default function Home() {
         void queryClient.cancelQueries({ queryKey: sectionKeys.homeItems(sectionId) });
       });
     };
-  }, [homeRefreshSignal, layout, layoutResetKey, queryClient]);
+  }, [cacheResetKey, layout, queryClient]);
 
   useEffect(() => {
     if (layout.length === 0) return;
@@ -161,6 +225,8 @@ export default function Home() {
   };
   const heroSlot = renderHeroSlot(viewModel.hero, retrySection);
   const hasHeroSlot = heroSlot !== null;
+  const rowPlaceholderHeight = carouselIntrinsicHeight(cardPresentation.poster_size);
+  let readyRowIndex = 0;
 
   if (isLoading && !data) {
     return <HomePageSkeleton />;
@@ -198,7 +264,20 @@ export default function Home() {
             return null;
           }
           if (slot.state === "ready" && slot.section) {
-            return <SectionRow key={slot.layout.id} section={slot.section} />;
+            const rowIndex = readyRowIndex++;
+            return (
+              <DeferredHomeSection
+                key={slot.layout.id}
+                section={slot.section}
+                eager={rowIndex < EAGER_HOME_ROW_COUNT}
+                restorationReady={rowRestorationReady}
+                placeholderHeight={rowPlaceholderHeight}
+                restoreDelayMs={
+                  HOME_ROW_RESTORE_DELAY_MS +
+                  Math.max(0, rowIndex - EAGER_HOME_ROW_COUNT) * HOME_ROW_RESTORE_STAGGER_MS
+                }
+              />
+            );
           }
           if (slot.state === "error") {
             return (
@@ -226,6 +305,130 @@ export default function Home() {
       </div>
     </>
   );
+}
+
+function DeferredHomeSection({
+  section,
+  eager,
+  restorationReady,
+  placeholderHeight,
+  restoreDelayMs,
+}: {
+  section: ResolvedSection;
+  eager: boolean;
+  restorationReady: boolean;
+  placeholderHeight: string;
+  restoreDelayMs: number;
+}) {
+  // Even visible rows start as fixed-size opaque space for the first commit.
+  // This keeps a cold Home return small enough for the sidebar handoff to
+  // begin before card trees and cached poster load events are mounted.
+  const [rendered, setRendered] = useState(prefersReducedMotion);
+  const placeholderRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (rendered || !restorationReady) return;
+    if (eager) {
+      startTransition(() => setRendered(true));
+      return;
+    }
+    const placeholder = placeholderRef.current;
+    if (!placeholder || typeof IntersectionObserver === "undefined") {
+      setRendered(true);
+      return;
+    }
+
+    let revealed = false;
+    const reveal = () => {
+      if (revealed) return;
+      revealed = true;
+      observer.disconnect();
+      window.clearTimeout(restoreTimer);
+      startTransition(() => setRendered(true));
+    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        reveal();
+      },
+      { rootMargin: HOME_ROW_RENDER_MARGIN },
+    );
+    observer.observe(placeholder);
+    // IntersectionObserver keeps the first Home commit and near-viewport work
+    // small. It is not permanent virtualization: every row is restored just
+    // after the sidebar carry so browser Find and assistive technology
+    // can reach the complete page without requiring visual scrolling.
+    const restoreTimer = window.setTimeout(reveal, restoreDelayMs);
+    return () => {
+      revealed = true;
+      observer.disconnect();
+      window.clearTimeout(restoreTimer);
+    };
+  }, [eager, rendered, restorationReady, restoreDelayMs]);
+
+  if (rendered) return <SectionRow section={section} />;
+
+  return (
+    <div
+      ref={placeholderRef}
+      data-home-section-placeholder={section.id}
+      aria-hidden="true"
+      style={{ minHeight: placeholderHeight }}
+    />
+  );
+}
+
+function shouldWaitForSidebarReturn(): boolean {
+  const userAgent = typeof navigator === "undefined" ? "" : navigator.userAgent;
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    (isWebKitEngine(userAgent) || isFirefoxEngine(userAgent)) &&
+    window.matchMedia(DESKTOP_SIDEBAR_QUERY).matches &&
+    !prefersReducedMotion() &&
+    document.documentElement.dataset.sidebarVisualCollapsed === "true"
+  );
+}
+
+function readCachedHomeSections(queryClient: QueryClient, layout: ResolvedSectionLayout[]) {
+  return collectCachedHomeSections(layout, (sectionId) =>
+    queryClient.getQueryData<HomeSectionItemsResponse>(sectionKeys.homeItems(sectionId)),
+  );
+}
+
+function freshCachedHomeSectionIds(
+  queryClient: QueryClient,
+  layout: ResolvedSectionLayout[],
+): Set<string> {
+  const freshAfter = Date.now() - HOME_SECTION_STALE_TIME;
+  return new Set(
+    layout
+      .filter((section) => {
+        const state = queryClient.getQueryState<HomeSectionItemsResponse>(
+          sectionKeys.homeItems(section.id),
+        );
+        return Boolean(
+          state?.data !== undefined && !state.isInvalidated && state.dataUpdatedAt > freshAfter,
+        );
+      })
+      .map((section) => section.id),
+  );
+}
+
+function mapsHaveSameEntries<K, V>(left: Map<K, V>, right: Map<K, V>): boolean {
+  if (left.size !== right.size) return false;
+  for (const [key, value] of left) {
+    if (right.get(key) !== value) return false;
+  }
+  return true;
+}
+
+function setsHaveSameEntries<T>(left: Set<T>, right: Set<T>): boolean {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    if (!right.has(value)) return false;
+  }
+  return true;
 }
 
 function renderHeroSlot(hero: HomeSectionSlot | null, retrySection: (sectionId: string) => void) {

--- a/web/src/pages/ItemDetail/DetailHero.test.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.test.tsx
@@ -4,6 +4,24 @@ import { describe, expect, it } from "vitest";
 import DetailHero from "./DetailHero";
 
 describe("DetailHero artwork revisions", () => {
+  it("keeps the above-fold primary content on one bounded reveal surface", () => {
+    const { container } = render(<DetailHero title="Blade Runner" />);
+
+    expect(container.querySelector(".detail-hero-primary-content")).not.toBeNull();
+  });
+
+  it("reserves the logo box before the image decodes", () => {
+    const { container } = render(
+      <DetailHero title="Blade Runner" logoUrl="/blade-runner-logo.rev-a.webp" />,
+    );
+
+    const logo = container.querySelector<HTMLImageElement>(
+      'img[src="/blade-runner-logo.rev-a.webp"]',
+    );
+    expect(logo).toHaveClass("h-20", "w-full", "lg:h-28");
+    expect(logo).not.toHaveClass("max-h-20", "lg:max-h-28");
+  });
+
   it("treats a changed poster URL as unloaded until that revision finishes loading", () => {
     const { rerender } = render(<DetailHero title="Blade Runner" posterUrl="/poster.rev-a.webp" />);
 

--- a/web/src/pages/ItemDetail/DetailHero.test.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import DetailHero from "./DetailHero";
+
+vi.mock("@/lib/thumbhash", () => ({
+  decodeThumbhash: (thumbhash: string) => `data:image/png;base64,${thumbhash}`,
+}));
 
 describe("DetailHero artwork revisions", () => {
   it("keeps the above-fold primary content on one bounded reveal surface", () => {
@@ -44,5 +48,29 @@ describe("DetailHero artwork revisions", () => {
     fireEvent.load(replacement);
     expect(replacement).toHaveClass("opacity-100");
     expect(replacementPlaceholder).toHaveClass("opacity-0");
+  });
+
+  it("keeps the backdrop placeholder behind the image throughout its fade", () => {
+    const { container } = render(
+      <DetailHero
+        title="Blade Runner"
+        backdropUrl="/backdrop.rev-a.webp"
+        backdropThumbhash="placeholder"
+      />,
+    );
+
+    const artwork = container.querySelector<HTMLElement>(".hero-backdrop-artwork");
+    const backdrop = container.querySelector<HTMLImageElement>('img[src="/backdrop.rev-a.webp"]');
+    expect(artwork).toHaveStyle({
+      backgroundImage: 'url("data:image/png;base64,placeholder")',
+    });
+    expect(backdrop).toHaveClass("opacity-0", "transition-opacity", "duration-300");
+
+    fireEvent.load(backdrop!);
+
+    expect(backdrop).toHaveClass("opacity-100", "transition-opacity", "duration-300");
+    expect(artwork).toHaveStyle({
+      backgroundImage: 'url("data:image/png;base64,placeholder")',
+    });
   });
 });

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -148,7 +148,9 @@ export default function DetailHero({
             !isCompact && aside ? "lg:grid-cols-[minmax(0,1fr)_280px] lg:items-end" : ""
           }`}
         >
-          <div className={`flex flex-col gap-6 ${!hidePoster ? "lg:flex-row lg:items-end" : ""}`}>
+          <div
+            className={`detail-hero-primary-content flex flex-col gap-6 ${!hidePoster ? "lg:flex-row lg:items-end" : ""}`}
+          >
             {/* Poster */}
             {!hidePoster && (
               <div
@@ -210,7 +212,7 @@ export default function DetailHero({
                     src={logoUrl}
                     alt=""
                     decoding="async"
-                    className="mb-4 max-h-20 max-w-[420px] object-contain object-left lg:max-h-28 lg:max-w-[480px]"
+                    className="mb-4 h-20 w-full max-w-[420px] object-contain object-left lg:h-28 lg:max-w-[480px]"
                   />
                 </>
               ) : (

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -103,7 +103,7 @@ export default function DetailHero({
         <div
           className="hero-backdrop-artwork absolute inset-0 h-full w-full"
           style={{
-            ...(backdropPlaceholder && !backdropLoaded
+            ...(backdropPlaceholder
               ? {
                   backgroundImage: `url(${backdropPlaceholder})`,
                   backgroundSize: "cover",

--- a/web/src/pages/ItemDetail/index.test.tsx
+++ b/web/src/pages/ItemDetail/index.test.tsx
@@ -47,7 +47,10 @@ vi.mock("@/pages/ItemDetail/EbookContent", () => ({
 }));
 
 import ItemDetail from "./index";
-import { SidebarItemDetailsReadyContext } from "@/components/sidebarItemNavigationContext";
+import {
+  SidebarItemDetailsReadyContext,
+  SidebarItemEnteredFromHomeContext,
+} from "@/components/sidebarItemNavigationContext";
 
 describe("ItemDetail", () => {
   beforeEach(() => {
@@ -85,6 +88,97 @@ describe("ItemDetail", () => {
 
     expect(markup).not.toContain("Catalog Detail");
     expect(markup).toContain("animate-pulse");
+  });
+
+  it("uses a small opaque skeleton with no pulsing work for Home entries", () => {
+    const markup = renderToStaticMarkup(
+      <SidebarItemEnteredFromHomeContext.Provider value>
+        <SidebarItemDetailsReadyContext.Provider value={false}>
+          <ItemDetail />
+        </SidebarItemDetailsReadyContext.Provider>
+      </SidebarItemEnteredFromHomeContext.Provider>,
+    );
+
+    expect(markup).toContain("home-item-transition-shell");
+    expect(markup).toContain("min-h-[60dvh]");
+    expect(markup).toContain("home-item-transition-poster");
+    expect(markup).toContain("home-item-transition-title");
+    expect(markup.match(/home-item-transition-block/g)).toHaveLength(8);
+    expect(markup).not.toContain("animate-pulse");
+  });
+
+  it("keeps the opaque Home shell while item data is still loading", () => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    const markup = renderToStaticMarkup(
+      <SidebarItemEnteredFromHomeContext.Provider value>
+        <SidebarItemDetailsReadyContext.Provider value>
+          <ItemDetail />
+        </SidebarItemDetailsReadyContext.Provider>
+      </SidebarItemEnteredFromHomeContext.Provider>,
+    );
+
+    expect(markup).toContain("home-item-transition-shell");
+    expect(markup).not.toContain("animate-pulse");
+  });
+
+  it("matches the compact hero height for a season Home entry", () => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: { content_id: "season-1", title: "Season 1", type: "season" },
+      isLoading: false,
+      error: null,
+    });
+
+    const markup = renderToStaticMarkup(
+      <SidebarItemEnteredFromHomeContext.Provider value>
+        <SidebarItemDetailsReadyContext.Provider value={false}>
+          <ItemDetail />
+        </SidebarItemDetailsReadyContext.Provider>
+      </SidebarItemEnteredFromHomeContext.Provider>,
+    );
+
+    expect(markup).toContain("min-h-[max(35vh,300px)]");
+    expect(markup).not.toContain("min-h-[60dvh]");
+  });
+
+  it("matches episode and audiobook poster geometry without loading artwork", () => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: { content_id: "episode-1", title: "Pilot", type: "episode" },
+      isLoading: false,
+      error: null,
+    });
+
+    const episodeMarkup = renderToStaticMarkup(
+      <SidebarItemEnteredFromHomeContext.Provider value>
+        <SidebarItemDetailsReadyContext.Provider value={false}>
+          <ItemDetail />
+        </SidebarItemDetailsReadyContext.Provider>
+      </SidebarItemEnteredFromHomeContext.Provider>,
+    );
+
+    expect(episodeMarkup).not.toContain("home-item-transition-poster");
+
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: { content_id: "audiobook-1", title: "Dune", type: "audiobook" },
+      isLoading: false,
+      error: null,
+    });
+
+    const audiobookMarkup = renderToStaticMarkup(
+      <SidebarItemEnteredFromHomeContext.Provider value>
+        <SidebarItemDetailsReadyContext.Provider value={false}>
+          <ItemDetail />
+        </SidebarItemDetailsReadyContext.Provider>
+      </SidebarItemEnteredFromHomeContext.Provider>,
+    );
+
+    expect(audiobookMarkup).toContain("home-item-transition-poster");
+    expect(audiobookMarkup).toContain("aspect-square");
+    expect(audiobookMarkup).not.toContain("src=");
   });
 
   it("routes ebook items to ebook detail content", () => {

--- a/web/src/pages/ItemDetail/index.test.tsx
+++ b/web/src/pages/ItemDetail/index.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -124,6 +125,52 @@ describe("ItemDetail", () => {
 
     expect(markup).toContain("home-item-transition-shell");
     expect(markup).not.toContain("animate-pulse");
+  });
+
+  it.each([
+    ["season", { content_id: "season-1", title: "Season 1", type: "season" }],
+    ["episode", { content_id: "episode-1", title: "Pilot", type: "episode" }],
+    ["audiobook", { content_id: "audiobook-1", title: "Dune", type: "audiobook" }],
+    [
+      "logo",
+      {
+        content_id: "movie-123",
+        title: "Catalog Detail",
+        type: "movie",
+        logo_url: "/api/v1/items/movie-123/logo",
+      },
+    ],
+  ])("keeps neutral shell geometry when cold %s data resolves mid-handoff", (_, item) => {
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    const homeEntry = () => (
+      <SidebarItemEnteredFromHomeContext.Provider value>
+        <SidebarItemDetailsReadyContext.Provider value={false}>
+          <ItemDetail />
+        </SidebarItemDetailsReadyContext.Provider>
+      </SidebarItemEnteredFromHomeContext.Provider>
+    );
+    const view = render(homeEntry());
+    const initialShell = screen.getByTestId("home-item-transition-shell");
+    const initialGeometry = initialShell.innerHTML;
+
+    expect(initialGeometry).toContain("min-h-[60dvh]");
+    expect(initialGeometry).toContain("home-item-transition-poster");
+    expect(initialGeometry).toContain("aspect-[2/3]");
+
+    mocks.useCatalogItemDetail.mockReturnValue({
+      data: item,
+      isLoading: false,
+      error: null,
+    });
+    view.rerender(homeEntry());
+
+    expect(screen.getByTestId("home-item-transition-shell")).toBe(initialShell);
+    expect(screen.getByTestId("home-item-transition-shell").innerHTML).toBe(initialGeometry);
   });
 
   it("matches the compact hero height for a season Home entry", () => {

--- a/web/src/pages/ItemDetail/index.tsx
+++ b/web/src/pages/ItemDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Navigate, useParams, useSearchParams } from "react-router";
 import { useCatalogItemDetail } from "@/hooks/queries/catalogRead";
 import type { ItemDetail } from "@/api/types";
@@ -74,11 +74,34 @@ function ItemDetailSkeleton() {
   );
 }
 
+interface HomeItemTransitionShape {
+  compact: boolean;
+  hidePoster: boolean;
+  squarePoster: boolean;
+  hasLogo: boolean;
+}
+
+const NEUTRAL_HOME_ITEM_TRANSITION_SHAPE: HomeItemTransitionShape = {
+  compact: false,
+  hidePoster: false,
+  squarePoster: false,
+  hasLogo: false,
+};
+
+function getHomeItemTransitionShape(item?: ItemDetail): HomeItemTransitionShape {
+  if (!item) return NEUTRAL_HOME_ITEM_TRANSITION_SHAPE;
+
+  return {
+    compact: item.type === "season",
+    hidePoster: item.type === "episode",
+    squarePoster: item.type === "audiobook",
+    hasLogo: Boolean(item.logo_url),
+  };
+}
+
 function HomeItemTransitionShell({ item }: { item?: ItemDetail }) {
-  const compact = item?.type === "season";
-  const hidePoster = item?.type === "episode";
-  const squarePoster = item?.type === "audiobook";
-  const hasLogo = Boolean(item?.logo_url);
+  const [shape] = useState(() => getHomeItemTransitionShape(item));
+  const { compact, hidePoster, squarePoster, hasLogo } = shape;
 
   return (
     <div
@@ -156,7 +179,7 @@ export default function ItemDetail() {
 
   if (loading || !itemDetailsReady) {
     if (enteredItemFromHome) {
-      return <HomeItemTransitionShell item={item} />;
+      return <HomeItemTransitionShell key={id} item={item} />;
     }
     return <ItemDetailSkeleton />;
   }

--- a/web/src/pages/ItemDetail/index.tsx
+++ b/web/src/pages/ItemDetail/index.tsx
@@ -17,7 +17,10 @@ import {
   CrewSkeleton,
   RecommendationGridSkeleton,
 } from "./components/SectionSkeletons";
-import { useSidebarItemDetailsReady } from "@/components/sidebarItemNavigationContext";
+import {
+  useSidebarItemDetailsReady,
+  useSidebarItemEnteredFromHome,
+} from "@/components/sidebarItemNavigationContext";
 import { parseOptionalLibraryId } from "@/components/sidebarItemNavigation";
 
 function ItemDetailSkeleton() {
@@ -71,12 +74,77 @@ function ItemDetailSkeleton() {
   );
 }
 
+function HomeItemTransitionShell({ item }: { item?: ItemDetail }) {
+  const compact = item?.type === "season";
+  const hidePoster = item?.type === "episode";
+  const squarePoster = item?.type === "audiobook";
+  const hasLogo = Boolean(item?.logo_url);
+
+  return (
+    <div
+      data-testid="home-item-transition-shell"
+      className="bg-background min-h-screen"
+      aria-busy="true"
+    >
+      <span className="sr-only">Loading item details</span>
+      <section aria-hidden="true" className="border-border/10 border-b">
+        <div
+          className={`page-shell-wide flex flex-col justify-end pb-8 ${
+            compact
+              ? "min-h-[max(35vh,300px)] pt-20 lg:min-h-[42vh]"
+              : "min-h-[60dvh] pt-28 lg:min-h-[72dvh]"
+          }`}
+        >
+          <div className={`flex flex-col gap-6 ${!hidePoster ? "lg:flex-row lg:items-end" : ""}`}>
+            {!hidePoster && (
+              <div
+                data-testid="home-item-transition-poster"
+                className={`home-item-transition-block flex-shrink-0 rounded-lg border border-solid shadow-[var(--shadow-md)] ${
+                  squarePoster
+                    ? compact
+                      ? "aspect-square w-[180px] sm:w-[200px]"
+                      : "aspect-square w-[200px] sm:w-[260px]"
+                    : compact
+                      ? "aspect-[2/3] w-[140px] sm:w-[160px]"
+                      : "aspect-[2/3] w-[170px] sm:w-[220px]"
+                }`}
+              />
+            )}
+
+            <div className="max-w-3xl flex-1">
+              <div className="home-item-transition-block mb-4 h-3 w-16 rounded-full" />
+              <div
+                data-testid="home-item-transition-title"
+                className={`home-item-transition-block mb-4 rounded-lg ${
+                  hasLogo
+                    ? "h-20 w-full max-w-[420px] lg:h-28 lg:max-w-[480px]"
+                    : compact
+                      ? "h-10 w-full max-w-sm sm:h-11"
+                      : "h-12 w-full max-w-lg sm:h-14 lg:h-16"
+                }`}
+              />
+              <div className="home-item-transition-block mb-4 h-5 w-52 max-w-full rounded-md" />
+              <div className="home-item-transition-block mb-4 h-4 w-36 rounded-md" />
+              <div className="max-w-2xl space-y-2">
+                <div className="home-item-transition-block h-4 w-full rounded-md" />
+                <div className="home-item-transition-block h-4 w-4/5 rounded-md" />
+              </div>
+              <div className="home-item-transition-block mt-6 h-10 w-32 rounded-full" />
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
 export default function ItemDetail() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const libraryId = parseOptionalLibraryId(searchParams.get("libraryId"));
   const { data: item, isLoading: loading, error: itemError } = useCatalogItemDetail(id, libraryId);
   const itemDetailsReady = useSidebarItemDetailsReady();
+  const enteredItemFromHome = useSidebarItemEnteredFromHome();
 
   useDocumentTitle(item?.title ?? "Item");
 
@@ -87,6 +155,9 @@ export default function ItemDetail() {
   }, [itemError]);
 
   if (loading || !itemDetailsReady) {
+    if (enteredItemFromHome) {
+      return <HomeItemTransitionShell item={item} />;
+    }
     return <ItemDetailSkeleton />;
   }
 


### PR DESCRIPTION
## What this fixes

Related issue: N/A — narrow fix

I have been testing the Home to item transition across Chrome, Safari/WebKit, Orion and Firefox. Opening an item and returning Home could become visibly jagged, especially after opening several different items. Each engine exposed a different part of the same problem:

- Chrome was snapshotting two large pages while the live sidebar and cached content were also moving.
- Safari and Orion could combine the compensated and animated sidebar states into one WebKit paint.
- Firefox restored hundreds of cached Home links before its Back animation could get moving.

This keeps the desktop Home/item boundary lightweight. Navigation semantics remain unchanged on mobile and other routes; the shared WebKit paint handoff also covers item-route entry and exit. Ready Home rows are progressively staged on every first Home commit so the page does not mount thousands of cached card nodes at once.

## What changed

### Chrome and the shared Home/item path

- Skip full-page View Transition snapshots only for desktop `/` to `/item/*` navigation in either direction.
- Let the live compositor-driven sidebar carry the motion.
- Keep the committed handoff shell in place until a cached detail tree is ready to swap in without blocking the final sidebar frames.
- Use eight fixed opaque skeleton blocks during the handoff. They do not pulse, load artwork, blur, measure content or stay mounted after the real detail paints.
- Reserve fixed responsive logo space and give only the bounded poster/copy group a 250 ms opacity settle. There is no transform, filter, backdrop blur or full-page transition layer.
- Match Home item entry and return at 340 ms while every other route keeps its existing timing.
- Seed Home synchronously from the query cache, mount two ready rows first, and restore deferred rows through bounded observers and timers.
- Keep only the active Home hero slide's Ken Burns animation and `will-change`. Hidden slides no longer animate or re-render their parent when images finish loading.

### Safari, Orion and other WebKit browsers

- Add one WebKit-only paint boundary before changing the visual sidebar state. Chrome, Edge and Firefox keep their existing handoff timing.
- Hold ready Home section rows, normally cache-seeded, behind the fixed-height opaque placeholders until the live return transform ends or is cancelled.
- Use the existing 760 ms hard deadline as the final fallback so a hidden tab or interrupted transition cannot strand placeholders.

### Firefox

- Keep Firefox's original one-frame opening and Back handoff.
- Move cached Home row reconstruction out of the live return motion. This is the expensive work that rebuilt 577 item links before the animation started.
- Require both Gecko and Firefox product tokens so Chromium is not accidentally included. Firefox on iOS correctly stays on the WebKit path.

## Scope and safeguards

- Full-page snapshot suppression and the engine-specific Home return gate target desktop Home to item to Home
- The shared WebKit paint handoff applies to item-route entry and exit; desktop non-item to item links also use the bounded prefetch/interception path
- Modified clicks, new tabs and direct item loads keep their navigation semantics; mobile and non-Home routes do not use the Home snapshot suppression
- Reduced motion bypasses the animation gates
- Deferred Home rows are temporary, not permanent virtualization. Every row is restored for browser Find and assistive technology
- Transform completion, transition cancellation, missing-stage handling and the hard deadline all release deferred work
- Observers, timeouts, animation frames and transition listeners are cleared on completion or unmount
- No retained page, cloned DOM, page snapshot cache, worker, background task, image preload or unbounded collection
- No blur was added

## Chrome benchmark

Measured against the same authenticated library in real Chrome controlled through Chrome DevTools at 1200 x 681, DPR 2. The production baseline used five repeated cycles. The patch was exercised through the local Vite server, so absolute route timings are diagnostic rather than a production-bundle apples-to-apples comparison. DOM, animation count and lifecycle measurements are exact.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Home DOM at the first sampled return paint | ~7,580 nodes | 2,181 nodes | 5,399 fewer, ~71.2% reduction |
| Home rows mounted at that first sample | 10 | 3 mounted + 7 fixed placeholders | Heavy card work moved out of the handoff |
| Settled Home rows | 10 | 10 | No permanent virtualization |
| Simultaneous Home hero Ken Burns animations | 10 | 1 | 90% reduction |
| Longest Back long task in the five-cycle runs | 299 ms | 182 ms | 117 ms shorter, ~39.1% reduction |
| Navigation CLS in the broader trace/stress runs | 0.05 | 0 to 0.001 | Near-zero in patched stress runs |

Raw production baseline, five cycles:

| Measurement | Open | Back |
| --- | ---: | ---: |
| Route commit median | 7.5 ms | 9.1 ms |
| Detail-ready median | 33.8 ms | n/a |
| Median p95 frame gap | 33.3 ms | 17.7 ms |
| Worst frame gap | 215.7 ms | 300 ms |
| Frame gaps over 20 / 33 / 50 ms | 12 / 12 / 6 | 8 / 8 / 7 |
| Long tasks | 1 task, 55 ms total | 5 tasks, 1,398 ms total; 299 ms longest |
| Layout shift | 0.0402 | 0 |

The production baseline also recorded INP 173 ms, Home to item LCP 1,156 ms, Back LCP 802 ms, CLS 0.05 and 40 ms forced reflow.

Patched stress checks:

- Five distinct cached items: detail reveal median ~439 ms after the intentional sidebar carry; Back completion samples 137 to 199 ms; longest long-task samples 123 to 182 ms; CLS at or below 0.0004.
- Twelve distinct open/Back cycles: no stuck gate, stable settled DOM and no monotonic heap retention. After idle GC, the final observed heap sample returned below the starting sample.
- Ten cycles across five different series and then the same five cached: 10/10 showed exactly eight opaque blocks with zero pulse during the handoff; 10/10 removed every block and painted the detail by the settled sample; Home contained zero leftover transition nodes.
- Same-item repeat check after matching entry and return timing: 5/5 cached opens completed with the 340 ms boundary token, zero pulsing fallback, a settled detail tree and no stuck shell or overlay.
- Home ultimately restored all 10 rows and approximately 7,547 settled nodes.

## Safari and WebKit benchmark

Measured in real Safari 26.5.2 through Apple SafariDriver at a 1440px desktop width, using the same authenticated library and ten repeated Home to item to Home cycles.

| Metric | Before | After |
| --- | ---: | ---: |
| Item links mounted in the critical Back handoff | 157 | 1 |
| Worst measured Back transition frame | 70 ms | 26 ms |
| Back transition frames over 50 ms | Present | 0/10 cycles |
| Layout shifts | 0 | 0 |

Eight of the ten final Back cycles had a worst transition frame of 17 to 18 ms. Opening also uses the WebKit-specific two-frame paint handoff and remained smooth in the final checks. I also manually repeated the flow in Orion and confirmed the final WebKit motion stayed smooth.


### Final-head Safari acceptance rerun

I reran the two maintainer-blocking cases on final head `c5968f90` in a fresh real Safari 26.5.2 session at 1440 x 900. Three different series were opened and returned from consecutively in the same authenticated session with trusted WebDriver activation.

| Final-head metric | Result |
| --- | ---: |
| Back route commit and first usable Home content | 76 to 97 ms |
| First two Home rows available | 76 to 97 ms, 97 real links |
| Lower work still deferred during live motion | 8 fixed placeholders |
| Return transform settled | 485 to 498 ms |
| Fully restored Home | 1,403 to 1,412 ms, 577 links |
| Final placeholders / transition shells | 0 / 0 in all 3 cycles |
| Layout shift | 0 in all Open and Back samples |
| Long tasks | 0 in all Open and Back samples |
| Backdrop fade coverage | 52 sampled fade frames |
| Backdrop frames missing the thumbhash placeholder | 0 |

The whole 2.2-second Back samples, including staged lower-row reconstruction after the live transform, recorded two frame gaps over 50 ms per cycle. None were long tasks, the eager rows were already usable, and every Home finished cleanly. The backdrop placeholder remained behind the real image for every sampled fade frame, removing the transparent flash without adding retained state, caching, timers or observers.

## Firefox benchmark

Measured in real Firefox 154.0.1 through Mozilla geckodriver 0.37.1 at a 1440px desktop width, using the same library and ten repeated Home to different item to Home cycles.

| Metric | Before | After |
| --- | ---: | ---: |
| Return transform start | 116 to 143 ms | 44 to 50 ms |
| Cycles with a frame over 50 ms before or during the live return transform | 7/10 | 0/10 |
| Frames over 50 ms in the full 1.35 s return sample | 7 | 3, all after the transform while rows filled |
| Opening cycles with a frame over 50 ms | 0/10 | 0/10 |
| Layout shift score | 0 | 0 |

I manually repeated opening different items and returning Home in the controlled Firefox window after the automated run. The final opening and Back motion both remained smooth.

## Browser coverage and personal verification

These were real browser sessions rather than user-agent emulation:

- Chrome controlled through Chrome DevTools
- Safari 26.5.2 controlled through Apple SafariDriver
- Firefox 154.0.1 controlled through Mozilla geckodriver 0.37.1
- Orion manually tested on its WebKit engine

I personally tested first opens, cached opens, repeated same-item opens, more than ten different items, Back, modified links and reduced-motion behavior. Chrome remained smooth, the Orion/Safari return repaint was removed, and the final Firefox result was smooth without changing its opening path.

## Validation

- 151 focused navigation, Home, layout, sidebar, hero, skeleton and item-detail tests passed on the final head
- TypeScript project check passed
- Prettier passed
- ESLint passed with zero errors for the final touched files
- Fork CI passed Go, Web and docs on the exact merged commit; that commit also produced the verified build-119 image used for deployment
- Manual Chrome, Orion/WebKit and Firefox checks completed against the authenticated test library

Development and benchmark history is available in [fork PR #74](https://github.com/blurbery/silo-server/pull/74) and [fork PR #75](https://github.com/blurbery/silo-server/pull/75).

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): `gpt-5.6-sol` (Codex Ultra mode; used for all work in this PR)
- Involvement: AI-assisted. I, blurbery, orchestrated and directed the work, set the performance and safety requirements, reproduced the browser-specific failures, and personally verified the final behavior. Codex assisted with implementation, tests, browser instrumentation, and benchmark collection.
- Adversarial review: The complete navigation diff and state machine were reviewed by the maintainer and CodeRabbit. The original cold-cache shell-geometry blocker was resolved in `f2d859e4` by freezing one geometry snapshot per item route and using neutral geometry when detail data is initially absent. The maintainer then identified two final acceptance blockers: cached Home rows remained empty until the WebKit/Firefox release gate, and the detail thumbhash disappeared before the real backdrop completed its opacity fade. Final commit `c5968f90` keeps the bounded first two Home rows eligible after the lightweight return commit while lower rows remain gated, and retains the thumbhash behind the real image for the entire fade. Regression tests cover eager-row availability before transition end or deadline, unrelated transition events, deadline release, and placeholder persistence after image load. All 151 tests in the 11 touched test files pass, along with TypeScript, ESLint, Prettier and local-path verification. Real Chrome, Firefox and Safari runs completed with no stuck shell, no final placeholders, no layout shift and no backdrop flash; the final Safari run restored all 577 links on three consecutive item returns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smoother Home-to-item navigation with tailored loading placeholders and content reveal animations.
  * Improved Home page rendering during sidebar transitions with progressive loading for lower sections.
  * Added reduced-motion support to minimize animations when requested.

* **Bug Fixes**
  * Corrected hero backdrop animation so only the visible slide animates.
  * Improved sidebar transition timing and navigation behavior across browsers.
  * Preserved artwork sizing while images load and refined detail-page presentation.
  * Improved route transitions between Home and item details on desktop.

* **Tests**
  * Expanded coverage for navigation, animations, lazy loading, responsive behavior, and browser-specific transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


