### PR TITLE
feat(admin): add bulk collection and section deletion

### DIFF
--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -377,17 +377,25 @@ func (h *SectionHandler) HandleDeleteSection(w http.ResponseWriter, r *http.Requ
 
 	existing, err := h.repo.GetByID(r.Context(), id)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "not_found", "Section not found")
+		writeSectionDeleteError(w, err)
 		return
 	}
 	collectionID := strings.TrimSpace(sections.ParseCollectionConfig(existing.Config).LibraryCollectionID)
 
 	if err := h.repo.Delete(r.Context(), id); err != nil {
-		writeError(w, http.StatusNotFound, "not_found", "Section not found")
+		writeSectionDeleteError(w, err)
 		return
 	}
 	h.deleteUnreferencedSectionManagedCollection(r.Context(), collectionID)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func writeSectionDeleteError(w http.ResponseWriter, err error) {
+	if errors.Is(err, sections.ErrSectionNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "Section not found")
+		return
+	}
+	writeError(w, http.StatusInternalServerError, "internal_error", "Failed to delete section")
 }
 
 func (h *SectionHandler) deleteUnreferencedSectionManagedCollection(ctx context.Context, collectionID string) {

--- a/internal/api/handlers/sections_test.go
+++ b/internal/api/handlers/sections_test.go
@@ -89,6 +89,37 @@ func TestSectionBackdropPathUsesExpectedVariants(t *testing.T) {
 	}
 }
 
+func TestWriteSectionDeleteErrorDistinguishesMissingSectionsFromRepositoryFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{
+			name:       "missing section",
+			err:        fmt.Errorf("loading section: %w", sections.ErrSectionNotFound),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "repository failure",
+			err:        fmt.Errorf("database unavailable"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+
+			writeSectionDeleteError(recorder, tt.err)
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", recorder.Code, tt.wantStatus, recorder.Body.String())
+			}
+		})
+	}
+}
+
 func TestBuildSectionsResponseEnrichesEpisodeMetadata(t *testing.T) {
 	seasonNumber := 1
 	episodeNumber := 1

--- a/web/src/components/BulkSelectionCheckbox.tsx
+++ b/web/src/components/BulkSelectionCheckbox.tsx
@@ -1,0 +1,25 @@
+interface BulkSelectionCheckboxProps {
+  label: string;
+  selected: boolean;
+  onSelectionChange: (checked: boolean, extendRange: boolean) => void;
+}
+
+export function BulkSelectionCheckbox({
+  label,
+  selected,
+  onSelectionChange,
+}: BulkSelectionCheckboxProps) {
+  return (
+    <input
+      type="checkbox"
+      className="accent-primary size-4 shrink-0 cursor-pointer"
+      checked={selected}
+      aria-label={label}
+      onClick={(event) => event.stopPropagation()}
+      onChange={(event) => {
+        const shiftKey = event.nativeEvent instanceof MouseEvent && event.nativeEvent.shiftKey;
+        onSelectionChange(event.target.checked, shiftKey);
+      }}
+    />
+  );
+}

--- a/web/src/components/collections/admin/CollectionRow.test.tsx
+++ b/web/src/components/collections/admin/CollectionRow.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LibraryCollection } from "@/api/types";
+
+import { CollectionRow } from "./CollectionRow";
+
+const selection = vi.hoisted(() => ({
+  selectOnly: vi.fn(),
+  toggleOne: vi.fn(),
+  selectRange: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("./GroupsBoard", () => ({
+  useSelection: () => ({
+    isSelected: () => false,
+    selectOnly: selection.selectOnly,
+    toggleOne: selection.toggleOne,
+    selectRange: selection.selectRange,
+  }),
+}));
+
+const collection = {
+  id: "collection-two",
+  title: "Collection Two",
+  collection_type: "manual",
+  item_count: 2,
+} as LibraryCollection;
+
+function renderRow() {
+  return render(
+    <CollectionRow
+      collection={collection}
+      parentGroupID="group-one"
+      parentCollectionIDs={["collection-one", "collection-two", "collection-three"]}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onSync={vi.fn()}
+    />,
+  );
+}
+
+describe("CollectionRow selection", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("toggles only its checkbox on a normal click", () => {
+    renderRow();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Collection Two" }));
+
+    expect(selection.toggleOne).toHaveBeenCalledWith("collection-two", "collection", "group-one");
+    expect(selection.selectOnly).not.toHaveBeenCalled();
+    expect(selection.selectRange).not.toHaveBeenCalled();
+  });
+
+  it("selects through the anchor on a shift-click", () => {
+    renderRow();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Collection Two" }), {
+      shiftKey: true,
+    });
+
+    expect(selection.selectRange).toHaveBeenCalledWith(
+      "collection-two",
+      "collection",
+      "group-one",
+      ["collection-one", "collection-two", "collection-three"],
+      true,
+    );
+    expect(selection.selectOnly).not.toHaveBeenCalled();
+    expect(selection.toggleOne).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/collections/admin/CollectionRow.tsx
+++ b/web/src/components/collections/admin/CollectionRow.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useSelection, type SelectionKind } from "./GroupsBoard";
+import { BulkSelectionCheckbox } from "@/components/BulkSelectionCheckbox";
 
 export interface CollectionRowProps {
   collection: LibraryCollection;
@@ -60,6 +61,14 @@ export function CollectionRow({
     }
   }
 
+  function onSelectionChange(checked: boolean, extendRange: boolean) {
+    if (extendRange) {
+      selectRange(collection.id, kind, parentGroupID, parentCollectionIDs, checked);
+    } else {
+      toggleOne(collection.id, kind, parentGroupID);
+    }
+  }
+
   return (
     <div
       ref={setNodeRef}
@@ -70,6 +79,11 @@ export function CollectionRow({
         selected && "bg-primary/10 border-l-primary border-l-2",
       )}
     >
+      <BulkSelectionCheckbox
+        label={`Select ${collection.title}`}
+        selected={selected}
+        onSelectionChange={onSelectionChange}
+      />
       <button
         type="button"
         {...attributes}

--- a/web/src/components/collections/admin/GroupsBoard.tsx
+++ b/web/src/components/collections/admin/GroupsBoard.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useContext, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -17,6 +18,7 @@ import {
 } from "@/hooks/queries/admin/collectionGroups";
 import { GroupCard } from "./GroupCard";
 import { UngroupedSection } from "./UngroupedSection";
+import { updateCheckboxSelection } from "@/lib/checkboxSelection";
 
 // ---------------------------------------------------------------------------
 // Selection context
@@ -30,8 +32,6 @@ interface AnchorRef {
 }
 
 export interface SelectionContextValue {
-  selectedIds: Set<string>;
-  selectionKind: SelectionKind | null;
   isSelected: (id: string) => boolean;
   selectOnly: (id: string, kind: SelectionKind, groupID: string) => void;
   toggleOne: (id: string, kind: SelectionKind, groupID: string) => void;
@@ -40,8 +40,8 @@ export interface SelectionContextValue {
     kind: SelectionKind,
     groupID: string,
     groupCollectionIDs: string[],
+    checked?: boolean,
   ) => void;
-  clear: () => void;
 }
 
 export const SelectionContext = createContext<SelectionContextValue | null>(null);
@@ -71,6 +71,8 @@ export interface GroupsBoardProps {
   onEditCollection: (collection: LibraryCollection) => void;
   onDeleteCollection: (collection: LibraryCollection) => void;
   onSyncCollection: (collection: LibraryCollection) => void;
+  selectedIds: Set<string>;
+  setSelectedIds: Dispatch<SetStateAction<Set<string>>>;
   syncingCollectionID?: string | null;
 }
 
@@ -87,27 +89,35 @@ export function GroupsBoard({
   onEditCollection,
   onDeleteCollection,
   onSyncCollection,
+  selectedIds,
+  setSelectedIds,
   syncingCollectionID = null,
 }: GroupsBoardProps) {
   // --- selection state ---
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [selectionKind, setSelectionKind] = useState<SelectionKind | null>(null);
+  const selectionKindRef = useRef<SelectionKind | null>(null);
   const anchorRef = useRef<AnchorRef | null>(null);
 
   const isSelected = (id: string) => selectedIds.has(id);
 
-  const selectOnly = (id: string, kind: SelectionKind, groupID: string) => {
-    setSelectedIds(new Set([id]));
-    setSelectionKind(kind);
+  const setSelectionAnchor = (id: string, kind: SelectionKind, groupID: string) => {
+    selectionKindRef.current = kind;
     anchorRef.current = { id, groupID };
   };
 
+  const selectOnly = (id: string, kind: SelectionKind, groupID: string) => {
+    setSelectedIds(new Set([id]));
+    setSelectionAnchor(id, kind, groupID);
+  };
+
   const toggleOne = (id: string, kind: SelectionKind, groupID: string) => {
-    if (selectionKind !== null && kind !== selectionKind) {
+    if (
+      selectedIds.size > 0 &&
+      selectionKindRef.current !== null &&
+      kind !== selectionKindRef.current
+    ) {
       // cross-kind: replace with just this item
       setSelectedIds(new Set([id]));
-      setSelectionKind(kind);
-      anchorRef.current = { id, groupID };
+      setSelectionAnchor(id, kind, groupID);
       return;
     }
     setSelectedIds((prev) => {
@@ -119,8 +129,7 @@ export function GroupsBoard({
       }
       return next;
     });
-    setSelectionKind(kind);
-    anchorRef.current = { id, groupID };
+    setSelectionAnchor(id, kind, groupID);
   };
 
   const selectRange = (
@@ -128,59 +137,49 @@ export function GroupsBoard({
     kind: SelectionKind,
     groupID: string,
     groupCollectionIDs: string[],
+    checked = true,
   ) => {
     const anchor = anchorRef.current;
     if (
+      selectedIds.size === 0 ||
       !anchor ||
       anchor.groupID !== groupID ||
-      (selectionKind !== null && kind !== selectionKind)
+      !groupCollectionIDs.includes(anchor.id) ||
+      !groupCollectionIDs.includes(id) ||
+      (selectionKindRef.current !== null && kind !== selectionKindRef.current)
     ) {
-      // No valid anchor in this group — fall back to selectOnly
-      selectOnly(id, kind, groupID);
+      // Start a new range from this row.
+      if (checked) {
+        setSelectedIds(new Set([id]));
+      } else {
+        setSelectedIds((previous) => {
+          const next = new Set(previous);
+          next.delete(id);
+          return next;
+        });
+      }
+      setSelectionAnchor(id, kind, groupID);
       return;
     }
-    const anchorIdx = groupCollectionIDs.indexOf(anchor.id);
-    const currentIdx = groupCollectionIDs.indexOf(id);
-    if (anchorIdx === -1 || currentIdx === -1) {
-      selectOnly(id, kind, groupID);
-      return;
-    }
-    const lo = Math.min(anchorIdx, currentIdx);
-    const hi = Math.max(anchorIdx, currentIdx);
-    const rangeIds = groupCollectionIDs.slice(lo, hi + 1);
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      for (const rid of rangeIds) next.add(rid);
-      return next;
-    });
-    setSelectionKind(kind);
+    setSelectedIds((previous) =>
+      updateCheckboxSelection(previous, groupCollectionIDs, anchor.id, id, checked, true),
+    );
+    selectionKindRef.current = kind;
     // anchor stays unchanged on range extends
   };
 
-  const clear = () => {
+  const clearSelection = () => {
     setSelectedIds(new Set());
-    setSelectionKind(null);
+    selectionKindRef.current = null;
     anchorRef.current = null;
   };
 
   const selection: SelectionContextValue = {
-    selectedIds,
-    selectionKind,
     isSelected,
     selectOnly,
     toggleOne,
     selectRange,
-    clear,
   };
-
-  // --- Escape key to clear selection ---
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") clear();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, []);
 
   // --- dnd state ---
   const sensors = useSensors(
@@ -210,7 +209,7 @@ export function GroupsBoard({
         setDraggedIds(flattenedSelectionInVisualOrder(groups, ungrouped, selectedIds));
       } else {
         // Dragging an unselected row — clear selection, drag just this one
-        clear();
+        clearSelection();
         setDraggedIds([aData.id]);
       }
     } else {
@@ -311,7 +310,7 @@ export function GroupsBoard({
       });
 
       // Clear selection after successful drop
-      clear();
+      clearSelection();
     }
 
     setDraggedIds([]);

--- a/web/src/components/sections/EditableSectionRows.test.tsx
+++ b/web/src/components/sections/EditableSectionRows.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SortableSectionTableRow } from "./EditableSectionRows";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+function renderRow(onSelectionChange: (checked: boolean, extendRange: boolean) => void) {
+  return render(
+    <table>
+      <tbody>
+        <SortableSectionTableRow
+          section={{
+            id: "section-two",
+            title: "Section Two",
+            sectionType: "recently_added",
+            itemLimit: 12,
+            featured: false,
+            enabled: true,
+          }}
+          canReorder={false}
+          libraries={[]}
+          collectionLabels={new Map()}
+          selected={false}
+          selectionLabel="Select Section Two home section"
+          onSelectionChange={onSelectionChange}
+          onEdit={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+describe("SortableSectionTableRow selection", () => {
+  it("selects only its checkbox on a normal click", () => {
+    const onSelectionChange = vi.fn();
+    renderRow(onSelectionChange);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Section Two home section" }));
+
+    expect(onSelectionChange).toHaveBeenCalledWith(true, false);
+  });
+
+  it("requests a range selection on a shift-click", () => {
+    const onSelectionChange = vi.fn();
+    renderRow(onSelectionChange);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Section Two home section" }), {
+      shiftKey: true,
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledWith(true, true);
+  });
+});

--- a/web/src/components/sections/EditableSectionRows.tsx
+++ b/web/src/components/sections/EditableSectionRows.tsx
@@ -9,6 +9,7 @@ import { Eye, EyeOff, GripVertical, Pencil, Star, Trash2 } from "lucide-react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { TableCell, TableRow } from "@/components/ui/table";
+import { BulkSelectionCheckbox } from "@/components/BulkSelectionCheckbox";
 
 export interface EditableSectionViewModel {
   id: string;
@@ -130,6 +131,9 @@ export function SortableSectionTableRow({
   libraries,
   collectionLabels,
   catalog,
+  selected,
+  selectionLabel,
+  onSelectionChange,
   onEdit,
   onDelete,
 }: {
@@ -138,6 +142,9 @@ export function SortableSectionTableRow({
   libraries: Library[];
   collectionLabels: Map<string, string>;
   catalog?: RecipeCatalogResponse;
+  selected: boolean;
+  selectionLabel: string;
+  onSelectionChange: (checked: boolean, extendRange: boolean) => void;
   onEdit: () => void;
   onDelete: () => void;
 }) {
@@ -152,7 +159,14 @@ export function SortableSectionTableRow({
   };
 
   return (
-    <TableRow ref={setNodeRef} style={style}>
+    <TableRow ref={setNodeRef} style={style} data-state={selected ? "selected" : undefined}>
+      <TableCell className="w-10">
+        <BulkSelectionCheckbox
+          label={selectionLabel}
+          selected={selected}
+          onSelectionChange={onSelectionChange}
+        />
+      </TableCell>
       <TableCell>
         {canReorder ? (
           <button

--- a/web/src/hooks/queries/admin/collections.test.tsx
+++ b/web/src/hooks/queries/admin/collections.test.tsx
@@ -1,0 +1,157 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ApiClientError } from "@/api/client";
+import { useDeleteAdminCollections } from "./collections";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const invalidateAdminCollectionQueriesMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastWarningMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return { ...actual, api: apiMock };
+});
+
+vi.mock("../collectionSurfaceRefresh", () => ({
+  invalidateAdminCollectionQueries: invalidateAdminCollectionQueriesMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    warning: toastWarningMock,
+    error: toastErrorMock,
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function renderDeleteCollectionsHook() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useDeleteAdminCollections(), { wrapper });
+}
+
+describe("useDeleteAdminCollections", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deduplicates collection IDs and limits each request batch to four", async () => {
+    const firstBatch = deferred<void>();
+    apiMock
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockResolvedValue(undefined);
+    invalidateAdminCollectionQueriesMock.mockResolvedValue(undefined);
+    const { result } = renderDeleteCollectionsHook();
+
+    let mutation!: Promise<unknown>;
+    act(() => {
+      mutation = result.current.mutateAsync([
+        "collection-1",
+        "collection-2",
+        "collection-3",
+        "collection-4",
+        "collection-5",
+        "collection-6",
+        "collection-1",
+      ]);
+    });
+
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(4));
+    expect(result.current.progress).toEqual({ completed: 0, total: 6 });
+    await act(async () => {
+      firstBatch.resolve();
+      await mutation;
+    });
+
+    expect(apiMock.mock.calls).toEqual([
+      ["/admin/collections/collection-1", { method: "DELETE" }],
+      ["/admin/collections/collection-2", { method: "DELETE" }],
+      ["/admin/collections/collection-3", { method: "DELETE" }],
+      ["/admin/collections/collection-4", { method: "DELETE" }],
+      ["/admin/collections/collection-5", { method: "DELETE" }],
+      ["/admin/collections/collection-6", { method: "DELETE" }],
+    ]);
+    expect(result.current.progress).toBeNull();
+    expect(toastSuccessMock).toHaveBeenCalledWith("Deleted 6 collections");
+    expect(invalidateAdminCollectionQueriesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues after an unexpected failure and reports the partial result", async () => {
+    apiMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Collection is used by one or more sections"))
+      .mockResolvedValueOnce(undefined);
+    invalidateAdminCollectionQueriesMock.mockResolvedValue(undefined);
+    const { result } = renderDeleteCollectionsHook();
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.mutateAsync(["collection-1", "collection-2", "collection-3"]);
+    });
+
+    expect(response).toEqual({
+      requested: 3,
+      deleted: 2,
+      kept: 0,
+      failed: 1,
+      firstError: "Collection is used by one or more sections",
+    });
+    expect(apiMock).toHaveBeenCalledTimes(3);
+    expect(toastWarningMock).toHaveBeenCalledWith("Deleted 2 of 3 collections", {
+      description: "Collection is used by one or more sections",
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(invalidateAdminCollectionQueriesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats missing collections as cleared and reports protected collections as kept", async () => {
+    apiMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new ApiClientError(404, "not_found", "Collection not found"))
+      .mockRejectedValueOnce(
+        new ApiClientError(409, "collection_in_use", "Collection is used by one or more sections"),
+      );
+    invalidateAdminCollectionQueriesMock.mockResolvedValue(undefined);
+    const { result } = renderDeleteCollectionsHook();
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.mutateAsync(["collection-1", "collection/2", "collection-3"]);
+    });
+
+    expect(response).toEqual({
+      requested: 3,
+      deleted: 2,
+      kept: 1,
+      failed: 0,
+      firstError: undefined,
+    });
+    expect(apiMock).toHaveBeenNthCalledWith(2, "/admin/collections/collection%2F2", {
+      method: "DELETE",
+    });
+    expect(toastWarningMock).toHaveBeenCalledWith("Deleted 2 collections", {
+      description: "Kept 1 collection in use by home or library sections",
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/queries/admin/collections.ts
+++ b/web/src/hooks/queries/admin/collections.ts
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ApiClientError, api } from "@/api/client";
@@ -24,6 +25,7 @@ import type {
 } from "@/lib/collectionTemplates";
 import { adminKeys, sectionKeys } from "../keys";
 import { invalidateAdminCollectionQueries } from "../collectionSurfaceRefresh";
+import { runBulkDelete, type BulkDeleteProgress } from "../bulkDelete";
 
 const ADMIN_STALE_TIME = 30_000;
 
@@ -264,6 +266,64 @@ export function useDeleteAdminCollection() {
       toast.error(error instanceof Error ? error.message : "Failed to delete");
     },
   });
+}
+
+export function useDeleteAdminCollections() {
+  const queryClient = useQueryClient();
+  const [progress, setProgress] = useState<BulkDeleteProgress | null>(null);
+
+  const mutation = useMutation({
+    onMutate: (ids) => {
+      setProgress({ completed: 0, total: new Set(ids).size });
+    },
+    mutationFn: (ids: string[]) =>
+      runBulkDelete(
+        ids,
+        (id) =>
+          api<void>(`/admin/collections/${encodeURIComponent(id)}`, {
+            method: "DELETE",
+          }),
+        (error) => {
+          if (error instanceof ApiClientError && error.status === 404) {
+            return "deleted";
+          }
+          if (
+            error instanceof ApiClientError &&
+            error.status === 409 &&
+            error.code === "collection_in_use"
+          ) {
+            return "kept";
+          }
+          return "failed";
+        },
+        setProgress,
+      ),
+    onSuccess: async ({ requested, deleted, kept, failed, firstError }) => {
+      const keptDescription = `Kept ${kept} collection${kept === 1 ? "" : "s"} in use by home or library sections`;
+
+      if (failed === 0 && kept === 0) {
+        toast.success(`Deleted ${deleted} collection${deleted === 1 ? "" : "s"}`);
+      } else if (failed === 0) {
+        toast.warning(`Deleted ${deleted} collection${deleted === 1 ? "" : "s"}`, {
+          description: keptDescription,
+        });
+      } else if (deleted > 0 || kept > 0) {
+        toast.warning(`Deleted ${deleted} of ${requested} collections`, {
+          description: [kept > 0 ? keptDescription : "", firstError].filter(Boolean).join(". "),
+        });
+      } else {
+        toast.error(`Failed to delete ${failed} collection${failed === 1 ? "" : "s"}`, {
+          description: firstError,
+        });
+      }
+      await invalidateAdminCollectionQueries(queryClient);
+    },
+    onSettled: () => {
+      setProgress(null);
+    },
+  });
+
+  return { ...mutation, progress };
 }
 
 export interface ReorderAdminCollectionsArgs {

--- a/web/src/hooks/queries/bulkDelete.ts
+++ b/web/src/hooks/queries/bulkDelete.ts
@@ -1,0 +1,65 @@
+export interface BulkDeleteResult {
+  requested: number;
+  deleted: number;
+  kept: number;
+  failed: number;
+  firstError?: string;
+}
+
+export interface BulkDeleteProgress {
+  completed: number;
+  total: number;
+}
+
+type RejectedDeleteOutcome = "deleted" | "kept" | "failed";
+
+const BULK_DELETE_BATCH_SIZE = 4;
+
+export async function runBulkDelete(
+  ids: string[],
+  deleteOne: (id: string) => Promise<unknown>,
+  classifyRejection: (error: unknown) => RejectedDeleteOutcome,
+  onProgress: (progress: BulkDeleteProgress) => void,
+): Promise<BulkDeleteResult> {
+  const uniqueIds = [...new Set(ids)];
+  let deleted = 0;
+  let kept = 0;
+  let failed = 0;
+  let firstError: string | undefined;
+
+  for (let offset = 0; offset < uniqueIds.length; offset += BULK_DELETE_BATCH_SIZE) {
+    const batch = uniqueIds.slice(offset, offset + BULK_DELETE_BATCH_SIZE);
+    const results = await Promise.allSettled(batch.map((id) => deleteOne(id)));
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        deleted += 1;
+        continue;
+      }
+      const outcome = classifyRejection(result.reason);
+      if (outcome === "deleted") {
+        deleted += 1;
+      } else if (outcome === "kept") {
+        kept += 1;
+      } else {
+        if (failed === 0 && result.reason instanceof Error) {
+          firstError = result.reason.message;
+        }
+        failed += 1;
+      }
+    }
+
+    onProgress({
+      completed: Math.min(offset + batch.length, uniqueIds.length),
+      total: uniqueIds.length,
+    });
+  }
+
+  return {
+    requested: uniqueIds.length,
+    deleted,
+    kept,
+    failed,
+    firstError,
+  };
+}

--- a/web/src/hooks/queries/sections.ts
+++ b/web/src/hooks/queries/sections.ts
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/api/client";
+import { toast } from "sonner";
+import { ApiClientError, api } from "@/api/client";
 import type {
   SectionsResponse,
   HomeLayoutResponse,
@@ -13,6 +15,7 @@ import type {
 } from "@/api/types";
 import { sectionKeys } from "./keys";
 import { invalidateAdminCollectionQueries } from "./collectionSurfaceRefresh";
+import { runBulkDelete, type BulkDeleteProgress } from "./bulkDelete";
 
 /**
  * Home section data outlives the default client-wide gcTime on purpose.
@@ -206,6 +209,49 @@ export function useDeleteSection() {
       void invalidateAdminCollectionQueries(qc);
     },
   });
+}
+
+export function useDeleteSections() {
+  const qc = useQueryClient();
+  const [progress, setProgress] = useState<BulkDeleteProgress | null>(null);
+
+  const mutation = useMutation({
+    onMutate: (ids) => {
+      setProgress({ completed: 0, total: new Set(ids).size });
+    },
+    mutationFn: (ids: string[]) =>
+      runBulkDelete(
+        ids,
+        (id) =>
+          api<void>(`/admin/sections/${encodeURIComponent(id)}`, {
+            method: "DELETE",
+          }),
+        (error) => (error instanceof ApiClientError && error.status === 404 ? "deleted" : "failed"),
+        setProgress,
+      ),
+    onSuccess: async ({ requested, deleted, failed, firstError }) => {
+      if (failed === 0) {
+        toast.success(`Deleted ${deleted} section${deleted === 1 ? "" : "s"}`);
+      } else if (deleted > 0) {
+        toast.warning(`Deleted ${deleted} of ${requested} sections`, {
+          description: firstError,
+        });
+      } else {
+        toast.error(`Failed to delete ${failed} section${failed === 1 ? "" : "s"}`, {
+          description: firstError,
+        });
+      }
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: sectionKeys.all }),
+        invalidateAdminCollectionQueries(qc),
+      ]);
+    },
+    onSettled: () => {
+      setProgress(null);
+    },
+  });
+
+  return { ...mutation, progress };
 }
 
 export function useReorderSections() {

--- a/web/src/hooks/queries/sectionsBulkDelete.test.tsx
+++ b/web/src/hooks/queries/sectionsBulkDelete.test.tsx
@@ -1,0 +1,131 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ApiClientError } from "@/api/client";
+import { sectionKeys } from "./keys";
+import { useDeleteSections } from "./sections";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const invalidateAdminCollectionQueriesMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastWarningMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/api/client")>("@/api/client");
+  return { ...actual, api: apiMock };
+});
+
+vi.mock("./collectionSurfaceRefresh", () => ({
+  invalidateAdminCollectionQueries: invalidateAdminCollectionQueriesMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    warning: toastWarningMock,
+    error: toastErrorMock,
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function renderDeleteSectionsHook() {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { ...renderHook(() => useDeleteSections(), { wrapper }), invalidateQueries };
+}
+
+describe("useDeleteSections", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deduplicates section IDs and limits each request batch to four", async () => {
+    const firstBatch = deferred<void>();
+    apiMock
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockResolvedValue(undefined);
+    invalidateAdminCollectionQueriesMock.mockResolvedValue(undefined);
+    const { result, invalidateQueries } = renderDeleteSectionsHook();
+
+    let mutation!: Promise<unknown>;
+    act(() => {
+      mutation = result.current.mutateAsync([
+        "section-1",
+        "section-2",
+        "section-3",
+        "section-4",
+        "section-5",
+        "section-6",
+        "section-1",
+      ]);
+    });
+
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(4));
+    expect(result.current.progress).toEqual({ completed: 0, total: 6 });
+    await act(async () => {
+      firstBatch.resolve();
+      await mutation;
+    });
+
+    expect(apiMock.mock.calls).toEqual([
+      ["/admin/sections/section-1", { method: "DELETE" }],
+      ["/admin/sections/section-2", { method: "DELETE" }],
+      ["/admin/sections/section-3", { method: "DELETE" }],
+      ["/admin/sections/section-4", { method: "DELETE" }],
+      ["/admin/sections/section-5", { method: "DELETE" }],
+      ["/admin/sections/section-6", { method: "DELETE" }],
+    ]);
+    expect(result.current.progress).toBeNull();
+    expect(toastSuccessMock).toHaveBeenCalledWith("Deleted 6 sections");
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: sectionKeys.all });
+    expect(invalidateAdminCollectionQueriesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats missing sections as deleted and reports unexpected failures", async () => {
+    apiMock
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new ApiClientError(404, "not_found", "Section not found"))
+      .mockRejectedValueOnce(new ApiClientError(500, "internal_error", "Database unavailable"));
+    invalidateAdminCollectionQueriesMock.mockResolvedValue(undefined);
+    const { result } = renderDeleteSectionsHook();
+
+    let response: unknown;
+    await act(async () => {
+      response = await result.current.mutateAsync(["section-1", "section/2", "section-3"]);
+    });
+
+    expect(response).toEqual({
+      requested: 3,
+      deleted: 2,
+      kept: 0,
+      failed: 1,
+      firstError: "Database unavailable",
+    });
+    expect(apiMock).toHaveBeenNthCalledWith(2, "/admin/sections/section%2F2", {
+      method: "DELETE",
+    });
+    expect(toastWarningMock).toHaveBeenCalledWith("Deleted 2 of 3 sections", {
+      description: "Database unavailable",
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(invalidateAdminCollectionQueriesMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/checkboxSelection.test.ts
+++ b/web/src/lib/checkboxSelection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { updateCheckboxSelection } from "./checkboxSelection";
+
+describe("updateCheckboxSelection", () => {
+  const order = ["one", "two", "three", "four"];
+
+  it("toggles one item without replacing the existing selection", () => {
+    expect([
+      ...updateCheckboxSelection(new Set(["one"]), order, "one", "three", true, false),
+    ]).toEqual(["one", "three"]);
+    expect([
+      ...updateCheckboxSelection(new Set(["one", "three"]), order, "three", "one", false, false),
+    ]).toEqual(["three"]);
+  });
+
+  it("selects an inclusive range when shift-clicking an unchecked item", () => {
+    expect([
+      ...updateCheckboxSelection(new Set(["one"]), order, "one", "three", true, true),
+    ]).toEqual(["one", "two", "three"]);
+  });
+
+  it("clears an inclusive range when shift-clicking a checked item", () => {
+    expect([
+      ...updateCheckboxSelection(
+        new Set(["one", "two", "three", "four"]),
+        order,
+        "one",
+        "three",
+        false,
+        true,
+      ),
+    ]).toEqual(["four"]);
+  });
+
+  it("falls back to changing one item when the anchor is no longer visible", () => {
+    expect([
+      ...updateCheckboxSelection(new Set(["outside"]), order, "outside", "three", true, true),
+    ]).toEqual(["outside", "three"]);
+  });
+
+  it("uses visual row occurrences when one item appears more than once", () => {
+    const rows = ["1:shared", "1:alpha", "2:beta", "2:shared"];
+    const collectionIdByRow = new Map([
+      ["1:shared", "shared"],
+      ["1:alpha", "alpha"],
+      ["2:beta", "beta"],
+      ["2:shared", "shared"],
+    ]);
+
+    expect([
+      ...updateCheckboxSelection(
+        new Set(["beta"]),
+        rows,
+        "2:beta",
+        "2:shared",
+        true,
+        true,
+        (rowId) => collectionIdByRow.get(rowId) ?? rowId,
+      ),
+    ]).toEqual(["beta", "shared"]);
+  });
+});

--- a/web/src/lib/checkboxSelection.ts
+++ b/web/src/lib/checkboxSelection.ts
@@ -1,0 +1,28 @@
+export function updateCheckboxSelection(
+  selectedIds: ReadonlySet<string>,
+  orderedIds: readonly string[],
+  anchorId: string | null,
+  targetId: string,
+  checked: boolean,
+  extendRange: boolean,
+  selectionIdFor: (orderedId: string) => string = (orderedId) => orderedId,
+): Set<string> {
+  const next = new Set(selectedIds);
+  const anchorIndex = anchorId === null ? -1 : orderedIds.indexOf(anchorId);
+  const targetIndex = orderedIds.indexOf(targetId);
+  const idsToUpdate =
+    extendRange && anchorIndex >= 0 && targetIndex >= 0
+      ? orderedIds.slice(Math.min(anchorIndex, targetIndex), Math.max(anchorIndex, targetIndex) + 1)
+      : [targetId];
+
+  for (const id of idsToUpdate) {
+    const selectionId = selectionIdFor(id);
+    if (checked) {
+      next.add(selectionId);
+    } else {
+      next.delete(selectionId);
+    }
+  }
+
+  return next;
+}

--- a/web/src/pages/AdminCollections.test.tsx
+++ b/web/src/pages/AdminCollections.test.tsx
@@ -1,14 +1,43 @@
 import { describe, expect, it } from "vitest";
+import type { LibraryCollection } from "@/api/types";
 
 import {
   buildAdminCollectionEditorPath,
   buildTMDBPresetSourceInput,
+  collectionsInAdminScope,
   parseTMDBPresetSourceConfig,
   toAdminCollectionBuilderValue,
   toAdminCollectionRequest,
 } from "./adminCollectionsShared";
 
 describe("AdminCollections helpers", () => {
+  it("uses the rendered board as the destructive scope for one library", () => {
+    const allCollections = [
+      { id: "all-only" },
+      { id: "ungrouped" },
+      { id: "grouped" },
+    ] as LibraryCollection[];
+    const grouped = { id: "grouped" } as LibraryCollection;
+    const ungrouped = { id: "ungrouped" } as LibraryCollection;
+
+    expect(
+      collectionsInAdminScope(
+        allCollections,
+        {
+          groups: [{ collections: [grouped] }, { collections: [grouped] }],
+          ungrouped: [ungrouped],
+        },
+        7,
+      ).map((collection) => collection.id),
+    ).toEqual(["ungrouped", "grouped"]);
+  });
+
+  it("uses the unscoped collection list when all libraries are selected", () => {
+    const allCollections = [{ id: "one" }, { id: "two" }] as LibraryCollection[];
+
+    expect(collectionsInAdminScope(allCollections, undefined, null)).toEqual(allCollections);
+  });
+
   it("seeds builder state with multi-library scope", () => {
     const draft = toAdminCollectionBuilderValue(
       {

--- a/web/src/pages/AdminCollections.tsx
+++ b/web/src/pages/AdminCollections.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import type { AdminJob, Library, LibraryCollection, LibraryCollectionGroup } from "@/api/types";
@@ -12,6 +13,7 @@ import {
 import {
   useAdminCollections,
   useDeleteAdminCollection,
+  useDeleteAdminCollections,
   useSyncAdminCollection,
   useTemplateBundleApplyJobs,
 } from "@/hooks/queries/admin/collections";
@@ -43,7 +45,9 @@ import {
   Trash2,
 } from "lucide-react";
 import { CollectionTemplateGallery } from "@/components/CollectionTemplateGallery";
-import { buildAdminCollectionEditorPath } from "./adminCollectionsShared";
+import { BulkSelectionCheckbox } from "@/components/BulkSelectionCheckbox";
+import { updateCheckboxSelection } from "@/lib/checkboxSelection";
+import { buildAdminCollectionEditorPath, collectionsInAdminScope } from "./adminCollectionsShared";
 
 export default function AdminCollections() {
   const queryClient = useQueryClient();
@@ -62,6 +66,9 @@ export default function AdminCollections() {
   const [confirmDeleteCollection, setConfirmDeleteCollection] = useState<LibraryCollection | null>(
     null,
   );
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+  const [confirmDeleteSelected, setConfirmDeleteSelected] = useState(false);
+  const [selectedCollectionIds, setSelectedCollectionIds] = useState<Set<string>>(new Set());
 
   const allCollections = useAdminCollections();
   const libraryCounts = useMemo(
@@ -69,7 +76,12 @@ export default function AdminCollections() {
     [libraries, allCollections.data],
   );
 
+  function clearCollectionSelection() {
+    setSelectedCollectionIds(new Set());
+  }
+
   const setSelectedLibraryId = (libraryId: number | null) => {
+    clearCollectionSelection();
     setSearchParams((current) => {
       const next = new URLSearchParams(current);
       if (libraryId) {
@@ -82,16 +94,25 @@ export default function AdminCollections() {
   };
 
   const board = useAdminCollectionsBoard(selectedLibraryId ?? undefined);
+  const collectionsInScope = useMemo(
+    () => collectionsInAdminScope(allCollections.data ?? [], board.data, selectedLibraryId),
+    [allCollections.data, board.data, selectedLibraryId],
+  );
+  const selectedCollections = useMemo(
+    () => collectionsInScope.filter((collection) => selectedCollectionIds.has(collection.id)),
+    [collectionsInScope, selectedCollectionIds],
+  );
   const createGroup = useCreateCollectionGroup(selectedLibraryId ?? 0);
   const updateGroup = useUpdateCollectionGroup(selectedLibraryId ?? 0);
   const deleteGroup = useDeleteCollectionGroup(selectedLibraryId ?? 0);
   const deleteCollection = useDeleteAdminCollection();
+  const deleteCollections = useDeleteAdminCollections();
   const syncCollection = useSyncAdminCollection();
   const isAllLibraries = selectedLibraryId === null;
   const applyJobs = useTemplateBundleApplyJobs();
   useEventChannel("jobs");
   const latestApplyJob = applyJobs.data?.[0] ?? null;
-  const activeApplyJob = latestApplyJob ? isActiveTemplateBundleApplyJob(latestApplyJob) : false;
+  const activeApplyJob = latestApplyJob !== null && isActiveTemplateBundleApplyJob(latestApplyJob);
   const lastInvalidatedJobID = useRef<string | null>(null);
 
   useEffect(() => {
@@ -102,6 +123,21 @@ export default function AdminCollections() {
     void invalidateAdminCollectionQueries(queryClient);
     void queryClient.invalidateQueries({ queryKey: sectionKeys.all });
   }, [activeApplyJob, latestApplyJob, queryClient]);
+
+  useEffect(() => {
+    const clearSelection = (event: KeyboardEvent) => {
+      if (
+        event.key === "Escape" &&
+        confirmDeleteCollection === null &&
+        !confirmDeleteSelected &&
+        !confirmDeleteAll
+      ) {
+        setSelectedCollectionIds(new Set());
+      }
+    };
+    window.addEventListener("keydown", clearSelection);
+    return () => window.removeEventListener("keydown", clearSelection);
+  }, [confirmDeleteAll, confirmDeleteCollection, confirmDeleteSelected]);
 
   if (allCollections.isLoading && libraries.length === 0) {
     return (
@@ -130,9 +166,35 @@ export default function AdminCollections() {
     board.data &&
     boardCollectionCount === 0 &&
     !hasRegularBoardGroups;
+  const selectedLibrary = libraries.find((library) => library.id === selectedLibraryId) ?? null;
+  const collectionDeletionNotice =
+    "Silo will keep collections that are still used by home or library sections. This action cannot be undone.";
+  const deleteAllDescription = selectedLibrary
+    ? `Delete all ${collectionsInScope.length} collections shown for ${selectedLibrary.name}? Shared collections will also be removed from their other libraries. ${collectionDeletionNotice}`
+    : `Delete all ${collectionsInScope.length} server collections? ${collectionDeletionNotice}`;
+  const deleteSelectedDescription = `Delete ${selectedCollections.length} selected collection${selectedCollections.length === 1 ? "" : "s"}? ${collectionDeletionNotice}`;
+  const deleteProgressLabel = `Deleting ${deleteCollections.progress?.completed ?? 0} of ${deleteCollections.progress?.total ?? collectionsInScope.length} collections`;
+
+  function handleDeleteSelected() {
+    if (!activeApplyJob && selectedCollections.length > 0) {
+      deleteCollections.mutate(selectedCollections.map((collection) => collection.id));
+    }
+    setConfirmDeleteSelected(false);
+  }
+
+  function handleDeleteAll() {
+    if (!activeApplyJob && collectionsInScope.length > 0) {
+      deleteCollections.mutate(collectionsInScope.map((collection) => collection.id));
+    }
+    setConfirmDeleteAll(false);
+  }
 
   return (
-    <div className="space-y-6">
+    <div
+      className="space-y-6"
+      aria-busy={deleteCollections.isPending}
+      inert={deleteCollections.isPending ? true : undefined}
+    >
       <ConfirmDialog
         open={confirmDeleteCollection !== null}
         onOpenChange={(open) => {
@@ -151,6 +213,26 @@ export default function AdminCollections() {
           }
           setConfirmDeleteCollection(null);
         }}
+      />
+
+      <ConfirmDialog
+        open={confirmDeleteSelected}
+        onOpenChange={setConfirmDeleteSelected}
+        title="Delete selected collections"
+        description={deleteSelectedDescription}
+        confirmLabel="Delete selected"
+        variant="destructive"
+        onConfirm={handleDeleteSelected}
+      />
+
+      <ConfirmDialog
+        open={confirmDeleteAll}
+        onOpenChange={setConfirmDeleteAll}
+        title="Delete all collections"
+        description={deleteAllDescription}
+        confirmLabel="Delete all"
+        variant="destructive"
+        onConfirm={handleDeleteAll}
       />
 
       <div className="page-header gap-5">
@@ -177,6 +259,37 @@ export default function AdminCollections() {
           <Button size="sm" variant="outline" onClick={() => setGalleryOpen(true)}>
             <Sparkles className="mr-1 h-4 w-4" /> Browse Templates
           </Button>
+          {selectedCollections.length > 0 ? (
+            <>
+              <Badge variant="secondary">{selectedCollections.length} selected</Badge>
+              <Button size="sm" variant="ghost" onClick={clearCollectionSelection}>
+                Clear
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={deleteCollections.isPending || activeApplyJob}
+                onClick={() => setConfirmDeleteSelected(true)}
+              >
+                <Trash2 data-icon="inline-start" /> Delete Selected
+              </Button>
+            </>
+          ) : null}
+          {collectionsInScope.length > 0 ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={deleteCollections.isPending || activeApplyJob}
+              onClick={() => setConfirmDeleteAll(true)}
+            >
+              {deleteCollections.isPending ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="mr-1 h-4 w-4" />
+              )}
+              {deleteCollections.isPending ? `${deleteProgressLabel}…` : "Delete All"}
+            </Button>
+          ) : null}
           <Button
             size="sm"
             onClick={() => navigate(buildAdminCollectionEditorPath("new", selectedLibraryId))}
@@ -200,6 +313,8 @@ export default function AdminCollections() {
           libraries={libraries}
           collections={allCollections.data ?? []}
           isLoading={allCollections.isLoading}
+          selectedIds={selectedCollectionIds}
+          setSelectedIds={setSelectedCollectionIds}
           syncingCollectionID={syncCollection.variables?.id ?? null}
           onEdit={(collection, libraryId) =>
             navigate(buildAdminCollectionEditorPath(collection.id, libraryId))
@@ -241,6 +356,8 @@ export default function AdminCollections() {
               libraryId: selectedLibraryId,
             })
           }
+          selectedIds={selectedCollectionIds}
+          setSelectedIds={setSelectedCollectionIds}
           syncingCollectionID={syncCollection.variables?.id ?? null}
         />
       )}
@@ -433,6 +550,8 @@ function AllLibraryCollectionsOverview({
   libraries,
   collections,
   isLoading,
+  selectedIds,
+  setSelectedIds,
   syncingCollectionID,
   onEdit,
   onDelete,
@@ -443,6 +562,8 @@ function AllLibraryCollectionsOverview({
   libraries: Library[];
   collections: LibraryCollection[];
   isLoading: boolean;
+  selectedIds: Set<string>;
+  setSelectedIds: Dispatch<SetStateAction<Set<string>>>;
   syncingCollectionID: string | null;
   onEdit: (collection: LibraryCollection, libraryId: number) => void;
   onDelete: (collection: LibraryCollection) => void;
@@ -454,6 +575,40 @@ function AllLibraryCollectionsOverview({
     () => buildAllLibrarySections(libraries, collections),
     [libraries, collections],
   );
+  const selectionRows = useMemo(
+    () =>
+      sections.flatMap((section) =>
+        section.collections.map((collection) => ({
+          rowId: `${section.library.id}:${collection.id}`,
+          collectionId: collection.id,
+        })),
+      ),
+    [sections],
+  );
+  const selectionOrder = useMemo(() => selectionRows.map((row) => row.rowId), [selectionRows]);
+  const collectionIdByRow = useMemo(
+    () => new Map(selectionRows.map((row) => [row.rowId, row.collectionId])),
+    [selectionRows],
+  );
+  const selectionAnchorRef = useRef<string | null>(null);
+
+  const updateSelection = (rowId: string, checked: boolean, extendRange: boolean) => {
+    const anchorId = extendRange && selectedIds.size > 0 ? selectionAnchorRef.current : null;
+    setSelectedIds((previous) =>
+      updateCheckboxSelection(
+        previous,
+        selectionOrder,
+        anchorId,
+        rowId,
+        checked,
+        extendRange,
+        (selectedRowId) => collectionIdByRow.get(selectedRowId) ?? selectedRowId,
+      ),
+    );
+    if (anchorId === null || !selectionOrder.includes(anchorId)) {
+      selectionAnchorRef.current = rowId;
+    }
+  };
 
   if (isLoading) {
     return (
@@ -499,18 +654,25 @@ function AllLibraryCollectionsOverview({
             </Badge>
           </div>
           <div className="divide-y">
-            {section.collections.map((collection) => (
-              <AllLibraryCollectionRow
-                key={`${section.library.id}:${collection.id}`}
-                collection={collection}
-                libraries={libraries}
-                libraryId={section.library.id}
-                isSyncing={syncingCollectionID === collection.id}
-                onEdit={() => onEdit(collection, section.library.id)}
-                onDelete={() => onDelete(collection)}
-                onSync={() => onSync(collection, section.library.id)}
-              />
-            ))}
+            {section.collections.map((collection) => {
+              const rowId = `${section.library.id}:${collection.id}`;
+              return (
+                <AllLibraryCollectionRow
+                  key={rowId}
+                  collection={collection}
+                  libraries={libraries}
+                  libraryId={section.library.id}
+                  selected={selectedIds.has(collection.id)}
+                  isSyncing={syncingCollectionID === collection.id}
+                  onSelectionChange={(checked, extendRange) =>
+                    updateSelection(rowId, checked, extendRange)
+                  }
+                  onEdit={() => onEdit(collection, section.library.id)}
+                  onDelete={() => onDelete(collection)}
+                  onSync={() => onSync(collection, section.library.id)}
+                />
+              );
+            })}
           </div>
         </section>
       ))}
@@ -522,7 +684,9 @@ function AllLibraryCollectionRow({
   collection,
   libraries,
   libraryId,
+  selected,
   isSyncing,
+  onSelectionChange,
   onEdit,
   onDelete,
   onSync,
@@ -530,7 +694,9 @@ function AllLibraryCollectionRow({
   collection: LibraryCollection;
   libraries: Library[];
   libraryId: number;
+  selected: boolean;
   isSyncing: boolean;
+  onSelectionChange: (checked: boolean, extendRange: boolean) => void;
   onEdit: () => void;
   onDelete: () => void;
   onSync: () => void;
@@ -539,9 +705,16 @@ function AllLibraryCollectionRow({
   const collectionLibraries = collectionLibraryIDs(collection)
     .map((id) => libraries.find((library) => library.id === id)?.name ?? `Library ${id}`)
     .join(", ");
+  const rowLibraryName =
+    libraries.find((library) => library.id === libraryId)?.name ?? `library ${libraryId}`;
 
   return (
     <div className="flex items-center gap-3 px-4 py-3">
+      <BulkSelectionCheckbox
+        label={`Select ${collection.title} in ${rowLibraryName}`}
+        selected={selected}
+        onSelectionChange={onSelectionChange}
+      />
       {collection.poster_url ? (
         <img src={collection.poster_url} alt="" className="h-12 w-8 rounded object-cover" />
       ) : (

--- a/web/src/pages/AdminSections.tsx
+++ b/web/src/pages/AdminSections.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Library, PageSectionConfig } from "@/api/types";
 import {
   useAdminSections,
@@ -6,6 +6,7 @@ import {
   useCreateSection,
   useUpdateSection,
   useDeleteSection,
+  useDeleteSections,
   useReorderSections,
   useRestoreDefaultSections,
 } from "@/hooks/queries/sections";
@@ -18,6 +19,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useAdminCollections, useImportTraktCollection } from "@/hooks/queries/admin/collections";
 import { useAdminLibraries } from "@/hooks/queries/admin/libraries";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -37,7 +39,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus, RotateCcw } from "lucide-react";
+import { Loader2, Plus, RotateCcw, Trash2 } from "lucide-react";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { toast } from "sonner";
 import { buildSectionReorderEntries } from "./adminSectionOrder";
@@ -60,6 +62,7 @@ import type { DragStartEvent, DragEndEvent } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import type { LibraryCollection } from "@/api/types";
+import { updateCheckboxSelection } from "@/lib/checkboxSelection";
 
 function formatCollectionOptionLabel(
   collection: { title: string; library_id: number },
@@ -182,7 +185,12 @@ export default function AdminSections() {
   const [orderedSections, setOrderedSections] = useState<PageSectionConfig[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const [confirmDeleteSection, setConfirmDeleteSection] = useState<PageSectionConfig | null>(null);
+  const [confirmDeleteSelected, setConfirmDeleteSelected] = useState(false);
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+  const [selectedSectionIds, setSelectedSectionIds] = useState<Set<string>>(new Set());
+  const selectionAnchorRef = useRef<string | null>(null);
   const deleteMutation = useDeleteSection();
+  const deleteSectionsMutation = useDeleteSections();
   const reorderMutation = useReorderSections();
   const restoreDefaultsMutation = useRestoreDefaultSections();
   const [confirmRestoreOpen, setConfirmRestoreOpen] = useState(false);
@@ -199,9 +207,18 @@ export default function AdminSections() {
   const updateMutation = useUpdateSection();
 
   const sections = useMemo(() => data?.sections ?? [], [data?.sections]);
+  const orderedSectionIds = useMemo(
+    () => orderedSections.map((section) => section.id),
+    [orderedSections],
+  );
+  const selectedSections = useMemo(
+    () => orderedSections.filter((section) => selectedSectionIds.has(section.id)),
+    [orderedSections, selectedSectionIds],
+  );
   const isHomeScope = scope === "home";
-  const canManageLibrarySections = librariesList.length > 0 && selectedLibraryId !== null;
-  const canDrag = !reorderMutation.isPending && (isHomeScope || canManageLibrarySections);
+  const canManageCurrentScope =
+    isHomeScope || (librariesList.length > 0 && selectedLibraryId !== null);
+  const canDrag = !reorderMutation.isPending && canManageCurrentScope;
 
   useEffect(() => {
     if (librariesList.length === 0) {
@@ -225,6 +242,54 @@ export default function AdminSections() {
   useEffect(() => {
     setOrderedSections(sections);
   }, [sections]);
+
+  useEffect(() => {
+    const clearSelection = (event: KeyboardEvent) => {
+      if (
+        event.key === "Escape" &&
+        confirmDeleteSection === null &&
+        !confirmDeleteSelected &&
+        !confirmDeleteAll
+      ) {
+        setSelectedSectionIds(new Set());
+        selectionAnchorRef.current = null;
+      }
+    };
+    window.addEventListener("keydown", clearSelection);
+    return () => window.removeEventListener("keydown", clearSelection);
+  }, [confirmDeleteAll, confirmDeleteSection, confirmDeleteSelected]);
+
+  function clearSectionSelection() {
+    setSelectedSectionIds(new Set());
+    selectionAnchorRef.current = null;
+  }
+
+  function handleScopeChange(nextScope: string) {
+    clearSectionSelection();
+    setScope(nextScope);
+  }
+
+  function handleLibraryChange(libraryId: number) {
+    clearSectionSelection();
+    setSelectedLibraryId(libraryId);
+  }
+
+  function updateSectionSelection(sectionId: string, checked: boolean, extendRange: boolean) {
+    const anchorId = extendRange && selectedSectionIds.size > 0 ? selectionAnchorRef.current : null;
+    setSelectedSectionIds((previous) =>
+      updateCheckboxSelection(
+        previous,
+        orderedSectionIds,
+        anchorId,
+        sectionId,
+        checked,
+        extendRange,
+      ),
+    );
+    if (anchorId === null || !orderedSectionIds.includes(anchorId)) {
+      selectionAnchorRef.current = sectionId;
+    }
+  }
 
   function handleDelete(section: PageSectionConfig) {
     setConfirmDeleteSection(section);
@@ -263,6 +328,29 @@ export default function AdminSections() {
   }
 
   const activeSection = activeId ? (orderedSections.find((s) => s.id === activeId) ?? null) : null;
+  const selectedLibraryName = librariesList.find((library) => library.id === activeLibraryId)?.name;
+  const sectionScopeLabel = isHomeScope ? "home" : `${selectedLibraryName ?? "library"} library`;
+  const sectionDeletionNotice =
+    "Silo will also try to remove section-managed collections that are no longer referenced. This action cannot be undone.";
+  const deleteAllDescription = isHomeScope
+    ? `Delete all ${orderedSections.length} home sections? ${sectionDeletionNotice}`
+    : `Delete all ${orderedSections.length} sections shown for ${selectedLibraryName ?? "this library"}? ${sectionDeletionNotice}`;
+  const deleteSelectedDescription = `Delete ${selectedSections.length} selected section${selectedSections.length === 1 ? "" : "s"}? ${sectionDeletionNotice}`;
+  const deleteProgressLabel = `Deleting ${deleteSectionsMutation.progress?.completed ?? 0} of ${deleteSectionsMutation.progress?.total ?? orderedSections.length} sections`;
+
+  function handleDeleteSelectedSections() {
+    if (canManageCurrentScope && selectedSections.length > 0) {
+      deleteSectionsMutation.mutate(selectedSections.map((section) => section.id));
+    }
+    setConfirmDeleteSelected(false);
+  }
+
+  function handleDeleteAllSections() {
+    if (canManageCurrentScope && orderedSections.length > 0) {
+      deleteSectionsMutation.mutate(orderedSections.map((section) => section.id));
+    }
+    setConfirmDeleteAll(false);
+  }
 
   function normalizeLibraryIDs(ids: number[] | undefined): number[] {
     if (!ids || ids.length === 0) return [];
@@ -381,20 +469,42 @@ export default function AdminSections() {
   if (isLoading) return <div className="p-4">Loading sections...</div>;
 
   return (
-    <div className="space-y-6">
+    <div
+      className="space-y-6"
+      aria-busy={deleteSectionsMutation.isPending}
+      inert={deleteSectionsMutation.isPending ? true : undefined}
+    >
       <ConfirmDialog
         open={confirmDeleteSection !== null}
         onOpenChange={(open) => {
           if (!open) setConfirmDeleteSection(null);
         }}
         title="Delete section"
-        description={`Delete section "${confirmDeleteSection?.title}"? This action cannot be undone.`}
+        description={`Delete section "${confirmDeleteSection?.title}"? Silo will also try to remove any section-managed collection that is no longer referenced. This action cannot be undone.`}
         confirmLabel="Delete"
         variant="destructive"
         onConfirm={() => {
           if (confirmDeleteSection) deleteMutation.mutate(confirmDeleteSection.id);
           setConfirmDeleteSection(null);
         }}
+      />
+      <ConfirmDialog
+        open={confirmDeleteSelected}
+        onOpenChange={setConfirmDeleteSelected}
+        title="Delete selected sections"
+        description={deleteSelectedDescription}
+        confirmLabel="Delete selected"
+        variant="destructive"
+        onConfirm={handleDeleteSelectedSections}
+      />
+      <ConfirmDialog
+        open={confirmDeleteAll}
+        onOpenChange={setConfirmDeleteAll}
+        title="Delete all sections"
+        description={deleteAllDescription}
+        confirmLabel="Delete all"
+        variant="destructive"
+        onConfirm={handleDeleteAllSections}
       />
       <Dialog
         open={confirmRestoreOpen}
@@ -466,13 +576,11 @@ export default function AdminSections() {
         <div className="space-y-3">
           <h1 className="page-title text-[clamp(2rem,4vw,3rem)]">Sections</h1>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <Button
             size="sm"
             variant="outline"
-            disabled={
-              (!isHomeScope && !canManageLibrarySections) || restoreDefaultsMutation.isPending
-            }
+            disabled={!canManageCurrentScope || restoreDefaultsMutation.isPending}
             onClick={() => setConfirmRestoreOpen(true)}
           >
             <RotateCcw className="mr-1 h-4 w-4" /> Restore Defaults
@@ -480,14 +588,14 @@ export default function AdminSections() {
           <Button
             size="sm"
             variant="outline"
-            disabled={!isHomeScope && !canManageLibrarySections}
+            disabled={!canManageCurrentScope}
             onClick={() => setGalleryOpen(true)}
           >
             <Plus className="mr-1 h-4 w-4" /> Add from Gallery
           </Button>
           <Button
             size="sm"
-            disabled={!isHomeScope && !canManageLibrarySections}
+            disabled={!canManageCurrentScope}
             onClick={() => {
               setEditingSection(null);
               setDialogOpen(true);
@@ -495,10 +603,45 @@ export default function AdminSections() {
           >
             <Plus className="mr-1 h-4 w-4" /> Add Section
           </Button>
+          {selectedSections.length > 0 ? (
+            <>
+              <Badge variant="secondary">{selectedSections.length} selected</Badge>
+              <Button size="sm" variant="ghost" onClick={clearSectionSelection}>
+                Clear
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                disabled={deleteSectionsMutation.isPending || !canManageCurrentScope}
+                onClick={() => setConfirmDeleteSelected(true)}
+              >
+                <Trash2 data-icon="inline-start" /> Delete Selected
+              </Button>
+            </>
+          ) : null}
+          {orderedSections.length > 0 ? (
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={
+                deleteSectionsMutation.isPending ||
+                restoreDefaultsMutation.isPending ||
+                !canManageCurrentScope
+              }
+              onClick={() => setConfirmDeleteAll(true)}
+            >
+              {deleteSectionsMutation.isPending ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="mr-1 h-4 w-4" />
+              )}
+              {deleteSectionsMutation.isPending ? `${deleteProgressLabel}…` : "Delete All"}
+            </Button>
+          ) : null}
         </div>
       </div>
 
-      <Tabs value={scope} onValueChange={setScope}>
+      <Tabs value={scope} onValueChange={handleScopeChange}>
         <TabsList>
           <TabsTrigger value="home">Home</TabsTrigger>
           <TabsTrigger value="library">Library</TabsTrigger>
@@ -512,7 +655,7 @@ export default function AdminSections() {
             <LibraryPicker
               libraries={librariesList}
               value={selectedLibraryId}
-              onChange={setSelectedLibraryId}
+              onChange={handleLibraryChange}
             />
           ) : (
             <p className="text-muted-foreground text-sm">
@@ -539,6 +682,9 @@ export default function AdminSections() {
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-10">
+                  <span className="sr-only">Select</span>
+                </TableHead>
                 <TableHead className="w-8"></TableHead>
                 <TableHead>Title</TableHead>
                 <TableHead>Type</TableHead>
@@ -561,13 +707,18 @@ export default function AdminSections() {
                     libraries={librariesList}
                     collectionLabels={collectionLabels}
                     catalog={recipeCatalog}
+                    selected={selectedSectionIds.has(section.id)}
+                    selectionLabel={`Select ${section.title} ${sectionScopeLabel} section`}
+                    onSelectionChange={(checked, extendRange) =>
+                      updateSectionSelection(section.id, checked, extendRange)
+                    }
                     onEdit={() => handleEdit(section)}
                     onDelete={() => handleDelete(section)}
                   />
                 ))}
                 {orderedSections.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={7} className="text-muted-foreground py-8 text-center">
+                    <TableCell colSpan={8} className="text-muted-foreground py-8 text-center">
                       No sections configured for {scope} scope.
                     </TableCell>
                   </TableRow>

--- a/web/src/pages/adminCollectionsShared.tsx
+++ b/web/src/pages/adminCollectionsShared.tsx
@@ -86,6 +86,25 @@ export function buildAdminCollectionsReturnPath(libraryId?: number | null) {
   return libraryId ? `/admin/collections?libraryId=${libraryId}` : "/admin/collections";
 }
 
+interface AdminCollectionsBoardSnapshot {
+  groups: Array<{ collections: LibraryCollection[] }>;
+  ungrouped: LibraryCollection[];
+}
+
+export function collectionsInAdminScope(
+  allCollections: LibraryCollection[],
+  board: AdminCollectionsBoardSnapshot | undefined,
+  selectedLibraryId: number | null,
+): LibraryCollection[] {
+  let collections = allCollections;
+  if (selectedLibraryId !== null) {
+    if (!board) return [];
+    collections = [...board.ungrouped, ...board.groups.flatMap((group) => group.collections)];
+  }
+
+  return [...new Map(collections.map((collection) => [collection.id, collection])).values()];
+}
+
 export function toAdminCollectionBuilderValue(
   collection: LibraryCollection | null,
   initialLibraryId: number | null,


### PR DESCRIPTION
## Problem

Related issue: N/A — maintainer-requested admin workflow

Collections and Sections only supported one-at-a-time deletion. Clearing a populated server required repeated confirmation, and collection deletes that were blocked by section references did not provide a useful bulk result.

## Approach

- Add checkboxes, inclusive Shift-click ranges, Clear, Delete Selected, and scope-aware Delete All controls to Collections and Sections.
- Keep shared collection occurrences distinct while calculating an All Libraries range, then map them back to one collection ID for deletion.
- Delete in batches of four, continue after individual failures, report progress, and invalidate affected queries once after the batch.
- Treat missing rows as already deleted. Keep collections referenced by sections and report that count separately.
- Return HTTP 500 for section repository failures instead of mislabeling them as 404, so bulk deletion cannot report a database failure as success.
- Describe section-managed collection cleanup as best effort, matching the server behavior.

## Validation

Exact head: `b98a8a03d159bd72f5606709ef428529ee6d2a7d`

- `make embed-stub` — passed
- `go build ./...` — passed
- `gofmt -l .` — no output
- `go vet ./...` — passed
- `golangci-lint run --new-from-merge-base="origin/main" ./...` with v2.12.2 — passed with 0 issues; emitted one warning about a stale deleted-worktree cache entry
- `make test-go` — passed
- `pnpm install --frozen-lockfile` — passed
- `pnpm run lint` — passed with 0 errors and 174 existing warnings
- `pnpm run format:check` — passed
- `pnpm run build` — passed
- `make test-web` — 355 files passed, 2,970 tests passed
- `make verify-settings-bindings-all` — passed
- `make verify-playback-fixtures` — passed
- `make verify-local-paths` — passed
- Focused handler and web regression tests — passed
- Two independent post-fix reviews covering destructive selection, error classification, cleanup semantics, and API compatibility — no findings

The shared-development identity and health checks passed, and the local frontend proxy returned a healthy Silo response. Exact-head browser interaction was not completed: the collaborative preview loaded the sign-in route, but snapshot and DOM automation failed in both reused and fresh tabs. No deletion requests were sent, and no screenshot is attached.

## Risks

No migration or response-shape change. The admin section DELETE endpoint now returns 500 for repository failures that were previously reported as 404. A library-scoped collection deletion still removes a shared collection from every library after the confirmation explicitly warns about that behavior.

## AI Disclosure

- Tool(s): Codex in T3 Code
- Model(s): gpt-5.6-sol
- Involvement: Fully AI-generated; awaiting human verification
- Adversarial review: Three independent initial review passes found an occurrence-range bug, false-success section error handling, and overpromised cleanup copy. All three were fixed. Two independent post-fix passes reviewed selection/deletion correctness and contract behavior and found no remaining issues.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bulk selection and deletion for collections and sections.
  - Supports checkbox selection, Shift-click range selection, confirmation dialogs, progress indicators, and scoped operations.
  - Added clear selection behavior and disabled controls during deletion or template application.
  - Collections that cannot be deleted remain available with appropriate feedback.

- **Bug Fixes**
  - Section deletion now reports missing items as `404 Not Found` and unexpected failures as `500 Internal Server Error`.
  - Improved handling and messaging for partial bulk-deletion results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->