### PR TITLE
fix(tonemap): allow cold NVENC probes to initialize

### DIFF
--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -20,8 +20,13 @@ import (
 
 const (
 	probeCommandTimeout = 5 * time.Second
-	probeNegativeTTL    = 15 * time.Second
-	probeTimeoutSlack   = time.Second
+	// An NVENC smoke test initializes the NVIDIA driver, decoder, CUDA tone-map
+	// filter, and encoder in a fresh FFmpeg process. Older cards can take longer
+	// than the ordinary command budget on the first CUDA use even when the same
+	// pipeline is fully supported once initialized.
+	nvencProbeCommandTimeout = 30 * time.Second
+	probeNegativeTTL         = 15 * time.Second
+	probeTimeoutSlack        = time.Second
 	// probeEndpointSlack covers what a capability endpoint spends around the
 	// tone-map matrix itself: one bounded hardware detection walk (30s in
 	// playback.hwAccelWalkTimeout), the transformation registry's three 3s
@@ -272,13 +277,14 @@ func capabilityCoversAllSourceKinds(capabilities Capabilities, mode Mode, backen
 // ProbeTotalTimeout budgets one bounded deadline for every listing and smoke
 // command the selected backend and device set can execute.
 func ProbeTotalTimeout(hardwareBackend, hardwareDevice string) time.Duration {
-	commandCount := 2 + len(AllSourceKinds())
+	total := time.Duration(2+len(AllSourceKinds())) * probeCommandTimeout
 	backend := strings.ToLower(strings.TrimSpace(hardwareBackend))
 	switch backend {
 	case BackendQSV, BackendVAAPI, BackendNVENC, BackendVideoToolbox:
-		commandCount += len(AllSourceKinds()) * len(probeDevices(hardwareDevice, backend))
+		hardwareCommandCount := len(AllSourceKinds()) * len(probeDevices(hardwareDevice, backend))
+		total += time.Duration(hardwareCommandCount) * hardwareProbeCommandTimeout(backend)
 	}
-	return time.Duration(commandCount)*probeCommandTimeout + probeTimeoutSlack
+	return total + probeTimeoutSlack
 }
 
 // ProbeEndpointTimeout includes auto-backend discovery and response overhead
@@ -316,7 +322,7 @@ func MaxProbeRequestTimeout() time.Duration {
 	for i := range MaxProbedDevices {
 		devices = append(devices, defaultDRIRenderDevice+strconv.Itoa(i))
 	}
-	return ProbeRequestTimeout(BackendQSV, strings.Join(devices, ","))
+	return ProbeRequestTimeout(BackendNVENC, strings.Join(devices, ","))
 }
 
 // ProbeRequestTimeout gives a remote caller additional transport and response
@@ -352,7 +358,7 @@ func ProbeWithRunner(
 		softwareFilter = selected
 	}
 	if softwareFilter != "" && hasToken(encoders, "libx264") {
-		kinds := smokeSourceKinds(ctx, run, ffmpegPath, func(kind SourceKind) []string {
+		kinds := smokeSourceKinds(ctx, run, ffmpegPath, probeCommandTimeout, func(kind SourceKind) []string {
 			return softwareSmokeArgs(fixturePath, kind, softwareFilter)
 		})
 		if len(kinds) > 0 {
@@ -376,7 +382,7 @@ func hardwareSmokeSourceKinds(ctx context.Context, run CommandRunner, ffmpegPath
 	devices := probeDevices(hardwareDevice, backend)
 	validated := AllSourceKinds()
 	for _, device := range devices {
-		supported := smokeSourceKinds(ctx, run, ffmpegPath, func(kind SourceKind) []string {
+		supported := smokeSourceKinds(ctx, run, ffmpegPath, hardwareProbeCommandTimeout(backend), func(kind SourceKind) []string {
 			return hardwareSmokeArgs(fixturePath, backend, device, kind)
 		})
 		validated = intersectSourceKinds(validated, supported)
@@ -385,6 +391,15 @@ func hardwareSmokeSourceKinds(ctx context.Context, run CommandRunner, ffmpegPath
 		}
 	}
 	return validated
+}
+
+// hardwareProbeCommandTimeout allows CUDA and NVENC to finish cold driver
+// initialization without widening the command deadline for other backends.
+func hardwareProbeCommandTimeout(backend string) time.Duration {
+	if strings.EqualFold(strings.TrimSpace(backend), BackendNVENC) {
+		return nvencProbeCommandTimeout
+	}
+	return probeCommandTimeout
 }
 
 // probeDevices parses the configured device list and supplies the backend's
@@ -467,7 +482,13 @@ func runCommand(ctx context.Context, name string, args ...string) ([]byte, error
 // runBounded applies the per-command probe deadline within the caller's total
 // deadline.
 func runBounded(ctx context.Context, run CommandRunner, name string, args ...string) ([]byte, error) {
-	commandCtx, cancel := context.WithTimeout(ctx, probeCommandTimeout)
+	return runBoundedWithTimeout(ctx, probeCommandTimeout, run, name, args...)
+}
+
+// runBoundedWithTimeout executes one probe command under the supplied backend-
+// specific deadline while retaining the caller's total probe deadline.
+func runBoundedWithTimeout(ctx context.Context, timeout time.Duration, run CommandRunner, name string, args ...string) ([]byte, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	return run(commandCtx, name, args...)
 }
@@ -500,11 +521,12 @@ func smokeSourceKinds(
 	ctx context.Context,
 	run CommandRunner,
 	ffmpegPath string,
+	commandTimeout time.Duration,
 	argsFor func(SourceKind) []string,
 ) []SourceKind {
 	kinds := make([]SourceKind, 0, len(AllSourceKinds()))
 	for _, kind := range AllSourceKinds() {
-		if _, err := runBounded(ctx, run, ffmpegPath, argsFor(kind)...); err == nil {
+		if _, err := runBoundedWithTimeout(ctx, commandTimeout, run, ffmpegPath, argsFor(kind)...); err == nil {
 			kinds = append(kinds, kind)
 		}
 	}

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -77,26 +77,28 @@ func TestVideoToolboxListingGateRequiresCompletePipeline(t *testing.T) {
 // TestProbeTotalTimeoutCoversBoundedCommandMatrix verifies the deadline covers every possible probe command.
 func TestProbeTotalTimeoutCoversBoundedCommandMatrix(t *testing.T) {
 	tests := []struct {
-		name    string
-		backend string
-		device  string
-		count   int
+		name     string
+		backend  string
+		device   string
+		expected time.Duration
 	}{
-		{name: "software", backend: BackendSoftware, count: 7},
-		{name: "one hardware device", backend: BackendQSV, device: "/dev/dri/renderD128", count: 12},
-		{name: "two hardware devices", backend: BackendVAAPI, device: "/dev/dri/renderD128,/dev/dri/renderD129", count: 17},
-		{name: "VideoToolbox", backend: BackendVideoToolbox, count: 12},
+		{name: "software", backend: BackendSoftware, expected: 36 * time.Second},
+		{name: "one QSV device", backend: BackendQSV, device: "/dev/dri/renderD128", expected: 61 * time.Second},
+		{name: "two VAAPI devices", backend: BackendVAAPI, device: "/dev/dri/renderD128,/dev/dri/renderD129", expected: 86 * time.Second},
+		{name: "one NVENC device", backend: BackendNVENC, device: "0", expected: 186 * time.Second},
+		{name: "VideoToolbox", backend: BackendVideoToolbox, expected: 61 * time.Second},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			want := time.Duration(tt.count)*probeCommandTimeout + probeTimeoutSlack
-			if got := ProbeTotalTimeout(tt.backend, tt.device); got != want {
-				t.Fatalf("ProbeTotalTimeout() = %s, want %s", got, want)
+			if got := ProbeTotalTimeout(tt.backend, tt.device); got != tt.expected {
+				t.Fatalf("ProbeTotalTimeout() = %s, want %s", got, tt.expected)
 			}
 		})
 	}
 }
 
+// TestProbeEndpointTimeoutCoversDetectionAndProbeBudgets verifies that endpoint
+// and transport budgets include their complete backend-specific probe matrix.
 func TestProbeEndpointTimeoutCoversDetectionAndProbeBudgets(t *testing.T) {
 	if got, want := ProbeEndpointTimeout(BackendQSV, "/dev/dri/renderD128"), 106*time.Second; got != want {
 		t.Fatalf("ProbeEndpointTimeout() = %s, want %s", got, want)
@@ -107,11 +109,30 @@ func TestProbeEndpointTimeoutCoversDetectionAndProbeBudgets(t *testing.T) {
 	if got, want := ProbeRequestTimeout(BackendQSV, "/dev/dri/renderD128"), 111*time.Second; got != want {
 		t.Fatalf("ProbeRequestTimeout() = %s, want %s", got, want)
 	}
+	if got, want := ProbeEndpointTimeout(BackendNVENC, "0"), 231*time.Second; got != want {
+		t.Fatalf("ProbeEndpointTimeout(NVENC) = %s, want %s", got, want)
+	}
+	if got, want := ProbeRequestTimeout(BackendNVENC, "0"), 236*time.Second; got != want {
+		t.Fatalf("ProbeRequestTimeout(NVENC) = %s, want %s", got, want)
+	}
 	// The slack has to outlast a full hardware detection walk plus the
 	// transformation registry probe, or a node answers 503 while its own
 	// detection is still running.
 	if probeEndpointSlack < 30*time.Second+3*3*time.Second {
 		t.Fatalf("probeEndpointSlack = %s, too small for detection and registry probes", probeEndpointSlack)
+	}
+}
+
+// TestHardwareProbeCommandTimeoutExtendsOnlyNVENC prevents cold-start headroom
+// from silently widening the existing limits for other probe backends.
+func TestHardwareProbeCommandTimeoutExtendsOnlyNVENC(t *testing.T) {
+	if got := hardwareProbeCommandTimeout(BackendNVENC); got != nvencProbeCommandTimeout {
+		t.Fatalf("NVENC command timeout = %s, want %s", got, nvencProbeCommandTimeout)
+	}
+	for _, backend := range []string{BackendQSV, BackendVAAPI, BackendVideoToolbox, BackendSoftware, ""} {
+		if got := hardwareProbeCommandTimeout(backend); got != probeCommandTimeout {
+			t.Fatalf("%q command timeout = %s, want %s", backend, got, probeCommandTimeout)
+		}
 	}
 }
 
@@ -493,9 +514,11 @@ func TestProbeDevicesCapsTheConfiguredSet(t *testing.T) {
 
 	// The budget a node advertises for that capped set is therefore never above
 	// what its callers allow — which is the property the cap exists for.
-	if advertised, ceiling := ProbeRequestTimeout(BackendQSV, strings.Join(configured, ",")),
-		MaxProbeRequestTimeout(); advertised > ceiling {
-		t.Fatalf("advertised %v exceeds the %v callers allow", advertised, ceiling)
+	for _, backend := range []string{BackendQSV, BackendVAAPI, BackendNVENC, BackendVideoToolbox} {
+		if advertised, ceiling := ProbeRequestTimeout(backend, strings.Join(configured, ",")),
+			MaxProbeRequestTimeout(); advertised > ceiling {
+			t.Fatalf("%s advertised %v exceeds the %v callers allow", backend, advertised, ceiling)
+		}
 	}
 
 	// A set inside the cap is untouched.


### PR DESCRIPTION
## Problem

Related issue: #843

Tone-map smoke commands currently share a 5-second per-command deadline across every backend. That is long enough for warm NVENC probes, but not for CUDA/NVENC initialization on some cold systems.

On an Unraid Docker host with NVIDIA driver 580.178.04 and a GeForce GTX 1050 Ti, the exact single-frame PQ CUDA/NVENC smoke command completed successfully in 14.916 seconds from a cold start. Under the existing 5-second deadline, valid PQ and HLG probes were canceled. Hardware tone mapping was therefore omitted from the capability inventory and playback returned `tone map capability discovery is temporarily unavailable`.

This is independent of the undersized decoder fixture fixed by #843. Both conditions were present on the reported Pascal system.

## Approach

Give only NVENC hardware smoke commands a 30-second deadline. Listing commands, software tone mapping, QSV, VAAPI, and VideoToolbox retain the existing 5-second deadline because no evidence supports widening them.

The timeout is attached to each smoke command rather than made global. A successful command returns immediately; 30 seconds is only the failure ceiling. The extra headroom avoids setting a 15-second limit immediately adjacent to the measured 14.916-second cold start.

The change also recalculates every composed budget from the backend-specific command deadline:

- total local probe timeout;
- remote endpoint timeout;
- advertised request timeout; and
- the maximum accepted remote-node timeout.

The adversarial review found that the last ceiling was still priced from QSV. That would have allowed a node to advertise the larger NVENC budget and then had the caller clamp it below the node's own deadline. `MaxProbeRequestTimeout` now uses NVENC, the slowest supported command matrix, and the device-cap regression test covers QSV, VAAPI, NVENC, and VideoToolbox.

## Validation

Measured on the affected GTX 1050 Ti deployment with the production FFmpeg command shape and the corrected fixture from #843:

```text
source kind  5-second result  elapsed
pq           timeout (124)    5017 ms
hlg          timeout (124)    5019 ms
hlg_bt709    timeout (124)    5014 ms
sdr_bt709    success          2548 ms
sdr_bt2020   success          3138 ms
```

The cold PQ command completed successfully when allowed to continue:

```text
exit: 0
elapsed: 14.916341445 s
```

A subsequent warm PQ run completed in 839 ms. This confirms that the failure was initialization latency rather than an unsupported decoder, filter, or encoder.

End-to-end deployment validation with software HDR tone mapping disabled reported:

```text
container: HLS
video:     HEVC 2160p -> H.264 1608p
mode:      HW NVENC
tone map:  Hardware
audio:     TrueHD Atmos 7.1 -> AAC 5.1
```

The audio conversion is independent of the video capability fix.

Local validation on Linux, Go 1.26.4:

```text
$ go test ./internal/tonemap -count=1
ok  github.com/Silo-Server/silo-server/internal/tonemap

$ go build ./...
PASS

$ go vet ./...
PASS

$ golangci-lint run --new-from-merge-base=upstream/main ./...
0 issues.

$ pnpm run build
PASS

$ pnpm run lint
0 errors, 174 pre-existing warnings

$ pnpm run format:check
All matched files use Prettier code style!

$ pnpm test
360 test files passed; 3019 tests passed

$ make verify-settings-bindings-all verify-playback-fixtures verify-local-paths
settings bindings are current
web settings binding is current
playback fixtures are current
```

`make test-go` exercised the complete suite but was not fully green locally:

- `TestNonToneMapStartDoesNotProbeLiveMetadata` encountered `text file busy` while executing a newly written temporary script; the isolated rerun passed.
- `TestRemoteTranscodeStartTimeoutCoversColdProbePreflightAndReadiness` expects `3m29s` but receives `3m43s`. The isolated test fails with the identical values on unmodified `upstream/main`, so this is an existing baseline mismatch.

An earlier resource-constrained container run also timed out in unrelated Go and Web packages; each reported Go package and all four reported Web files passed when rerun separately. The final local Web run above passed in full.

## Risks

A genuinely broken NVENC path can now take up to 30 seconds per failed source-kind smoke command to classify. Discovery is shared and cached, successful commands return immediately, and other backends retain their previous limit. Remote endpoint and request budgets grow consistently with the work they permit, avoiding a caller-side timeout before the node's probe can finish.

No settings, API schema, migrations, or playback command graphs change.

## AI Disclosure

- Tool(s): OpenAI Codex desktop app
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: Reviewed the complete diff and all timeout compositions; compared cold and warm production FFmpeg timings; limited the widened deadline to NVENC; rejected a global timeout increase; found and fixed the stale remote maximum-budget calculation; expanded backend/device-cap tests; and separated the decoder-fixture compatibility issue into #843.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for hardware video probing.
  * NVENC detection now allows additional time for slower commands while other hardware backends retain their existing limits.
  * Probe request timeout calculations now more accurately reflect the selected hardware backend.
  * Improved validation across all supported hardware backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->