### PR TITLE
fix(jellycompat): make seasonId authoritative on /Shows/{id}/Episodes to match Jellyfin (fixes #395)

### DIFF
--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1566,10 +1566,33 @@ func (h *ItemsHandler) HandleEpisodes(w http.ResponseWriter, r *http.Request) {
 	}
 	query := parseItemsQuery(r, h.codec)
 
-	seriesID, err := h.codec.DecodeStringID(EncodedIDItem, chi.URLParam(r, "id"))
-	if err != nil {
-		writeError(w, http.StatusNotFound, "NotFound", "Series not found")
-		return
+	var seriesID string
+	var requestedSeasonID string
+
+	if rawSeasonID := strings.TrimSpace(newCaseInsensitiveQuery(r.URL.Query()).Get("SeasonId")); rawSeasonID != "" {
+		decodedSeasonID, decodeErr := h.codec.DecodeStringID(EncodedIDSeason, rawSeasonID)
+		if decodeErr != nil {
+			writeError(w, http.StatusNotFound, "NotFound", "Season not found")
+			return
+		}
+		requestedSeasonID = decodedSeasonID
+		if h.seasonRepo != nil {
+			season, seasonErr := h.seasonRepo.GetByID(r.Context(), requestedSeasonID)
+			if seasonErr == nil && season != nil {
+				seriesID = season.SeriesID
+			}
+		}
+		if seriesID == "" {
+			writeError(w, http.StatusNotFound, "NotFound", "Season not found")
+			return
+		}
+	} else {
+		id, err := h.codec.DecodeStringID(EncodedIDItem, chi.URLParam(r, "id"))
+		if err != nil {
+			writeError(w, http.StatusNotFound, "NotFound", "Series not found")
+			return
+		}
+		seriesID = id
 	}
 
 	// AdjacentTo (Wholphin autoplay/skip) only needs the requested episode plus
@@ -1578,16 +1601,6 @@ func (h *ItemsHandler) HandleEpisodes(w http.ResponseWriter, r *http.Request) {
 	if query.adjacentTo != "" {
 		h.writeAdjacentEpisodesResponse(w, r, session, query, seriesID)
 		return
-	}
-
-	var requestedSeasonID string
-	if rawSeasonID := strings.TrimSpace(newCaseInsensitiveQuery(r.URL.Query()).Get("SeasonId")); rawSeasonID != "" {
-		decodedSeasonID, decodeErr := h.codec.DecodeStringID(EncodedIDSeason, rawSeasonID)
-		if decodeErr != nil {
-			writeError(w, http.StatusNotFound, "NotFound", "Season not found")
-			return
-		}
-		requestedSeasonID = decodedSeasonID
 	}
 
 	h.writeSeriesEpisodesResponse(w, r, session, query, seriesID, requestedSeasonID, false)

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -1578,7 +1578,11 @@ func (h *ItemsHandler) HandleEpisodes(w http.ResponseWriter, r *http.Request) {
 		requestedSeasonID = decodedSeasonID
 		if h.seasonRepo != nil {
 			season, seasonErr := h.seasonRepo.GetByID(r.Context(), requestedSeasonID)
-			if seasonErr == nil && season != nil {
+			if seasonErr != nil && !errors.Is(seasonErr, catalog.ErrSeasonNotFound) {
+				writeError(w, http.StatusInternalServerError, "InternalServerError", "Database error")
+				return
+			}
+			if season != nil {
 				seriesID = season.SeriesID
 			}
 		}

--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -744,6 +744,73 @@ func TestHandleUpcoming_MissingSeriesId_ReturnsEmptyNot404(t *testing.T) {
 	}
 }
 
+// TestHandleEpisodes_AuthoritativeSeasonID verifies that Swiftfin's call shape
+// GET /Shows/{seasonID}/Episodes?seasonId={seasonID} (where the path {id} segment
+// holds an EncodedIDSeason ID) treats seasonId as authoritative, resolves the owning
+// series, and returns the season's episodes without a 404 series-decode failure.
+func TestHandleEpisodes_AuthoritativeSeasonID(t *testing.T) {
+	codec := NewResourceIDCodec()
+	seriesContentID := "series-1"
+	seasonContentID := "season-1"
+	encodedSeasonID := codec.EncodeStringID(EncodedIDSeason, seasonContentID)
+
+	contentSvc := &countingContentService{
+		seasons: []upstreamSeason{
+			{ContentID: seasonContentID, SeasonNumber: 1, Title: "Season 1", EpisodeCount: 2},
+		},
+	}
+	episodeRepo := &fakeSeasonEpisodeRepo{bySeason: map[string][]*models.Episode{
+		episodeBySeasonKey(seriesContentID, 1): {
+			{ContentID: "ep-1", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 1, Title: "E1"},
+			{ContentID: "ep-2", SeriesID: seriesContentID, SeasonID: seasonContentID, SeasonNumber: 1, EpisodeNumber: 2, Title: "E2"},
+		},
+	}}
+	h := &ItemsHandler{
+		content:     contentSvc,
+		userData:    &mockUserDataService{},
+		codec:       codec,
+		mapper:      newMapper(codec, &config.Config{}),
+		images:      NewImageCache(time.Hour, time.Now),
+		episodeRepo: episodeRepo,
+		seasonRepo: &fakeSeasonByIDRepo{seasons: map[string]*models.Season{
+			seasonContentID: {ContentID: seasonContentID, SeriesID: seriesContentID, SeasonNumber: 1},
+		}},
+	}
+
+	result := performEpisodesRequest(t, h, "/Shows/"+encodedSeasonID+"/Episodes?SeasonId="+encodedSeasonID, encodedSeasonID)
+	if result.TotalRecordCount != 2 || len(result.Items) != 2 {
+		t.Fatalf("expected 2 episodes for Swiftfin seasonId query, got total=%d items=%+v", result.TotalRecordCount, result.Items)
+	}
+	if result.Items[0].Name != "E1" || result.Items[1].Name != "E2" {
+		t.Fatalf("unexpected episode names: %+v", result.Items)
+	}
+}
+
+// TestHandleEpisodes_UnknownSeasonIDReturnsNotFound verifies that an unresolvable
+// seasonId query parameter returns 404 NotFound.
+func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
+	codec := NewResourceIDCodec()
+	unknownSeasonID := codec.EncodeStringID(EncodedIDSeason, "missing-season")
+	h := &ItemsHandler{
+		codec:      codec,
+		seasonRepo: &fakeSeasonByIDRepo{seasons: map[string]*models.Season{}},
+	}
+
+	req := httptest.NewRequest("GET", "/Shows/anything/Episodes?SeasonId="+unknownSeasonID, nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", unknownSeasonID)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx)
+	ctx = context.WithValue(ctx, compatSessionKey, &Session{StreamAppUserID: 1, ProfileID: "profile-1"})
+
+	rec := httptest.NewRecorder()
+	h.HandleEpisodes(rec, req.WithContext(ctx))
+
+	if rec.Code != 404 {
+		t.Fatalf("expected status 404 for unknown SeasonId; got %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {


### PR DESCRIPTION
### Summary
Fixes #395.

When Swiftfin or other Jellyfin clients browse a TV season's episode list, the client calls:
\GET /Shows/{seasonID}/Episodes?seasonId={seasonID}\`n
Previously, \HandleEpisodes\ in \internal/jellycompat/handlers_items.go\ attempted to decode the path segment \{id}\ as an \EncodedIDItem\ (Series ID) before inspecting the \SeasonId\ query parameter. Because \{seasonID}\ is encoded as \EncodedIDSeason\, this failed with \404 Series not found\.

### Changes
- Updated \HandleEpisodes\ to check for \SeasonId\ in the query string first. If present, it is decoded as \EncodedIDSeason\, resolved to \season.SeriesID\ via \seasonRepo.GetByID\, and used for episode lookup (matching Jellyfin \TvShowsController.cs\ behavior).
- Added \TestHandleEpisodes_AuthoritativeSeasonID\ and \TestHandleEpisodes_UnknownSeasonIDReturnsNotFound\ unit tests to \internal/jellycompat/handlers_items_test.go\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed episode requests with a season filter so they correctly resolve and display episodes for the selected season.
  * Added a clear “Season not found” response when the requested season cannot be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->