### PR TITLE
fix(web): send "original" quality preference instead of rewriting it to "auto"

### DIFF
--- a/web/src/hooks/queries/qualityPreference.test.ts
+++ b/web/src/hooks/queries/qualityPreference.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  effective: undefined as Record<string, { value: unknown }> | undefined,
+}));
+
+vi.mock("@/hooks/queries/settingValues", () => ({
+  useEffectiveSettings: () => ({ data: mocks.effective, isLoading: false }),
+}));
+
+import { SETTING_KEYS } from "@/lib/settingsContract";
+
+import { useQualityPreference } from "./qualityPreference";
+
+function setResolved(value: unknown) {
+  mocks.effective =
+    value === undefined ? undefined : { [SETTING_KEYS.PLAYBACK_PREFERRED_QUALITY]: { value } };
+}
+
+describe("useQualityPreference", () => {
+  it("passes 'original' through unchanged — it is a distinct wire value from 'auto' (#849)", () => {
+    setResolved("original");
+    const { result } = renderHook(() => useQualityPreference("1080p"));
+    expect(result.current).toBe("original");
+  });
+
+  it("passes resolution rungs and auto through unchanged", () => {
+    for (const value of ["auto", "480p", "720p", "1080p", "2160p"]) {
+      setResolved(value);
+      const { result } = renderHook(() => useQualityPreference(null));
+      expect(result.current).toBe(value);
+    }
+  });
+
+  it("falls back to the profile column until the settings read resolves", () => {
+    setResolved(undefined);
+    const { result } = renderHook(() => useQualityPreference("720p"));
+    expect(result.current).toBe("720p");
+  });
+
+  it("returns null with no resolved value and no fallback", () => {
+    setResolved(undefined);
+    const { result } = renderHook(() => useQualityPreference());
+    expect(result.current).toBeNull();
+  });
+});

--- a/web/src/hooks/queries/qualityPreference.ts
+++ b/web/src/hooks/queries/qualityPreference.ts
@@ -11,11 +11,14 @@ import { SETTING_KEYS } from "@/lib/settingsContract";
  * carry two axes. Left alone, choosing a quality would appear to save and then
  * change nothing about what plays.
  *
- * The canonical vocabulary is already what these consumers parse — "auto",
- * "480p", "720p", "1080p", "2160p" — so the value passes straight through.
- * "original" means "do not cap", which is what "auto" already expresses to
- * every consumer, so it maps there rather than reaching a resolution table
- * that has no entry for it.
+ * The canonical vocabulary — "auto", "original", "480p", "720p", "1080p",
+ * "2160p" — passes through unchanged. "original" and "auto" are distinct wire
+ * values: the server's planner preserves the source for "original" (subject
+ * only to the hard bitrate cap) but adapts "auto" to device limits, bandwidth
+ * evidence, and metered connections. Web-side consumers that look resolutions
+ * up in a table treat "original" the same as "auto" — no cap — but the value
+ * sent to the server must stay "original" or the user's choice is discarded
+ * (#849).
  *
  * `fallback` is the profile column, used until the settings read resolves (and
  * if it fails). Playback must never block on a preferences fetch, and the
@@ -26,6 +29,5 @@ export function useQualityPreference(fallback?: string | null): string | null {
   const resolved = data?.[SETTING_KEYS.PLAYBACK_PREFERRED_QUALITY]?.value;
 
   if (typeof resolved !== "string") return fallback ?? null;
-  if (resolved === "original") return "auto";
   return resolved;
 }

--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -892,15 +892,11 @@ export function WatchPlaybackHost() {
     item: activeItem,
     currentProfile,
     seriesEpisodes,
-    // "original" means no cap, which every consumer already spells "auto".
+    // Passed through verbatim: "original" and "auto" are distinct wire values
+    // (the planner preserves the source for "original", adapts for "auto").
     // Undefined until the read resolves, which leaves the profile-column
     // fallback in place rather than blocking playback on a settings fetch.
-    qualityPreference:
-      canonicalQuality === undefined
-        ? undefined
-        : canonicalQuality === "original"
-          ? "auto"
-          : canonicalQuality,
+    qualityPreference: canonicalQuality,
   });
   // The resolved answer already folds in the profile layer, so the props built
   // from the profile record are only the pre-resolution fallback.


### PR DESCRIPTION
## Problem

Setting **Preferred quality** to *Original quality* had no effect in the web player: the client rewrote the canonical `"original"` setting value to `"auto"` before building the playback start request. The server's planner treats those as materially different modes — `ResolveQualityPolicyV3` preserves the source for `original` (overridden only by the hard bitrate cap), while `auto` adapts to device resolution limits, bandwidth evidence, and metered connections. The result reported in #849: a 480p / 1.5 Mbps transcode of a 1080p H.264 source the browser could direct play, with a 200 Mbps cap configured.

The rewrite existed in two places, both with a comment claiming the values are equivalent "to every consumer":

- `web/src/hooks/queries/qualityPreference.ts` (`useQualityPreference`)
- `web/src/playback/WatchPlaybackChrome.tsx` (inline in `WatchPlaybackHost`)

## Change

Pass the value through verbatim and update both comments to state the actual contract: `original` and `auto` are distinct wire values, and only web-side *resolution table* consumers may treat them alike (as "no cap").

No web-side consumer needed changes; each already handles `"original"`:

- `pickBestAttributes` (`versionRankingUtils.ts`) resolves unknown ranks to "no cap" and considers all versions.
- The quality menu (`resolveActiveQualityOptionId` in `playback-info.ts`) matches the plan's source-preserving rung by its exact `"original"` id.
- `usePlaybackSession` and `buildStartRequestV3` pass the string through; existing tests already exercise `"original"` on those paths.
- The server accepts the value today: `NormalizeQualityV3` recognizes `original` / `source` / `max`.

Silo Apple and Silo Android keep `original` distinct (`SiloQualityPresets.swift`, `QualityPresets.kt` / `PlaybackVersionSelector.kt`), so this was web-only — no client follow-up needed. No API or jellycompat change; the wire contract is untouched, the client just stops discarding the user's choice.

Not addressed here: the secondary observation in #849 (401-then-200 race on the effective-settings read, which can leave the legacy profile-column fallback active on a cold start). That is a separate defect from the value rewrite.

## Validation

- `pnpm exec vitest run` on the touched suites: 5 files, 94 tests passed.
- `make test-web`: 356 files, 3048 tests passed.
- `eslint` on touched files: 0 errors (2 pre-existing warnings on untouched `WatchPlaybackChrome.tsx` lines); `tsc --noEmit` clean; prettier clean.
- New unit test `qualityPreference.test.ts` pins the pass-through of `"original"` and the fallback behavior.

Related issue: #849

## AI Disclosure

- Tool(s): Claude Code
- Model(s): claude-fable-5
- Involvement: Fully AI-generated, human verified
- Adversarial review: enumerated every web-src consumer of the quality-preference value and verified each handles `"original"` (version ranking, quality-menu resolution, session wire path); cross-checked the server planner (`ResolveQualityPolicyV3`, `NormalizeQualityV3`) to confirm the wire value is accepted and takes the source-preserving path; checked silo-apple and silo-android for the same rewrite (absent). No findings requiring further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the distinct “Original” and “Auto” video quality preferences during playback.
  * Improved quality preference resolution when settings are unavailable, including fallback behavior.
* **Tests**
  * Added coverage for quality preference values, profile fallbacks, unresolved settings, and unavailable preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->