### PR TITLE
fix(notifications): preserve poster artwork for request approval and decline notifications (fixes #727)

### DIFF
--- a/internal/notifications/discord_dm.go
+++ b/internal/notifications/discord_dm.go
@@ -133,6 +133,10 @@ func (c *discordChannel) send(ctx context.Context, tx pgx.Tx, userID int, _ stri
 
 	if c.posterURL != nil {
 		for i := range rows {
+			if rows[i].PosterPath == "" && isRequestLifecycleType(rows[i].Type) {
+				flags := parseRequestFlags(rows[i].ReasonFlags)
+				rows[i].PosterPath = flags.PosterPath
+			}
 			rows[i].PosterURL = c.posterURL(ctx, rows[i].PosterPath, rows[i].PosterSourcePath)
 		}
 	}

--- a/internal/notifications/discord_embed_meta.go
+++ b/internal/notifications/discord_embed_meta.go
@@ -106,6 +106,8 @@ func publicArtworkURL(path string) string {
 		return "https://artworks.thetvdb.com/" + strings.TrimPrefix(path, "tvdb://")
 	case strings.HasPrefix(path, "http://"), strings.HasPrefix(path, "https://"):
 		return path
+	case strings.HasPrefix(path, "/"):
+		return tmdbRawImageURL(path)
 	default:
 		return ""
 	}

--- a/internal/notifications/dispatcher.go
+++ b/internal/notifications/dispatcher.go
@@ -53,6 +53,11 @@ func PayloadForRow(row DeliveryRow) DeliveryRowPayload {
 	if len(reasonFlags) == 0 {
 		reasonFlags = json.RawMessage("{}")
 	}
+	posterPath := row.PosterPath
+	if posterPath == "" && isRequestLifecycleType(row.Type) {
+		flags := parseRequestFlags(row.ReasonFlags)
+		posterPath = flags.PosterPath
+	}
 	return DeliveryRowPayload{
 		ID:              row.ID,
 		Type:            row.Type,
@@ -64,7 +69,7 @@ func PayloadForRow(row DeliveryRow) DeliveryRowPayload {
 		EpisodeTitle:    row.EpisodeTitle,
 		SeasonNumber:    row.SeasonNumber,
 		EpisodeNumber:   row.EpisodeNumber,
-		PosterPath:      row.PosterPath,
+		PosterPath:      posterPath,
 		PosterThumbhash: row.PosterThumbhash,
 		ReasonFlags:     reasonFlags,
 		CreatedAt:       row.CreatedAt,

--- a/internal/notifications/request_notifier.go
+++ b/internal/notifications/request_notifier.go
@@ -32,11 +32,12 @@ const (
 // display fields); approved/declined rows have no catalog item yet, so the
 // title rides along.
 type RequestFlags struct {
-	RequestID string `json:"request_id"`
-	TMDBID    int    `json:"tmdb_id"`
-	MediaType string `json:"media_type"`
-	Title     string `json:"title,omitempty"`
-	Year      int    `json:"year,omitempty"`
+	RequestID  string `json:"request_id"`
+	TMDBID     int    `json:"tmdb_id"`
+	MediaType  string `json:"media_type"`
+	Title      string `json:"title,omitempty"`
+	Year       int    `json:"year,omitempty"`
+	PosterPath string `json:"poster_path,omitempty"`
 	// Reason is the admin's decline message, when one was given.
 	Reason string `json:"reason,omitempty"`
 }
@@ -192,11 +193,12 @@ func (s *System) dispatchRequestLifecycle(ctx context.Context, req requests.Requ
 		return nil
 	}
 	flags := RequestFlags{
-		RequestID: req.ID,
-		TMDBID:    req.TMDBID,
-		MediaType: string(req.MediaType),
-		Title:     req.Title,
-		Reason:    req.DeclineReason,
+		RequestID:  req.ID,
+		TMDBID:     req.TMDBID,
+		MediaType:  string(req.MediaType),
+		Title:      req.Title,
+		PosterPath: req.PosterPath,
+		Reason:     req.DeclineReason,
 	}
 	if req.Year != nil {
 		flags.Year = *req.Year

--- a/internal/notifications/system.go
+++ b/internal/notifications/system.go
@@ -298,11 +298,9 @@ func (s *System) discordPosterURL(ctx context.Context, posterPath, posterSourceP
 func (s *System) PayloadForRow(ctx context.Context, row DeliveryRow) DeliveryRowPayload {
 	payload := PayloadForRow(row)
 	if payload.PosterPath != "" {
-		if s != nil && s.images != nil {
+		payload.PosterURL = publicArtworkURL(payload.PosterPath)
+		if payload.PosterURL == "" && s != nil && s.images != nil {
 			payload.PosterURL = s.images.PresignImageURL(ctx, payload.PosterPath, "poster", "")
-		}
-		if payload.PosterURL == "" {
-			payload.PosterURL = publicArtworkURL(payload.PosterPath)
 		}
 	}
 	return payload

--- a/internal/notifications/system.go
+++ b/internal/notifications/system.go
@@ -297,8 +297,13 @@ func (s *System) discordPosterURL(ctx context.Context, posterPath, posterSourceP
 // poster URL when an image resolver is configured.
 func (s *System) PayloadForRow(ctx context.Context, row DeliveryRow) DeliveryRowPayload {
 	payload := PayloadForRow(row)
-	if s != nil && s.images != nil && row.PosterPath != "" {
-		payload.PosterURL = s.images.PresignImageURL(ctx, row.PosterPath, "poster", "")
+	if payload.PosterPath != "" {
+		if s != nil && s.images != nil {
+			payload.PosterURL = s.images.PresignImageURL(ctx, payload.PosterPath, "poster", "")
+		}
+		if payload.PosterURL == "" {
+			payload.PosterURL = publicArtworkURL(payload.PosterPath)
+		}
 	}
 	return payload
 }

--- a/internal/notifications/webhook_logic_test.go
+++ b/internal/notifications/webhook_logic_test.go
@@ -485,6 +485,33 @@ func TestGenericWebhookPayloadRequestDeclined(t *testing.T) {
 	}
 }
 
+func TestRequestApprovedPreservesPosterPath(t *testing.T) {
+	row := DeliveryRow{
+		Delivery: Delivery{
+			ID:        "01APPROVED",
+			ProfileID: "profile-1",
+			Type:      DeliveryTypeRequestApproved,
+			ReasonFlags: []byte(`{"request_id":"01REQ","tmdb_id":3683,"media_type":"movie",` +
+				`"title":"The Silence of the Lambs","year":1991,"poster_path":"/2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg"}`),
+			CreatedAt: time.Date(2026, 8, 17, 17, 48, 49, 0, time.UTC),
+		},
+	}
+	payload := PayloadForRow(row)
+	if payload.PosterPath != "/2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg" {
+		t.Fatalf("PayloadForRow PosterPath = %q, want /2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg", payload.PosterPath)
+	}
+
+	sys := &System{}
+	sysPayload := sys.PayloadForRow(context.Background(), row)
+	if sysPayload.PosterPath != "/2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg" {
+		t.Fatalf("System.PayloadForRow PosterPath = %q, want /2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg", sysPayload.PosterPath)
+	}
+	wantURL := "https://image.tmdb.org/t/p/w500/2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg"
+	if sysPayload.PosterURL != wantURL {
+		t.Fatalf("System.PayloadForRow PosterURL = %q, want %q", sysPayload.PosterURL, wantURL)
+	}
+}
+
 func TestBuildDiscordWebhookPayloadTestMarker(t *testing.T) {
 	payload, err := BuildDiscordWebhookPayload(webhookTestRow(), true)
 	if err != nil {

--- a/internal/notifications/webhook_logic_test.go
+++ b/internal/notifications/webhook_logic_test.go
@@ -501,8 +501,8 @@ func TestRequestApprovedPreservesPosterPath(t *testing.T) {
 		t.Fatalf("PayloadForRow PosterPath = %q, want /2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg", payload.PosterPath)
 	}
 
-	sys := &System{}
-	sysPayload := sys.PayloadForRow(context.Background(), row)
+	sys := &System{images: fakePresigner{}}
+	sysPayload := sys.PayloadForRow(t.Context(), row)
 	if sysPayload.PosterPath != "/2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg" {
 		t.Fatalf("System.PayloadForRow PosterPath = %q, want /2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg", sysPayload.PosterPath)
 	}

--- a/internal/notifications/webhook_sender.go
+++ b/internal/notifications/webhook_sender.go
@@ -138,6 +138,10 @@ func (s *webhookSender) send(ctx context.Context, hook *Webhook, row DeliveryRow
 	if err != nil {
 		return webhookSendResult{Message: "webhook URL could not be decrypted"}
 	}
+	if row.PosterPath == "" && isRequestLifecycleType(row.Type) {
+		flags := parseRequestFlags(row.ReasonFlags)
+		row.PosterPath = flags.PosterPath
+	}
 	if hook.Type == WebhookTypeDiscord && s.posterURL != nil {
 		row.PosterURL = s.posterURL(ctx, row.PosterPath, row.PosterSourcePath)
 	}

--- a/internal/notifications/webpush_logic_test.go
+++ b/internal/notifications/webpush_logic_test.go
@@ -52,6 +52,21 @@ func TestBuildWebPushPayload(t *testing.T) {
 		}
 	})
 
+	t.Run("request approved carries poster icon", func(t *testing.T) {
+		row := DeliveryRow{Delivery: Delivery{ID: "01APPROVED", Type: DeliveryTypeRequestApproved}}
+		raw, err := buildWebPushPayload(row, "https://cdn.example.com/approved-poster.jpg")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var payload webPushPayload
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload.Icon != "https://cdn.example.com/approved-poster.jpg" {
+			t.Fatalf("unexpected icon %q, want https://cdn.example.com/approved-poster.jpg", payload.Icon)
+		}
+	})
+
 	t.Run("webhook auto-disable routes to settings", func(t *testing.T) {
 		row := DeliveryRow{Delivery: Delivery{ID: "01X", Type: DeliveryTypeWebhookAutoDisabled}}
 		raw, err := buildWebPushPayload(row, "")

--- a/internal/notifications/webpush_sender.go
+++ b/internal/notifications/webpush_sender.go
@@ -57,12 +57,7 @@ func buildWebPushPayload(row DeliveryRow, posterURL string) ([]byte, error) {
 		URL:        display.URL,
 		Tag:        row.ID,
 		DeliveryID: row.ID,
-	}
-	switch row.Type {
-	case DeliveryTypeEpisodeAvailable:
-		payload.Icon = posterURL
-	case DeliveryTypeRequestFulfilled:
-		payload.Icon = posterURL
+		Icon:       posterURL,
 	}
 	return json.Marshal(payload)
 }


### PR DESCRIPTION
## Summary

Fixes #727.

`request.approved` and `request.declined` notifications dropped poster artwork even when the media request had a TMDB poster path. Approval and decline deliveries have no catalog item yet, so their database join cannot supply artwork.

## Changes

- Preserve the request poster path in `RequestFlags` for approval and decline deliveries.
- Resolve raw TMDB image paths to public CDN URLs for inbox, websocket, web-push, Discord DM, and Discord webhook payloads.
- Prefer publicly resolvable provider artwork before treating a path as cached server storage. This prevents `/abc.jpg` TMDB paths from becoming signed URLs for nonexistent S3 objects.
- Include a web-push icon whenever the notification payload resolves a poster URL.
- Cover the request lifecycle path with a configured image resolver so the test matches production wiring.

## Regression proof

Before the precedence fix, the resolver-present test failed with:

```text
System.PayloadForRow PosterURL = "https://s3.example.com//2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg?sig=abc", want "https://image.tmdb.org/t/p/w500/2nkPrhf4YIyMFelfe4zdOnGRYz5.jpg"
```

The same test passes after provider artwork is resolved before cached storage.

## Validation

- `go test ./internal/notifications/... -count=1` — passed.
- `go build ./...` — passed.
- `gofmt -l .` — passed with no output.
- `go vet ./...` — passed.
- `golangci-lint run --new-from-merge-base="origin/main" ./...` with v2.12.2 — passed with 0 issues.
- `make test-go` — passed.
- `pnpm run lint` — passed with existing warnings only.
- `pnpm run format:check` — passed.
- `pnpm run build` — passed with existing bundle-size and font-resolution warnings.
- `make test-web` — 355 test files and 3,042 tests passed.
- `make verify-settings-bindings-all` — passed.
- `make verify-playback-fixtures` — passed.
- `make verify-local-paths` — passed.

No API shape changed; existing `poster_path` and `poster_url` fields now carry the request artwork. Jellyfin compatibility is unaffected because these are Silo-native notifications.

## AI Disclosure

- Tool(s): Codex in T3 Code
- Model(s): `gpt-5.6-sol`
- Involvement: AI-assisted
- Adversarial review: Three independent review passes traced the inbox, websocket, web-push, webhook, and storage-resolution paths. They found the S3-before-TMDB precedence defect. The fix was reproduced with a resolver-present regression test and checked with the full repository validation gate listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request-related notifications now retain poster artwork more reliably.
  * Discord, webhook, and web push notifications display the correct poster image for approved and other request lifecycle updates.
  * Artwork paths can now resolve to public TMDB image URLs, with a fallback for unavailable public links.
  * Web push notifications consistently use available poster artwork as their icon.
  * Episode requests with season identifiers now resolve correctly, while unknown seasons return a clear not-found response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->