### PR TITLE
fix(playback): preserve remux timeline on recovery

### DIFF
--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -1716,9 +1716,14 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 			// timeline position or return 404 for copy-mode segments outside the
 			// current manifest window.
 			if err != nil && errors.Is(err, playback.ErrSegmentNotFound) && decision.RestartOnTimeout {
-				seekSeconds, ok, seekErr := transcodeSession.RestartSeekTarget(segNum)
-				if seekErr != nil && !errors.Is(seekErr, playback.ErrManifestNotReady) {
-					slog.ErrorContext(r.Context(), "resolve transcode seek target", "component", "api", "error", seekErr, "segment", segmentName, "session", sessionID, "playback_session_id", sessionID)
+				target, ok, restartErr := h.tm.RestartSegmentLocked(
+					r.Context(),
+					sessionID,
+					transcodeSession,
+					segNum,
+				)
+				if restartErr != nil && !errors.Is(restartErr, playback.ErrManifestNotReady) {
+					slog.ErrorContext(r.Context(), "restart transcode at missing segment", "component", "api", "error", restartErr, "segment", segmentName, "session", sessionID, "playback_session_id", sessionID)
 				}
 
 				// Copy-mode with an unresolved seek target (ok=false, no error)
@@ -1727,11 +1732,13 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 				// client retries while the session keeps producing manifest.
 				// Mirrors the transcode-node guard in
 				// internal/transcodenode/server.go.
-				if !ok && seekErr == nil && transcodeSession.IsCopyVideo() {
+				if !ok && restartErr == nil && transcodeSession.IsCopyVideo() {
 					err = playback.ErrSegmentNotFound
 				}
 
-				if ok {
+				if restartErr != nil {
+					err = restartErr
+				} else if ok {
 					slog.InfoContext(r.Context(), "transcode seek restart", "component", "api",
 						"segment", segmentName,
 						"requested_segment", segNum,
@@ -1742,33 +1749,25 @@ func (h *PlaybackHandler) HandleGetTranscodeSegment(w http.ResponseWriter, r *ht
 						"wait_timeout_ms", decision.WaitTimeout.Milliseconds(),
 						"restart_on_timeout", decision.RestartOnTimeout,
 						"reason", decision.Reason,
-						"seek_seconds", seekSeconds,
+						"seek_seconds", target.SeekSeconds,
+						"stream_origin_seconds", target.StreamOriginSeconds,
+						"resolved_start_segment", target.StartSegmentNumber,
 						"session", sessionID,
 						"playback_session_id", sessionID,
 					)
-					if restartErr := h.tm.RestartSessionLocked(
-						r.Context(),
-						sessionID,
-						transcodeSession,
-						seekSeconds,
-						segNum,
-					); restartErr == nil {
-						// Throttler + exit monitor re-arm via the session's
-						// restart hook.
-						segmentLease, err = transcodeSession.WaitForOpenSegment(segmentName, 30*time.Second)
-						if err == nil && strings.EqualFold(transcodeSession.Opts().TargetCodecVideo, "copy") {
-							// Copy-mode seeks can resume as soon as the target segment
-							// exists, but that sometimes leaves the player one segment
-							// away from stalling while FFmpeg catches up. Briefly wait
-							// for a single lookahead fragment when available so the
-							// first resumed playback window is less brittle.
-							nextSegmentName := fmt.Sprintf("seg_%05d.m4s", segNum+1)
-							if nextSegment, nextErr := transcodeSession.WaitForOpenSegment(nextSegmentName, 1200*time.Millisecond); nextErr == nil {
-								_ = nextSegment.Close()
-							}
+					// Throttler + exit monitor re-arm via the session's
+					// restart hook.
+					segmentLease, err = transcodeSession.WaitForOpenSegment(segmentName, 30*time.Second)
+					if err == nil && strings.EqualFold(transcodeSession.Opts().TargetCodecVideo, "copy") {
+						// Copy-mode seeks can resume as soon as the target segment
+						// exists, but that sometimes leaves the player one segment
+						// away from stalling while FFmpeg catches up. Briefly wait
+						// for a single lookahead fragment when available so the
+						// first resumed playback window is less brittle.
+						nextSegmentName := fmt.Sprintf("seg_%05d.m4s", segNum+1)
+						if nextSegment, nextErr := transcodeSession.WaitForOpenSegment(nextSegmentName, 1200*time.Millisecond); nextErr == nil {
+							_ = nextSegment.Close()
 						}
-					} else {
-						err = restartErr
 					}
 				}
 			}

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -351,6 +352,84 @@ func TestHeaderAuthenticatedMediaEnforcesHLSOwnerOnEveryRequest(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+func TestGetTranscodeSegment_CopyRecoveryUsesResolvedManifestNumber(t *testing.T) {
+	outputDir := t.TempDir()
+	ffmpegPath := filepath.Join(outputDir, "ffmpeg")
+	launchMarker := filepath.Join(outputDir, "launched")
+	manifest := "#EXTM3U\\n#EXT-X-VERSION:7\\n#EXT-X-TARGETDURATION:3\\n#EXT-X-MEDIA-SEQUENCE:9\\n#EXT-X-MAP:URI=\"init.mp4\"\\n#EXTINF:2.669000,\\nseg_00009.m4s\\n#EXTINF:1.669000,\\nseg_00010.m4s\\n#EXTINF:1.668000,\\nseg_00011.m4s\\n"
+	ffmpeg := `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "framecrc" ]; then
+    printf '%s\n' '#tb 0: 1/1000'
+    printf '%s\n' '0, 18000, 18000, 41, 1024, 0x12345678'
+    exit 0
+  fi
+done
+printf '%b' '` + manifest + `' > '` + filepath.Join(outputDir, "stream.m3u8") + `'
+if [ ! -e '` + launchMarker + `' ]; then
+  : > '` + launchMarker + `'
+  printf ahead > '` + filepath.Join(outputDir, "seg_00011.m4s") + `'
+else
+  printf recovered > '` + filepath.Join(outputDir, "seg_00010.m4s") + `'
+  printf ahead > '` + filepath.Join(outputDir, "seg_00011.m4s") + `'
+fi
+exec sleep 30
+`
+	if err := os.WriteFile(ffmpegPath, []byte(ffmpeg), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+
+	const sessionID = "copy-recovery-session"
+	transcodeSession, err := playback.StartTranscode(context.Background(), playback.TranscodeOpts{
+		SessionID:              sessionID,
+		InputPath:              "/media/movie.mkv",
+		OutputDir:              outputDir,
+		FFmpegPath:             ffmpegPath,
+		SeekSeconds:            18.261,
+		StreamOriginSeconds:    18,
+		CopySeekAnchorResolved: true,
+		TargetCodecVideo:       "copy",
+		TargetCodecAudio:       "copy",
+		SegmentDuration:        2,
+		StartSegmentNumber:     9,
+	})
+	if err != nil {
+		t.Fatalf("StartTranscode: %v", err)
+	}
+	t.Cleanup(func() { _ = transcodeSession.Close() })
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, statErr := os.Stat(filepath.Join(outputDir, "seg_00011.m4s")); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("initial fake transcode did not become observable")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	sessions := playback.NewSessionManager(0, 0)
+	sessions.RegisterReconstructed(&playback.Session{ID: sessionID, UserID: 1, PlayMethod: playback.PlayTranscode})
+	handler := NewPlaybackHandler(sessions)
+	handler.TranscodeManager().RegisterTranscodeSession(sessionID, transcodeSession)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/playback/transcode/"+sessionID+"/segment/seg_00010.m4s", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("session_id", sessionID)
+	routeCtx.URLParams.Add("name", "seg_00010.m4s")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+	rr := httptest.NewRecorder()
+	handler.HandleGetTranscodeSegment(rr, req)
+
+	if rr.Code != http.StatusOK || rr.Body.String() != "recovered" {
+		t.Fatalf("segment response = %d %q, want 200 recovered", rr.Code, rr.Body.String())
+	}
+	opts := transcodeSession.Opts()
+	if opts.StartSegmentNumber != 9 || !opts.CopySeekAnchorResolved || math.Abs(opts.StreamOriginSeconds-18) > 0.0001 {
+		t.Fatalf("recovery opts = %+v, want start=9 origin=18 resolved=true", opts)
 	}
 }
 

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -881,10 +881,15 @@ func (h *PlaybackHandler) HandleHLSSegment(w http.ResponseWriter, r *http.Reques
 			}
 
 			if err != nil && errors.Is(err, playback.ErrSegmentNotFound) && decision.RestartOnTimeout {
-				seekSeconds, ok, seekErr := transcodeSession.RestartSeekTarget(segNum)
-				if seekErr != nil && !errors.Is(seekErr, playback.ErrManifestNotReady) {
-					slog.ErrorContext(r.Context(), "resolve transcode seek target", "component", "jellycompat",
-						"error", seekErr,
+				target, ok, restartErr := h.tm.RestartSegmentLocked(
+					r.Context(),
+					playSession.UpstreamSessionID,
+					transcodeSession,
+					segNum,
+				)
+				if restartErr != nil && !errors.Is(restartErr, playback.ErrManifestNotReady) {
+					slog.ErrorContext(r.Context(), "restart transcode at missing segment", "component", "jellycompat",
+						"error", restartErr,
 						"segment", segmentName,
 						"play_session", playSessionID,
 						"session", playSession.UpstreamSessionID,
@@ -898,11 +903,13 @@ func (h *PlaybackHandler) HandleHLSSegment(w http.ResponseWriter, r *http.Reques
 				// client retries while the session keeps producing manifest.
 				// Mirrors the transcode-node guard in
 				// internal/transcodenode/server.go.
-				if !ok && seekErr == nil && transcodeSession.IsCopyVideo() {
+				if !ok && restartErr == nil && transcodeSession.IsCopyVideo() {
 					err = playback.ErrSegmentNotFound
 				}
 
-				if ok {
+				if restartErr != nil {
+					err = restartErr
+				} else if ok {
 					slog.InfoContext(r.Context(), "transcode seek restart", "component", "jellycompat",
 						"segment", segmentName,
 						"requested_segment", segNum,
@@ -912,23 +919,15 @@ func (h *PlaybackHandler) HandleHLSSegment(w http.ResponseWriter, r *http.Reques
 						"last_produced_age_ms", lastProducedAgeMS,
 						"wait_timeout_ms", decision.WaitTimeout.Milliseconds(),
 						"reason", decision.Reason,
-						"seek_seconds", seekSeconds,
+						"seek_seconds", target.SeekSeconds,
+						"stream_origin_seconds", target.StreamOriginSeconds,
+						"resolved_start_segment", target.StartSegmentNumber,
 						"play_session", playSessionID,
 						"session", playSession.UpstreamSessionID,
 						"playback_session_id", playSession.UpstreamSessionID,
 					)
 
-					if restartErr := h.tm.RestartSessionLocked(
-						r.Context(),
-						playSession.UpstreamSessionID,
-						transcodeSession,
-						seekSeconds,
-						segNum,
-					); restartErr == nil {
-						segmentLease, err = transcodeSession.WaitForOpenSegment(segmentName, 30*time.Second)
-					} else {
-						err = restartErr
-					}
+					segmentLease, err = transcodeSession.WaitForOpenSegment(segmentName, 30*time.Second)
 				}
 			}
 		} else if transcodeSession.IsRunning() {

--- a/internal/playback/copy_seek_anchor.go
+++ b/internal/playback/copy_seek_anchor.go
@@ -3,7 +3,6 @@ package playback
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"os/exec"
@@ -24,16 +23,6 @@ var (
 	copySeekProbeSlots = make(chan struct{}, maxConcurrentCopySeekProbes)
 )
 
-type copySeekProbePacket struct {
-	PTSSeconds string `json:"pts_time"`
-	DTSSeconds string `json:"dts_time"`
-	Flags      string `json:"flags"`
-}
-
-type copySeekProbeOutput struct {
-	Packets []copySeekProbePacket `json:"packets"`
-}
-
 type copySeekAnchor struct {
 	seconds float64
 	segment int
@@ -45,10 +34,11 @@ type copySeekAnchor struct {
 // so callers need both timestamps: requestedSeekSeconds remains the -ss input,
 // while the returned anchor defines the stream's real timeline origin.
 //
-// The tiny read interval is intentional. ffprobe asks the demuxer to seek to
-// requestedSeekSeconds, which lands on the same preceding key packet FFmpeg
-// uses, then emits only the packets at that seek point instead of scanning the
-// media from the beginning.
+// The one-packet framecrc output is intentional. ffprobe read intervals discard
+// Matroska pre-roll at an exact keyframe boundary, while FFmpeg stream copy
+// emits that preceding packet. Running FFmpeg with the transport's real seek
+// and timestamp policy observes the packet the HLS muxer will actually receive
+// without decoding or writing media output.
 func ResolveCopySeekAnchor(
 	ctx context.Context,
 	ffmpegPath string,
@@ -66,8 +56,9 @@ func ResolveCopySeekAnchor(
 		segmentDuration = DefaultSegmentDuration
 	}
 
+	resolvedFFmpegPath := ResolveFFmpegPath(ffmpegPath)
 	key := strings.Join([]string{
-		ffprobePathFromFFmpeg(ffmpegPath),
+		resolvedFFmpegPath,
 		inputPath,
 		strconv.FormatFloat(requestedSeekSeconds, 'f', 6, 64),
 		strconv.Itoa(segmentDuration),
@@ -81,7 +72,7 @@ func ResolveCopySeekAnchor(
 		case <-probeCtx.Done():
 			return copySeekAnchor{}, probeCtx.Err()
 		}
-		seconds, segment, err := resolveCopySeekAnchor(probeCtx, ffmpegPath, inputPath, requestedSeekSeconds, segmentDuration)
+		seconds, segment, err := resolveCopySeekAnchor(probeCtx, resolvedFFmpegPath, inputPath, requestedSeekSeconds, segmentDuration)
 		return copySeekAnchor{seconds: seconds, segment: segment}, err
 	})
 
@@ -105,16 +96,22 @@ func resolveCopySeekAnchor(
 	segmentDuration int,
 ) (float64, int, error) {
 
-	interval := strconv.FormatFloat(requestedSeekSeconds, 'f', 6, 64) + "%+0.001"
-	cmd := exec.CommandContext(ctx, ffprobePathFromFFmpeg(ffmpegPath),
+	cmd := exec.CommandContext(ctx, ffmpegPath,
 		"-v", "error",
+		"-fflags", "+genpts+fastseek",
+		"-analyzeduration", "3000000",
+		"-probesize", "5000000",
+		"-ss", fmt.Sprintf("%.3f", requestedSeekSeconds),
+		"-i", inputPath,
 		// Match the remux transport's 0:V:0 map. Uppercase V excludes attached
 		// pictures, thumbnails, and cover art from the video stream ordinal.
-		"-select_streams", "V:0",
-		"-read_intervals", interval,
-		"-show_entries", "packet=pts_time,dts_time,flags",
-		"-of", "json",
-		inputPath,
+		"-map", "0:V:0",
+		"-c:v", "copy",
+		"-copyts",
+		"-avoid_negative_ts", "disabled",
+		"-frames:v", "1",
+		"-f", "framecrc",
+		"-",
 	)
 	var stdout bytes.Buffer
 	stderr := newBoundedTailBuffer(stderrTailMaxBytes)
@@ -122,24 +119,36 @@ func resolveCopySeekAnchor(
 	cmd.Stderr = stderr
 	if err := cmd.Run(); err != nil {
 		if tail := truncateStderr(stderr.String()); tail != "" {
-			return 0, 0, fmt.Errorf("resolve copy seek anchor: ffprobe failed: %w (stderr: %s)", err, tail)
+			return 0, 0, fmt.Errorf("resolve copy seek anchor: ffmpeg failed: %w (stderr: %s)", err, tail)
 		}
-		return 0, 0, fmt.Errorf("resolve copy seek anchor: ffprobe failed: %w", err)
+		return 0, 0, fmt.Errorf("resolve copy seek anchor: ffmpeg failed: %w", err)
 	}
 
-	var output copySeekProbeOutput
-	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
-		return 0, 0, fmt.Errorf("resolve copy seek anchor: decode ffprobe output: %w", err)
-	}
-	for _, packet := range output.Packets {
-		if !strings.Contains(packet.Flags, "K") {
+	timeBaseNumerator, timeBaseDenominator := int64(0), int64(0)
+	for line := range bytes.SplitSeq(stdout.Bytes(), []byte("\n")) {
+		trimmed := strings.TrimSpace(string(line))
+		if strings.HasPrefix(trimmed, "#tb 0:") {
+			parts := strings.Split(strings.TrimSpace(strings.TrimPrefix(trimmed, "#tb 0:")), "/")
+			if len(parts) != 2 {
+				continue
+			}
+			timeBaseNumerator, _ = strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+			timeBaseDenominator, _ = strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
 			continue
 		}
-		timestamp := packet.PTSSeconds
-		if timestamp == "" || strings.EqualFold(timestamp, "N/A") {
-			timestamp = packet.DTSSeconds
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || timeBaseNumerator <= 0 || timeBaseDenominator <= 0 {
+			continue
 		}
-		anchor, err := strconv.ParseFloat(timestamp, 64)
+		fields := strings.Split(trimmed, ",")
+		if len(fields) < 3 || strings.TrimSpace(fields[0]) != "0" {
+			continue
+		}
+		timestamp := strings.TrimSpace(fields[2])
+		if timestamp == "" || strings.EqualFold(timestamp, "N/A") {
+			timestamp = strings.TrimSpace(fields[1])
+		}
+		timestampTicks, err := strconv.ParseInt(timestamp, 10, 64)
+		anchor := float64(timestampTicks) * float64(timeBaseNumerator) / float64(timeBaseDenominator)
 		if err != nil || math.IsNaN(anchor) || math.IsInf(anchor, 0) {
 			continue
 		}
@@ -147,5 +156,5 @@ func resolveCopySeekAnchor(
 		return anchor, int(anchor / float64(segmentDuration)), nil
 	}
 
-	return 0, 0, fmt.Errorf("resolve copy seek anchor: ffprobe returned no key packet")
+	return 0, 0, fmt.Errorf("resolve copy seek anchor: ffmpeg returned no video packet timestamp")
 }

--- a/internal/playback/copy_seek_anchor_test.go
+++ b/internal/playback/copy_seek_anchor_test.go
@@ -16,49 +16,45 @@ import (
 func TestResolveCopySeekAnchorUsesKeyPacketTimestamp(t *testing.T) {
 	dir := t.TempDir()
 	ffmpegPath := filepath.Join(dir, "ffmpeg")
-	ffprobePath := filepath.Join(dir, "ffprobe")
-	argsPath := filepath.Join(dir, "ffprobe-args")
-	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write fake ffmpeg: %v", err)
-	}
+	argsPath := filepath.Join(dir, "ffmpeg-args")
 	probe := `#!/bin/sh
 printf '%s\n' "$@" > "` + argsPath + `"
-printf '%s' '{"packets":[{"pts_time":"N/A","dts_time":"14.500000","flags":"K__"}]}'
+printf '%s\n' '#tb 0: 1/1000'
+printf '%s\n' '0,      14500,      14750,       41,   178989, 0xd16e41c4'
 `
-	if err := os.WriteFile(ffprobePath, []byte(probe), 0o755); err != nil {
-		t.Fatalf("write fake ffprobe: %v", err)
+	if err := os.WriteFile(ffmpegPath, []byte(probe), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
 	}
 
 	anchor, segment, err := ResolveCopySeekAnchor(context.Background(), ffmpegPath, "/media/movie.mkv", 18.261, 2)
 	if err != nil {
 		t.Fatalf("ResolveCopySeekAnchor: %v", err)
 	}
-	if anchor != 14.5 || segment != 7 {
-		t.Fatalf("resolved anchor = %v, segment = %d; want 14.5, 7", anchor, segment)
+	if anchor != 14.75 || segment != 7 {
+		t.Fatalf("resolved anchor = %v, segment = %d; want 14.75, 7", anchor, segment)
 	}
 	args, err := os.ReadFile(argsPath)
 	if err != nil {
-		t.Fatalf("read ffprobe args: %v", err)
+		t.Fatalf("read ffmpeg args: %v", err)
 	}
-	if !strings.Contains(string(args), "-select_streams\nV:0\n") {
-		t.Fatalf("ffprobe did not select the remux video stream:\n%s", args)
+	for _, want := range []string{"-fflags\n+genpts+fastseek\n", "-analyzeduration\n3000000\n", "-probesize\n5000000\n", "-ss\n18.261\n", "-map\n0:V:0\n", "-c:v\ncopy\n", "-copyts\n", "-avoid_negative_ts\ndisabled\n", "-frames:v\n1\n", "-f\nframecrc\n"} {
+		if !strings.Contains(string(args), want) {
+			t.Fatalf("ffmpeg args missing %q:\n%s", want, args)
+		}
 	}
 }
 
 func TestResolveCopySeekAnchorCoalescesMatchingConcurrentProbes(t *testing.T) {
 	dir := t.TempDir()
 	ffmpegPath := filepath.Join(dir, "ffmpeg")
-	ffprobePath := filepath.Join(dir, "ffprobe")
 	countPath := filepath.Join(dir, "probe-count")
-	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatalf("write fake ffmpeg: %v", err)
-	}
 	probe := "#!/bin/sh\n" +
 		"printf x >> \"" + countPath + "\"\n" +
 		"sleep 0.1\n" +
-		"printf '%s' '{\"packets\":[{\"pts_time\":\"16.000000\",\"flags\":\"K__\"}]}'\n"
-	if err := os.WriteFile(ffprobePath, []byte(probe), 0o755); err != nil {
-		t.Fatalf("write fake ffprobe: %v", err)
+		"printf '%s\\n' '#tb 0: 1/1000'\n" +
+		"printf '%s\\n' '0,      15833,      16000,       41,   178989, 0xd16e41c4'\n"
+	if err := os.WriteFile(ffmpegPath, []byte(probe), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
 	}
 
 	start := make(chan struct{})
@@ -88,7 +84,7 @@ func TestResolveCopySeekAnchorCoalescesMatchingConcurrentProbes(t *testing.T) {
 		t.Fatalf("read probe count: %v", err)
 	}
 	if string(count) != "x" {
-		t.Fatalf("ffprobe executions = %d, want 1", len(count))
+		t.Fatalf("ffmpeg probe executions = %d, want 1", len(count))
 	}
 }
 
@@ -123,7 +119,7 @@ func TestResolveCopySeekAnchorMatchesRealLongGOPHEVC(t *testing.T) {
 		t.Fatalf("generate long-GOP HEVC fixture: %v\n%s", err, output)
 	}
 
-	probeCtx, cancelProbe := context.WithTimeout(context.Background(), 5*time.Second)
+	probeCtx, cancelProbe := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancelProbe()
 	anchor, segment, err := ResolveCopySeekAnchor(probeCtx, ffmpegPath, sourcePath, 18.261, 2)
 	if err != nil {
@@ -131,6 +127,34 @@ func TestResolveCopySeekAnchorMatchesRealLongGOPHEVC(t *testing.T) {
 	}
 	if math.Abs(anchor-10) > 0.001 || segment != 5 {
 		t.Fatalf("resolved anchor = %v, segment = %d; want 10, 5", anchor, segment)
+	}
+
+	// An exact keyframe seek is the recovery boundary that regressed in #839:
+	// Matroska emits the preceding keyframe while MP4 starts at the requested
+	// keyframe. The resolver must model FFmpeg's real copy path for both.
+	exactMKVAnchor, exactMKVSegment, err := ResolveCopySeekAnchor(probeCtx, ffmpegPath, sourcePath, 10, 2)
+	if err != nil {
+		t.Fatalf("ResolveCopySeekAnchor exact MKV keyframe: %v", err)
+	}
+	if math.Abs(exactMKVAnchor) > 0.001 || exactMKVSegment != 0 {
+		t.Fatalf("exact MKV anchor = %v, segment = %d; want 0, 0", exactMKVAnchor, exactMKVSegment)
+	}
+
+	mp4Path := filepath.Join(t.TempDir(), "long-gop-hevc.mp4")
+	remux := exec.Command(ffmpegPath,
+		"-hide_banner", "-loglevel", "error",
+		"-i", sourcePath,
+		"-map", "0:V:0", "-c:v", "copy", "-an", "-y", mp4Path,
+	)
+	if output, err := remux.CombinedOutput(); err != nil {
+		t.Fatalf("remux long-GOP HEVC fixture to MP4: %v\n%s", err, output)
+	}
+	exactMP4Anchor, exactMP4Segment, err := ResolveCopySeekAnchor(probeCtx, ffmpegPath, mp4Path, 10, 2)
+	if err != nil {
+		t.Fatalf("ResolveCopySeekAnchor exact MP4 keyframe: %v", err)
+	}
+	if math.Abs(exactMP4Anchor-10) > 0.001 || exactMP4Segment != 5 {
+		t.Fatalf("exact MP4 anchor = %v, segment = %d; want 10, 5", exactMP4Anchor, exactMP4Segment)
 	}
 
 	outputDir := filepath.Join(t.TempDir(), "hls")

--- a/internal/playback/restart_locked_test.go
+++ b/internal/playback/restart_locked_test.go
@@ -3,8 +3,10 @@ package playback
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -26,6 +28,99 @@ func newFakeFFmpegSession(t *testing.T) *TranscodeSession {
 			FFmpegPath: bin,
 			OutputDir:  dir,
 		},
+	}
+}
+
+func TestRestartSegmentLocked_UsesResolvedCopyAnchorAndManifestNumber(t *testing.T) {
+	dir := t.TempDir()
+	manifest := strings.Join([]string{
+		"#EXTM3U",
+		"#EXT-X-VERSION:7",
+		"#EXT-X-TARGETDURATION:3",
+		"#EXT-X-MEDIA-SEQUENCE:9",
+		"#EXT-X-MAP:URI=\"init.mp4\"",
+		"#EXTINF:2.669000,",
+		"seg_00009.m4s",
+		"#EXTINF:1.669000,",
+		"seg_00010.m4s",
+		"#EXTINF:1.668000,",
+		"seg_00011.m4s",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(dir, "stream.m3u8"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	argsPath := filepath.Join(dir, "restart-args")
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	ffmpeg := `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "framecrc" ]; then
+    printf '%s\n' '#tb 0: 1/1000'
+    printf '%s\n' '0, 18000, 18000, 41, 1024, 0x12345678'
+    exit 0
+  fi
+done
+printf '%s\n' "$@" > "` + argsPath + `"
+exec sleep 30
+`
+	if err := os.WriteFile(ffmpegPath, []byte(ffmpeg), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+
+	s := &TranscodeSession{
+		outputDir: dir,
+		opts: TranscodeOpts{
+			SessionID:              "sess-copy",
+			InputPath:              "/media/movie.mkv",
+			OutputDir:              dir,
+			FFmpegPath:             ffmpegPath,
+			SeekSeconds:            18.261,
+			StreamOriginSeconds:    18,
+			CopySeekAnchorResolved: true,
+			TargetCodecVideo:       "copy",
+			TargetCodecAudio:       "copy",
+			SegmentDuration:        2,
+			StartSegmentNumber:     9,
+		},
+	}
+	m := NewTranscodeManager()
+	m.RegisterTranscodeSession("sess-copy", s)
+	t.Cleanup(func() { _ = s.Close() })
+
+	target, ok, err := m.RestartSegmentLocked(context.Background(), "sess-copy", s, 10)
+	if err != nil {
+		t.Fatalf("RestartSegmentLocked: %v", err)
+	}
+	if !ok {
+		t.Fatal("RestartSegmentLocked returned ok=false")
+	}
+	if math.Abs(target.SeekSeconds-20.669) > 0.0001 || math.Abs(target.StreamOriginSeconds-18) > 0.0001 ||
+		target.StartSegmentNumber != 9 || !target.CopySeekAnchorResolved {
+		t.Fatalf("restart target = %+v, want seek=20.669 origin=18 start=9 resolved=true", target)
+	}
+
+	opts := s.Opts()
+	if math.Abs(opts.SeekSeconds-20.669) > 0.0001 || math.Abs(opts.StreamOriginSeconds-18) > 0.0001 ||
+		opts.StartSegmentNumber != 9 || !opts.CopySeekAnchorResolved {
+		t.Fatalf("live restart opts = %+v, want resolved copy timeline", opts)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, statErr := os.Stat(argsPath); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("restart process did not record its arguments")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read restart args: %v", err)
+	}
+	if !strings.Contains(string(args), "-ss\n20.669\n") || !strings.Contains(string(args), "-start_number\n9\n") {
+		t.Fatalf("restart args do not preserve resolved timeline:\n%s", args)
 	}
 }
 

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -2788,6 +2788,29 @@ func (s *TranscodeSession) RestartWithCopySeekAnchor(
 	return s.restart(ctx, seekSeconds, startSegment, streamOriginSeconds, true)
 }
 
+// RestartSegment resolves and applies one missing-segment recovery as a single
+// operation. Callers hold their session lifecycle lock around this method so
+// the manifest used for copy-anchor mapping cannot be replaced by another
+// restart before the resolved numbering is applied.
+func (s *TranscodeSession) RestartSegment(ctx context.Context, segNum int) (SegmentRecoveryTarget, bool, error) {
+	target, ok, err := s.ResolveSegmentRecoveryTarget(ctx, segNum)
+	if err != nil || !ok {
+		return SegmentRecoveryTarget{}, ok, err
+	}
+
+	if target.CopySeekAnchorResolved {
+		err = s.RestartWithCopySeekAnchor(
+			ctx,
+			target.SeekSeconds,
+			target.StartSegmentNumber,
+			target.StreamOriginSeconds,
+		)
+	} else {
+		err = s.Restart(ctx, target.SeekSeconds, target.StartSegmentNumber)
+	}
+	return target, true, err
+}
+
 // restartFlight carries the outcome of an in-flight restart so a concurrent
 // caller waits for it and receives the result instead of assuming success and
 // falling through to a stream the failed restart never produced.
@@ -3245,29 +3268,9 @@ func (s *TranscodeSession) IsCopyVideo() bool {
 // segment using the current on-disk manifest. The bool return is false when
 // the segment is not present in the manifest yet.
 func (s *TranscodeSession) SegmentStartTime(segNum int) (float64, bool, error) {
-	s.mu.Lock()
-	manifestPath := filepath.Join(s.outputDir, "stream.m3u8")
-	baseSeekSeconds := s.opts.SeekSeconds
-	if strings.EqualFold(s.opts.TargetCodecVideo, "copy") && s.opts.CopySeekAnchorResolved {
-		baseSeekSeconds = s.opts.StreamOriginSeconds
-	}
-	s.mu.Unlock()
-
-	manifest, err := os.ReadFile(manifestPath)
+	baseSeekSeconds, timeline, err := s.manifestTimelineSnapshot()
 	if err != nil {
-		if os.IsNotExist(err) {
-			return 0, false, ErrManifestNotReady
-		}
-		return 0, false, fmt.Errorf("read manifest: %w", err)
-	}
-
-	timeline, err := parseManifestTimeline(manifest)
-	if err != nil {
-		return 0, false, fmt.Errorf("parse manifest timeline: %w", err)
-	}
-
-	if len(timeline.entries) == 0 {
-		return 0, false, ErrManifestNotReady
+		return 0, false, err
 	}
 
 	currentTime := baseSeekSeconds
@@ -3279,6 +3282,104 @@ func (s *TranscodeSession) SegmentStartTime(segNum int) (float64, bool, error) {
 	}
 
 	return 0, false, nil
+}
+
+func (s *TranscodeSession) manifestTimelineSnapshot() (float64, manifestTimeline, error) {
+	s.mu.Lock()
+	manifestPath := filepath.Join(s.outputDir, "stream.m3u8")
+	baseSeekSeconds := s.opts.SeekSeconds
+	if strings.EqualFold(s.opts.TargetCodecVideo, "copy") && s.opts.CopySeekAnchorResolved {
+		baseSeekSeconds = s.opts.StreamOriginSeconds
+	}
+	s.mu.Unlock()
+
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, manifestTimeline{}, ErrManifestNotReady
+		}
+		return 0, manifestTimeline{}, fmt.Errorf("read manifest: %w", err)
+	}
+
+	timeline, err := parseManifestTimeline(manifest)
+	if err != nil {
+		return 0, manifestTimeline{}, fmt.Errorf("parse manifest timeline: %w", err)
+	}
+
+	if len(timeline.entries) == 0 {
+		return 0, manifestTimeline{}, ErrManifestNotReady
+	}
+	return baseSeekSeconds, timeline, nil
+}
+
+const copySegmentStartMatchTolerance = 50 * time.Millisecond
+
+// segmentNumberAtSourceTime maps an actual copied packet timestamp back onto
+// the existing playlist. Copy HLS segment durations follow source keyframes,
+// so fixed-duration arithmetic cannot preserve the URI numbering after a
+// restart. The timestamp must match a real segment boundary; returning false is
+// safer than publishing shifted content when the bounded manifest no longer
+// contains the preceding anchor.
+func (s *TranscodeSession) segmentNumberAtSourceTime(sourceSeconds float64) (int, bool, error) {
+	baseSeekSeconds, timeline, err := s.manifestTimelineSnapshot()
+	if err != nil {
+		return 0, false, err
+	}
+
+	currentTime := baseSeekSeconds
+	for _, entry := range timeline.entries {
+		if math.Abs(currentTime-sourceSeconds) <= copySegmentStartMatchTolerance.Seconds() {
+			return entry.number, true, nil
+		}
+		currentTime += entry.duration
+	}
+
+	return 0, false, nil
+}
+
+// SegmentRecoveryTarget describes the FFmpeg seek and HLS numbering for one
+// missing-segment recovery. Copy-video recovery may begin before the requested
+// segment when the demuxer emits pre-roll; encoded recovery remains exact.
+type SegmentRecoveryTarget struct {
+	SeekSeconds            float64
+	StreamOriginSeconds    float64
+	StartSegmentNumber     int
+	CopySeekAnchorResolved bool
+}
+
+// ResolveSegmentRecoveryTarget preserves the existing manifest's
+// URI-to-source-time mapping across a missing-segment restart.
+func (s *TranscodeSession) ResolveSegmentRecoveryTarget(ctx context.Context, segNum int) (SegmentRecoveryTarget, bool, error) {
+	seekSeconds, ok, err := s.RestartSeekTarget(segNum)
+	if err != nil || !ok {
+		return SegmentRecoveryTarget{}, ok, err
+	}
+
+	target := SegmentRecoveryTarget{SeekSeconds: seekSeconds, StartSegmentNumber: segNum}
+	opts := s.Opts()
+	if !strings.EqualFold(opts.TargetCodecVideo, "copy") {
+		return target, true, nil
+	}
+
+	streamOriginSeconds, _, err := ResolveCopySeekAnchor(
+		ctx,
+		opts.FFmpegPath,
+		opts.InputPath,
+		seekSeconds,
+		opts.SegmentDuration,
+	)
+	if err != nil {
+		return SegmentRecoveryTarget{}, false, err
+	}
+	startSegmentNumber, ok, err := s.segmentNumberAtSourceTime(streamOriginSeconds)
+	if err != nil || !ok {
+		return SegmentRecoveryTarget{}, ok, err
+	}
+
+	target.StreamOriginSeconds = streamOriginSeconds
+	target.StartSegmentNumber = startSegmentNumber
+	target.CopySeekAnchorResolved = true
+	return target, true, nil
 }
 
 // RestartSeekTarget resolves the source-timeline time to restart FFmpeg for

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -282,6 +282,26 @@ func (m *TranscodeManager) RestartSessionLocked(ctx context.Context, sessionID s
 	})
 }
 
+// RestartSegmentLocked resolves and restarts one missing HLS segment under the
+// per-session lifecycle lock. Copy-video resolution reads the current manifest,
+// so keeping resolution and restart inside the same lock preserves the mapping
+// it observed.
+func (m *TranscodeManager) RestartSegmentLocked(
+	ctx context.Context,
+	sessionID string,
+	ts *TranscodeSession,
+	segNum int,
+) (SegmentRecoveryTarget, bool, error) {
+	var target SegmentRecoveryTarget
+	var ok bool
+	err := m.restartSessionLocked(sessionID, ts, func() error {
+		var restartErr error
+		target, ok, restartErr = ts.RestartSegment(ctx, segNum)
+		return restartErr
+	})
+	return target, ok, err
+}
+
 func (m *TranscodeManager) restartSessionLocked(sessionID string, ts *TranscodeSession, restart func() error) error {
 	unlock := m.LockSessionLifecycle(sessionID)
 	defer unlock()

--- a/internal/playback/transcode_manifest_test.go
+++ b/internal/playback/transcode_manifest_test.go
@@ -1,6 +1,7 @@
 package playback
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -595,6 +596,78 @@ func TestRestartSeekTarget_CopyModeUsesManifestTimelineWhenAvailable(t *testing.
 	}
 	if math.Abs(got-20.669) > 0.0001 {
 		t.Fatalf("RestartSeekTarget(10) = %.6f, want 20.669", got)
+	}
+}
+
+func TestResolveSegmentRecoveryTarget_CopyMapsActualAnchorToManifestNumber(t *testing.T) {
+	manifest := strings.Join([]string{
+		"#EXTM3U",
+		"#EXT-X-VERSION:7",
+		"#EXT-X-TARGETDURATION:3",
+		"#EXT-X-MEDIA-SEQUENCE:9",
+		"#EXT-X-MAP:URI=\"init.mp4\"",
+		"#EXTINF:2.669000,",
+		"seg_00009.m4s",
+		"#EXTINF:1.669000,",
+		"seg_00010.m4s",
+		"#EXTINF:1.668000,",
+		"seg_00011.m4s",
+		"",
+	}, "\n")
+
+	tests := []struct {
+		name             string
+		anchorMillis     int
+		wantStartSegment int
+		wantOrigin       float64
+	}{
+		{name: "Matroska pre-roll uses preceding manifest slot", anchorMillis: 18000, wantStartSegment: 9, wantOrigin: 18},
+		{name: "MP4 exact seek keeps requested manifest slot", anchorMillis: 20669, wantStartSegment: 10, wantOrigin: 20.669},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(tempDir, "stream.m3u8"), []byte(manifest), 0o644); err != nil {
+				t.Fatalf("write manifest: %v", err)
+			}
+			ffmpegPath := filepath.Join(tempDir, "ffmpeg")
+			probe := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' '#tb 0: 1/1000'\nprintf '%%s\\n' '0, %d, %d, 41, 1024, 0x12345678'\n", tt.anchorMillis, tt.anchorMillis)
+			if err := os.WriteFile(ffmpegPath, []byte(probe), 0o755); err != nil {
+				t.Fatalf("write fake ffmpeg: %v", err)
+			}
+
+			session := &TranscodeSession{
+				outputDir: tempDir,
+				opts: TranscodeOpts{
+					InputPath:              "/media/movie.mkv",
+					FFmpegPath:             ffmpegPath,
+					SeekSeconds:            18.261,
+					StreamOriginSeconds:    18,
+					CopySeekAnchorResolved: true,
+					TargetCodecVideo:       "copy",
+					SegmentDuration:        2,
+					StartSegmentNumber:     9,
+				},
+			}
+
+			target, ok, err := session.ResolveSegmentRecoveryTarget(context.Background(), 10)
+			if err != nil {
+				t.Fatalf("ResolveSegmentRecoveryTarget: %v", err)
+			}
+			if !ok {
+				t.Fatal("ResolveSegmentRecoveryTarget returned ok=false")
+			}
+			if math.Abs(target.SeekSeconds-20.669) > 0.0001 {
+				t.Fatalf("SeekSeconds = %.6f, want 20.669", target.SeekSeconds)
+			}
+			if target.StartSegmentNumber != tt.wantStartSegment {
+				t.Fatalf("StartSegmentNumber = %d, want %d", target.StartSegmentNumber, tt.wantStartSegment)
+			}
+			if math.Abs(target.StreamOriginSeconds-tt.wantOrigin) > 0.0001 || !target.CopySeekAnchorResolved {
+				t.Fatalf("copy anchor = %.6f resolved=%v, want %.6f resolved=true", target.StreamOriginSeconds, target.CopySeekAnchorResolved, tt.wantOrigin)
+			}
+		})
 	}
 }
 

--- a/internal/transcodenode/restart_locked_test.go
+++ b/internal/transcodenode/restart_locked_test.go
@@ -3,11 +3,80 @@ package transcodenode
 import (
 	"context"
 	"errors"
+	"math"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/playback"
 )
+
+func TestRestartSegmentLocked_UsesResolvedCopyAnchorAndManifestNumber(t *testing.T) {
+	dir := t.TempDir()
+	ffmpegPath := filepath.Join(dir, "ffmpeg")
+	manifest := "#EXTM3U\\n#EXT-X-VERSION:7\\n#EXT-X-TARGETDURATION:3\\n#EXT-X-MEDIA-SEQUENCE:9\\n#EXT-X-MAP:URI=\"init.mp4\"\\n#EXTINF:2.669000,\\nseg_00009.m4s\\n#EXTINF:1.669000,\\nseg_00010.m4s\\n#EXTINF:1.668000,\\nseg_00011.m4s\\n"
+	ffmpeg := `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "framecrc" ]; then
+    printf '%s\n' '#tb 0: 1/1000'
+    printf '%s\n' '0, 18000, 18000, 41, 1024, 0x12345678'
+    exit 0
+  fi
+done
+printf '%b' '` + manifest + `' > '` + filepath.Join(dir, "stream.m3u8") + `'
+exec sleep 30
+`
+	if err := os.WriteFile(ffmpegPath, []byte(ffmpeg), 0o755); err != nil {
+		t.Fatalf("write fake ffmpeg: %v", err)
+	}
+
+	const sessionID = "copy-node-recovery"
+	session, err := playback.StartTranscode(context.Background(), playback.TranscodeOpts{
+		SessionID:              sessionID,
+		InputPath:              "/media/movie.mkv",
+		OutputDir:              dir,
+		FFmpegPath:             ffmpegPath,
+		SeekSeconds:            18.261,
+		StreamOriginSeconds:    18,
+		CopySeekAnchorResolved: true,
+		TargetCodecVideo:       "copy",
+		TargetCodecAudio:       "copy",
+		SegmentDuration:        2,
+		StartSegmentNumber:     9,
+	})
+	if err != nil {
+		t.Fatalf("StartTranscode: %v", err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "stream.m3u8")); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("initial fake transcode did not publish its manifest")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	server := &Server{sessions: map[string]*playback.TranscodeSession{sessionID: session}}
+	target, ok, err := server.restartSegmentLocked(context.Background(), sessionID, session, 10)
+	if err != nil {
+		t.Fatalf("restartSegmentLocked: %v", err)
+	}
+	if !ok {
+		t.Fatal("restartSegmentLocked returned ok=false")
+	}
+	if math.Abs(target.SeekSeconds-20.669) > 0.0001 || math.Abs(target.StreamOriginSeconds-18) > 0.0001 ||
+		target.StartSegmentNumber != 9 || !target.CopySeekAnchorResolved {
+		t.Fatalf("restart target = %+v, want seek=20.669 origin=18 start=9 resolved=true", target)
+	}
+	opts := session.Opts()
+	if opts.StartSegmentNumber != 9 || !opts.CopySeekAnchorResolved || math.Abs(opts.StreamOriginSeconds-18) > 0.0001 {
+		t.Fatalf("node recovery opts = %+v, want start=9 origin=18 resolved=true", opts)
+	}
+}
 
 // The node's segment-recovery restart must also run under the per-session
 // lifecycle lock so it cannot race a fresh start or reconstruct into the same

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -340,6 +340,25 @@ func (s *Server) restartSessionLocked(ctx context.Context, sessionID string, ses
 	return session.Restart(ctx, seekSeconds, startSegment)
 }
 
+// restartSegmentLocked resolves and applies missing-segment recovery while the
+// node's lifecycle lock keeps the current manifest and live session stable.
+func (s *Server) restartSegmentLocked(
+	ctx context.Context,
+	sessionID string,
+	session *playback.TranscodeSession,
+	segNum int,
+) (playback.SegmentRecoveryTarget, bool, error) {
+	unlock := s.lockSessionLifecycle(sessionID)
+	defer unlock()
+	s.mu.RLock()
+	live, ok := s.sessions[sessionID]
+	s.mu.RUnlock()
+	if !ok || live != session {
+		return playback.SegmentRecoveryTarget{}, false, playback.ErrSessionSuperseded
+	}
+	return session.RestartSegment(ctx, segNum)
+}
+
 // NewServer creates a new transcode server.
 func NewServer(watcher *nodeconfig.Watcher, tracker *nodesessions.Tracker) *Server {
 	var trackerImpl sessionTracker
@@ -1959,12 +1978,19 @@ func (s *Server) handleSegment(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if err != nil && err == playback.ErrSegmentNotFound && decision.RestartOnTimeout {
-				seekSeconds, ok, seekErr := session.RestartSeekTarget(segNum)
-				if seekErr != nil && !errors.Is(seekErr, playback.ErrManifestNotReady) {
-					slog.ErrorContext(r.Context(), "resolve transcode node seek target", "component", "transcodenode", "error", seekErr, "segment", name, "session", sessionID, "playback_session_id", sessionID)
+				target, ok, restartErr := s.restartSegmentLocked(
+					r.Context(),
+					sessionID,
+					session,
+					segNum,
+				)
+				if restartErr != nil && !errors.Is(restartErr, playback.ErrManifestNotReady) {
+					slog.ErrorContext(r.Context(), "restart transcode node at missing segment", "component", "transcodenode", "error", restartErr, "segment", name, "session", sessionID, "playback_session_id", sessionID)
 				}
 
-				if ok {
+				if restartErr != nil {
+					err = restartErr
+				} else if ok {
 					slog.InfoContext(r.Context(), "transcode node seek restart", "component", "transcodenode",
 						"segment", name,
 						"requested_segment", segNum,
@@ -1974,24 +2000,16 @@ func (s *Server) handleSegment(w http.ResponseWriter, r *http.Request) {
 						"last_produced_age_ms", lastProducedAgeMS,
 						"wait_timeout_ms", decision.WaitTimeout.Milliseconds(),
 						"reason", decision.Reason,
-						"seek_seconds", seekSeconds,
+						"seek_seconds", target.SeekSeconds,
+						"stream_origin_seconds", target.StreamOriginSeconds,
+						"resolved_start_segment", target.StartSegmentNumber,
 						"session", sessionID,
 						"playback_session_id", sessionID,
 					)
 
-					if restartErr := s.restartSessionLocked(
-						r.Context(),
-						sessionID,
-						session,
-						seekSeconds,
-						segNum,
-					); restartErr == nil {
-						segmentLease, err = session.WaitForOpenSegment(name, 30*time.Second)
-					} else {
-						err = restartErr
-					}
+					segmentLease, err = session.WaitForOpenSegment(name, 30*time.Second)
 				}
-				if !ok && session.IsCopyVideo() {
+				if !ok && restartErr == nil && session.IsCopyVideo() {
 					err = playback.ErrSegmentNotFound
 				}
 			}


### PR DESCRIPTION
## Problem

Related issue: #839
Closes #839

When a copy-remux segment had been pruned, backward-seek recovery restarted FFmpeg at the requested segment's source time and reused that segment number. Matroska can emit a preceding keyframe at an exact seek boundary, so the restarted content was shifted by one URI. Safari then requested the expected segment and stalled on content from the wrong timeline position.

## Approach

- Resolve the actual first copied video packet by running FFmpeg's real fast-seek and stream-copy path with a one-packet `framecrc` sink. The previous `ffprobe -read_intervals` probe discarded Matroska pre-roll and could report the wrong anchor.
- Map that packet timestamp back to an existing manifest boundary before choosing `-start_number`, preserving the established URI-to-source-time mapping. If the bounded manifest no longer contains the anchor, recovery fails safely instead of guessing.
- Hold the existing per-session lifecycle lock across manifest resolution and restart.
- Use the same recovery path for native playback, transcode nodes, and Jellyfin-compatible local HLS.
- Add regressions for real long-GOP HEVC in MKV and MP4, manifest numbering, lifecycle restart behavior, the native HTTP path, and the transcode-node wrapper.

No API, database, settings, or client contract changes are required.

## Validation

Passed:

```text
go build ./...
go vet ./...
golangci-lint run --new-from-merge-base=origin/main ./...
0 issues.

go test ./internal/playback -run '(ResolveCopySeekAnchor|ResolveSegmentRecoveryTarget|RestartSegmentLocked|RestartSeekTarget|SegmentStartTime|CleanStaleOutputForRestart)' -count=1
ok github.com/Silo-Server/silo-server/internal/playback

go test ./internal/api/handlers -count=1
ok github.com/Silo-Server/silo-server/internal/api/handlers

go test ./internal/transcodenode -count=1
ok github.com/Silo-Server/silo-server/internal/transcodenode

go test ./internal/jellycompat -count=1
ok github.com/Silo-Server/silo-server/internal/jellycompat

pnpm --dir web run lint
0 errors, 174 existing warnings

pnpm --dir web run format:check
All matched files use Prettier code style!

pnpm --dir web run build
✓ built

make test-web
Test Files 355 passed (355)
Tests 2970 passed (2970)

make verify-settings-bindings-all
settings bindings are current
web settings binding is current

make verify-playback-fixtures
playback fixtures are current

make verify-local-paths
```

`make test-go` completed all packages except one timing-sensitive transcode-node test: `TestHandleDownloadPrepareTrackingDoesNotBlockAndRemovesAfterTrack`. That test passed immediately in isolation, and the complete `internal/transcodenode` package passed in a separate serial run. The failure is outside the changed recovery path.

The pre-fix failure was reproduced on production with a remuxed MKV and is documented in #839. Post-fix production validation has not been run because this branch is not deployed.

## Risks

Copy-video recovery now performs one additional bounded FFmpeg probe. It is singleflight-coalesced, limited to four concurrent probes, and has a 15-second timeout. If the probe or manifest mapping cannot resolve safely, the request returns an error/retryable miss rather than serving a misnumbered segment.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: Reviewed the complete diff and the native, node, and Jellyfin-compatible call paths for stream selection, timestamp precision, bounded-manifest eviction, restart races, and failure behavior. Real FFmpeg tests challenged the key assumption with both MKV pre-roll and MP4 exact-keyframe behavior. The review replaced the inaccurate ffprobe design, kept resolution and restart under the lifecycle lock, and made unresolved mappings fail safely. No API, migration, security, or client-contract changes were found.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when HLS segments are missing, especially for copy-mode playback.
  * Recovery now uses the correct resolved keyframe and manifest segment, reducing playback failures and timeline mismatches.
  * Improved handling of segment restart errors and fallback behavior.
  * Fixed keyframe detection across different media container formats.

* **Tests**
  * Added coverage for copy-mode recovery, manifest mapping, keyframe detection, and restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->