### PR TITLE
fix(playback): scope Android Media3 HLS sample entries

### DIFF
--- a/docs/design/schemas/playback-v3/v3/decision-response.schema.json
+++ b/docs/design/schemas/playback-v3/v3/decision-response.schema.json
@@ -405,6 +405,13 @@
         "video_codec": {
           "type": "string"
         },
+        "video_sample_entry": {
+          "type": "string",
+          "enum": [
+            "hvc1",
+            "dvh1"
+          ]
+        },
         "audio_codec": {
           "type": "string"
         },

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -4323,6 +4323,7 @@ func seekReanchorIdentityChangesV3(record *playback.AttemptRecordV3, candidate *
 	add("mime_type", candidate.Stream.MIMEType != current.Stream.MIMEType)
 	add("header_refresh", candidate.Stream.HeaderRefresh != current.Stream.HeaderRefresh)
 	add("video_codec", candidate.EffectiveRecipe.VideoCodec != current.EffectiveRecipe.VideoCodec)
+	add("video_sample_entry", candidate.EffectiveRecipe.VideoSampleEntry != current.EffectiveRecipe.VideoSampleEntry)
 	add("audio_codec", candidate.EffectiveRecipe.AudioCodec != current.EffectiveRecipe.AudioCodec)
 	add("resolution", !optionalIntEqualV3(candidate.EffectiveRecipe.Width, current.EffectiveRecipe.Width) || !optionalIntEqualV3(candidate.EffectiveRecipe.Height, current.EffectiveRecipe.Height))
 	add("frame_rate", !optionalFloatEqualV3(candidate.EffectiveRecipe.FrameRate, current.EffectiveRecipe.FrameRate))
@@ -5296,6 +5297,9 @@ func videoBitstreamFilterForPlanV3(plan *playback.PlanV3) string {
 func videoSampleEntryForPlanV3(plan *playback.PlanV3) string {
 	if plan == nil || plan.Delivery != playback.DeliveryRemuxHLSV3 {
 		return ""
+	}
+	if plan.EffectiveRecipe.VideoSampleEntry != "" {
+		return plan.EffectiveRecipe.VideoSampleEntry
 	}
 	for _, transformation := range plan.Transformations {
 		if transformation.Name == playback.TransformationServerDV7HDR10V3 {

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -2601,9 +2601,10 @@ func TestSeekReanchorIdentityChangesV3ReportsOnlyChangedFieldNames(t *testing.T)
 	candidate.PlanID = "plan:candidate"
 	candidate.Delivery = playback.DeliveryRemuxHLSV3
 	candidate.Stream.Container = "hls"
+	candidate.EffectiveRecipe.VideoSampleEntry = playback.VideoSampleEntryHVC1
 	candidate.EffectiveRecipe.AudioCodec = "ac3"
 	got := strings.Join(seekReanchorIdentityChangesV3(record, &candidate), ",")
-	if want := "plan_id,delivery,container,audio_codec"; got != want {
+	if want := "plan_id,delivery,container,video_sample_entry,audio_codec"; got != want {
 		t.Fatalf("changed fields = %q, want %q", got, want)
 	}
 }
@@ -3335,6 +3336,12 @@ func TestVideoSampleEntryForPlanV3(t *testing.T) {
 			name: "stripped HDR10",
 			plan: &playback.PlanV3{Delivery: playback.DeliveryRemuxHLSV3,
 				Transformations: []playback.TransformationV3{{Name: playback.TransformationServerDV7HDR10V3}}},
+			want: playback.VideoSampleEntryHVC1,
+		},
+		{
+			name: "explicit native HLS recipe",
+			plan: &playback.PlanV3{Delivery: playback.DeliveryRemuxHLSV3,
+				EffectiveRecipe: playback.EffectiveRecipeV3{VideoCodec: "hevc", VideoSampleEntry: playback.VideoSampleEntryHVC1}},
 			want: playback.VideoSampleEntryHVC1,
 		},
 		{

--- a/internal/playback/device_quirks_v3.go
+++ b/internal/playback/device_quirks_v3.go
@@ -49,6 +49,15 @@ func hlsEAC3AudioCorrectionV3(source SourceDescriptorV3, request StartRequestV3)
 	return &quirk, true
 }
 
+// usesFirstPartyAndroidMedia3HLSV3 identifies the legacy Silo Android clients
+// that already opt into the device-quirks contract. Current clients advertise
+// native_hls_playback_v1 on the HLS delivery directly; this bounded fallback
+// keeps existing build 15 installs on the same native Media3 byte recipe.
+func usesFirstPartyAndroidMedia3HLSV3(request StartRequestV3) bool {
+	return deviceQuirkProtocolAvailableV3(request) &&
+		strings.EqualFold(strings.TrimSpace(request.ClientPlaybackContext.Device.Platform), "android")
+}
+
 func dv8HDR10PlusRuntimeCorrectionV3(source SourceDescriptorV3, request StartRequestV3, deliveryClass string) (*AppliedQuirkV3, bool) {
 	if !deviceQuirkProtocolAvailableV3(request) || source.DVProfile != 8 || !source.HDR10Plus ||
 		!isAmazonFireTVV3(request) || !deliverySupportsFeatureV3(request, deliveryClass, ClientDV8HDR10PlusSanitizerV3) {

--- a/internal/playback/device_quirks_v3.go
+++ b/internal/playback/device_quirks_v3.go
@@ -7,6 +7,7 @@ const (
 	QuirkFireTVAFTKRTEAC3HLSV3      = "android.fire_tv.aftkrt.eac3_7_1_hls_audio_adapt_v1"
 	QuirkFireTVDV8HDR10PlusV3       = "android.fire_tv.dv8_hdr10plus_sei_v1"
 	QuirkFirefoxMatroskaAACTimingV3 = "web.firefox.matroska_aac_timestamps_v1"
+	legacyAndroidMedia3HLSBuildV3   = "15"
 )
 
 func high10DecodeOverrideV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
@@ -49,13 +50,14 @@ func hlsEAC3AudioCorrectionV3(source SourceDescriptorV3, request StartRequestV3)
 	return &quirk, true
 }
 
-// usesFirstPartyAndroidMedia3HLSV3 identifies the legacy Silo Android clients
-// that already opt into the device-quirks contract. Current clients advertise
-// native_hls_playback_v1 on the HLS delivery directly; this bounded fallback
-// keeps existing build 15 installs on the same native Media3 byte recipe.
+// usesFirstPartyAndroidMedia3HLSV3 identifies the exact legacy Silo Android
+// build that predates native_hls_playback_v1 but already reports its build and
+// opts into the device-quirks contract. Current clients advertise the native
+// HLS feature on the delivery directly.
 func usesFirstPartyAndroidMedia3HLSV3(request StartRequestV3) bool {
 	return deviceQuirkProtocolAvailableV3(request) &&
-		strings.EqualFold(strings.TrimSpace(request.ClientPlaybackContext.Device.Platform), "android")
+		strings.EqualFold(strings.TrimSpace(request.ClientPlaybackContext.Device.Platform), "android") &&
+		strings.TrimSpace(request.ClientPlaybackContext.AppBuild) == legacyAndroidMedia3HLSBuildV3
 }
 
 func dv8HDR10PlusRuntimeCorrectionV3(source SourceDescriptorV3, request StartRequestV3, deliveryClass string) (*AppliedQuirkV3, bool) {

--- a/internal/playback/plan_key_v3.go
+++ b/internal/playback/plan_key_v3.go
@@ -34,6 +34,7 @@ func DeterministicPlanIDV3(attemptID string, requestedFileID, effectiveFileID in
 		string(plan.Subtitle.Mode),
 		strings.Join(transformations, ","),
 	}
+	parts = appendVideoSampleEntryIdentityV3(parts, plan.EffectiveRecipe.VideoSampleEntry)
 	parts = appendQuirkIdentityV3(parts, plan)
 	parts = append(parts, PlanRecipeVersionV3)
 	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
@@ -63,6 +64,7 @@ func PlanAttemptKeyV3(plan PlanV3, outputContextID string, localMutations []stri
 		string(plan.Subtitle.Mode),
 		strings.Join(transformations, ","),
 	}
+	parts = appendVideoSampleEntryIdentityV3(parts, plan.EffectiveRecipe.VideoSampleEntry)
 	parts = appendQuirkIdentityV3(parts, plan)
 	parts = append(parts,
 		outputContextID,
@@ -72,6 +74,13 @@ func PlanAttemptKeyV3(plan PlanV3, outputContextID string, localMutations []stri
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(canonical))
 	return fmt.Sprintf("v3:%016x", h.Sum64())
+}
+
+func appendVideoSampleEntryIdentityV3(parts []string, sampleEntry string) []string {
+	if sampleEntry = strings.ToLower(strings.TrimSpace(sampleEntry)); sampleEntry != "" {
+		return append(parts, "sample_entry="+sampleEntry)
+	}
+	return parts
 }
 
 func appendQuirkIdentityV3(parts []string, plan PlanV3) []string {

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -513,6 +513,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			plan := cloneRemuxPlanCandidateV3(remuxBase)
 			plan.Delivery = DeliveryRemuxHLSV3
 			plan.Stream = StreamV3{Protocol: StreamHLSV3, Container: "hls", MIMEType: "application/vnd.apple.mpegurl", Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
+			plan.EffectiveRecipe.VideoSampleEntry = hlsVideoSampleEntryV3(source, input.Request, dvStrip)
 			hlsAudioChannels := 0
 			if hlsTranscodeAudio {
 				if !input.hlsRegistry().Available(TransformationAudioToAACV3) {
@@ -577,6 +578,23 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	}
 
 	return terminalPlannerResultV3("adaptation_unavailable", "No validated playback route is available for this source and output route.", false)
+}
+
+// Native HLS consumers use hvc1/dvh1 byte recipes. Web MediaSource clients
+// keep the server's existing FFmpeg-default labeling unless they explicitly
+// advertise the delivery-scoped native-HLS feature.
+func hlsVideoSampleEntryV3(source SourceDescriptorV3, request StartRequestV3, dvStrip bool) string {
+	if !strings.EqualFold(source.VideoCodec, "hevc") {
+		return ""
+	}
+	if !deliverySupportsFeatureV3(request, DeliveryClassHLSV3, ClientNativeHLSPlaybackV3) &&
+		!usesFirstPartyAndroidMedia3HLSV3(request) {
+		return ""
+	}
+	if !dvStrip && (source.DVProfile == 5 || source.DVProfile == 8) {
+		return VideoSampleEntryDVH1
+	}
+	return VideoSampleEntryHVC1
 }
 
 // availableQualitiesV3 publishes the server ladder rungs a client could

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -70,6 +70,7 @@ const (
 	ClaimClientManagedDynamicRangeV3 = "client_managed_dynamic_range_v1"
 	ClaimClientSelectedAudioTrackV3  = "client_selected_audio_track_v1"
 	ClientDV8HDR10PlusSanitizerV3    = "client_dv8_hdr10plus_sanitizer_v1"
+	ClientNativeHLSPlaybackV3        = "native_hls_playback_v1"
 	ClientPostResumeRecoveryV3       = "client_post_resume_video_recovery_v1"
 	ClientSurfaceRecoveryV3          = "client_surface_recovery_v1"
 	DeviceQuirkRegistryRevisionV3    = "2026-07-13.1"
@@ -623,15 +624,16 @@ type TimelineV3 struct {
 }
 
 type EffectiveRecipeV3 struct {
-	VideoCodec    string   `json:"video_codec,omitempty"`
-	AudioCodec    string   `json:"audio_codec,omitempty"`
-	Width         *int     `json:"width,omitempty"`
-	Height        *int     `json:"height,omitempty"`
-	FrameRate     *float64 `json:"frame_rate,omitempty"`
-	BitrateKbps   *int     `json:"bitrate_kbps,omitempty"`
-	DynamicRange  string   `json:"dynamic_range,omitempty"`
-	AudioChannels *int     `json:"audio_channels,omitempty"`
-	AudioLayout   string   `json:"audio_layout,omitempty"`
+	VideoCodec       string   `json:"video_codec,omitempty"`
+	VideoSampleEntry string   `json:"video_sample_entry,omitempty"`
+	AudioCodec       string   `json:"audio_codec,omitempty"`
+	Width            *int     `json:"width,omitempty"`
+	Height           *int     `json:"height,omitempty"`
+	FrameRate        *float64 `json:"frame_rate,omitempty"`
+	BitrateKbps      *int     `json:"bitrate_kbps,omitempty"`
+	DynamicRange     string   `json:"dynamic_range,omitempty"`
+	AudioChannels    *int     `json:"audio_channels,omitempty"`
+	AudioLayout      string   `json:"audio_layout,omitempty"`
 }
 
 type SourceDescriptorV3 struct {

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -389,6 +389,24 @@ func TestPlanAttemptKeyV3Fixture(t *testing.T) {
 	}
 }
 
+func TestPlanIdentityIncludesVideoSampleEntry(t *testing.T) {
+	plan := PlanV3{
+		PlanID:          "plan:sample-entry",
+		Delivery:        DeliveryRemuxHLSV3,
+		Stream:          StreamV3{Protocol: StreamHLSV3, Container: "hls"},
+		EffectiveRecipe: EffectiveRecipeV3{VideoCodec: "hevc"},
+	}
+	withoutEntryID := DeterministicPlanIDV3("attempt-sample-entry", 42, 42, plan)
+	withoutEntryKey := PlanAttemptKeyV3(plan, "output-1", nil)
+	plan.EffectiveRecipe.VideoSampleEntry = VideoSampleEntryHVC1
+	if withEntryID := DeterministicPlanIDV3("attempt-sample-entry", 42, 42, plan); withEntryID == withoutEntryID {
+		t.Fatal("sample-entry change did not alter the deterministic plan id")
+	}
+	if withEntryKey := PlanAttemptKeyV3(plan, "output-1", nil); withEntryKey == withoutEntryKey {
+		t.Fatal("sample-entry change did not alter the plan-attempt key")
+	}
+}
+
 func TestProtocolV3ConformanceMatrixCoversReleaseTrain(t *testing.T) {
 	var matrix ConformanceMatrixV3
 	body, err := os.ReadFile("testdata/protocol_v3/conformance_matrix.json")
@@ -984,6 +1002,100 @@ func TestPlanPlaybackV3SafariNativeHLSAvoidsProgressiveDVRemux(t *testing.T) {
 		result.TargetVideoCodec != "copy" || result.PlayMethod != PlayRemux ||
 		!result.Plan.Claims.Video.DolbyVision {
 		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+	}
+}
+
+func TestHLSVideoSampleEntryV3ScopesNativeRecipes(t *testing.T) {
+	tests := []struct {
+		name         string
+		platform     string
+		deviceQuirks bool
+		nativeHLS    bool
+		dvProfile    int
+		dvStrip      bool
+		want         string
+	}{
+		{name: "legacy Android plain HEVC", platform: "android", deviceQuirks: true, want: VideoSampleEntryHVC1},
+		{name: "legacy Android Profile 7 strip", platform: "android", deviceQuirks: true, dvProfile: 7, dvStrip: true, want: VideoSampleEntryHVC1},
+		{name: "legacy Android Profile 8 preserve", platform: "android", deviceQuirks: true, dvProfile: 8, want: VideoSampleEntryDVH1},
+		{name: "unscoped Android client", platform: "android", dvProfile: 8, want: ""},
+		{name: "web MediaSource", platform: "web", deviceQuirks: true, dvProfile: 7, dvStrip: true, want: ""},
+		{name: "explicit native HLS Profile 7 strip", platform: "tvos", nativeHLS: true, dvProfile: 7, dvStrip: true, want: VideoSampleEntryHVC1},
+		{name: "explicit native HLS Profile 8 preserve", platform: "tvos", nativeHLS: true, dvProfile: 8, want: VideoSampleEntryDVH1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := validStartRequestV3()
+			req.ClientPlaybackContext.Device.Platform = test.platform
+			if test.deviceQuirks {
+				req.ClientFeatures = append(req.ClientFeatures, FeatureDeviceQuirksV3)
+			}
+			if test.nativeHLS {
+				hls := req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+				hls.Features = append(hls.Features, ClientNativeHLSPlaybackV3)
+				req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+			}
+			source := SourceDescriptorV3{VideoCodec: "hevc", DVProfile: test.dvProfile}
+			if got := hlsVideoSampleEntryV3(source, req, test.dvStrip); got != test.want {
+				t.Fatalf("sample entry = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlanPlaybackV3AndroidMedia3HLSRecipesAcrossSourceQualities(t *testing.T) {
+	profiles := []struct {
+		name           string
+		profile        int
+		compatibility  int
+		videoRangeType string
+		hdr            *HDRCapabilitiesV3
+		wantEntry      string
+	}{
+		{name: "Profile 7 strip", profile: 7, compatibility: 6, videoRangeType: "DOVIWithEL", hdr: &HDRCapabilitiesV3{HDR10: true}, wantEntry: VideoSampleEntryHVC1},
+		{name: "Profile 8 preserve", profile: 8, compatibility: 1, videoRangeType: "DOVIWithHDR10", hdr: &HDRCapabilitiesV3{DolbyVisionProfiles: []int{8}, DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6, BLCompatibilityIDs: []int{1}}}}, wantEntry: VideoSampleEntryDVH1},
+	}
+	for _, profile := range profiles {
+		for _, quality := range []string{"auto", QualityOriginalV3, "2160p"} {
+			t.Run(profile.name+"/"+quality, func(t *testing.T) {
+				file := detailedFixtureFileV3()
+				file.CodecAudio = "truehd"
+				file.AudioChannels = 8
+				file.AudioTracks[0] = models.AudioTrack{Codec: "truehd", Channels: 8, Layout: "7.1", Default: true}
+				file.VideoTracks[0].DVProfile = profile.profile
+				file.VideoTracks[0].DVBLCompatID = profile.compatibility
+				file.VideoTracks[0].DVLevel = 6
+				file.VideoTracks[0].ColorTransfer = "smpte2084"
+				file.VideoTracks[0].VideoRange = "DolbyVision"
+				file.VideoTracks[0].VideoRangeType = profile.videoRangeType
+
+				req := validStartRequestV3()
+				req.QualityPreference = quality
+				req.ClientPlaybackContext.Device.Platform = "android"
+				req.ClientFeatures = append(req.ClientFeatures, FeatureDeviceQuirksV3)
+				req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
+				req.Capabilities.HDRDetails = profile.hdr
+				req.ClientPlaybackContext.Output.HDRDetails = profile.hdr
+				delete(req.ClientPlaybackContext.Deliveries, DeliveryClassOriginalHTTPV3)
+				delete(req.ClientPlaybackContext.Deliveries, DeliveryClassProgressiveV3)
+				hls := req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+				hls.VideoCodecs = []string{"hevc"}
+				hls.AudioDecodeCodecs = []string{"aac"}
+				hls.HDRDetails = profile.hdr
+				req.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+
+				result := PlanPlaybackV3(PlannerInputV3{
+					Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+					Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3(),
+				})
+				if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxHLSV3 || result.TargetVideoCodec != "copy" || !result.TranscodeAudio {
+					t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+				}
+				if got := result.Plan.EffectiveRecipe.VideoSampleEntry; got != profile.wantEntry {
+					t.Fatalf("sample entry = %q, want %q", got, profile.wantEntry)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -1009,16 +1009,19 @@ func TestHLSVideoSampleEntryV3ScopesNativeRecipes(t *testing.T) {
 	tests := []struct {
 		name         string
 		platform     string
+		appBuild     string
 		deviceQuirks bool
 		nativeHLS    bool
 		dvProfile    int
 		dvStrip      bool
 		want         string
 	}{
-		{name: "legacy Android plain HEVC", platform: "android", deviceQuirks: true, want: VideoSampleEntryHVC1},
-		{name: "legacy Android Profile 7 strip", platform: "android", deviceQuirks: true, dvProfile: 7, dvStrip: true, want: VideoSampleEntryHVC1},
-		{name: "legacy Android Profile 8 preserve", platform: "android", deviceQuirks: true, dvProfile: 8, want: VideoSampleEntryDVH1},
-		{name: "unscoped Android client", platform: "android", dvProfile: 8, want: ""},
+		{name: "legacy Android plain HEVC", platform: "android", appBuild: legacyAndroidMedia3HLSBuildV3, deviceQuirks: true, want: VideoSampleEntryHVC1},
+		{name: "legacy Android Profile 7 strip", platform: "android", appBuild: legacyAndroidMedia3HLSBuildV3, deviceQuirks: true, dvProfile: 7, dvStrip: true, want: VideoSampleEntryHVC1},
+		{name: "legacy Android Profile 8 preserve", platform: "android", appBuild: legacyAndroidMedia3HLSBuildV3, deviceQuirks: true, dvProfile: 8, want: VideoSampleEntryDVH1},
+		{name: "Android quirks without legacy build", platform: "android", deviceQuirks: true, dvProfile: 8, want: ""},
+		{name: "Android quirks on another build", platform: "android", appBuild: "16", deviceQuirks: true, dvProfile: 8, want: ""},
+		{name: "unscoped Android legacy build", platform: "android", appBuild: legacyAndroidMedia3HLSBuildV3, dvProfile: 8, want: ""},
 		{name: "web MediaSource", platform: "web", deviceQuirks: true, dvProfile: 7, dvStrip: true, want: ""},
 		{name: "explicit native HLS Profile 7 strip", platform: "tvos", nativeHLS: true, dvProfile: 7, dvStrip: true, want: VideoSampleEntryHVC1},
 		{name: "explicit native HLS Profile 8 preserve", platform: "tvos", nativeHLS: true, dvProfile: 8, want: VideoSampleEntryDVH1},
@@ -1027,6 +1030,7 @@ func TestHLSVideoSampleEntryV3ScopesNativeRecipes(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			req := validStartRequestV3()
 			req.ClientPlaybackContext.Device.Platform = test.platform
+			req.ClientPlaybackContext.AppBuild = test.appBuild
 			if test.deviceQuirks {
 				req.ClientFeatures = append(req.ClientFeatures, FeatureDeviceQuirksV3)
 			}
@@ -1072,6 +1076,7 @@ func TestPlanPlaybackV3AndroidMedia3HLSRecipesAcrossSourceQualities(t *testing.T
 				req := validStartRequestV3()
 				req.QualityPreference = quality
 				req.ClientPlaybackContext.Device.Platform = "android"
+				req.ClientPlaybackContext.AppBuild = legacyAndroidMedia3HLSBuildV3
 				req.ClientFeatures = append(req.ClientFeatures, FeatureDeviceQuirksV3)
 				req.Capabilities.VideoDecode = []VideoDecodeCapabilityV3{{Codec: "hevc", Profiles: []string{"main 10"}, Levels: []int{153}, BitDepths: []int{10}, MaxWidth: 3840, MaxHeight: 2160, MaxFrameRate: 60, MaxBitrateKbps: 80_000, Hardware: true}}
 				req.Capabilities.HDRDetails = profile.hdr


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix reproduced and validated on a live deployment.

Two first-party Android users on build 15 could not reliably start HEVC/Dolby Vision playback. The client showed `Playback unavailable (transcode_start_failed)`, and the server logs showed the HLS transport failing before useful playback with an unsupported video sample-entry recipe.

The root problem was a delivery-boundary mismatch: Android's native Media3 HLS path was being treated like a web MediaSource/hls.js consumer. FFmpeg's default `hev1` labeling could reach a client path that needed the native `hvc1`/`dvh1` recipes. Broadly allowing `hev1` was not a complete fix—it cleared the first check and then Profile 8 failed at the next validation step, while also risking a web behavior change.

The DV7 HDR10 fallback toggle was not the root cause. It exposed a route whose byte recipe still needed the correct sample-entry label.

## Approach

- Add delivery-scoped `native_hls_playback_v1` evidence for native HLS consumers.
- Keep a bounded compatibility path for existing first-party Android build 15 clients that already advertise `device_quirks_v1`.
- Freeze the byte-affecting sample entry into the effective recipe: `hvc1` for ordinary HEVC and DV7-to-HDR10 output; `dvh1` when preserving DV5/DV8.
- Include the sample entry in deterministic plan/attempt identity and seek-reanchor comparison so a changed byte recipe cannot reuse stale playback state.
- Keep unscoped clients and web MediaSource behavior unchanged.
- Cover explicit native HLS, the build 15 compatibility path, unscoped/web negatives, Auto, Original, 2160p, DV7, and DV8.

This closes out both stages of the Android failure with one scoped contract instead of loosening a global allowlist.

## Validation

Focused server checks passed:

```text
go test ./internal/playback \
  -run 'Test(HLSVideoSampleEntryV3ScopesNativeRecipes|PlanPlaybackV3AndroidMedia3HLSRecipesAcrossSourceQualities|PlanIdentityIncludesVideoSampleEntry)$'
ok github.com/Silo-Server/silo-server/internal/playback

go test ./internal/api/handlers \
  -run 'Test(VideoSampleEntryForPlanV3|SeekReanchorIdentityChangesV3ReportsOnlyChangedFieldNames)$'
ok github.com/Silo-Server/silo-server/internal/api/handlers

go test ./internal/playback/contract
ok github.com/Silo-Server/silo-server/internal/playback/contract

make verify-playback-fixtures verify-local-paths
playback fixtures are current

git diff --check upstream/main...HEAD
<no output>
```

The broader local command completed the full handler package successfully and the contract package passed. The playback package's unrelated fake-GPU/FFmpeg hardware-probe tests were killed by the local macOS process environment; the changed playback tests above passed. GitHub CI will run the repository's unrestricted full matrix.

### Production benchmark

I deployed equivalent behavior as server build 122 and tested it with the two affected users on the unchanged Android build 15:

- User 1's first Auto DV8 2160p route was ready in 102 ms. Manifest, init, subtitle, and media requests were all HTTP 200, with progress reaching 204 seconds.
- User 1 then ran seven DV7 2160p sessions at roughly 68–89 Mbps, including seeks and resumes. Those sessions delivered 174/174 media segments successfully with no playback 4xx/5xx responses.
- User 2 ran five HLS remux sessions plus a separate direct-play session of about ten minutes. The HLS runs delivered 106/107 initial segment requests; the sole early 404 was a seek race, rebuilt immediately, and did not recur. The direct-play run produced 46 successful progress updates with clean 200/206 responses.
- Across the post-deploy window there were no playback 5xx responses and none of the previous `unsupported video sample-entry`, `transcode_start_failed`, or `spawn_failed` signatures. There were no genuine FFmpeg crashes.

Both users confirmed the fix, and User 2 continued watching multiple titles without another issue. The live sessions cover Auto and 2160p/4K, DV7/DV8, audio-copy/AAC adaptation, seeks/resumes, HLS remux, and direct play; source tests cover Auto, Original, and 2160p planning.

## Related work

- Companion Android PR: [Silo-Server/silo-android#262](https://github.com/Silo-Server/silo-android/pull/262)
- Production implementation and deploy trail: [blurbery/silo-server#79](https://github.com/blurbery/silo-server/pull/79) and [blurbery/silo-android#5](https://github.com/blurbery/silo-android/pull/5)
- [#657](https://github.com/Silo-Server/silo-server/pull/657) corrects the DV7-to-HDR10 byte stream; this PR supplies the native-HLS sample-entry contract for those bytes.
- [#790](https://github.com/Silo-Server/silo-server/pull/790) keeps the Android E-AC-3 fallback on copied video; this PR makes that HLS copy route start reliably for native Media3.

This is the remaining piece that closes out the observed Android startup incident. It complements those PRs rather than replacing their separate byte-filter and audio-routing fixes.

## Risks

No database, migration, setting, or deployment change. The response schema addition is optional and additive. The compatibility fallback is limited to Android build 15 requests that also opt into the device-quirks contract, and the explicit capability is limited to HLS. Original, progressive, Apple, web, and unrelated Android routes retain their current behavior.

## AI Disclosure

- Tool(s): OpenAI Codex desktop
- Model(s): Codex Sol (`gpt-5.6-sol`), Ultra reasoning
- Involvement: AI-assisted. I directed the investigation and fix, supplied the affected-user reports, made the scope decisions, and helped reproduce and validate it on my live server.
- Adversarial review: We rejected the broad `hev1` allowlist approach, traced the final sample entry through local and remote HLS execution, checked plan identity and seek replacement, verified unscoped/web negatives, and covered the affected quality and Dolby Vision combinations. The live build 15 sessions above were the final acceptance test.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native HLS playback support for selecting HEVC video sample-entry formats.
  * Added support for preserving Dolby Vision and standard HEVC sample-entry details in playback recipes.
  * Playback plans now account for video sample-entry changes when identifying and reanchoring streams.

* **Bug Fixes**
  * Improved Android Media3 HLS handling for supported legacy builds across quality preferences and Dolby Vision profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



