### PR TITLE
fix(jellycompat): harden negotiated session advisory locks

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +22,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by

--- a/internal/jellycompat/playback_sessions_postgres.go
+++ b/internal/jellycompat/playback_sessions_postgres.go
@@ -3,6 +3,8 @@ package jellycompat
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/watchsync"
@@ -41,6 +44,60 @@ var (
 )
 
 var jsonNULCodePoint = []byte(`\u0000`)
+
+const (
+	negotiatedSessionLegacyAdvisoryLockQuery = `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`
+	negotiatedSessionAdvisoryLockQuery       = `SELECT pg_advisory_xact_lock($1::bigint)`
+)
+
+// negotiatedSessionAdvisoryLockKey maps one negotiation scope into Postgres's
+// signed 64-bit advisory-lock key space without sending any client-derived text
+// to the versioned lock query. PostgreSQL text parameters reject NUL; deriving
+// a fixed-width key locally lets a later release retire the legacy text lock
+// after this release has bridged rolling upgrades.
+//
+// Length framing keeps component boundaries unambiguous even when a value
+// itself contains a NUL or another delimiter. SHA-256 distributes keys before
+// truncation to PostgreSQL's 64-bit bigint advisory-lock namespace. A collision
+// only serializes unrelated negotiations because the subsequent DELETE remains
+// scoped by exact values.
+func negotiatedSessionAdvisoryLockKey(compatToken, clientDeviceID, routeItemID string) int64 {
+	const domain = "silo:jellycompat:negotiated-session:v1"
+	framed := make([]byte, 0, len(domain)+3*8+len(compatToken)+len(clientDeviceID)+len(routeItemID))
+	framed = append(framed, domain...)
+	for _, component := range [...]string{compatToken, clientDeviceID, routeItemID} {
+		framed = binary.BigEndian.AppendUint64(framed, uint64(len(component)))
+		framed = append(framed, component...)
+	}
+	digest := sha256.Sum256(framed)
+	return int64(binary.BigEndian.Uint64(digest[:8]))
+}
+
+type negotiatedSessionAdvisoryLockExecutor interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+}
+
+func acquireNegotiatedSessionAdvisoryLock(
+	ctx context.Context,
+	executor negotiatedSessionAdvisoryLockExecutor,
+	compatToken, clientDeviceID, routeItemID string,
+) error {
+	// Current-main processes know only the legacy text-derived key. Taking it
+	// first preserves mutual exclusion during a rolling upgrade; every upgraded
+	// process then takes the versioned bigint key in the same order. Once this
+	// bridge has shipped for a full release, a later release can remove the
+	// legacy acquisition while still coordinating with bridged processes.
+	legacyScope := negotiatedPlaybackScope(compatToken, clientDeviceID, routeItemID)
+	if _, err := executor.Exec(ctx, negotiatedSessionLegacyAdvisoryLockQuery, legacyScope); err != nil {
+		return fmt.Errorf("acquiring legacy negotiated playback session advisory lock: %w", err)
+	}
+
+	lockKey := negotiatedSessionAdvisoryLockKey(compatToken, clientDeviceID, routeItemID)
+	if _, err := executor.Exec(ctx, negotiatedSessionAdvisoryLockQuery, lockKey); err != nil {
+		return fmt.Errorf("acquiring versioned negotiated playback session advisory lock: %w", err)
+	}
+	return nil
+}
 
 // marshalPlaybackSession removes NUL code points from every nested string in
 // the JSON document. PostgreSQL JSONB rejects U+0000 even when Go's encoder
@@ -218,8 +275,9 @@ func (d *DurableCompatPlaybackStore) replaceUnstartedNegotiation(
 
 	var removed []string
 	if session.CompatToken != "" && session.ClientDeviceID != "" && session.RouteItemID != "" {
-		scope := negotiatedPlaybackScope(session.CompatToken, session.ClientDeviceID, session.RouteItemID)
-		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, scope); err != nil {
+		if err := acquireNegotiatedSessionAdvisoryLock(
+			ctx, tx, session.CompatToken, session.ClientDeviceID, session.RouteItemID,
+		); err != nil {
 			return nil, err
 		}
 		rows, err := tx.Query(ctx, `

--- a/internal/jellycompat/playback_sessions_postgres_test.go
+++ b/internal/jellycompat/playback_sessions_postgres_test.go
@@ -3,6 +3,7 @@ package jellycompat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,8 +12,196 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/watchsync"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+var negotiatedSessionAdvisoryLockKeySink int64
+
+func TestNegotiatedSessionAdvisoryLockKeyIsPinnedAndSeparatesRepresentativeInputs(t *testing.T) {
+	t.Parallel()
+
+	baseline := negotiatedSessionAdvisoryLockKey("token", "device", "route")
+	const wantBaseline int64 = -2277851018424744338
+	if baseline != wantBaseline {
+		t.Fatalf("key = %d, want pinned value %d", baseline, wantBaseline)
+	}
+	for i := 0; i < 100; i++ {
+		if got := negotiatedSessionAdvisoryLockKey("token", "device", "route"); got != baseline {
+			t.Fatalf("key changed between calls: first=%d call_%d=%d", baseline, i, got)
+		}
+	}
+
+	testCases := []struct {
+		name           string
+		compatToken    string
+		clientDeviceID string
+		routeItemID    string
+	}{
+		{name: "baseline", compatToken: "token", clientDeviceID: "device", routeItemID: "route"},
+		{name: "component boundary left", compatToken: "ab", clientDeviceID: "c", routeItemID: "d"},
+		{name: "component boundary right", compatToken: "a", clientDeviceID: "bc", routeItemID: "d"},
+		{name: "delimiter in token", compatToken: "a\x00b", clientDeviceID: "c", routeItemID: "d"},
+		{name: "delimiter in device", compatToken: "a", clientDeviceID: "b\x00c", routeItemID: "d"},
+		{name: "reordered components", compatToken: "device", clientDeviceID: "token", routeItemID: "route"},
+		{name: "empty components", compatToken: "", clientDeviceID: "", routeItemID: ""},
+		{
+			name:           "long components",
+			compatToken:    strings.Repeat("t", 4096),
+			clientDeviceID: strings.Repeat("d", 4096),
+			routeItemID:    strings.Repeat("r", 4096),
+		},
+	}
+
+	seen := make(map[int64]string, len(testCases))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := negotiatedSessionAdvisoryLockKey(tc.compatToken, tc.clientDeviceID, tc.routeItemID)
+			if prior, exists := seen[key]; exists {
+				t.Fatalf("unexpected representative collision with %q: %d", prior, key)
+			}
+			seen[key] = tc.name
+		})
+	}
+}
+
+func TestNegotiatedSessionAdvisoryLockQueriesArePinned(t *testing.T) {
+	t.Parallel()
+
+	if negotiatedSessionLegacyAdvisoryLockQuery != `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))` {
+		t.Fatalf("legacy advisory lock query changed: %q", negotiatedSessionLegacyAdvisoryLockQuery)
+	}
+	if negotiatedSessionAdvisoryLockQuery != `SELECT pg_advisory_xact_lock($1::bigint)` {
+		t.Fatalf("advisory lock query can accept text again: %q", negotiatedSessionAdvisoryLockQuery)
+	}
+}
+
+type negotiatedSessionAdvisoryLockCall struct {
+	query string
+	args  []any
+}
+
+type negotiatedSessionAdvisoryLockRecorder struct {
+	calls  []negotiatedSessionAdvisoryLockCall
+	failAt int
+	err    error
+}
+
+func (r *negotiatedSessionAdvisoryLockRecorder) Exec(_ context.Context, query string, args ...any) (pgconn.CommandTag, error) {
+	r.calls = append(r.calls, negotiatedSessionAdvisoryLockCall{
+		query: query,
+		args:  append([]any(nil), args...),
+	})
+	if r.failAt == len(r.calls) {
+		return pgconn.CommandTag{}, r.err
+	}
+	return pgconn.CommandTag{}, nil
+}
+
+func TestAcquireNegotiatedSessionAdvisoryLockBridgesLegacyThenBigint(t *testing.T) {
+	t.Parallel()
+
+	recorder := &negotiatedSessionAdvisoryLockRecorder{}
+	err := acquireNegotiatedSessionAdvisoryLock(
+		context.Background(), recorder,
+		"token\x00with-delimiter", "device", "route\x00item",
+	)
+	if err != nil {
+		t.Fatalf("acquire advisory lock: %v", err)
+	}
+	if len(recorder.calls) != 2 {
+		t.Fatalf("call count = %d, want 2", len(recorder.calls))
+	}
+	legacy := recorder.calls[0]
+	if legacy.query != negotiatedSessionLegacyAdvisoryLockQuery {
+		t.Fatalf("legacy query = %q, want %q", legacy.query, negotiatedSessionLegacyAdvisoryLockQuery)
+	}
+	if len(legacy.args) != 1 {
+		t.Fatalf("legacy argument count = %d, want 1", len(legacy.args))
+	}
+	legacyScope, ok := legacy.args[0].(string)
+	if !ok {
+		t.Fatalf("legacy advisory lock argument type = %T, want string", legacy.args[0])
+	}
+	if strings.ContainsRune(legacyScope, '\x00') {
+		t.Fatalf("legacy advisory lock scope contains NUL: %q", legacyScope)
+	}
+
+	versioned := recorder.calls[1]
+	if versioned.query != negotiatedSessionAdvisoryLockQuery {
+		t.Fatalf("versioned query = %q, want %q", versioned.query, negotiatedSessionAdvisoryLockQuery)
+	}
+	if len(versioned.args) != 1 {
+		t.Fatalf("versioned argument count = %d, want 1", len(versioned.args))
+	}
+	if _, ok := versioned.args[0].(int64); !ok {
+		t.Fatalf("versioned advisory lock argument type = %T, want int64", versioned.args[0])
+	}
+}
+
+func TestAcquireNegotiatedSessionAdvisoryLockPropagatesDatabaseError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		failAt int
+	}{
+		{name: "legacy lock", failAt: 1},
+		{name: "versioned lock", failAt: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wantErr := errors.New("lock unavailable")
+			recorder := &negotiatedSessionAdvisoryLockRecorder{failAt: tc.failAt, err: wantErr}
+			err := acquireNegotiatedSessionAdvisoryLock(context.Background(), recorder, "token", "device", "route")
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("error = %v, want wrapped %v", err, wantErr)
+			}
+			if len(recorder.calls) != tc.failAt {
+				t.Fatalf("call count = %d, want %d", len(recorder.calls), tc.failAt)
+			}
+		})
+	}
+}
+
+func BenchmarkNegotiatedSessionAdvisoryLockKey(b *testing.B) {
+	testCases := []struct {
+		name           string
+		compatToken    string
+		clientDeviceID string
+		routeItemID    string
+	}{
+		{
+			name:           "typical",
+			compatToken:    strings.Repeat("a", 64),
+			clientDeviceID: "android-tv-device",
+			routeItemID:    "01J8Y2KJ0B9AZ7Q48H1S6X3CME",
+		},
+		{
+			name:           "embedded-NUL",
+			compatToken:    "token\x00with\x00separators",
+			clientDeviceID: "device",
+			routeItemID:    "route\x00item",
+		},
+		{
+			name:           "long-4KiB-components",
+			compatToken:    strings.Repeat("t", 4096),
+			clientDeviceID: strings.Repeat("d", 4096),
+			routeItemID:    strings.Repeat("r", 4096),
+		},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.compatToken) + len(tc.clientDeviceID) + len(tc.routeItemID)))
+			for i := 0; i < b.N; i++ {
+				negotiatedSessionAdvisoryLockKeySink = negotiatedSessionAdvisoryLockKey(
+					tc.compatToken, tc.clientDeviceID, tc.routeItemID,
+				)
+			}
+		})
+	}
+}
 
 func TestMarshalPlaybackSessionStripsNestedNUL(t *testing.T) {
 	wantLiteral := `literal\u0000text`
@@ -71,6 +260,87 @@ func newCompatTestPool(t *testing.T) *pgxpool.Pool {
 		t.Skip("test database has not applied jellycompat playback sessions migration")
 	}
 	return pool
+}
+
+func TestNegotiatedSessionAdvisoryLockCoordinatesAcrossRollingUpgrade(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	const (
+		compatToken    = "rolling-token"
+		clientDeviceID = "rolling-device"
+		routeItemID    = "rolling-route"
+	)
+
+	bridgedTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin bridged transaction: %v", err)
+	}
+	t.Cleanup(func() { _ = bridgedTx.Rollback(ctx) })
+	if err := acquireNegotiatedSessionAdvisoryLock(
+		ctx, bridgedTx, compatToken, clientDeviceID, routeItemID,
+	); err != nil {
+		t.Fatalf("acquire bridged advisory locks: %v", err)
+	}
+
+	legacyTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin legacy transaction: %v", err)
+	}
+	t.Cleanup(func() { _ = legacyTx.Rollback(ctx) })
+	legacyScope := negotiatedPlaybackScope(compatToken, clientDeviceID, routeItemID)
+	var legacyAcquired bool
+	if err := legacyTx.QueryRow(
+		ctx,
+		`SELECT pg_try_advisory_xact_lock(hashtextextended($1, 0))`,
+		legacyScope,
+	).Scan(&legacyAcquired); err != nil {
+		t.Fatalf("try legacy advisory lock: %v", err)
+	}
+	if legacyAcquired {
+		t.Fatal("legacy writer bypassed bridged advisory lock")
+	}
+
+	versionedTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin versioned transaction: %v", err)
+	}
+	t.Cleanup(func() { _ = versionedTx.Rollback(ctx) })
+	lockKey := negotiatedSessionAdvisoryLockKey(compatToken, clientDeviceID, routeItemID)
+	var versionedAcquired bool
+	if err := versionedTx.QueryRow(
+		ctx,
+		`SELECT pg_try_advisory_xact_lock($1::bigint)`,
+		lockKey,
+	).Scan(&versionedAcquired); err != nil {
+		t.Fatalf("try versioned advisory lock: %v", err)
+	}
+	if versionedAcquired {
+		t.Fatal("versioned writer bypassed bridged advisory lock")
+	}
+
+	if err := bridgedTx.Rollback(ctx); err != nil {
+		t.Fatalf("release bridged advisory locks: %v", err)
+	}
+	if err := legacyTx.QueryRow(
+		ctx,
+		`SELECT pg_try_advisory_xact_lock(hashtextextended($1, 0))`,
+		legacyScope,
+	).Scan(&legacyAcquired); err != nil {
+		t.Fatalf("retry legacy advisory lock: %v", err)
+	}
+	if !legacyAcquired {
+		t.Fatal("legacy advisory lock remained unavailable after bridge released")
+	}
+	if err := versionedTx.QueryRow(
+		ctx,
+		`SELECT pg_try_advisory_xact_lock($1::bigint)`,
+		lockKey,
+	).Scan(&versionedAcquired); err != nil {
+		t.Fatalf("retry versioned advisory lock: %v", err)
+	}
+	if !versionedAcquired {
+		t.Fatal("versioned advisory lock remained unavailable after bridge released")
+	}
 }
 
 // A session written by one store instance must be reloadable by a fresh instance


### PR DESCRIPTION
## Problem

Related work: #599, #616, #842

A production incident exposed the original negotiated-session failure mode: client-derived scope text containing NUL reached PostgreSQL, the advisory-lock query failed before the upsert, and the negotiated playback session remained cache-only.

#842 now strips NUL and length-frames the legacy text scope, so current main no longer has that immediate failure. This PR hardens the boundary further and provides a safe migration path to a fixed-width, versioned advisory-lock key. A direct switch from the current text-derived key to a bigint key would allow old and new processes to enter the same replacement critical section during a rolling upgrade.

This closes out the negotiated-session advisory-lock subproblem with a tested migration bridge. It does not close the broader database-test and CI work in #599. It also supersedes the delimiter-based advisory-lock design in the closed draft #616.

## Approach

- Derive a signed 64-bit key locally from a domain-separated, length-framed SHA-256 input.
- Send only that `int64` to the versioned PostgreSQL advisory-lock query.
- During this bridge release, acquire the current legacy text-derived lock first and the versioned bigint lock second.
- Keep the lock order fixed as legacy then versioned for every upgraded process.
- Leave the exact `DELETE` predicates, upsert, expiration, cache behavior, API contract, and playback policy unchanged.

The bridge gives adjacent-version rolling-upgrade compatibility:

- current-main legacy-only processes coordinate with bridged processes through the legacy lock;
- bridged processes coordinate with a later versioned-only release through the bigint lock.

A later release can retire the legacy acquisition after this bridge has shipped through a full release cycle. Operators should not skip directly from a legacy-only build to a future versioned-only build during a mixed-version rollout.

A theoretical 64-bit collision only over-serializes unrelated negotiation scopes. It cannot delete or replace the wrong row because the mutation still uses all original values as exact predicates.

## Validation

### Focused regression coverage

- Focused lock, scope, and persistence tests: pass.
- New lock-key and lock-order tests repeated 100 times: pass.
- Focused race run: pass.
- `go vet ./internal/jellycompat`: pass.
- `make embed-stub && go build ./...`: pass.
- `make verify-playback-fixtures`: pass.
- `make verify-local-paths`: pass.
- Repository-wide `gofmt -l .`: clean.
- `git diff --check`: clean.

The tests pin:

- the versioned key golden vector;
- stable results across repeated calls;
- component boundaries, reordered fields, embedded NUL, empty values, and three 4 KiB components;
- the exact legacy and bigint SQL query shapes;
- mandatory legacy-to-versioned acquisition order;
- error propagation from either lock acquisition;
- adjacent legacy-only, bridged, and versioned-only PostgreSQL lock coordination.

The real PostgreSQL integration test compiles and is available when `SILO_TEST_DATABASE_URL` is set. It skipped locally because that variable was not configured. I separately ran a transient, read-only PostgreSQL advisory-lock proof with the exact query forms: while one transaction held both locks, legacy-only and versioned-only contenders returned `false|false`; after rollback, both returned `true|true`. No row was written or changed.

### Production evidence

The versioned bigint key derivation and persistence path were deployed before this upstream contribution. The compatibility bridge itself was not deployed; it is covered by the ordering tests, integration test, and read-only PostgreSQL proof above.

Six-hour baseline before deployment:

- 13 negotiated-session persistence warnings;
- 0 playback-start failures;
- the root database error was PostgreSQL rejecting NUL in the text advisory-lock parameter.

Post-deployment aggregate since the service restart:

- 3 successful PlaybackInfo negotiations, all HTTP 2xx;
- 133 direct-stream requests: 127 HTTP 206 responses and 6 successful HTTP 200 HEAD requests;
- 336 progress updates, all HTTP 204;
- 2 new durable negotiated-session rows;
- 0 persistence warnings;
- 0 PostgreSQL UTF-8/NUL errors;
- 0 playback-start errors;
- 0 panic or fatal events;
- service healthy with zero container restarts.

These are anonymized aggregates. No user, device, media, session, network, or account identifiers are included.

### Key-derivation benchmark

Apple M4, darwin/arm64, five runs:

| input | time/op range | bytes/op | allocs/op |
|---|---:|---:|---:|
| typical identifiers | 111.4 to 114.5 ns | 176 | 1 |
| embedded NUL | 84.70 to 86.17 ns | 112 | 1 |
| three 4 KiB components | 5.160 to 5.313 us | 13,568 | 1 |

This benchmark measures the local key-derivation helper only. It is not an end-to-end playback or database-latency benchmark. The bridge intentionally adds one advisory-lock database round trip during negotiated-session replacement.

### Upstream baseline CI repairs

The exact upstream base commit was already red before this PR. Initial CI runs surfaced two independent test-tree defects, both now repaired with no production-code change:

1. `internal/jellycompat/handlers_items_test.go` contained one extra blank line. Removing it is the complete `gofmt` diff, and repository-wide formatting now passes.
2. `fakeSeasonByIDRepo` returned a fresh `errors.New("season not found")` instead of the real repository contract, `catalog.ErrSeasonNotFound`. The production handler correctly treated that unexpected error as a database failure, causing `TestHandleEpisodes_UnknownSeasonIDReturnsNotFound` to expect 404 but receive 500. The fake now returns the catalog sentinel. Production behavior is unchanged.

The corrected 404 contract test, authoritative season test, and related season-parent tests passed 10 consecutive targeted runs. Build, formatting, vet, changed-line lint, settings bindings, and playback fixtures passed in the subsequent remote Go job before its full test step reached the inherited sentinel mismatch. The latest full CI run passes: Go (8m28s), Web (7m16s), Docs hygiene (11s), and the CodeRabbit status check.

The Go settings-binding check was current. The combined web settings verification could not finish locally because the restricted environment could not reach the npm registry; the remote Web job passed after the first update and remains authoritative.

## Risks

- One additional advisory-lock query is executed per fully scoped negotiation during the bridge release. Segment delivery is unaffected because this is not on the segment-request hot path.
- All upgraded processes acquire locks in the same order, preventing a new deadlock cycle within this path.
- The versioned key is deliberately pinned. Changing its domain, framing, byte order, digest selection, or signed conversion requires another migration plan.
- The two baseline CI repairs are test-only and do not change server runtime behavior.
- This does not change transcoding, media selection, codec compatibility, metadata resolution, Continue Watching selection, or client behavior.

## AI Disclosure

- Tool(s): OpenAI Codex
- Model(s): Codex Sol Ultra
- Involvement: AI-assisted. I orchestrated and directed the investigation, scope, production safety, testing, benchmarking, CI repair, and final approach. Codex implemented and reviewed the change.
- Adversarial review: An independent review rejected the first bigint-only version because it broke rolling-upgrade lock coordination. I directed the fix to use an ordered legacy-to-versioned bridge. The revised implementation was re-reviewed for lock ordering, adjacent-version interoperability, NUL handling, boundary ambiguity, collisions, error propagation, exact-delete safety, benchmark claims, and regression scope. The CI repairs were constrained to the exact formatter output and the real catalog repository sentinel. No production handler change was made.

## Checklist

- [x] I read and can explain the complete diff.
- [x] The advisory-lock change is isolated; the two test-only upstream baseline repairs are documented separately.
- [x] I ran focused regression, repetition, race, vet, build, and repository verification checks.
- [x] Production evidence is aggregated and contains no personal information.
- [x] I documented the database-test boundary, CI baseline defects, and benchmark scope.

