### PR TITLE
fix(playback): normalize Windows and Android Firefox web audio

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +22,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by

--- a/internal/playback/device_quirks_v3.go
+++ b/internal/playback/device_quirks_v3.go
@@ -3,12 +3,13 @@ package playback
 import "strings"
 
 const (
-	QuirkFireTVAFTKRTHigh10V3       = "android.fire_tv.aftkrt.h264_high10_l52_v1"
-	QuirkFireTVAFTKRTEAC3HLSV3      = "android.fire_tv.aftkrt.eac3_7_1_hls_audio_adapt_v1"
-	QuirkFireTVDV8HDR10PlusV3       = "android.fire_tv.dv8_hdr10plus_sei_v1"
-	QuirkFirefoxMatroskaAACTimingV3 = "web.firefox.matroska_aac_timestamps_v1"
-	QuirkWindowsWebAudioNormalizeV3 = "web.windows.audio_normalization_v1"
-	legacyAndroidMedia3HLSBuildV3   = "15"
+	QuirkFireTVAFTKRTHigh10V3              = "android.fire_tv.aftkrt.h264_high10_l52_v1"
+	QuirkFireTVAFTKRTEAC3HLSV3             = "android.fire_tv.aftkrt.eac3_7_1_hls_audio_adapt_v1"
+	QuirkFireTVDV8HDR10PlusV3              = "android.fire_tv.dv8_hdr10plus_sei_v1"
+	QuirkFirefoxMatroskaAACTimingV3        = "web.firefox.matroska_aac_timestamps_v1"
+	QuirkWindowsWebAudioNormalizeV3        = "web.windows.audio_normalization_v1"
+	QuirkAndroidFirefoxWebAudioNormalizeV3 = "web.android.firefox.audio_normalization_v1"
+	legacyAndroidMedia3HLSBuildV3          = "15"
 )
 
 func high10DecodeOverrideV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
@@ -114,6 +115,31 @@ func windowsWebAudioNormalizationQuirkV3(source SourceDescriptorV3, request Star
 	return &quirk, true
 }
 
+// androidFirefoxWebAudioNormalizationQuirkV3 gives Firefox on Android the
+// timestamp-normalized AAC recipe for non-AAC source audio. The observed
+// mobile route crackles while directly decoding E-AC-3, but native AAC remains
+// unchanged unless the more specific Matroska AAC timing quirk applies.
+func androidFirefoxWebAudioNormalizationQuirkV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
+	codec := normalizeCodecV3(source.AudioCodec)
+	if !isAndroidFirefoxWebV3(request) || codec == "" || codec == audioCodecAACV3 {
+		return nil, false
+	}
+	quirk := AppliedQuirkV3{
+		ID:               QuirkAndroidFirefoxWebAudioNormalizeV3,
+		RegistryRevision: DeviceQuirkRegistryRevisionV3,
+		Action:           "audio_only_transcode",
+		Reason:           "Firefox on Android normalizes non-AAC source audio to timestamp-corrected AAC stereo while preserving copied video.",
+	}
+	return &quirk, true
+}
+
+func webAudioNormalizationQuirkV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
+	if quirk, ok := windowsWebAudioNormalizationQuirkV3(source, request); ok {
+		return quirk, true
+	}
+	return androidFirefoxWebAudioNormalizationQuirkV3(source, request)
+}
+
 func isWindowsWebV3(request StartRequestV3) bool {
 	device := request.ClientPlaybackContext.Device
 	if !strings.EqualFold(device.Platform, "web") {
@@ -121,6 +147,14 @@ func isWindowsWebV3(request StartRequestV3) bool {
 	}
 	userAgent := strings.ToLower(strings.TrimSpace(device.PlatformDetails["user_agent"]))
 	return strings.Contains(userAgent, "windows nt")
+}
+
+func isAndroidFirefoxWebV3(request StartRequestV3) bool {
+	if !isFirefoxWebV3(request) {
+		return false
+	}
+	userAgent := strings.ToLower(strings.TrimSpace(request.ClientPlaybackContext.Device.PlatformDetails["user_agent"]))
+	return strings.Contains(userAgent, "android")
 }
 
 func isFirefoxWebV3(request StartRequestV3) bool {

--- a/internal/playback/device_quirks_v3.go
+++ b/internal/playback/device_quirks_v3.go
@@ -7,6 +7,7 @@ const (
 	QuirkFireTVAFTKRTEAC3HLSV3      = "android.fire_tv.aftkrt.eac3_7_1_hls_audio_adapt_v1"
 	QuirkFireTVDV8HDR10PlusV3       = "android.fire_tv.dv8_hdr10plus_sei_v1"
 	QuirkFirefoxMatroskaAACTimingV3 = "web.firefox.matroska_aac_timestamps_v1"
+	QuirkWindowsWebAudioNormalizeV3 = "web.windows.audio_normalization_v1"
 	legacyAndroidMedia3HLSBuildV3   = "15"
 )
 
@@ -92,6 +93,34 @@ func firefoxMatroskaAACTimingQuirkV3(source SourceDescriptorV3, request StartReq
 		Reason:           "Firefox requires Matroska AAC timestamps to be normalized before MP4 or HLS packaging.",
 	}
 	return &quirk, true
+}
+
+// windowsWebAudioNormalizationQuirkV3 keeps video on a source-preserving route
+// while giving Windows browsers one stable audio contract. Every non-AAC
+// source codec is decoded server-side and re-encoded with the timestamp-
+// normalizing AAC recipe. Windows Firefox also normalizes AAC because its
+// audio path is the strictest target; other browsers keep native AAC.
+func windowsWebAudioNormalizationQuirkV3(source SourceDescriptorV3, request StartRequestV3) (*AppliedQuirkV3, bool) {
+	codec := normalizeCodecV3(source.AudioCodec)
+	if !isWindowsWebV3(request) || codec == "" || (codec == audioCodecAACV3 && !isFirefoxWebV3(request)) {
+		return nil, false
+	}
+	quirk := AppliedQuirkV3{
+		ID:               QuirkWindowsWebAudioNormalizeV3,
+		RegistryRevision: DeviceQuirkRegistryRevisionV3,
+		Action:           "audio_only_transcode",
+		Reason:           "Windows web playback normalizes source audio to timestamp-corrected AAC while preserving copied video; Firefox also normalizes native AAC.",
+	}
+	return &quirk, true
+}
+
+func isWindowsWebV3(request StartRequestV3) bool {
+	device := request.ClientPlaybackContext.Device
+	if !strings.EqualFold(device.Platform, "web") {
+		return false
+	}
+	userAgent := strings.ToLower(strings.TrimSpace(device.PlatformDetails["user_agent"]))
+	return strings.Contains(userAgent, "windows nt")
 }
 
 func isFirefoxWebV3(request StartRequestV3) bool {

--- a/internal/playback/device_quirks_v3_test.go
+++ b/internal/playback/device_quirks_v3_test.go
@@ -162,6 +162,48 @@ func TestFirefoxMatroskaAACTimingQuirkIsExact(t *testing.T) {
 	}
 }
 
+func TestWindowsWebAudioNormalizationQuirkIsExact(t *testing.T) {
+	request := validStartRequestV3()
+	request.ClientPlaybackContext.Device = DeviceContextV3{
+		Platform: "web",
+		PlatformDetails: map[string]string{
+			"user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0",
+		},
+	}
+	quirk, ok := windowsWebAudioNormalizationQuirkV3(SourceDescriptorV3{AudioCodec: "eac3"}, request)
+	if !ok || quirk == nil || quirk.ID != QuirkWindowsWebAudioNormalizeV3 || quirk.Action != "audio_only_transcode" {
+		t.Fatalf("Windows web audio normalization quirk = %#v, ok=%v", quirk, ok)
+	}
+	request.ClientPlaybackContext.Device.PlatformDetails["user_agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0"
+	quirk, ok = windowsWebAudioNormalizationQuirkV3(SourceDescriptorV3{AudioCodec: "aac"}, request)
+	if !ok || quirk == nil || quirk.ID != QuirkWindowsWebAudioNormalizeV3 {
+		t.Fatalf("Windows Firefox AAC quirk = %#v, ok=%v", quirk, ok)
+	}
+	request.ClientPlaybackContext.Device.PlatformDetails["user_agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Edg/151.0.0.0"
+
+	for _, test := range []struct {
+		name      string
+		platform  string
+		userAgent string
+		codec     string
+	}{
+		{name: "Windows AAC", platform: "web", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Edg/151.0.0.0", codec: "aac"},
+		{name: "Windows no codec", platform: "web", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Edg/151.0.0.0"},
+		{name: "macOS Edge", platform: "web", userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Edg/151.0.0.0", codec: "eac3"},
+		{name: "Android app", platform: "android", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)", codec: "eac3"},
+		{name: "missing UA", platform: "web", codec: "eac3"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := request
+			candidate.ClientPlaybackContext.Device.Platform = test.platform
+			candidate.ClientPlaybackContext.Device.PlatformDetails = map[string]string{"user_agent": test.userAgent}
+			if got, eligible := windowsWebAudioNormalizationQuirkV3(SourceDescriptorV3{AudioCodec: test.codec}, candidate); eligible || got != nil {
+				t.Fatalf("unexpected quirk = %#v, eligible=%v", got, eligible)
+			}
+		})
+	}
+}
+
 func TestPlanAttemptKeyV3DeviceQuirkIsStable(t *testing.T) {
 	width, height, bitrate := 3840, 2160, 60_000
 	plan := PlanV3{

--- a/internal/playback/device_quirks_v3_test.go
+++ b/internal/playback/device_quirks_v3_test.go
@@ -204,6 +204,42 @@ func TestWindowsWebAudioNormalizationQuirkIsExact(t *testing.T) {
 	}
 }
 
+func TestAndroidFirefoxWebAudioNormalizationQuirkIsExact(t *testing.T) {
+	request := validStartRequestV3()
+	request.ClientPlaybackContext.Device = DeviceContextV3{
+		Platform: "web",
+		PlatformDetails: map[string]string{
+			"user_agent": "Mozilla/5.0 (Android 16; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0",
+		},
+	}
+	quirk, ok := androidFirefoxWebAudioNormalizationQuirkV3(SourceDescriptorV3{AudioCodec: "eac3"}, request)
+	if !ok || quirk == nil || quirk.ID != QuirkAndroidFirefoxWebAudioNormalizeV3 || quirk.Action != "audio_only_transcode" {
+		t.Fatalf("Android Firefox web audio normalization quirk = %#v, ok=%v", quirk, ok)
+	}
+
+	for _, test := range []struct {
+		name      string
+		platform  string
+		userAgent string
+		codec     string
+	}{
+		{name: "native AAC", platform: "web", userAgent: "Mozilla/5.0 (Android 16; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0", codec: "aac"},
+		{name: "Android Chrome", platform: "web", userAgent: "Mozilla/5.0 (Linux; Android 16; Pixel 10) AppleWebKit/537.36 Chrome/151.0.0.0 Mobile Safari/537.36", codec: "eac3"},
+		{name: "desktop Firefox", platform: "web", userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:154.0) Gecko/20100101 Firefox/154.0", codec: "eac3"},
+		{name: "native Android app", platform: "android", userAgent: "Mozilla/5.0 (Android 16; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0", codec: "eac3"},
+		{name: "missing codec", platform: "web", userAgent: "Mozilla/5.0 (Android 16; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := request
+			candidate.ClientPlaybackContext.Device.Platform = test.platform
+			candidate.ClientPlaybackContext.Device.PlatformDetails = map[string]string{"user_agent": test.userAgent}
+			if got, eligible := androidFirefoxWebAudioNormalizationQuirkV3(SourceDescriptorV3{AudioCodec: test.codec}, candidate); eligible || got != nil {
+				t.Fatalf("unexpected quirk = %#v, eligible=%v", got, eligible)
+			}
+		})
+	}
+}
+
 func TestPlanAttemptKeyV3DeviceQuirkIsStable(t *testing.T) {
 	width, height, bitrate := 3840, 2160, 60_000
 	plan := PlanV3{

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -227,6 +227,8 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	clientManagedRange := clientManagesOriginalDynamicRangeV3(source, input.Request)
 	originalRangeOK := rangeOK || clientManagedRange
 	audioOK, passthrough, audioClaims := audioEligibilityV3(source, input.Request)
+	windowsAudioQuirk, normalizeWindowsAudio := windowsWebAudioNormalizationQuirkV3(source, input.Request)
+	firefoxAACTimingQuirk, normalizeMatroskaAAC := firefoxMatroskaAACTimingQuirkV3(source, input.Request)
 	originalAudioSelectionOK := audioSelectionUsesContainerDefaultV3(file, input.AudioTrackIndex) ||
 		clientSelectsOriginalAudioTrackV3(input.Request)
 	noAudioTrack := source.AudioCodec == "" && (file == nil || len(file.AudioTracks) == 0)
@@ -380,7 +382,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	// source. A decoder profile/max-instance claim alone is not proof of native
 	// dual-layer output, so the default Android route mirrors Silo Apple: P8.1
 	// base-layer Dolby Vision first, then same-file HDR10.
-	if source.DVProfile == 7 && quality.PreservesSource && videoOK && containerOK && audioOK && originalAudioSelectionOK && !subtitle.RequiresBurn {
+	if !normalizeWindowsAudio && source.DVProfile == 7 && quality.PreservesSource && videoOK && containerOK && audioOK && originalAudioSelectionOK && !subtitle.RequiresBurn {
 		if clientDV81Eligible {
 			plan := base
 			plan.Delivery = DeliveryOriginalHTTPV3
@@ -433,7 +435,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		}
 	}
 
-	if source.DVProfile != 7 && deliveryAvailableV3(input.Request, DeliveryClassOriginalHTTPV3) && containerOK && videoOK && originalRangeOK && audioOK && originalAudioSelectionOK && quality.PreservesSource && !subtitle.RequiresBurn {
+	if !normalizeWindowsAudio && source.DVProfile != 7 && deliveryAvailableV3(input.Request, DeliveryClassOriginalHTTPV3) && containerOK && videoOK && originalRangeOK && audioOK && originalAudioSelectionOK && quality.PreservesSource && !subtitle.RequiresBurn {
 		plan := base
 		plan.Delivery = DeliveryOriginalHTTPV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: source.Container, MIMEType: MimeFromExtension(file.FilePath), Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
@@ -464,11 +466,11 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		// contains 1024 samples. Copying those rounded timestamps into MP4/fMP4
 		// produces real sub-frame gaps and overlaps that Firefox renders as
 		// crackle. Keep video-copy remuxing, but re-encode the selected AAC track
-		// through the versioned timestamp-normalization recipe. Native original
-		// playback above remains byte-for-byte direct play.
-		firefoxAACTimingQuirk, normalizeMatroskaAAC := firefoxMatroskaAACTimingQuirkV3(source, input.Request)
-		progressiveTranscodeAudio := !progressiveAudioOK || normalizeMatroskaAAC
-		hlsTranscodeAudio := !hlsAudioOK || normalizeMatroskaAAC
+		// through the versioned timestamp-normalization recipe. Non-Windows native
+		// original playback above remains byte-for-byte direct play; Windows
+		// Firefox is deliberately forced through this branch.
+		progressiveTranscodeAudio := !progressiveAudioOK || normalizeMatroskaAAC || normalizeWindowsAudio
+		hlsTranscodeAudio := !hlsAudioOK || normalizeMatroskaAAC || normalizeWindowsAudio
 		hlsAudioQuirk, hlsAudioQuirkOK := hlsEAC3AudioCorrectionV3(source, input.Request)
 		progressiveAudioConvertOK := false
 		if progressiveTranscodeAudio && deliveryAvailableV3(input.Request, DeliveryClassProgressiveV3) {
@@ -511,6 +513,9 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		if normalizeMatroskaAAC {
 			appendAppliedQuirkV3(&progressivePlan, *firefoxAACTimingQuirk, "")
 		}
+		if normalizeWindowsAudio && !normalizeMatroskaAAC {
+			appendAppliedQuirkV3(&progressivePlan, *windowsAudioQuirk, "")
+		}
 		if !dvStrip {
 			applyCopiedVideoQuirksV3(&progressivePlan, source, input.Request, high10Quirk)
 		}
@@ -546,9 +551,12 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 				}
 				// HLS packaging cannot safely copy non-native codecs such as
 				// DTS, TrueHD, or Opus. Preserve surround when adapting those
-				// codecs; a native codec rejected by the scoped client claim
-				// keeps the normal compatibility downmix policy.
-				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, !hlsNativeAudioCodecV3(source.AudioCodec))
+				// codecs on clients with a proven multichannel path. Windows web
+				// deliberately keeps the conservative AAC stereo contract used
+				// by progressive delivery so an HLS fallback cannot reintroduce
+				// the platform-specific audio failure.
+				preserveSurround := !hlsNativeAudioCodecV3(source.AudioCodec) && !normalizeWindowsAudio
+				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, preserveSurround)
 				plan.EffectiveRecipe.AudioCodec = "aac"
 				plan.EffectiveRecipe.AudioChannels = intPointerV3(hlsAudioChannels)
 				plan.EffectiveRecipe.AudioLayout = audioLayoutForChannelsV3(hlsAudioChannels)
@@ -558,6 +566,9 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			}
 			if normalizeMatroskaAAC {
 				appendAppliedQuirkV3(&plan, *firefoxAACTimingQuirk, "")
+			}
+			if normalizeWindowsAudio && !normalizeMatroskaAAC {
+				appendAppliedQuirkV3(&plan, *windowsAudioQuirk, "")
 			}
 			if hlsAudioQuirkOK && !hlsTranscodeAudio {
 				if !input.hlsRemuxRegistry().Available(TransformationAudioToAACV3) {
@@ -698,6 +709,8 @@ const (
 func planAudioOnlyV3(input PlannerInputV3, file *models.MediaFile, source SourceDescriptorV3) PlannerResultV3 {
 	request := input.Request
 	audioOK, _, audioClaims := audioEligibilityV3(source, request)
+	windowsAudioQuirk, normalizeWindowsAudio := windowsWebAudioNormalizationQuirkV3(source, request)
+	firefoxAACTimingQuirk, normalizeMatroskaAAC := firefoxMatroskaAACTimingQuirkV3(source, request)
 	originalAudioSelectionOK := audioSelectionUsesContainerDefaultV3(file, input.AudioTrackIndex) ||
 		clientSelectsOriginalAudioTrackV3(request)
 	bandwidthCapKbps := optionalValueV3(request.BandwidthCapKbps)
@@ -727,8 +740,14 @@ func planAudioOnlyV3(input PlannerInputV3, file *models.MediaFile, source Source
 		SubtitleFidelityPolicy: subtitlePolicyNameV3(request.SubtitleFidelityPreference),
 		Timeline:               TimelineV3{SourceStartSeconds: floatOrZeroV3(request.StartPosition), PlayerStartSeconds: floatOrZeroV3(request.StartPosition), CanSeekAnywhere: true, SeekRestoration: "player_position"},
 	}
+	if normalizeWindowsAudio && !normalizeMatroskaAAC {
+		appendAppliedQuirkV3(&base, *windowsAudioQuirk, "")
+	}
+	if normalizeWindowsAudio && normalizeMatroskaAAC {
+		appendAppliedQuirkV3(&base, *firefoxAACTimingQuirk, "")
+	}
 	containerOK := containsFoldV3(request.Capabilities.Containers, source.Container)
-	if audioOK && containerOK && !bandwidthCapExceeded && originalAudioSelectionOK && deliveryAvailableV3(request, DeliveryClassOriginalHTTPV3) {
+	if !normalizeWindowsAudio && audioOK && containerOK && !bandwidthCapExceeded && originalAudioSelectionOK && deliveryAvailableV3(request, DeliveryClassOriginalHTTPV3) {
 		plan := base
 		plan.Delivery = DeliveryOriginalHTTPV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: source.Container, MIMEType: MimeFromExtension(file.FilePath), Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
@@ -741,7 +760,7 @@ func planAudioOnlyV3(input PlannerInputV3, file *models.MediaFile, source Source
 	if !deliveryAvailableV3(request, DeliveryClassProgressiveV3) {
 		return terminalPlannerResultV3("adaptation_unavailable", "No validated playback route is available for this audio source.", false)
 	}
-	transcodeAudio := !audioOK || bandwidthCapExceeded
+	transcodeAudio := !audioOK || bandwidthCapExceeded || normalizeWindowsAudio
 	var progressiveRegistry *TransformationRegistryV3
 	if transcodeAudio {
 		progressiveRegistry = input.progressiveRemuxRegistry()
@@ -869,6 +888,8 @@ func applyAudioOnlyAACConversionV3(plan *PlanV3, targetChannels, targetBitrateKb
 // sends the user chasing a problem that is not blocking them. Retryable
 // infrastructure failures and the client-route terminal keep their own reasons.
 func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescriptorV3, quality QualityResultV3, subtitle SubtitlePolicyResultV3, reasonOverride string, subtitleForcedAdaptation bool) PlannerResultV3 {
+	windowsAudioQuirk, normalizeWindowsAudio := windowsWebAudioNormalizationQuirkV3(source, input.Request)
+	firefoxAACTimingQuirk, normalizeMatroskaAAC := firefoxMatroskaAACTimingQuirkV3(source, input.Request)
 	if !deliveryAvailableV3(input.Request, DeliveryClassHLSV3) {
 		return terminalPlannerResultV3("client_hls_unsupported", "The client cannot execute the required HLS adaptation route.", false)
 	}
@@ -916,9 +937,11 @@ func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescri
 	plan.EffectiveRecipe.Width = intPointerV3(quality.Width)
 	plan.EffectiveRecipe.Height = intPointerV3(quality.Height)
 	plan.EffectiveRecipe.BitrateKbps = intPointerV3(quality.BitrateKbps)
-	// Surround sources keep 5.1 through the AAC re-encode (universal Media3
-	// decode); only stereo/mono sources — and unknown layouts — downmix to 2.0.
-	targetAudioChannels := aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, true)
+	// Surround sources normally keep 5.1 through the AAC re-encode (universal
+	// Media3 decode). Windows web uses the same AAC stereo contract as its
+	// source-preserving remux routes so a quality change, subtitle burn, or
+	// exhausted copy route cannot bring the crackle back.
+	targetAudioChannels := aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, !normalizeWindowsAudio)
 	audioLayout := audioLayoutForChannelsV3(targetAudioChannels)
 	plan.EffectiveRecipe.AudioChannels = intPointerV3(targetAudioChannels)
 	plan.EffectiveRecipe.AudioLayout = audioLayout
@@ -926,6 +949,12 @@ func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescri
 		TransformationV3{Name: TransformationVideoToH264V3, Executor: ExecutorServerV3, RecipeVersion: TransformationVideoToH264RecipeVersionV3, ValidatedClaims: []string{ClaimH264DecodeV3}},
 		TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}},
 	)
+	if normalizeWindowsAudio && normalizeMatroskaAAC {
+		appendAppliedQuirkV3(&plan, *firefoxAACTimingQuirk, "")
+	}
+	if normalizeWindowsAudio && !normalizeMatroskaAAC {
+		appendAppliedQuirkV3(&plan, *windowsAudioQuirk, "")
+	}
 	toneMapPolicy := toneMapRecipe.policy
 	toneMapMode := toneMapRecipe.mode
 	toneMapResolution := toneMapRecipe.resolution

--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -227,7 +227,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	clientManagedRange := clientManagesOriginalDynamicRangeV3(source, input.Request)
 	originalRangeOK := rangeOK || clientManagedRange
 	audioOK, passthrough, audioClaims := audioEligibilityV3(source, input.Request)
-	windowsAudioQuirk, normalizeWindowsAudio := windowsWebAudioNormalizationQuirkV3(source, input.Request)
+	webAudioQuirk, normalizeWebAudio := webAudioNormalizationQuirkV3(source, input.Request)
 	firefoxAACTimingQuirk, normalizeMatroskaAAC := firefoxMatroskaAACTimingQuirkV3(source, input.Request)
 	originalAudioSelectionOK := audioSelectionUsesContainerDefaultV3(file, input.AudioTrackIndex) ||
 		clientSelectsOriginalAudioTrackV3(input.Request)
@@ -382,7 +382,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 	// source. A decoder profile/max-instance claim alone is not proof of native
 	// dual-layer output, so the default Android route mirrors Silo Apple: P8.1
 	// base-layer Dolby Vision first, then same-file HDR10.
-	if !normalizeWindowsAudio && source.DVProfile == 7 && quality.PreservesSource && videoOK && containerOK && audioOK && originalAudioSelectionOK && !subtitle.RequiresBurn {
+	if !normalizeWebAudio && source.DVProfile == 7 && quality.PreservesSource && videoOK && containerOK && audioOK && originalAudioSelectionOK && !subtitle.RequiresBurn {
 		if clientDV81Eligible {
 			plan := base
 			plan.Delivery = DeliveryOriginalHTTPV3
@@ -435,7 +435,7 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		}
 	}
 
-	if !normalizeWindowsAudio && source.DVProfile != 7 && deliveryAvailableV3(input.Request, DeliveryClassOriginalHTTPV3) && containerOK && videoOK && originalRangeOK && audioOK && originalAudioSelectionOK && quality.PreservesSource && !subtitle.RequiresBurn {
+	if !normalizeWebAudio && source.DVProfile != 7 && deliveryAvailableV3(input.Request, DeliveryClassOriginalHTTPV3) && containerOK && videoOK && originalRangeOK && audioOK && originalAudioSelectionOK && quality.PreservesSource && !subtitle.RequiresBurn {
 		plan := base
 		plan.Delivery = DeliveryOriginalHTTPV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: source.Container, MIMEType: MimeFromExtension(file.FilePath), Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
@@ -466,11 +466,12 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		// contains 1024 samples. Copying those rounded timestamps into MP4/fMP4
 		// produces real sub-frame gaps and overlaps that Firefox renders as
 		// crackle. Keep video-copy remuxing, but re-encode the selected AAC track
-		// through the versioned timestamp-normalization recipe. Non-Windows native
-		// original playback above remains byte-for-byte direct play; Windows
-		// Firefox is deliberately forced through this branch.
-		progressiveTranscodeAudio := !progressiveAudioOK || normalizeMatroskaAAC || normalizeWindowsAudio
-		hlsTranscodeAudio := !hlsAudioOK || normalizeMatroskaAAC || normalizeWindowsAudio
+		// through the versioned timestamp-normalization recipe. Unaffected native
+		// original playback above remains byte-for-byte direct play; the scoped
+		// Windows and Android Firefox routes are deliberately forced through this
+		// branch.
+		progressiveTranscodeAudio := !progressiveAudioOK || normalizeMatroskaAAC || normalizeWebAudio
+		hlsTranscodeAudio := !hlsAudioOK || normalizeMatroskaAAC || normalizeWebAudio
 		hlsAudioQuirk, hlsAudioQuirkOK := hlsEAC3AudioCorrectionV3(source, input.Request)
 		progressiveAudioConvertOK := false
 		if progressiveTranscodeAudio && deliveryAvailableV3(input.Request, DeliveryClassProgressiveV3) {
@@ -513,8 +514,8 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 		if normalizeMatroskaAAC {
 			appendAppliedQuirkV3(&progressivePlan, *firefoxAACTimingQuirk, "")
 		}
-		if normalizeWindowsAudio && !normalizeMatroskaAAC {
-			appendAppliedQuirkV3(&progressivePlan, *windowsAudioQuirk, "")
+		if normalizeWebAudio && !normalizeMatroskaAAC {
+			appendAppliedQuirkV3(&progressivePlan, *webAudioQuirk, "")
 		}
 		if !dvStrip {
 			applyCopiedVideoQuirksV3(&progressivePlan, source, input.Request, high10Quirk)
@@ -551,11 +552,11 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 				}
 				// HLS packaging cannot safely copy non-native codecs such as
 				// DTS, TrueHD, or Opus. Preserve surround when adapting those
-				// codecs on clients with a proven multichannel path. Windows web
-				// deliberately keeps the conservative AAC stereo contract used
-				// by progressive delivery so an HLS fallback cannot reintroduce
-				// the platform-specific audio failure.
-				preserveSurround := !hlsNativeAudioCodecV3(source.AudioCodec) && !normalizeWindowsAudio
+				// codecs on clients with a proven multichannel path. Affected web
+				// routes deliberately keep the conservative AAC stereo contract
+				// used by progressive delivery so an HLS fallback cannot
+				// reintroduce the platform-specific audio failure.
+				preserveSurround := !hlsNativeAudioCodecV3(source.AudioCodec) && !normalizeWebAudio
 				hlsAudioChannels = aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, preserveSurround)
 				plan.EffectiveRecipe.AudioCodec = "aac"
 				plan.EffectiveRecipe.AudioChannels = intPointerV3(hlsAudioChannels)
@@ -567,8 +568,8 @@ func PlanPlaybackV3(input PlannerInputV3) PlannerResultV3 {
 			if normalizeMatroskaAAC {
 				appendAppliedQuirkV3(&plan, *firefoxAACTimingQuirk, "")
 			}
-			if normalizeWindowsAudio && !normalizeMatroskaAAC {
-				appendAppliedQuirkV3(&plan, *windowsAudioQuirk, "")
+			if normalizeWebAudio && !normalizeMatroskaAAC {
+				appendAppliedQuirkV3(&plan, *webAudioQuirk, "")
 			}
 			if hlsAudioQuirkOK && !hlsTranscodeAudio {
 				if !input.hlsRemuxRegistry().Available(TransformationAudioToAACV3) {
@@ -709,7 +710,7 @@ const (
 func planAudioOnlyV3(input PlannerInputV3, file *models.MediaFile, source SourceDescriptorV3) PlannerResultV3 {
 	request := input.Request
 	audioOK, _, audioClaims := audioEligibilityV3(source, request)
-	windowsAudioQuirk, normalizeWindowsAudio := windowsWebAudioNormalizationQuirkV3(source, request)
+	webAudioQuirk, normalizeWebAudio := webAudioNormalizationQuirkV3(source, request)
 	firefoxAACTimingQuirk, normalizeMatroskaAAC := firefoxMatroskaAACTimingQuirkV3(source, request)
 	originalAudioSelectionOK := audioSelectionUsesContainerDefaultV3(file, input.AudioTrackIndex) ||
 		clientSelectsOriginalAudioTrackV3(request)
@@ -740,14 +741,14 @@ func planAudioOnlyV3(input PlannerInputV3, file *models.MediaFile, source Source
 		SubtitleFidelityPolicy: subtitlePolicyNameV3(request.SubtitleFidelityPreference),
 		Timeline:               TimelineV3{SourceStartSeconds: floatOrZeroV3(request.StartPosition), PlayerStartSeconds: floatOrZeroV3(request.StartPosition), CanSeekAnywhere: true, SeekRestoration: "player_position"},
 	}
-	if normalizeWindowsAudio && !normalizeMatroskaAAC {
-		appendAppliedQuirkV3(&base, *windowsAudioQuirk, "")
+	if normalizeWebAudio && !normalizeMatroskaAAC {
+		appendAppliedQuirkV3(&base, *webAudioQuirk, "")
 	}
-	if normalizeWindowsAudio && normalizeMatroskaAAC {
+	if normalizeWebAudio && normalizeMatroskaAAC {
 		appendAppliedQuirkV3(&base, *firefoxAACTimingQuirk, "")
 	}
 	containerOK := containsFoldV3(request.Capabilities.Containers, source.Container)
-	if !normalizeWindowsAudio && audioOK && containerOK && !bandwidthCapExceeded && originalAudioSelectionOK && deliveryAvailableV3(request, DeliveryClassOriginalHTTPV3) {
+	if !normalizeWebAudio && audioOK && containerOK && !bandwidthCapExceeded && originalAudioSelectionOK && deliveryAvailableV3(request, DeliveryClassOriginalHTTPV3) {
 		plan := base
 		plan.Delivery = DeliveryOriginalHTTPV3
 		plan.Stream = StreamV3{Protocol: StreamHTTPProgressiveV3, Container: source.Container, MIMEType: MimeFromExtension(file.FilePath), Headers: map[string]string{}, HeaderRefresh: HeaderRefreshNoneV3}
@@ -760,7 +761,7 @@ func planAudioOnlyV3(input PlannerInputV3, file *models.MediaFile, source Source
 	if !deliveryAvailableV3(request, DeliveryClassProgressiveV3) {
 		return terminalPlannerResultV3("adaptation_unavailable", "No validated playback route is available for this audio source.", false)
 	}
-	transcodeAudio := !audioOK || bandwidthCapExceeded || normalizeWindowsAudio
+	transcodeAudio := !audioOK || bandwidthCapExceeded || normalizeWebAudio
 	var progressiveRegistry *TransformationRegistryV3
 	if transcodeAudio {
 		progressiveRegistry = input.progressiveRemuxRegistry()
@@ -888,7 +889,7 @@ func applyAudioOnlyAACConversionV3(plan *PlanV3, targetChannels, targetBitrateKb
 // sends the user chasing a problem that is not blocking them. Retryable
 // infrastructure failures and the client-route terminal keep their own reasons.
 func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescriptorV3, quality QualityResultV3, subtitle SubtitlePolicyResultV3, reasonOverride string, subtitleForcedAdaptation bool) PlannerResultV3 {
-	windowsAudioQuirk, normalizeWindowsAudio := windowsWebAudioNormalizationQuirkV3(source, input.Request)
+	webAudioQuirk, normalizeWebAudio := webAudioNormalizationQuirkV3(source, input.Request)
 	firefoxAACTimingQuirk, normalizeMatroskaAAC := firefoxMatroskaAACTimingQuirkV3(source, input.Request)
 	if !deliveryAvailableV3(input.Request, DeliveryClassHLSV3) {
 		return terminalPlannerResultV3("client_hls_unsupported", "The client cannot execute the required HLS adaptation route.", false)
@@ -938,10 +939,10 @@ func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescri
 	plan.EffectiveRecipe.Height = intPointerV3(quality.Height)
 	plan.EffectiveRecipe.BitrateKbps = intPointerV3(quality.BitrateKbps)
 	// Surround sources normally keep 5.1 through the AAC re-encode (universal
-	// Media3 decode). Windows web uses the same AAC stereo contract as its
-	// source-preserving remux routes so a quality change, subtitle burn, or
-	// exhausted copy route cannot bring the crackle back.
-	targetAudioChannels := aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, !normalizeWindowsAudio)
+	// Media3 decode). Affected web routes use the same AAC stereo contract as
+	// their source-preserving remux routes so a quality change, subtitle burn,
+	// or exhausted copy route cannot bring the crackle back.
+	targetAudioChannels := aacOutputChannelsV3(input.Request, DeliveryClassHLSV3, source.AudioChannels, !normalizeWebAudio)
 	audioLayout := audioLayoutForChannelsV3(targetAudioChannels)
 	plan.EffectiveRecipe.AudioChannels = intPointerV3(targetAudioChannels)
 	plan.EffectiveRecipe.AudioLayout = audioLayout
@@ -949,11 +950,11 @@ func planVideoTranscodeV3(input PlannerInputV3, base PlanV3, source SourceDescri
 		TransformationV3{Name: TransformationVideoToH264V3, Executor: ExecutorServerV3, RecipeVersion: TransformationVideoToH264RecipeVersionV3, ValidatedClaims: []string{ClaimH264DecodeV3}},
 		TransformationV3{Name: TransformationAudioToAACV3, Executor: ExecutorServerV3, RecipeVersion: TransformationAudioToAACRecipeVersionV3, ValidatedClaims: []string{ClaimAudioDecodeV3}},
 	)
-	if normalizeWindowsAudio && normalizeMatroskaAAC {
+	if normalizeWebAudio && normalizeMatroskaAAC {
 		appendAppliedQuirkV3(&plan, *firefoxAACTimingQuirk, "")
 	}
-	if normalizeWindowsAudio && !normalizeMatroskaAAC {
-		appendAppliedQuirkV3(&plan, *windowsAudioQuirk, "")
+	if normalizeWebAudio && !normalizeMatroskaAAC {
+		appendAppliedQuirkV3(&plan, *webAudioQuirk, "")
 	}
 	toneMapPolicy := toneMapRecipe.policy
 	toneMapMode := toneMapRecipe.mode

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -3121,6 +3121,51 @@ func TestPlanPlaybackV3AudioOnlyPlansOriginalHTTP(t *testing.T) {
 	}
 }
 
+func TestPlanPlaybackV3WindowsWebAudioOnlyNormalizesAudio(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		codec     string
+		channels  int
+		container string
+		userAgent string
+		quirkID   string
+	}{
+		{name: "Edge EAC3", codec: "eac3", channels: 6, container: "mkv", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Edg/151.0.0.0", quirkID: QuirkWindowsWebAudioNormalizeV3},
+		{name: "Firefox Matroska AAC", codec: "aac", channels: 2, container: "mkv", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0", quirkID: QuirkFirefoxMatroskaAACTimingV3},
+		{name: "Firefox MP4 AAC", codec: "aac", channels: 2, container: "mp4", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0", quirkID: QuirkWindowsWebAudioNormalizeV3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := audioOnlyFixtureFileV3()
+			file.FilePath = "/media/audiobook." + test.container
+			file.Container = test.container
+			file.CodecAudio = test.codec
+			file.AudioChannels = test.channels
+			file.AudioTracks[0] = models.AudioTrack{Codec: test.codec, Channels: test.channels, SampleRate: 48_000, Default: true}
+			req := validStartRequestV3()
+			req.FileID = file.ID
+			req.Capabilities.CodecsAudio = []string{test.codec, "aac"}
+			req.Capabilities.Containers = []string{test.container, "mp4"}
+			req.ClientPlaybackContext.Device = DeviceContextV3{Platform: "web", PlatformDetails: map[string]string{"user_agent": test.userAgent}}
+			original := req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]
+			original.Containers = []string{test.container}
+			original.AudioDecodeCodecs = []string{test.codec}
+			req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3] = original
+			progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+			progressive.Containers = []string{"mp4"}
+			progressive.AudioDecodeCodecs = []string{"aac"}
+			req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+
+			result := PlanPlaybackV3(PlannerInputV3{Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0, Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: testTransformationRegistryV3()})
+			if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" || result.TargetAudioChannels != 2 {
+				t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+			}
+			if len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != test.quirkID {
+				t.Fatalf("applied quirks = %#v", result.Plan.AppliedQuirks)
+			}
+		})
+	}
+}
+
 func TestPlanPlaybackV3AudioOnlyHonorsBandwidthCap(t *testing.T) {
 	for _, test := range []struct {
 		name       string
@@ -3455,6 +3500,291 @@ func TestPlanPlaybackV3VideoRemuxAdaptsProgressiveWhenHLSVideoUnsupported(t *tes
 	if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" {
 		t.Fatalf("result = %s", ExplainPlannerResultV3(result))
 	}
+}
+
+func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
+	newInput := func(codec string, channels int, userAgent string) PlannerInputV3 {
+		file := detailedFixtureFileV3()
+		file.CodecVideo = "h264"
+		file.CodecAudio = codec
+		file.Resolution = "1080p"
+		file.Bitrate = 12_000
+		file.VideoTracks[0] = models.VideoTrack{Codec: "h264", Profile: "High", Level: 41, Width: 1920, Height: 1080, FrameRate: "24000/1001", Bitrate: 11_000, BitDepth: 8, VideoRange: "SDR", VideoRangeType: "SDR"}
+		file.AudioTracks[0] = models.AudioTrack{Codec: codec, Channels: channels, SampleRate: 48_000, Default: true}
+
+		req := validStartRequestV3()
+		req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+		req.Capabilities.AudioEvidence = EvidenceDeclaredV3
+		req.Capabilities.CodecsVideo = []string{"h264"}
+		req.Capabilities.CodecsAudio = []string{codec, "aac"}
+		req.Capabilities.Containers = []string{"mkv", "mp4"}
+		req.Capabilities.MaxResolution = "1080p"
+		req.ClientPlaybackContext.FormFactor = "desktop"
+		req.ClientPlaybackContext.Device = DeviceContextV3{Platform: "web", PlatformDetails: map[string]string{"user_agent": userAgent}}
+		original := req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]
+		original.Containers = []string{"mkv"}
+		original.VideoCodecs = []string{"h264"}
+		original.AudioDecodeCodecs = []string{codec}
+		req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3] = original
+		progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+		progressive.Containers = []string{"mp4"}
+		progressive.VideoCodecs = []string{"h264"}
+		progressive.AudioDecodeCodecs = []string{"aac"}
+		req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+		return PlannerInputV3{
+			Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+			Settings: PlannerSettingsV3{TranscodeEnabled: true}, Registry: testTransformationRegistryV3(),
+		}
+	}
+
+	browsers := map[string]string{
+		"Edge":    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0",
+		"Chrome":  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36",
+		"Firefox": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0",
+	}
+	codecs := []struct {
+		name     string
+		channels int
+	}{
+		{name: "mp3", channels: 2},
+		{name: "ac3", channels: 6},
+		{name: "eac3", channels: 6},
+		{name: "dts", channels: 6},
+		{name: "truehd", channels: 8},
+		{name: "opus", channels: 2},
+		{name: "vorbis", channels: 2},
+		{name: "flac", channels: 2},
+		{name: "alac", channels: 2},
+		{name: "pcm_s16le", channels: 2},
+	}
+	for browser, userAgent := range browsers {
+		for _, codec := range codecs {
+			t.Run(browser+"/"+codec.name, func(t *testing.T) {
+				result := PlanPlaybackV3(newInput(codec.name, codec.channels, userAgent))
+				if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || result.PlayMethod != PlayRemux || !result.TranscodeAudio || result.TargetAudioCodec != "aac" {
+					t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+				}
+				if result.Plan.EffectiveRecipe.VideoCodec != "h264" || result.Plan.EffectiveRecipe.AudioCodec != "aac" || result.TargetAudioChannels != 2 {
+					t.Fatalf("adapted recipe = %#v", result.Plan.EffectiveRecipe)
+				}
+				if result.Plan.DecisionReason != decisionReasonAudioAdaptationV3 || len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != TransformationAudioToAACV3 || result.Plan.Transformations[0].RecipeVersion != TransformationAudioToAACRecipeVersionV3 {
+					t.Fatalf("audio-only adaptation = %#v", result.Plan)
+				}
+				if len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkWindowsWebAudioNormalizeV3 {
+					t.Fatalf("applied quirks = %#v", result.Plan.AppliedQuirks)
+				}
+			})
+		}
+	}
+
+	t.Run("Firefox Matroska AAC", func(t *testing.T) {
+		result := PlanPlaybackV3(newInput("aac", 2, browsers["Firefox"]))
+		if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" {
+			t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+		}
+		if len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkFirefoxMatroskaAACTimingV3 {
+			t.Fatalf("applied quirks = %#v", result.Plan.AppliedQuirks)
+		}
+	})
+
+	t.Run("Firefox MP4 AAC", func(t *testing.T) {
+		input := newInput("aac", 2, browsers["Firefox"])
+		input.RequestedFile.FilePath = "/media/movie.mp4"
+		input.RequestedFile.Container = "mp4"
+		original := input.Request.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]
+		original.Containers = []string{"mp4"}
+		input.Request.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3] = original
+		result := PlanPlaybackV3(input)
+		if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" {
+			t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+		}
+		if len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkWindowsWebAudioNormalizeV3 {
+			t.Fatalf("applied quirks = %#v", result.Plan.AppliedQuirks)
+		}
+	})
+
+	t.Run("Edge AAC remains native", func(t *testing.T) {
+		result := PlanPlaybackV3(newInput("aac", 2, browsers["Edge"]))
+		if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 || result.PlayMethod != PlayDirect || result.TranscodeAudio || len(result.Plan.AppliedQuirks) != 0 {
+			t.Fatalf("native AAC route changed = %s", ExplainPlannerResultV3(result))
+		}
+	})
+
+	t.Run("macOS non-AAC remains native", func(t *testing.T) {
+		result := PlanPlaybackV3(newInput("eac3", 6, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0"))
+		if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 || result.PlayMethod != PlayDirect || result.TranscodeAudio || len(result.Plan.AppliedQuirks) != 0 {
+			t.Fatalf("non-Windows route changed = %s", ExplainPlannerResultV3(result))
+		}
+	})
+
+	t.Run("HLS fallback keeps video copied and audio normalized", func(t *testing.T) {
+		input := newInput("eac3", 6, browsers["Firefox"])
+		delete(input.Request.ClientPlaybackContext.Deliveries, DeliveryClassProgressiveV3)
+		hls := input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+		hls.Containers = []string{"hls"}
+		hls.VideoCodecs = []string{"h264"}
+		hls.AudioDecodeCodecs = []string{"aac"}
+		input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+		result := PlanPlaybackV3(input)
+		if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxHLSV3 || result.PlayMethod != PlayRemux || result.TargetVideoCodec != "copy" || result.TargetAudioCodec != "aac" || !result.TranscodeAudio {
+			t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+		}
+		if len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != TransformationAudioToAACV3 || result.Plan.Transformations[0].RecipeVersion != TransformationAudioToAACRecipeVersionV3 || len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkWindowsWebAudioNormalizeV3 {
+			t.Fatalf("HLS audio normalization = %#v", result.Plan)
+		}
+	})
+
+	t.Run("HLS-only non-native surround stays on AAC stereo contract", func(t *testing.T) {
+		input := newInput("dts", 6, browsers["Edge"])
+		delete(input.Request.ClientPlaybackContext.Deliveries, DeliveryClassProgressiveV3)
+		hls := input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+		hls.Containers = []string{"hls"}
+		hls.VideoCodecs = []string{"h264"}
+		hls.AudioDecodeCodecs = []string{"aac"}
+		input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+		result := PlanPlaybackV3(input)
+		if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxHLSV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" || result.TargetAudioChannels != 2 {
+			t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+		}
+		if result.Plan.EffectiveRecipe.VideoCodec != "h264" || result.Plan.EffectiveRecipe.AudioChannels == nil || *result.Plan.EffectiveRecipe.AudioChannels != 2 || len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkWindowsWebAudioNormalizeV3 {
+			t.Fatalf("HLS Windows recipe = %#v", result.Plan)
+		}
+	})
+
+	t.Run("full video transcode cannot reintroduce Windows audio path", func(t *testing.T) {
+		for _, test := range []struct {
+			name      string
+			codec     string
+			userAgent string
+			quirkID   string
+		}{
+			{name: "Edge EAC3", codec: "eac3", userAgent: browsers["Edge"], quirkID: QuirkWindowsWebAudioNormalizeV3},
+			{name: "Firefox Matroska AAC", codec: "aac", userAgent: browsers["Firefox"], quirkID: QuirkFirefoxMatroskaAACTimingV3},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				input := newInput(test.codec, 6, test.userAgent)
+				input.Request.QualityPreference = QualityRung720pHighV3
+				hls := input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+				hls.Containers = []string{"hls"}
+				hls.VideoCodecs = []string{"h264"}
+				hls.AudioDecodeCodecs = []string{"aac"}
+				input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+				result := PlanPlaybackV3(input)
+				if result.Plan == nil || result.Plan.Delivery != DeliveryTranscodeHLSV3 || result.PlayMethod != PlayTranscode || !result.TranscodeAudio || result.TargetVideoCodec != "h264" || result.TargetAudioCodec != "aac" || result.TargetAudioChannels != 2 {
+					t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+				}
+				if result.Plan.EffectiveRecipe.AudioChannels == nil || *result.Plan.EffectiveRecipe.AudioChannels != 2 || len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != test.quirkID {
+					t.Fatalf("transcode Windows recipe = %#v", result.Plan)
+				}
+			})
+		}
+	})
+
+	t.Run("missing AAC toolchain never falls back to crackling direct play", func(t *testing.T) {
+		for _, test := range []struct {
+			name      string
+			codec     string
+			userAgent string
+		}{
+			{name: "Edge EAC3", codec: "eac3", userAgent: browsers["Edge"]},
+			{name: "Firefox AAC", codec: "aac", userAgent: browsers["Firefox"]},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				input := newInput(test.codec, 2, test.userAgent)
+				input.Registry = NewTransformationRegistryV3(nil)
+				result := PlanPlaybackV3(input)
+				if result.Plan != nil || result.Terminal == nil || result.Terminal.Reason != TerminalAudioConversionUnsupportedV3 || !result.Terminal.Retryable {
+					t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+				}
+			})
+		}
+	})
+
+	t.Run("failed progressive retry keeps normalized AAC on HLS", func(t *testing.T) {
+		input := newInput("eac3", 6, browsers["Edge"])
+		hls := input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+		hls.Containers = []string{"hls"}
+		hls.VideoCodecs = []string{"h264"}
+		hls.AudioDecodeCodecs = []string{"aac"}
+		input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+		first := PlanPlaybackV3(input)
+		if first.Plan == nil || first.Plan.Delivery != DeliveryRemuxProgressiveV3 {
+			t.Fatalf("first = %s", ExplainPlannerResultV3(first))
+		}
+		input.AttemptedKeys = []string{first.Plan.PlanAttemptKey}
+		second := PlanPlaybackV3(input)
+		if second.Plan == nil || second.Plan.Delivery != DeliveryRemuxHLSV3 || second.TargetAudioCodec != "aac" || !second.TranscodeAudio {
+			t.Fatalf("second = %s", ExplainPlannerResultV3(second))
+		}
+		if len(second.Plan.AppliedQuirks) != 1 || second.Plan.AppliedQuirks[0].ID != QuirkWindowsWebAudioNormalizeV3 {
+			t.Fatalf("fallback quirks = %#v", second.Plan.AppliedQuirks)
+		}
+	})
+
+	t.Run("DV8 EAC3 keeps copied 4K HEVC", func(t *testing.T) {
+		file := detailedFixtureFileV3()
+		file.CodecAudio = "eac3"
+		file.AudioChannels = 6
+		file.AudioTracks[0] = models.AudioTrack{Codec: "eac3", Channels: 6, Layout: "5.1", SampleRate: 48_000, Default: true}
+		file.VideoTracks[0].DVProfile = 8
+		file.VideoTracks[0].DVLevel = 6
+		file.VideoTracks[0].DVBLCompatID = 1
+		file.VideoTracks[0].ColorTransfer = "smpte2084"
+		file.VideoTracks[0].VideoRange = "DolbyVision"
+		file.VideoTracks[0].VideoRangeType = "DOVIWithHDR10"
+		dv := &HDRCapabilitiesV3{
+			DolbyVisionProfiles:      []int{8},
+			DolbyVisionProfileLevels: []DolbyVisionProfileCapabilityV3{{Profile: 8, MaxLevel: 6, BLCompatibilityIDs: []int{1}}},
+		}
+		req := validStartRequestV3()
+		req.Capabilities.VideoEvidence = EvidenceDeclaredV3
+		req.Capabilities.AudioEvidence = EvidenceDeclaredV3
+		req.Capabilities.CodecsVideo = []string{"hevc"}
+		req.Capabilities.CodecsAudio = []string{"eac3", "aac"}
+		req.Capabilities.Containers = []string{"mkv", "mp4"}
+		req.Capabilities.HDRDetails = dv
+		req.ClientPlaybackContext.Device = DeviceContextV3{Platform: "web", PlatformDetails: map[string]string{"user_agent": browsers["Edge"]}}
+		req.ClientPlaybackContext.Output.HDRDetails = dv
+		original := req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]
+		original.Containers = []string{"mkv"}
+		original.VideoCodecs = []string{"hevc"}
+		original.AudioDecodeCodecs = []string{"eac3"}
+		original.HDRDetails = dv
+		req.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3] = original
+		progressive := req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3]
+		progressive.Containers = []string{"mp4"}
+		progressive.VideoCodecs = []string{"hevc"}
+		progressive.AudioDecodeCodecs = []string{"aac"}
+		progressive.HDRDetails = dv
+		req.ClientPlaybackContext.Deliveries[DeliveryClassProgressiveV3] = progressive
+
+		result := PlanPlaybackV3(PlannerInputV3{
+			Request: req, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+			Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3(),
+		})
+		if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || result.PlayMethod != PlayRemux || !result.TranscodeAudio || result.TargetAudioCodec != "aac" {
+			t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+		}
+		if result.Plan.EffectiveRecipe.VideoCodec != "hevc" || result.Plan.EffectiveRecipe.DynamicRange != DynamicRangeDolbyVisionV3 {
+			t.Fatalf("copied Dolby Vision recipe = %#v", result.Plan.EffectiveRecipe)
+		}
+		if len(result.Plan.Transformations) != 1 || result.Plan.Transformations[0].Name != TransformationAudioToAACV3 || len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkWindowsWebAudioNormalizeV3 {
+			t.Fatalf("audio-only workaround plan = %#v", result.Plan)
+		}
+
+		firefoxRequest := req
+		firefoxRequest.ClientPlaybackContext.Device.PlatformDetails = map[string]string{"user_agent": browsers["Firefox"]}
+		firefoxResult := PlanPlaybackV3(PlannerInputV3{
+			Request: firefoxRequest, RequestedFile: file, EffectiveFile: file, AudioTrackIndex: 0,
+			Settings: PlannerSettingsV3{TranscodeEnabled: true, Allow4KTranscode: true}, Registry: testTransformationRegistryV3(),
+		})
+		if firefoxResult.Plan == nil || firefoxResult.Plan.Delivery != DeliveryRemuxProgressiveV3 || !firefoxResult.TranscodeAudio {
+			t.Fatalf("Firefox result = %s", ExplainPlannerResultV3(firefoxResult))
+		}
+		if len(firefoxResult.Plan.AppliedQuirks) != 1 || firefoxResult.Plan.AppliedQuirks[0].ID != QuirkWindowsWebAudioNormalizeV3 {
+			t.Fatalf("Firefox copied-video quirks = %#v", firefoxResult.Plan.AppliedQuirks)
+		}
+	})
 }
 
 func TestPlanPlaybackV3MatroskaAACRemuxUsesTimestampNormalizedAudio(t *testing.T) {

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -3121,7 +3121,7 @@ func TestPlanPlaybackV3AudioOnlyPlansOriginalHTTP(t *testing.T) {
 	}
 }
 
-func TestPlanPlaybackV3WindowsWebAudioOnlyNormalizesAudio(t *testing.T) {
+func TestPlanPlaybackV3WebAudioOnlyNormalizesAudio(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		codec     string
@@ -3133,6 +3133,7 @@ func TestPlanPlaybackV3WindowsWebAudioOnlyNormalizesAudio(t *testing.T) {
 		{name: "Edge EAC3", codec: "eac3", channels: 6, container: "mkv", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Edg/151.0.0.0", quirkID: QuirkWindowsWebAudioNormalizeV3},
 		{name: "Firefox Matroska AAC", codec: "aac", channels: 2, container: "mkv", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0", quirkID: QuirkFirefoxMatroskaAACTimingV3},
 		{name: "Firefox MP4 AAC", codec: "aac", channels: 2, container: "mp4", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0", quirkID: QuirkWindowsWebAudioNormalizeV3},
+		{name: "Android Firefox EAC3", codec: "eac3", channels: 6, container: "mkv", userAgent: "Mozilla/5.0 (Android 16; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0", quirkID: QuirkAndroidFirefoxWebAudioNormalizeV3},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			file := audioOnlyFixtureFileV3()
@@ -3502,7 +3503,7 @@ func TestPlanPlaybackV3VideoRemuxAdaptsProgressiveWhenHLSVideoUnsupported(t *tes
 	}
 }
 
-func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
+func TestPlanPlaybackV3WebAudioNormalizationMatrix(t *testing.T) {
 	newInput := func(codec string, channels int, userAgent string) PlannerInputV3 {
 		file := detailedFixtureFileV3()
 		file.CodecVideo = "h264"
@@ -3542,6 +3543,7 @@ func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
 		"Chrome":  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36",
 		"Firefox": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:154.0) Gecko/20100101 Firefox/154.0",
 	}
+	androidFirefox := "Mozilla/5.0 (Android 16; Mobile; rv:154.0) Gecko/154.0 Firefox/154.0"
 	codecs := []struct {
 		name     string
 		channels int
@@ -3576,6 +3578,17 @@ func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
 			})
 		}
 	}
+	for _, codec := range codecs {
+		t.Run("Android Firefox/"+codec.name, func(t *testing.T) {
+			result := PlanPlaybackV3(newInput(codec.name, codec.channels, androidFirefox))
+			if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxProgressiveV3 || result.PlayMethod != PlayRemux || !result.TranscodeAudio || result.TargetAudioCodec != "aac" || result.TargetAudioChannels != 2 {
+				t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+			}
+			if len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkAndroidFirefoxWebAudioNormalizeV3 {
+				t.Fatalf("applied quirks = %#v", result.Plan.AppliedQuirks)
+			}
+		})
+	}
 
 	t.Run("Firefox Matroska AAC", func(t *testing.T) {
 		result := PlanPlaybackV3(newInput("aac", 2, browsers["Firefox"]))
@@ -3603,6 +3616,19 @@ func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
 		}
 	})
 
+	t.Run("Android Firefox MP4 AAC remains native", func(t *testing.T) {
+		input := newInput("aac", 2, androidFirefox)
+		input.RequestedFile.FilePath = "/media/movie.mp4"
+		input.RequestedFile.Container = "mp4"
+		original := input.Request.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3]
+		original.Containers = []string{"mp4"}
+		input.Request.ClientPlaybackContext.Deliveries[DeliveryClassOriginalHTTPV3] = original
+		result := PlanPlaybackV3(input)
+		if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 || result.PlayMethod != PlayDirect || result.TranscodeAudio || len(result.Plan.AppliedQuirks) != 0 {
+			t.Fatalf("native AAC route changed = %s", ExplainPlannerResultV3(result))
+		}
+	})
+
 	t.Run("Edge AAC remains native", func(t *testing.T) {
 		result := PlanPlaybackV3(newInput("aac", 2, browsers["Edge"]))
 		if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 || result.PlayMethod != PlayDirect || result.TranscodeAudio || len(result.Plan.AppliedQuirks) != 0 {
@@ -3614,6 +3640,30 @@ func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
 		result := PlanPlaybackV3(newInput("eac3", 6, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/151.0.0.0 Safari/537.36 Edg/151.0.0.0"))
 		if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 || result.PlayMethod != PlayDirect || result.TranscodeAudio || len(result.Plan.AppliedQuirks) != 0 {
 			t.Fatalf("non-Windows route changed = %s", ExplainPlannerResultV3(result))
+		}
+	})
+
+	t.Run("Android Chrome non-AAC remains native", func(t *testing.T) {
+		result := PlanPlaybackV3(newInput("eac3", 6, "Mozilla/5.0 (Linux; Android 16; Pixel 10) AppleWebKit/537.36 Chrome/151.0.0.0 Mobile Safari/537.36"))
+		if result.Plan == nil || result.Plan.Delivery != DeliveryOriginalHTTPV3 || result.PlayMethod != PlayDirect || result.TranscodeAudio || len(result.Plan.AppliedQuirks) != 0 {
+			t.Fatalf("Android Chrome route changed = %s", ExplainPlannerResultV3(result))
+		}
+	})
+
+	t.Run("Android Firefox HLS fallback keeps audio normalized", func(t *testing.T) {
+		input := newInput("eac3", 6, androidFirefox)
+		delete(input.Request.ClientPlaybackContext.Deliveries, DeliveryClassProgressiveV3)
+		hls := input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3]
+		hls.Containers = []string{"hls"}
+		hls.VideoCodecs = []string{"h264"}
+		hls.AudioDecodeCodecs = []string{"aac"}
+		input.Request.ClientPlaybackContext.Deliveries[DeliveryClassHLSV3] = hls
+		result := PlanPlaybackV3(input)
+		if result.Plan == nil || result.Plan.Delivery != DeliveryRemuxHLSV3 || !result.TranscodeAudio || result.TargetAudioCodec != "aac" || result.TargetAudioChannels != 2 {
+			t.Fatalf("result = %s", ExplainPlannerResultV3(result))
+		}
+		if len(result.Plan.AppliedQuirks) != 1 || result.Plan.AppliedQuirks[0].ID != QuirkAndroidFirefoxWebAudioNormalizeV3 {
+			t.Fatalf("HLS Android Firefox quirks = %#v", result.Plan.AppliedQuirks)
 		}
 	})
 
@@ -3660,6 +3710,7 @@ func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
 		}{
 			{name: "Edge EAC3", codec: "eac3", userAgent: browsers["Edge"], quirkID: QuirkWindowsWebAudioNormalizeV3},
 			{name: "Firefox Matroska AAC", codec: "aac", userAgent: browsers["Firefox"], quirkID: QuirkFirefoxMatroskaAACTimingV3},
+			{name: "Android Firefox EAC3", codec: "eac3", userAgent: androidFirefox, quirkID: QuirkAndroidFirefoxWebAudioNormalizeV3},
 		} {
 			t.Run(test.name, func(t *testing.T) {
 				input := newInput(test.codec, 6, test.userAgent)
@@ -3688,6 +3739,7 @@ func TestPlanPlaybackV3WindowsWebAudioNormalizationMatrix(t *testing.T) {
 		}{
 			{name: "Edge EAC3", codec: "eac3", userAgent: browsers["Edge"]},
 			{name: "Firefox AAC", codec: "aac", userAgent: browsers["Firefox"]},
+			{name: "Android Firefox EAC3", codec: "eac3", userAgent: androidFirefox},
 		} {
 			t.Run(test.name, func(t *testing.T) {
 				input := newInput(test.codec, 2, test.userAgent)


### PR DESCRIPTION
## Problem

Related issue: N/A — focused follow-up to [#824](https://github.com/Silo-Server/silo-server/pull/824).

Windows web playback still produced audible crackling after #824 when Edge directly decoded E-AC-3 5.1/Atmos from Matroska. Two sampled 180-second source windows each contained 5,625 packets at a consistent 0.032-second cadence with no PTS discontinuities, moving the practical failure boundary from the source packet clock to the Windows browser decode/output path.

After the Windows normalization fix was deployed, the same crackle was reproduced in Firefox running as a mobile browser on Android. That route does not contain `windows nt` in its user agent, so it did not receive the Windows compatibility policy.

The changes were developed and deployed fork-first in [blurbery/silo-server#82](https://github.com/blurbery/silo-server/pull/82) for Windows and [blurbery/silo-server#83](https://github.com/blurbery/silo-server/pull/83) for Android Firefox.

## Approach

- Give Windows web playback a conservative, timestamp-normalized AAC contract for every non-AAC source. Windows Firefox also normalizes AAC; the more specific Matroska AAC timing quirk still takes precedence in the recorded plan.
- Add a separate `web.android.firefox.audio_normalization_v1` quirk for non-AAC Android Firefox web sources rather than changing the deployed Windows quirk identifier.
- Keep copied video copied when the route permits it, while normalizing audio consistently across progressive remux, HLS remux and retry, full video transcode, and audio-only planning.
- Keep Android Firefox MP4 AAC native. Leave Android Chrome, the native Android client, non-Windows desktop Firefox, and Windows Edge/Chrome native AAC unchanged.
- Preserve mono. Downmix affected multichannel and Atmos routes to AAC stereo as an explicit compatibility tradeoff.
- Fail closed with the retryable audio-conversion terminal if the route's validated AAC toolchain is unavailable instead of falling back to the crackling direct route.
- Preserve upstream's delivery-scoped executor registries; no fork-only playback customizations are included.

This PR also retains the test-only base repairs in commit `955290d`: repository-wide formatting in `internal/jellycompat/handlers_items_test.go`, and a fake repository returning the production `catalog.ErrSeasonNotFound` sentinel. Neither changes production Jellyfin-compat behavior.

## Validation

Focused Android, Windows, Firefox, planner, remux, and AAC-argument coverage on the upstream branch:

```text
env GOCACHE="$PWD/.tmp-go-cache" go test ./internal/playback -run '^(TestAndroidFirefoxWebAudioNormalizationQuirkIsExact|TestWindowsWebAudioNormalizationQuirkIsExact|TestFirefoxMatroskaAACTimingQuirkIsExact|TestPlanPlaybackV3WebAudioOnlyNormalizesAudio|TestPlanPlaybackV3WebAudioNormalizationMatrix|TestPlanPlaybackV3MatroskaAACRemuxUsesTimestampNormalizedAudio|TestPlanPlaybackV3NativeMatroskaAACDirectPlayRemainsUnchanged|TestPlanPlaybackV3FirefoxIncompatibleAudioCodecsUseNormalizedAACRecipe|TestBuildRemuxArgsNormalizesAACAcrossSeekAnchors|TestAppendAudioArgsNormalizesEveryAACEncodeAndBoostsOnlySurroundToStereo)$' -count=1
ok  github.com/Silo-Server/silo-server/internal/playback  0.691s
```

Broader playback regression run, excluding this Mac host's hardware/GPU fixture executables:

```text
env GOCACHE="$PWD/.tmp-go-cache" go test ./internal/playback -skip '(?i)(hwaccel|hwprobe|gpu|nvenc|qsv|vaapi|videotoolbox|configureddevice|acquirehwdevice|hardwaretonemap)' -count=1
ok  github.com/Silo-Server/silo-server/internal/playback  21.236s
```

Additional checks:

```text
env GOCACHE="$PWD/.tmp-go-cache" go vet ./internal/playback
result: success

env GOCACHE="$PWD/.tmp-go-cache" make verify-playback-fixtures
playback fixtures are current

make verify-local-paths
result: success

gofmt -l internal/playback/device_quirks_v3.go internal/playback/device_quirks_v3_test.go internal/playback/plan_v3.go internal/playback/protocol_v3_test.go
result: no output

git diff --check
result: no output
```

The matrix covers AAC plus ten non-AAC codec families; progressive, HLS-only, retry-to-HLS, full-transcode, audio-only, and missing-toolchain routes; and negative scoping for Android Chrome, the native Android app, desktop Firefox, missing user agents/codecs, and native AAC paths.

Fork validation for the complete combined behavior:

- [PR CI run 33392721688](https://github.com/blurbery/silo-server/actions/runs/33392721688): Go, Web, and docs hygiene passed.
- [Post-merge CI run 33393486458](https://github.com/blurbery/silo-server/actions/runs/33393486458): Go, Web, and docs hygiene passed on merge commit `60bdc1c8`.
- [Multi-architecture image run 33393486475](https://github.com/blurbery/silo-server/actions/runs/33393486475): linux/amd64, linux/arm64, and manifest publication passed.

The exact deployed fork image is `build-126`, revision `60bdc1c8f2bd5113b34dd1ebaec9690ce2d59f95`, manifest digest `sha256:80a9efdffad279e6b686f9eddecad068ba175218e377d3945ade15b431a950f6`. After deployment:

- The Silo container was healthy with restart count `0`, and the public health endpoint returned HTTP 200.
- A short in-memory 5.1-to-stereo encode using the production `aresample=async=1` and limiter recipe completed successfully.
- No panic, fatal, or error-level startup lines were present in the bounded log check.
- Postgres and Redis retained their original container IDs and remained healthy with zero restarts.

Native listening confirmation on the Android device is still required.

## Risks

- Affected non-AAC playback consumes audio-transcode capacity, although video remains stream-copied when possible.
- Multichannel and Atmos sources lose spatial fidelity because they are deliberately downmixed to AAC stereo.
- Windows Firefox AAC receives another lossy encode; Android Firefox MP4 AAC and Windows Edge/Chrome AAC do not.
- Detection depends on the web client supplying the relevant user-agent markers. Firefox Android desktop-site mode may omit the Android marker.
- There are no API, schema, migration, authentication, or database changes.

## AI Disclosure

- Tool(s): OpenAI Codex desktop, GitHub CLI, Go toolchain, Docker Compose, and FFmpeg
- Model(s): `gpt-5.6-sol`
- Involvement: AI-assisted; I supplied the real-device reproduction, selected the AAC/stereo compatibility tradeoff, and directed the fork-first fix, deployment, and upstream port as `@blurbery`.
- Adversarial review: The complete diff was checked against positive and negative user-agent boundaries, AAC precedence, native direct-play preservation, progressive and HLS remuxes, retries, full transcode, audio-only playback, missing-toolchain failure, copied-video behavior, and upstream's delivery-scoped registries. No fork-only customization, API/schema change, credential, or local-path leak remains in the audio diff.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback compatibility for Windows web browsers and Firefox on Android by normalizing unsupported audio to AAC stereo.
  - Updated video, remux, and audio-only playback paths to apply consistent audio conversion when required.
  - Improved handling of invalid series identifiers, returning an empty result instead of a 404 response.

- **Tests**
  - Added coverage for browser-specific audio normalization and invalid series identifier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->