### PR TITLE
fix(tonemap): enlarge the NVDEC probe fixture

### DIFF
--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -32,13 +32,16 @@ const (
 	probeRequestSlack  = 5 * time.Second
 )
 
-// One deterministic 64x64 Main 10 HEVC frame. Keeping the compressed fixture
+// One deterministic 256x256 Main 10 HEVC frame. Keeping the compressed fixture
 // in the binary lets production probes exercise the real decoder without
 // depending on a media mount or generating source files with an encoder whose
-// availability is itself under test.
+// availability is itself under test. The dimensions deliberately exceed the
+// 144x144 minimum reported by Pascal-generation NVIDIA NVDEC; the old 64x64
+// fixture produced a false negative on otherwise capable GPUs such as the
+// GeForce GTX 1050 Ti.
 const decodeProbeFixtureBitDepth = 10
 
-const decodeProbeFixtureBase64 = "AAAAAUABDAH//wIgAAADAJAAAAMAAAMAHpWUCQAAAAFCAQECIAAAAwCQAAADAAADAB6gIIEE2WVlSkwvAWgIAAADAAgAAAMACEAAAAABRAHAc8CJAAABKAGsTtcff/U+nK/q+A=="
+const decodeProbeFixtureBase64 = "AAAAAUABDAH//wQIAAADAJ2oAAADAAD/ugJAAAAAAUIBAQQIAAADAJ2oAAADAAD/oAgIBATZbpKTC8BaAgAAAwACAAADAAIQAAAAAUQBwHGJEgAAASgBrBbgS3G0f////Pv////tVP2ox2hZslSupK6krqSupK7frt+u367frt+u367frszYCj///9yP+45+4B9sj2WPZY9lj2WPZf9l/2X/Zf9l/2X/Zf9lkAQv///uR/3HP3APtkeyx7LHsseyx7L/sv+y/7L/sv+y/7L/ssgjv///WO/rDXqy3UjtJ+0n7SftJ+0p/Sn9Kf0p/Sn9Kf0p/SgZv///Eg/iKnhzHCIL8wvzC/ML8wv1+/X79fv1+/X79fv1+/Md5///rbv1r11jtqm6mXqZepl6mXqafpp+mn6afpp+mn6afpmJf///pN/0kv0bvoTect5y3nLect5z/nP+c/5z/nP+c/5z/nM6P//9VI+qTmpQFOSEXYRdhF2EXYRl9GX0ZfRl9GX0ZfRl9GBz///piP0u50mBooieGJ4YnhieGJ5fnl+eX55fnl+eX55fniHX//+u//XX/W3+rv6e/p7+nv6e/p/+n/6f/p/+n/6f/p/+n13///yyj5X+ZSwSQoGbgZuBm4GbgaXxpfGl8aXxpfGl8aXxn3n//9oH+z0+y49iB1qHWodah1qHWv9a/1r/Wv9a/1r/Wv9anf///kJ/yCPx3PjCeGp4anhqeGp4b/hv+G/4b/hv+G/4b/hrwf//5od8zmsxFpYHEP8Q/xD/EP8RT5FPkU+RT5FPkU+RT5EQH//+r1fVybVRKodSRNJE0kTSRNJI+kj6SPpI+kj6SPpI+kVZ////y3n5ag5VUyV5GxkbGRsZGxkbvxu/G78bvxu/G78bvxtmA7EMv/IDBiETjInjAOXAAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAKOA"
 
 // CommandRunner executes a bounded external command and returns its combined
 // output. Tests inject it to model individual FFmpeg capabilities and failures.

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -2,8 +2,10 @@ package tonemap
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -15,6 +17,55 @@ import (
 	"time"
 )
 
+// TestDecodeProbeFixtureCoversPascalNVDECMinimum prevents the embedded decoder
+// sample from regressing below the minimum frame size accepted by Pascal NVDEC.
+func TestDecodeProbeFixtureCoversPascalNVDECMinimum(t *testing.T) {
+	ffprobePath, err := exec.LookPath("ffprobe")
+	if err != nil {
+		t.Skip("ffprobe is not installed")
+	}
+	fixturePath, cleanup, err := writeDecodeProbeFixture()
+	if err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	defer cleanup()
+
+	output, err := exec.Command(
+		ffprobePath,
+		"-v", "error",
+		"-select_streams", "v:0",
+		"-show_entries", "stream=width,height,pix_fmt",
+		"-of", "json",
+		fixturePath,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("probe fixture: %v: %s", err, output)
+	}
+	var result struct {
+		Streams []struct {
+			Width  int    `json:"width"`
+			Height int    `json:"height"`
+			PixFmt string `json:"pix_fmt"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("decode fixture metadata: %v: %s", err, output)
+	}
+	if len(result.Streams) != 1 {
+		t.Fatalf("fixture streams = %d, want 1", len(result.Streams))
+	}
+	const pascalNVDECMinimumDimension = 144
+	stream := result.Streams[0]
+	if stream.Width < pascalNVDECMinimumDimension || stream.Height < pascalNVDECMinimumDimension {
+		t.Fatalf("fixture dimensions = %dx%d, must be at least %dx%d for Pascal NVDEC", stream.Width, stream.Height, pascalNVDECMinimumDimension, pascalNVDECMinimumDimension)
+	}
+	if stream.PixFmt != "yuv420p10le" {
+		t.Fatalf("fixture pixel format = %q, want yuv420p10le", stream.PixFmt)
+	}
+}
+
+// TestHardwareSmokeFilterNVENCPreservesSourceBitDepth verifies that the CUDA
+// fallback graph downloads SDR base layers using their actual source bit depth.
 func TestHardwareSmokeFilterNVENCPreservesSourceBitDepth(t *testing.T) {
 	for _, test := range []struct {
 		name     string


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

The embedded HEVC Main 10 decoder fixture is 64x64. Pascal-generation NVIDIA NVDEC rejects that frame before tone mapping is exercised because its advertised minimum decode size is 144x144. On a GeForce GTX 1050 Ti this produced:

```text
Video width 64 not within range from 144 to 8192
```

The failed smoke test removes the NVENC hardware tone-map capability even though the GPU, driver, CUDA filter, and NVENC encoder can handle the real stream. Playback then reports that no validated HDR-preserving or tone-map recipe is installed, or that tone-map capability discovery is temporarily unavailable.

## Approach

Replace the deterministic 64x64 HEVC Main 10 frame with a deterministic 256x256 HEVC Main 10 frame. The probe remains self-contained: it does not require a media mount or an encoder to generate its input.

Add a regression test that inspects the embedded frame with `ffprobe` and requires:

- exactly one video stream;
- width and height of at least 144 pixels; and
- `yuv420p10le` pixel format.

256x256 is intentionally small while clearing Pascal NVDEC's minimum dimension. The `ffprobe` test skips when that external binary is unavailable; the normal unit tests remain usable in minimal development environments.

## Validation

Real deployment validation used Silo in Docker on Unraid with NVIDIA driver 580.178.04 and a GeForce GTX 1050 Ti:

- The previous fixture failed deterministically with `Video width 64 not within range from 144 to 8192`.
- The replacement fixture completed the same CUDA decode / `tonemap_cuda` / `h264_nvenc` smoke path successfully.
- With this fixture and the companion cold-start timeout fix, Silo reported `HW NVENC` and `HW Tone Map` while converting HEVC 2160p to H.264 1608p HLS. Software HDR tone mapping was disabled. The simultaneous TrueHD Atmos 7.1 to AAC 5.1 conversion is an independent audio transcode.

Local validation on Linux, Go 1.26.4:

```text
$ go test -v ./internal/tonemap -run '^TestDecodeProbeFixtureCoversPascalNVDECMinimum$' -count=1
--- PASS: TestDecodeProbeFixtureCoversPascalNVDECMinimum (0.03s)

$ go test ./internal/tonemap
ok  github.com/Silo-Server/silo-server/internal/tonemap

$ go build ./...
PASS

$ go vet ./...
PASS

$ golangci-lint run --new-from-merge-base=upstream/main ./...
0 issues.

$ make verify-settings-bindings-all verify-playback-fixtures verify-local-paths
settings bindings are current
web settings binding is current
playback fixtures are current
```

`make test-go` passed every package except the existing `TestRemoteTranscodeStartTimeoutCoversColdProbePreflightAndReadiness` failure in `internal/jellycompat` (`3m43s`, expected `3m29s`). The same test was run on the unmodified `upstream/main` commit and failed with the identical values, confirming that it is a baseline failure unrelated to this diff.

## Risks

The embedded fixture is larger, increasing the binary by less than 1 KiB. Probe behavior is otherwise unchanged. GPUs that accepted the 64x64 frame also accept the standards-compliant 256x256 frame.

## AI Disclosure

- Tool(s): OpenAI Codex desktop app
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: Reviewed the complete diff and probe call path; validated the fixture metadata with real `ffprobe`; ran the exact CUDA decode, tone-map, and NVENC encode path on a GTX 1050 Ti; separated an independent cold-start timeout into a second pull request; and reproduced the only full-suite failure unchanged on `upstream/main`.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hardware-accelerated video decoding detection for compatible NVIDIA Pascal GPUs.
  - Prevented capable GPUs, including the GeForce GTX 1050 Ti, from being incorrectly identified as unsupported.

- **Tests**
  - Added validation that the decoding probe uses sufficient video dimensions and the expected 10-bit pixel format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->