### PR TITLE
fix(images): verify public artwork delivery before fallback

### DIFF
--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -107,8 +107,9 @@ same client-facing GET path rather than treating an S3 storage HEAD as proof
 that the public URL works.
 
 The practical consequence for a client is that shortly after a server upgrade,
-`image_size=large` may return an image narrower than the table above. It is never
-a broken URL, and no client action is required: the correct width appears once
+`image_size=large` may return an image narrower than the table above. The server
+validates the selected URL through its own delivery route and falls back
+automatically; no client action is required to pick up the correct width once
 the pass completes. URLs served from a fallback carry a shortened expiry so the
 real rung is picked up promptly rather than a day later. Externally delivered
 wide-rung URLs are also revalidated on that shorter cadence, because public
@@ -116,9 +117,9 @@ delivery health can change independently of the backing object. The first
 delivery error in a batch stops later entries from probing the same failing
 endpoint, bounding browse latency during an outage. This safe fallback is why
 the capability endpoint can continue advertising the `large` request semantic
-while a deployment's wide-rung backfill is incomplete. The check observes the
-server's route to the public endpoint; a CDN may still send a remote client to a
-different edge with transient edge-local state.
+while a deployment's wide-rung backfill is incomplete. The check does not prove
+client renderability or delivery from every CDN edge; a remote client may still
+reach an edge with transient edge-local state.
 
 ## Jellyfin compatibility
 

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -102,13 +102,21 @@ The wide rungs (780px posters and stills, 1280px logos) were added after this
 ladder shipped, so artwork cached by an earlier version has no object at those
 keys. A one-shot background pass regenerates it, and until that pass reaches a
 given image the server serves the next narrower rung it does have, ending at the
-original.
+original. With public or token-authenticated delivery, the server checks the
+same client-facing GET path rather than treating an S3 storage HEAD as proof
+that the public URL works.
 
 The practical consequence for a client is that shortly after a server upgrade,
 `image_size=large` may return an image narrower than the table above. It is never
 a broken URL, and no client action is required: the correct width appears once
 the pass completes. URLs served from a fallback carry a shortened expiry so the
-real rung is picked up promptly rather than a day later.
+real rung is picked up promptly rather than a day later. Externally delivered
+wide-rung URLs are also revalidated on that shorter cadence, because public
+delivery health can change independently of the backing object. This safe
+fallback is why the capability endpoint can continue advertising the `large`
+request semantic while a deployment's wide-rung backfill is incomplete. The
+check observes the server's route to the public endpoint; a CDN may still send
+a remote client to a different edge with transient edge-local state.
 
 ## Jellyfin compatibility
 

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -112,11 +112,13 @@ a broken URL, and no client action is required: the correct width appears once
 the pass completes. URLs served from a fallback carry a shortened expiry so the
 real rung is picked up promptly rather than a day later. Externally delivered
 wide-rung URLs are also revalidated on that shorter cadence, because public
-delivery health can change independently of the backing object. This safe
-fallback is why the capability endpoint can continue advertising the `large`
-request semantic while a deployment's wide-rung backfill is incomplete. The
-check observes the server's route to the public endpoint; a CDN may still send
-a remote client to a different edge with transient edge-local state.
+delivery health can change independently of the backing object. The first
+delivery error in a batch stops later entries from probing the same failing
+endpoint, bounding browse latency during an outage. This safe fallback is why
+the capability endpoint can continue advertising the `large` request semantic
+while a deployment's wide-rung backfill is incomplete. The check observes the
+server's route to the public endpoint; a CDN may still send a remote client to a
+different edge with transient edge-local state.
 
 ## Jellyfin compatibility
 

--- a/internal/metadata/image_ladder_fallback.go
+++ b/internal/metadata/image_ladder_fallback.go
@@ -20,6 +20,9 @@ const (
 	// Cached artwork is immutable per revision, so a hit cannot go stale except
 	// by deletion, which the reconciler already repairs.
 	existsCacheTTL = 24 * time.Hour
+	// externalAvailabilityCacheTTL is shorter because a public/token delivery
+	// path can stop serving an object independently of the backing S3 API.
+	externalAvailabilityCacheTTL = 15 * time.Minute
 	// missingExistsCacheTTL is how long a confirmed-absent object stays absent.
 	// It is short because absence is the transient state: the ladder backfill is
 	// generating the rung right now, and every viewer is being served a narrower
@@ -32,6 +35,40 @@ const (
 // presigner does not simply skips the fallback and presigns what was asked for.
 type s3ImageExistenceChecker interface {
 	ObjectExists(ctx context.Context, bucket, key string) (bool, error)
+}
+
+// s3ImageDeliveryChecker verifies newly added ladder rungs through the
+// separately authenticated URL path used by clients. External delivery is not
+// equivalent to storage existence: an S3 HEAD can succeed while the public
+// endpoint still returns 404.
+type s3ImageDeliveryChecker interface {
+	ObjectAvailable(ctx context.Context, bucket, key string) (bool, error)
+	UsesExternalAuth() bool
+}
+
+type imageAvailabilityCheck func(ctx context.Context, bucket, key string) (bool, error)
+
+type imageAvailabilityPolicy struct {
+	check           imageAvailabilityCheck
+	presentTTL      time.Duration
+	fallbackOnError bool
+}
+
+func availabilityPolicy(presigner s3ImagePresigner) imageAvailabilityPolicy {
+	if checker, ok := presigner.(s3ImageDeliveryChecker); ok && checker.UsesExternalAuth() {
+		return imageAvailabilityPolicy{
+			check:           checker.ObjectAvailable,
+			presentTTL:      externalAvailabilityCacheTTL,
+			fallbackOnError: true,
+		}
+	}
+	if checker, ok := presigner.(s3ImageExistenceChecker); ok {
+		return imageAvailabilityPolicy{
+			check:      checker.ObjectExists,
+			presentTTL: existsCacheTTL,
+		}
+	}
+	return imageAvailabilityPolicy{}
 }
 
 // ladderTypesWithAddedRung lists the image types that gained a rung in the
@@ -83,15 +120,16 @@ func variantKey(key, variant string) string {
 	return artworkkey.Variant(original, variant)
 }
 
-// ladderExistenceConcurrency bounds how many artwork existence checks run at
-// once for one batch. It keeps a large browse page off a serial chain of HEADs
-// without letting a single request open a hundred connections to storage.
+// ladderExistenceConcurrency bounds how many artwork availability checks run at
+// once for one batch. It keeps a large browse page off a serial chain of probes
+// without letting one request open a hundred storage or delivery connections.
 const ladderExistenceConcurrency = 12
 
 // ladderKey is the outcome of walking the ladder for one requested key.
 type ladderKey struct {
-	key      string
-	fellBack bool
+	key             string
+	fellBack        bool
+	revalidateAfter time.Duration
 }
 
 // resolveLadderKeys walks the ladder for a whole batch with bounded concurrency,
@@ -100,7 +138,7 @@ type ladderKey struct {
 // themselves without touching storage.
 func (r *PluginImageResolver) resolveLadderKeys(
 	ctx context.Context,
-	checker s3ImageExistenceChecker,
+	policy imageAvailabilityPolicy,
 	bucket string,
 	entries []resolveEntry,
 ) map[string]ladderKey {
@@ -108,7 +146,7 @@ func (r *PluginImageResolver) resolveLadderKeys(
 	for _, entry := range entries {
 		resolved[entry.originalPath] = ladderKey{key: entry.originalPath}
 	}
-	if checker == nil {
+	if policy.check == nil {
 		return resolved
 	}
 
@@ -130,15 +168,19 @@ func (r *PluginImageResolver) resolveLadderKeys(
 	group.SetLimit(ladderExistenceConcurrency)
 	for _, path := range pending {
 		group.Go(func() error {
-			key, fellBack := r.resolveLadderKey(ctx, checker, bucket, path)
+			key, fellBack := r.resolveLadderKey(ctx, policy, bucket, path)
 			mu.Lock()
-			resolved[path] = ladderKey{key: key, fellBack: fellBack}
+			resolved[path] = ladderKey{
+				key:             key,
+				fellBack:        fellBack,
+				revalidateAfter: policy.presentTTL,
+			}
 			mu.Unlock()
 			return nil
 		})
 	}
-	// resolveLadderKey never returns an error — a failed check degrades to
-	// presigning what was asked for — so there is nothing to surface here.
+	// resolveLadderKey never returns an error — a failed check degrades according
+	// to the selected storage or external-delivery policy.
 	_ = group.Wait()
 	return resolved
 }
@@ -148,10 +190,11 @@ func (r *PluginImageResolver) resolveLadderKeys(
 // return reports whether the answer is a fallback rather than what was asked
 // for, which the caller uses to shorten how long it caches the resolved URL.
 //
-// An existence check that errors is not treated as absence: storage being
-// briefly unreachable must not permanently downgrade everyone's artwork, so the
-// requested key is presigned optimistically and the result is not cached.
-func (r *PluginImageResolver) resolveLadderKey(ctx context.Context, checker s3ImageExistenceChecker, bucket, key string) (string, bool) {
+// A storage-only check that errors is not treated as absence: storage being
+// briefly unreachable must not permanently downgrade everyone's artwork. An
+// external-delivery error does fall back because it cannot prove that the URL
+// handed to a client will work. Errors are never cached in either mode.
+func (r *PluginImageResolver) resolveLadderKey(ctx context.Context, policy imageAvailabilityPolicy, bucket, key string) (string, bool) {
 	imageType, ok := needsExistenceCheck(key)
 	if !ok {
 		return key, false
@@ -159,9 +202,21 @@ func (r *PluginImageResolver) resolveLadderKey(ctx context.Context, checker s3Im
 
 	candidate := key
 	for {
-		exists, err := r.objectExists(ctx, checker, bucket, candidate)
+		exists, err := r.objectExists(ctx, policy.check, policy.presentTTL, bucket, candidate)
 		if err != nil {
-			return key, false
+			if !policy.fallbackOnError {
+				slog.DebugContext(ctx, "artwork existence check failed", "component", "metadata", "key", candidate, "error", err)
+				return key, false
+			}
+			slog.WarnContext(ctx, "external artwork delivery check failed; using lower rung", "component", "metadata", "key", candidate, "error", err)
+			next, hasNext := imagesize.NextLower(imageType, keyVariant(candidate))
+			if !hasNext {
+				return variantKey(key, artworkkey.OriginalVariant), true
+			}
+			// A delivery-wide error is likely to repeat for every candidate. The
+			// lower rungs predate the current ladder version, so select the next
+			// established one without multiplying timeout or rate-limit load.
+			return variantKey(key, next), true
 		}
 		if exists {
 			return candidate, candidate != key
@@ -176,9 +231,15 @@ func (r *PluginImageResolver) resolveLadderKey(ctx context.Context, checker s3Im
 	}
 }
 
-// objectExists answers from the existence cache when it can. Present and absent
-// are cached with different lifetimes; an error is not cached at all.
-func (r *PluginImageResolver) objectExists(ctx context.Context, checker s3ImageExistenceChecker, bucket, key string) (bool, error) {
+// objectExists answers from the availability cache when it can. Present and
+// absent answers are cached with different lifetimes; an error is not cached.
+func (r *PluginImageResolver) objectExists(
+	ctx context.Context,
+	check imageAvailabilityCheck,
+	presentTTL time.Duration,
+	bucket string,
+	key string,
+) (bool, error) {
 	cacheKey := bucket + "\x00" + key
 	if r.existsCache != nil {
 		if value, ok := r.existsCache.Get(cacheKey); ok {
@@ -186,16 +247,15 @@ func (r *PluginImageResolver) objectExists(ctx context.Context, checker s3ImageE
 		}
 	}
 
-	exists, err := checker.ObjectExists(ctx, bucket, key)
+	exists, err := check(ctx, bucket, key)
 	if err != nil {
-		slog.DebugContext(ctx, "artwork existence check failed", "component", "metadata", "key", key, "error", err)
 		return false, err
 	}
 
 	if r.existsCache != nil {
 		ttl := missingExistsCacheTTL
 		if exists {
-			ttl = existsCacheTTL
+			ttl = presentTTL
 		}
 		r.existsCache.Set(cacheKey, exists, ttl)
 	}
@@ -207,7 +267,13 @@ func (r *PluginImageResolver) objectExists(ctx context.Context, checker s3ImageE
 // as the missing rung could have been backfilled. Without this a viewer could
 // keep receiving the narrow image for a full day after the real one landed.
 func fallbackURLExpiry(expiry time.Time, now time.Time) time.Time {
-	clamped := now.Add(missingExistsCacheTTL + resolvedURLCacheSafetyMargin)
+	return revalidatedURLExpiry(expiry, now, missingExistsCacheTTL)
+}
+
+// revalidatedURLExpiry makes the resolved-URL cache release an externally
+// verified URL when its delivery-path availability is due to be checked again.
+func revalidatedURLExpiry(expiry time.Time, now time.Time, ttl time.Duration) time.Time {
+	clamped := now.Add(ttl + resolvedURLCacheSafetyMargin)
 	if clamped.Before(expiry) {
 		return clamped
 	}

--- a/internal/metadata/image_ladder_fallback.go
+++ b/internal/metadata/image_ladder_fallback.go
@@ -2,10 +2,12 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"path"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -43,7 +45,7 @@ type s3ImageExistenceChecker interface {
 // endpoint still returns 404.
 type s3ImageDeliveryChecker interface {
 	ObjectAvailable(ctx context.Context, bucket, key string) (bool, error)
-	UsesExternalAuth() bool
+	UsesExternalDelivery() bool
 }
 
 type imageAvailabilityCheck func(ctx context.Context, bucket, key string) (bool, error)
@@ -55,7 +57,7 @@ type imageAvailabilityPolicy struct {
 }
 
 func availabilityPolicy(presigner s3ImagePresigner) imageAvailabilityPolicy {
-	if checker, ok := presigner.(s3ImageDeliveryChecker); ok && checker.UsesExternalAuth() {
+	if checker, ok := presigner.(s3ImageDeliveryChecker); ok && checker.UsesExternalDelivery() {
 		return imageAvailabilityPolicy{
 			check:           checker.ObjectAvailable,
 			presentTTL:      externalAvailabilityCacheTTL,
@@ -69,6 +71,31 @@ func availabilityPolicy(presigner s3ImagePresigner) imageAvailabilityPolicy {
 		}
 	}
 	return imageAvailabilityPolicy{}
+}
+
+var errExternalDeliveryBatchUnavailable = errors.New("external artwork delivery unavailable for batch")
+
+// withBatchFailureCircuit stops a delivery outage from consuming one probe
+// timeout per worker wave. Checks already in flight may finish, but after the
+// first error no later entry in this batch reaches the external endpoint.
+func (p imageAvailabilityPolicy) withBatchFailureCircuit() imageAvailabilityPolicy {
+	if !p.fallbackOnError || p.check == nil {
+		return p
+	}
+
+	check := p.check
+	var failed atomic.Bool
+	p.check = func(ctx context.Context, bucket, key string) (bool, error) {
+		if failed.Load() {
+			return false, errExternalDeliveryBatchUnavailable
+		}
+		exists, err := check(ctx, bucket, key)
+		if err != nil && !failed.CompareAndSwap(false, true) {
+			return false, errExternalDeliveryBatchUnavailable
+		}
+		return exists, err
+	}
+	return p
 }
 
 // ladderTypesWithAddedRung lists the image types that gained a rung in the
@@ -160,6 +187,7 @@ func (r *PluginImageResolver) resolveLadderKeys(
 	if len(pending) == 0 {
 		return resolved
 	}
+	policy = policy.withBatchFailureCircuit()
 
 	var (
 		mu    sync.Mutex
@@ -208,7 +236,9 @@ func (r *PluginImageResolver) resolveLadderKey(ctx context.Context, policy image
 				slog.DebugContext(ctx, "artwork existence check failed", "component", "metadata", "key", candidate, "error", err)
 				return key, false
 			}
-			slog.WarnContext(ctx, "external artwork delivery check failed; using lower rung", "component", "metadata", "key", candidate, "error", err)
+			if !errors.Is(err, errExternalDeliveryBatchUnavailable) {
+				slog.WarnContext(ctx, "external artwork delivery check failed; using lower rung", "component", "metadata", "key", candidate, "error", err)
+			}
 			next, hasNext := imagesize.NextLower(imageType, keyVariant(candidate))
 			if !hasNext {
 				return variantKey(key, artworkkey.OriginalVariant), true

--- a/internal/metadata/image_ladder_fallback_test.go
+++ b/internal/metadata/image_ladder_fallback_test.go
@@ -12,11 +12,15 @@ import (
 // fakeS3ImageStore is a presigner that also answers existence checks, standing
 // in for *s3client.Client.
 type fakeS3ImageStore struct {
-	mu       sync.Mutex
-	existing map[string]bool
-	err      error
-	checks   []string
-	presigns []string
+	mu             sync.Mutex
+	existing       map[string]bool
+	deliverable    map[string]bool
+	deliveryErrors map[string]error
+	externalAuth   bool
+	err            error
+	checks         []string
+	deliveryChecks []string
+	presigns       []string
 }
 
 func newFakeS3ImageStore(existing ...string) *fakeS3ImageStore {
@@ -28,6 +32,8 @@ func newFakeS3ImageStore(existing ...string) *fakeS3ImageStore {
 }
 
 func (s *fakeS3ImageStore) Bucket() string { return "media" }
+
+func (s *fakeS3ImageStore) UsesExternalAuth() bool { return s.externalAuth }
 
 func (s *fakeS3ImageStore) PresignGetURL(_ context.Context, bucket, key string, _ time.Duration) (string, error) {
 	s.mu.Lock()
@@ -44,6 +50,19 @@ func (s *fakeS3ImageStore) ObjectExists(_ context.Context, _ string, key string)
 		return false, s.err
 	}
 	return s.existing[key], nil
+}
+
+func (s *fakeS3ImageStore) ObjectAvailable(_ context.Context, _ string, key string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deliveryChecks = append(s.deliveryChecks, key)
+	if err := s.deliveryErrors[key]; err != nil {
+		return false, err
+	}
+	if s.err != nil {
+		return false, s.err
+	}
+	return s.deliverable[key], nil
 }
 
 func (s *fakeS3ImageStore) checkCount() int {
@@ -115,6 +134,93 @@ func TestLadderFallbackWalksLogoLadder(t *testing.T) {
 
 	if got := resolvedKey(t, resolver, requested); got != present {
 		t.Fatalf("resolved key = %q, want %q", got, present)
+	}
+}
+
+// A storage HEAD is not proof that a separately authenticated public URL is
+// fetchable. The ladder must check the same delivery path the client will use.
+func TestLadderFallbackUsesClientDeliveryAvailability(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		present   string
+	}{
+		{
+			name:      "poster",
+			requested: "tmdb/movies/550/poster/w780.rev.webp",
+			present:   "tmdb/movies/550/poster/w500.rev.webp",
+		},
+		{
+			name:      "still",
+			requested: "tmdb/series/1396/seasons/1/episodes/1/still/w780.rev.webp",
+			present:   "tmdb/series/1396/seasons/1/episodes/1/still/w500.rev.webp",
+		},
+		{
+			name:      "logo",
+			requested: "tmdb/series/1396/logo/w1280.rev.webp",
+			present:   "tmdb/series/1396/logo/w500.rev.webp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newFakeS3ImageStore(tt.requested, tt.present)
+			store.externalAuth = true
+			store.deliverable = map[string]bool{tt.present: true}
+			resolver := newResolverWithStore(t, store)
+
+			if got := resolvedKey(t, resolver, tt.requested); got != tt.present {
+				t.Fatalf("resolved key = %q, want client-fetchable rung %q", got, tt.present)
+			}
+			if len(store.deliveryChecks) == 0 || store.deliveryChecks[0] != tt.requested {
+				t.Fatalf("delivery checks = %v, want requested rung checked first", store.deliveryChecks)
+			}
+			if len(store.checks) != 0 {
+				t.Fatalf("storage checks = %v, want client-delivery checks", store.checks)
+			}
+		})
+	}
+}
+
+func TestLadderFallbackRechecksExternalDeliveryForPromotion(t *testing.T) {
+	const requested = "tmdb/movies/550/poster/w780.rev.webp"
+	const present = "tmdb/movies/550/poster/w500.rev.webp"
+	store := newFakeS3ImageStore(requested, present)
+	store.externalAuth = true
+	store.deliverable = map[string]bool{present: true}
+	resolver := newResolverWithStore(t, store)
+
+	if got := resolvedKey(t, resolver, requested); got != present {
+		t.Fatalf("initial resolved key = %q, want fallback %q", got, present)
+	}
+
+	store.mu.Lock()
+	store.deliverable[requested] = true
+	store.mu.Unlock()
+	// Expiry drives these invalidations in production; do it directly so the
+	// unit test proves promotion without waiting for the real TTL.
+	resolver.existsCache.InvalidatePrefix("")
+	resolver.urlCache.InvalidatePrefix("")
+
+	if got := resolvedKey(t, resolver, requested); got != requested {
+		t.Fatalf("resolved key after delivery recovery = %q, want %q", got, requested)
+	}
+}
+
+func TestLadderFallbackUsesLowerRungWhenDeliveryCheckErrors(t *testing.T) {
+	const requested = "tmdb/movies/550/poster/w780.rev.webp"
+	const present = "tmdb/movies/550/poster/w500.rev.webp"
+	store := newFakeS3ImageStore(requested, present)
+	store.externalAuth = true
+	store.deliverable = map[string]bool{present: true}
+	store.deliveryErrors = map[string]error{requested: errors.New("delivery unavailable")}
+	resolver := newResolverWithStore(t, store)
+
+	if got := resolvedKey(t, resolver, requested); got != present {
+		t.Fatalf("resolved key = %q, want lower fetchable rung %q", got, present)
+	}
+	if len(store.deliveryChecks) != 1 || store.deliveryChecks[0] != requested {
+		t.Fatalf("delivery checks = %v, want one bounded check of requested rung", store.deliveryChecks)
 	}
 }
 
@@ -203,6 +309,22 @@ func TestLadderFallbackClampsResolvedURLLifetime(t *testing.T) {
 	}
 	if got := time.Until(*direct.ExpiresAt); got <= missingExistsCacheTTL+resolvedURLCacheSafetyMargin {
 		t.Fatalf("direct expiry in %v, want the full presign window", got)
+	}
+}
+
+func TestLadderFallbackClampsExternallyVerifiedURLLifetime(t *testing.T) {
+	const requested = "tmdb/movies/550/poster/w780.abc123.webp"
+	store := newFakeS3ImageStore(requested)
+	store.externalAuth = true
+	store.deliverable = map[string]bool{requested: true}
+	resolver := newResolverWithStore(t, store)
+
+	resolved := resolver.ResolveImageURLWithExpiry(t.Context(), requested, "featured")
+	if resolved.ExpiresAt == nil {
+		t.Fatal("externally verified URL has no expiry")
+	}
+	if got := time.Until(*resolved.ExpiresAt); got > externalAvailabilityCacheTTL+resolvedURLCacheSafetyMargin {
+		t.Fatalf("externally verified expiry in %v, want at most %v", got, externalAvailabilityCacheTTL+resolvedURLCacheSafetyMargin)
 	}
 }
 

--- a/internal/metadata/image_ladder_fallback_test.go
+++ b/internal/metadata/image_ladder_fallback_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -12,15 +13,17 @@ import (
 // fakeS3ImageStore is a presigner that also answers existence checks, standing
 // in for *s3client.Client.
 type fakeS3ImageStore struct {
-	mu             sync.Mutex
-	existing       map[string]bool
-	deliverable    map[string]bool
-	deliveryErrors map[string]error
-	externalAuth   bool
-	err            error
-	checks         []string
-	deliveryChecks []string
-	presigns       []string
+	mu               sync.Mutex
+	existing         map[string]bool
+	deliverable      map[string]bool
+	deliveryErrors   map[string]error
+	externalDelivery bool
+	err              error
+	checks           []string
+	deliveryChecks   []string
+	presigns         []string
+	deliveryStarted  chan<- string
+	deliveryRelease  <-chan struct{}
 }
 
 func newFakeS3ImageStore(existing ...string) *fakeS3ImageStore {
@@ -33,7 +36,7 @@ func newFakeS3ImageStore(existing ...string) *fakeS3ImageStore {
 
 func (s *fakeS3ImageStore) Bucket() string { return "media" }
 
-func (s *fakeS3ImageStore) UsesExternalAuth() bool { return s.externalAuth }
+func (s *fakeS3ImageStore) UsesExternalDelivery() bool { return s.externalDelivery }
 
 func (s *fakeS3ImageStore) PresignGetURL(_ context.Context, bucket, key string, _ time.Duration) (string, error) {
 	s.mu.Lock()
@@ -52,17 +55,36 @@ func (s *fakeS3ImageStore) ObjectExists(_ context.Context, _ string, key string)
 	return s.existing[key], nil
 }
 
-func (s *fakeS3ImageStore) ObjectAvailable(_ context.Context, _ string, key string) (bool, error) {
+func (s *fakeS3ImageStore) ObjectAvailable(ctx context.Context, _ string, key string) (bool, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.deliveryChecks = append(s.deliveryChecks, key)
-	if err := s.deliveryErrors[key]; err != nil {
+	started := s.deliveryStarted
+	release := s.deliveryRelease
+	err := s.deliveryErrors[key]
+	if err == nil {
+		err = s.err
+	}
+	deliverable := s.deliverable[key]
+	s.mu.Unlock()
+
+	if started != nil {
+		select {
+		case started <- key:
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+	if err != nil {
 		return false, err
 	}
-	if s.err != nil {
-		return false, s.err
-	}
-	return s.deliverable[key], nil
+	return deliverable, nil
 }
 
 func (s *fakeS3ImageStore) checkCount() int {
@@ -165,7 +187,7 @@ func TestLadderFallbackUsesClientDeliveryAvailability(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := newFakeS3ImageStore(tt.requested, tt.present)
-			store.externalAuth = true
+			store.externalDelivery = true
 			store.deliverable = map[string]bool{tt.present: true}
 			resolver := newResolverWithStore(t, store)
 
@@ -186,7 +208,7 @@ func TestLadderFallbackRechecksExternalDeliveryForPromotion(t *testing.T) {
 	const requested = "tmdb/movies/550/poster/w780.rev.webp"
 	const present = "tmdb/movies/550/poster/w500.rev.webp"
 	store := newFakeS3ImageStore(requested, present)
-	store.externalAuth = true
+	store.externalDelivery = true
 	store.deliverable = map[string]bool{present: true}
 	resolver := newResolverWithStore(t, store)
 
@@ -211,7 +233,7 @@ func TestLadderFallbackUsesLowerRungWhenDeliveryCheckErrors(t *testing.T) {
 	const requested = "tmdb/movies/550/poster/w780.rev.webp"
 	const present = "tmdb/movies/550/poster/w500.rev.webp"
 	store := newFakeS3ImageStore(requested, present)
-	store.externalAuth = true
+	store.externalDelivery = true
 	store.deliverable = map[string]bool{present: true}
 	store.deliveryErrors = map[string]error{requested: errors.New("delivery unavailable")}
 	resolver := newResolverWithStore(t, store)
@@ -221,6 +243,70 @@ func TestLadderFallbackUsesLowerRungWhenDeliveryCheckErrors(t *testing.T) {
 	}
 	if len(store.deliveryChecks) != 1 || store.deliveryChecks[0] != requested {
 		t.Fatalf("delivery checks = %v, want one bounded check of requested rung", store.deliveryChecks)
+	}
+}
+
+func TestLadderFallbackStopsDeliveryProbesAfterBatchFailure(t *testing.T) {
+	const entryCount = ladderExistenceConcurrency * 4
+
+	started := make(chan string, entryCount)
+	release := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(unblock)
+
+	store := newFakeS3ImageStore()
+	store.externalDelivery = true
+	store.err = errors.New("delivery unavailable")
+	store.deliveryStarted = started
+	store.deliveryRelease = release
+	resolver := newResolverWithStore(t, store)
+
+	entries := make([]resolveEntry, 0, entryCount)
+	for i := range entryCount {
+		entries = append(entries, resolveEntry{
+			originalPath: fmt.Sprintf("tmdb/movies/%d/poster/w780.rev.webp", i),
+		})
+	}
+
+	resolved := make(chan map[string]ladderKey, 1)
+	go func() {
+		resolved <- resolver.resolveLadderKeys(t.Context(), availabilityPolicy(store), store.Bucket(), entries)
+	}()
+
+	waitCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	for range ladderExistenceConcurrency {
+		select {
+		case <-started:
+		case <-waitCtx.Done():
+			t.Fatalf("delivery probes started = %d, want initial worker set of %d", len(started), ladderExistenceConcurrency)
+		}
+	}
+	select {
+	case key := <-started:
+		t.Fatalf("delivery probe %q exceeded the %d-worker limit before release", key, ladderExistenceConcurrency)
+	default:
+	}
+
+	unblock()
+	var got map[string]ladderKey
+	select {
+	case got = <-resolved:
+	case <-waitCtx.Done():
+		t.Fatal("ladder batch did not fall back after delivery failure")
+	}
+
+	store.mu.Lock()
+	deliveryChecks := append([]string(nil), store.deliveryChecks...)
+	store.mu.Unlock()
+	if len(deliveryChecks) > ladderExistenceConcurrency {
+		t.Fatalf("delivery checks = %d, want at most the initial worker set of %d", len(deliveryChecks), ladderExistenceConcurrency)
+	}
+	for _, entry := range entries {
+		want := strings.Replace(entry.originalPath, "/w780.", "/w500.", 1)
+		if result := got[entry.originalPath]; result.key != want || !result.fellBack {
+			t.Errorf("resolved[%q] = %#v, want fallback key %q", entry.originalPath, result, want)
+		}
 	}
 }
 
@@ -315,7 +401,7 @@ func TestLadderFallbackClampsResolvedURLLifetime(t *testing.T) {
 func TestLadderFallbackClampsExternallyVerifiedURLLifetime(t *testing.T) {
 	const requested = "tmdb/movies/550/poster/w780.abc123.webp"
 	store := newFakeS3ImageStore(requested)
-	store.externalAuth = true
+	store.externalDelivery = true
 	store.deliverable = map[string]bool{requested: true}
 	resolver := newResolverWithStore(t, store)
 

--- a/internal/metadata/image_resolver.go
+++ b/internal/metadata/image_resolver.go
@@ -326,16 +326,16 @@ func (r *PluginImageResolver) resolveS3Batch(
 	}
 	// Only the cached-key path walks the ladder: plugin- and http-resolved
 	// images do not live in this bucket and choose their own variant.
-	checker, _ := presigner.(s3ImageExistenceChecker)
+	policy := availabilityPolicy(presigner)
 	now := time.Now()
 	expiresAt := now.Add(ttl)
 
 	// Walk the ladder for the whole batch before presigning any of it. Each walk
-	// can cost a HEAD or two against storage, and a browse page resolves a
-	// hundred images: done one after another that is seconds of latency in front
-	// of the JSON. Presigning itself is local signing work, so only this part is
-	// worth parallelizing.
-	ladderKeys := r.resolveLadderKeys(ctx, checker, presigner.Bucket(), entries)
+	// can cost one or more storage HEADs or public-delivery probes, and a browse
+	// page resolves a hundred images: done one after another that is seconds of
+	// latency in front of the JSON. Presigning itself is local signing work, so
+	// only this part is worth parallelizing.
+	ladderKeys := r.resolveLadderKeys(ctx, policy, presigner.Bucket(), entries)
 
 	for _, entry := range entries {
 		resolvedKey := ladderKeys[entry.originalPath]
@@ -349,6 +349,8 @@ func (r *PluginImageResolver) resolveS3Batch(
 		expiry := expiresAt
 		if fellBack {
 			expiry = fallbackURLExpiry(expiry, now)
+		} else if resolvedKey.revalidateAfter > 0 {
+			expiry = revalidatedURLExpiry(expiry, now, resolvedKey.revalidateAfter)
 		}
 		resolved[entry.originalPath] = catalog.ResolvedImageURL{URL: url, ExpiresAt: &expiry}
 	}

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -339,10 +339,17 @@ func (c *Client) cloudflareTokenURL(key string) string {
 		"?" + c.tokenParam + "=" + ts + "-" + url.QueryEscape(token)
 }
 
-// UsesExternalAuth returns true if read URLs are served via a public endpoint
-// (token auth or public bucket) rather than S3 presigned URLs.
+// UsesExternalAuth reports whether the configured URL auth mode is public or
+// token-based. Use UsesExternalDelivery when endpoint availability matters.
 func (c *Client) UsesExternalAuth() bool {
 	return c.urlAuth == URLAuthCloudflareToken || c.urlAuth == URLAuthPublic
+}
+
+// UsesExternalDelivery reports whether generated read URLs actually use a
+// separately configured public or token-authenticated endpoint. An auth mode
+// without its endpoint still falls back to standard S3 presigning.
+func (c *Client) UsesExternalDelivery() bool {
+	return c.publicEndpoint != "" && c.UsesExternalAuth()
 }
 
 // PublicURL returns the deterministic public URL for an object based on the
@@ -443,7 +450,7 @@ func (c *Client) ObjectExists(ctx context.Context, bucket, key string) (bool, er
 // one-byte range avoids transferring the image body when the endpoint honors
 // ranges. Standard presigned delivery keeps using the cheaper storage HEAD.
 func (c *Client) ObjectAvailable(ctx context.Context, bucket, key string) (bool, error) {
-	if !c.UsesExternalAuth() || c.publicEndpoint == "" {
+	if !c.UsesExternalDelivery() {
 		return c.ObjectExists(ctx, bucket, key)
 	}
 

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -40,6 +41,11 @@ const (
 // streamUploadPartSize bounds per-upload memory for unsized streaming uploads.
 // S3-compatible backends require parts of at least 5 MiB (except the last).
 const streamUploadPartSize = 8 * 1024 * 1024
+
+// publicDeliveryProbeTimeout bounds request-path latency when the external
+// artwork endpoint is unavailable. Ladder resolution probes candidates in
+// descending order, so an unbounded client could stall a whole browse page.
+const publicDeliveryProbeTimeout = 5 * time.Second
 
 // BucketConfig holds the configuration for connecting to a single S3 bucket.
 // Each bucket may have different credentials and endpoints, allowing per-bucket
@@ -429,6 +435,49 @@ func (c *Client) ObjectExists(ctx context.Context, bucket, key string) (bool, er
 	}
 
 	return true, nil
+}
+
+// ObjectAvailable reports whether a client-facing read URL is fetchable now.
+// Public and token-authenticated endpoints are a separate delivery path from
+// the S3 API, so they are probed with the same GET method clients use. A
+// one-byte range avoids transferring the image body when the endpoint honors
+// ranges. Standard presigned delivery keeps using the cheaper storage HEAD.
+func (c *Client) ObjectAvailable(ctx context.Context, bucket, key string) (bool, error) {
+	if !c.UsesExternalAuth() || c.publicEndpoint == "" {
+		return c.ObjectExists(ctx, bucket, key)
+	}
+
+	readURL, err := c.PresignGetURL(ctx, bucket, key, publicDeliveryProbeTimeout)
+	if err != nil {
+		return false, err
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, publicDeliveryProbeTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, readURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("s3 create public delivery probe for %s/%s", bucket, key)
+	}
+	req.Header.Set("Range", "bytes=0-0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// The underlying url.Error includes the signed URL, so do not wrap it:
+		// token-auth query values must never reach logs.
+		return false, fmt.Errorf("s3 public delivery probe for %s/%s failed", bucket, key)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		var firstByte [1]byte
+		if _, err := io.ReadFull(resp.Body, firstByte[:]); err != nil {
+			return false, fmt.Errorf("s3 public delivery probe for %s/%s returned no readable body", bucket, key)
+		}
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone {
+		return false, nil
+	}
+	return false, fmt.Errorf("s3 public delivery probe for %s/%s returned status %d", bucket, key, resp.StatusCode)
 }
 
 // ObjectMatches checks that an immutable object exists with the expected

--- a/internal/s3client/client_test.go
+++ b/internal/s3client/client_test.go
@@ -274,6 +274,125 @@ func TestClientWithKeyPrefixPrefixesCloudflareTokenURL(t *testing.T) {
 	}
 }
 
+func TestClientObjectAvailableUsesExternalDeliveryPath(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		requests []recordedRequest
+	)
+	delivery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, recordedRequest{
+			Method:   r.Method,
+			Path:     r.URL.Path,
+			RawQuery: r.URL.RawQuery,
+			Body:     r.Header.Get("Range"),
+		})
+		mu.Unlock()
+
+		if r.URL.Path == "/silo/dev/poster/w780.webp" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = io.WriteString(w, "x")
+	}))
+	t.Cleanup(delivery.Close)
+
+	client := NewClient(BucketConfig{
+		Endpoint:       "https://s3.example.invalid",
+		PublicEndpoint: delivery.URL,
+		Region:         "us-east-1",
+		Bucket:         "silo",
+		KeyPrefix:      "silo/dev",
+		AccessKey:      "test",
+		SecretKey:      "test",
+		PathStyle:      true,
+		URLAuth:        URLAuthCloudflareToken,
+		TokenSecret:    "secret",
+	})
+
+	available, err := client.ObjectAvailable(t.Context(), client.Bucket(), "poster/w780.webp")
+	if err != nil || available {
+		t.Fatalf("large ObjectAvailable() = %v, %v, want false, nil", available, err)
+	}
+	available, err = client.ObjectAvailable(t.Context(), client.Bucket(), "poster/w500.webp")
+	if err != nil || !available {
+		t.Fatalf("medium ObjectAvailable() = %v, %v, want true, nil", available, err)
+	}
+
+	mu.Lock()
+	gotRequests := append([]recordedRequest(nil), requests...)
+	mu.Unlock()
+	if len(gotRequests) != 2 {
+		t.Fatalf("delivery requests = %#v, want two", gotRequests)
+	}
+	for _, req := range gotRequests {
+		if req.Method != http.MethodGet || req.Body != "bytes=0-0" {
+			t.Errorf("delivery request = %#v, want one-byte GET", req)
+		}
+		if parseQuery(req.RawQuery).Get("verify") == "" {
+			t.Errorf("delivery request = %#v, want Cloudflare auth token", req)
+		}
+	}
+}
+
+func TestClientObjectAvailableUsesStorageForPresignedURLs(t *testing.T) {
+	t.Parallel()
+
+	srv := newS3TestServer(t)
+	client := NewClient(BucketConfig{
+		Endpoint:  srv.URL(),
+		Region:    "us-east-1",
+		Bucket:    "silo",
+		AccessKey: "test",
+		SecretKey: "test",
+		PathStyle: true,
+		URLAuth:   URLAuthPresigned,
+	})
+
+	available, err := client.ObjectAvailable(t.Context(), client.Bucket(), "poster.webp")
+	if err != nil || !available {
+		t.Fatalf("ObjectAvailable() = %v, %v, want true, nil", available, err)
+	}
+	requests := srv.Requests()
+	if !containsRequest(requests, http.MethodHead, "/silo/poster.webp", "") {
+		t.Fatalf("requests = %#v, want storage HEAD", requests)
+	}
+	if containsRequest(requests, http.MethodGet, "/silo/poster.webp", "") {
+		t.Fatalf("requests = %#v, do not want a delivery GET for presigned S3", requests)
+	}
+}
+
+func TestClientObjectAvailableReportsExternalAuthFailureWithoutToken(t *testing.T) {
+	t.Parallel()
+
+	delivery := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(delivery.Close)
+
+	client := NewClient(BucketConfig{
+		Endpoint:       "https://s3.example.invalid",
+		PublicEndpoint: delivery.URL,
+		Region:         "us-east-1",
+		Bucket:         "silo",
+		AccessKey:      "test",
+		SecretKey:      "test",
+		URLAuth:        URLAuthCloudflareToken,
+		TokenSecret:    "do-not-log-this-secret",
+	})
+
+	available, err := client.ObjectAvailable(t.Context(), client.Bucket(), "poster.webp")
+	if err == nil || available {
+		t.Fatalf("ObjectAvailable() = %v, %v, want false and an auth-path error", available, err)
+	}
+	if strings.Contains(err.Error(), "verify=") || strings.Contains(err.Error(), "do-not-log-this-secret") {
+		t.Fatalf("ObjectAvailable() error leaked delivery credentials: %v", err)
+	}
+}
+
 func TestClientEffectivePresignTTLClampsCloudflareTokenTTL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/s3client/client_test.go
+++ b/internal/s3client/client_test.go
@@ -338,30 +338,37 @@ func TestClientObjectAvailableUsesExternalDeliveryPath(t *testing.T) {
 	}
 }
 
-func TestClientObjectAvailableUsesStorageForPresignedURLs(t *testing.T) {
+func TestClientObjectAvailableUsesStorageWithoutExternalDelivery(t *testing.T) {
 	t.Parallel()
 
-	srv := newS3TestServer(t)
-	client := NewClient(BucketConfig{
-		Endpoint:  srv.URL(),
-		Region:    "us-east-1",
-		Bucket:    "silo",
-		AccessKey: "test",
-		SecretKey: "test",
-		PathStyle: true,
-		URLAuth:   URLAuthPresigned,
-	})
+	for _, authMode := range []string{URLAuthPresigned, URLAuthPublic, URLAuthCloudflareToken} {
+		t.Run(authMode, func(t *testing.T) {
+			srv := newS3TestServer(t)
+			client := NewClient(BucketConfig{
+				Endpoint:  srv.URL(),
+				Region:    "us-east-1",
+				Bucket:    "silo",
+				AccessKey: "test",
+				SecretKey: "test",
+				PathStyle: true,
+				URLAuth:   authMode,
+			})
 
-	available, err := client.ObjectAvailable(t.Context(), client.Bucket(), "poster.webp")
-	if err != nil || !available {
-		t.Fatalf("ObjectAvailable() = %v, %v, want true, nil", available, err)
-	}
-	requests := srv.Requests()
-	if !containsRequest(requests, http.MethodHead, "/silo/poster.webp", "") {
-		t.Fatalf("requests = %#v, want storage HEAD", requests)
-	}
-	if containsRequest(requests, http.MethodGet, "/silo/poster.webp", "") {
-		t.Fatalf("requests = %#v, do not want a delivery GET for presigned S3", requests)
+			if client.UsesExternalDelivery() {
+				t.Fatal("UsesExternalDelivery() = true without a public endpoint")
+			}
+			available, err := client.ObjectAvailable(t.Context(), client.Bucket(), "poster.webp")
+			if err != nil || !available {
+				t.Fatalf("ObjectAvailable() = %v, %v, want true, nil", available, err)
+			}
+			requests := srv.Requests()
+			if !containsRequest(requests, http.MethodHead, "/silo/poster.webp", "") {
+				t.Fatalf("requests = %#v, want storage HEAD", requests)
+			}
+			if containsRequest(requests, http.MethodGet, "/silo/poster.webp", "") {
+				t.Fatalf("requests = %#v, do not want a delivery GET without external delivery", requests)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Related issue: #825

When public or token-authenticated artwork delivery was configured, the image
ladder treated a successful S3 `HeadObject` as proof that the client-facing URL
worked. A large poster, still, or logo could therefore be selected even when
that public URL returned 404 and a lower rung was available.

## Approach

- Add an S3 availability check that uses the generated client-facing URL for
  public and Cloudflare-token delivery. It sends a bounded `GET` with
  `Range: bytes=0-0` and requires both a successful status and a readable byte.
- Keep standard S3-presigned delivery on the existing `HeadObject` path.
- Walk to a verified lower rung on 404/410. For transport, authentication,
  rate-limit, or server errors, warn and select the next established rung
  without repeating the failure for every candidate.
- Revalidate externally delivered wide rungs after 15 minutes and align the
  resolved-URL cache expiry with that check, so a recovered large rung can be
  promoted.
- Keep `large` in the capability response: it remains a supported request
  semantic even when a particular item temporarily resolves to a narrower
  image.

The server-side probe may reach a different CDN edge from the client. It fixes
the observed storage-versus-public-delivery mismatch, but cannot rule out a
transient failure isolated to another edge.

## Validation

All of these commands passed:

```shell
go test ./internal/metadata ./internal/s3client -run '^(TestLadderFallback|TestClientObjectAvailable)' -count=1
go test -race ./internal/metadata ./internal/s3client -run '^(TestLadderFallback|TestClientObjectAvailable)' -count=1
make embed-stub
go build ./...
gofmt -l .
go vet ./...
golangci-lint run --allow-parallel-runners --new-from-merge-base="origin/main" ./...
make test-go
cd web
pnpm install --frozen-lockfile
pnpm run lint
pnpm run format:check
pnpm run build
cd ..
make test-web
make verify-settings-bindings-all
make verify-playback-fixtures
make verify-local-paths
```

Changed-line lint reported `0 issues`. The web suite passed 350 files and 2,954
tests; web lint exited successfully with the repository's existing warnings.

The regression test models the reported boundary directly: storage says the
large key exists, its client-delivery check fails, and the medium delivery check
succeeds for poster, still, and logo roles.

Not run: live CDN or physical tvOS validation. The delivery path is covered with
synthetic `httptest` endpoints, including Cloudflare-token URL generation,
range GETs, 404 fallback, 403 handling, and credential-redaction checks.

## Risks

- Cold external wide-rung candidates add bounded range GETs and are rechecked
  every 15 minutes per server process. A 404 can walk to lower candidates;
  transport and status errors stop after one request. Checks remain
  concurrency-limited.
- A CDN can route the server probe and a remote client to different edges, so
  edge-local failures remain possible.
- PR #774 replaces this direct artwork-delivery path and will need the same
  behavior revalidated if it lands first.
- This does not resolve #806. That issue reports an HTTP-200 legacy `w300` image
  that tvOS does not render, plus separate ladder-backfill queue starvation.

## AI Disclosure

- Tool(s): T3 Code (Codex harness); Claude Code through CLIProxy
- Model(s): `gpt-5.6-sol`; `fable`
- Involvement: AI-assisted
- Adversarial review: Fable reviewed the scoped diff for correctness, concurrency, cache behavior, security, and operational load. It identified repeated five-second probes during endpoint failures and silent 401/403 downgrades. The implementation now performs one bounded probe on non-missing errors, emits an operator-visible warning, treats non-404/410 statuses as errors, tests token redaction, and documents the remaining CDN-edge limitation.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved image delivery validation for public and authenticated URLs.
  * Image selection now falls back to an available lower-resolution image when delivery checks fail.
  * Recovered image resolutions are automatically restored when delivery becomes available again.
  * URL expiration is adjusted based on revalidation timing.

* **Bug Fixes**
  * Prevented repeated delivery checks after an endpoint reports an outage.
  * Improved handling of unavailable, expired, and partially delivered images.

* **Documentation**
  * Clarified how public and authenticated image availability is validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->