### PR TITLE
fix(web): refresh access token on 401 in playerFetch and clarify expired session message (fixes #851)

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +22,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -206,7 +206,7 @@ function getDeviceHeaders(): Record<string, string> {
   };
 }
 
-async function attemptRefresh(): Promise<boolean> {
+export async function attemptRefresh(): Promise<boolean> {
   const rt = getRefreshToken();
   if (!rt) return false;
 

--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -15,7 +15,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Pause, PictureInPicture2, Play, SkipBack, SkipForward, Tv, X } from "lucide-react";
 import { useLocation } from "react-router";
 import type { WatchDetail } from "@/api/types";
-import { getAccessToken, getOrCreateDeviceId, getProfileToken } from "@/api/client";
+import { attemptRefresh, getAccessToken, getOrCreateDeviceId, getProfileToken } from "@/api/client";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
@@ -495,6 +495,7 @@ export function WatchPlaybackHost() {
       getProfileId: () => storage.get(storage.KEYS.PROFILE_ID),
       getProfileToken: () => getProfileToken(),
       getDeviceId: () => getOrCreateDeviceId(),
+      refreshToken: () => attemptRefresh(),
     }),
     [],
   );

--- a/web/src/player/context/PlayerConfigContext.tsx
+++ b/web/src/player/context/PlayerConfigContext.tsx
@@ -16,6 +16,8 @@ export interface PlayerConfig {
   getProfileToken?: () => string | null;
   /** Stable device identity used for device-scoped playback settings. */
   getDeviceId: () => string;
+  /** Optional async token refresh callback on 401 response. */
+  refreshToken?: () => Promise<boolean>;
 }
 
 const PlayerConfigCtx = createContext<PlayerConfig | null>(null);

--- a/web/src/player/playback-errors.test.ts
+++ b/web/src/player/playback-errors.test.ts
@@ -172,6 +172,30 @@ describe("describePlaybackTransportError", () => {
     });
   });
 
+  it("describes 401 authentication errors distinctly from 403 permissions errors", () => {
+    expect(describePlaybackTransportError(new PlayerFetchError(401, "Unauthorized"))).toEqual({
+      title: "Authentication required",
+      message: "Your playback session has expired. Start playback again or sign in to continue.",
+    });
+
+    expect(describePlaybackTransportError(new PlayerFetchError(403, "Forbidden"))).toEqual({
+      title: "Playback unavailable",
+      message: "You do not have permission to play this item.",
+    });
+  });
+
+  it("describes 401 authentication errors distinctly from 403 permissions errors", () => {
+    expect(describePlaybackTransportError(new PlayerFetchError(401, "Unauthorized"))).toEqual({
+      title: "Authentication required",
+      message: "Your playback session has expired. Start playback again or sign in to continue.",
+    });
+
+    expect(describePlaybackTransportError(new PlayerFetchError(403, "Forbidden"))).toEqual({
+      title: "Playback unavailable",
+      message: "You do not have permission to play this item.",
+    });
+  });
+
   it("ignores 4xx statuses it has nothing specific to say about", () => {
     expect(
       describePlaybackTransportError(new PlayerFetchError(409, "Conflict", "stale_playback_plan")),

--- a/web/src/player/playback-errors.ts
+++ b/web/src/player/playback-errors.ts
@@ -164,7 +164,14 @@ export function describePlaybackTransportError(
     };
   }
 
-  if (error.status === 401 || error.status === 403) {
+  if (error.status === 401) {
+    return {
+      title: "Authentication required",
+      message: "Your playback session has expired. Start playback again or sign in to continue.",
+    };
+  }
+
+  if (error.status === 403) {
     return {
       title: "Playback unavailable",
       message: "You do not have permission to play this item.",

--- a/web/src/player/player-fetch.test.ts
+++ b/web/src/player/player-fetch.test.ts
@@ -56,4 +56,74 @@ describe("playerFetch", () => {
       }),
     );
   });
+
+  it("refreshes the access token and replays the request on 401 Unauthorized", async () => {
+    let token = "old-token";
+    const refreshFn = vi.fn(async () => {
+      token = "new-token";
+      return true;
+    });
+
+    const refreshConfig: PlayerConfig = {
+      ...config,
+      getAccessToken: () => token,
+      refreshToken: refreshFn,
+    };
+
+    let attempts = 0;
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      attempts++;
+      const authHeader = (init?.headers as Record<string, string>)?.["Authorization"];
+      if (attempts === 1) {
+        expect(authHeader).toBe("Bearer old-token");
+        return new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      expect(authHeader).toBe("Bearer new-token");
+      return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await playerFetch<{ status: string }>(refreshConfig, "/playback/heartbeat");
+    expect(res).toEqual({ status: "ok" });
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes the access token and replays the request on 401 Unauthorized", async () => {
+    let token = "old-token";
+    const refreshFn = vi.fn(async () => {
+      token = "new-token";
+      return true;
+    });
+
+    const refreshConfig: PlayerConfig = {
+      ...config,
+      getAccessToken: () => token,
+      refreshToken: refreshFn,
+    };
+
+    let attempts = 0;
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      attempts++;
+      const authHeader = (init?.headers as Record<string, string>)?.["Authorization"];
+      if (attempts === 1) {
+        expect(authHeader).toBe("Bearer old-token");
+        return new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      expect(authHeader).toBe("Bearer new-token");
+      return new Response(JSON.stringify({ status: "ok" }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await playerFetch<{ status: string }>(refreshConfig, "/playback/heartbeat");
+    expect(res).toEqual({ status: "ok" });
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/web/src/player/player-fetch.ts
+++ b/web/src/player/player-fetch.ts
@@ -57,10 +57,27 @@ export async function playerFetch<T>(
 
   headers["X-Silo-Device-Id"] = config.getDeviceId();
 
-  const res = await fetch(`${config.apiBaseUrl}${path}`, {
+  let res = await fetch(`${config.apiBaseUrl}${path}`, {
     ...options,
     headers,
   });
+
+  if (res.status === 401 && config.refreshToken) {
+    const refreshed = await config.refreshToken();
+    if (refreshed) {
+      const refreshedToken = config.getAccessToken();
+      const refreshedHeaders = { ...headers };
+      if (refreshedToken) {
+        refreshedHeaders["Authorization"] = `Bearer ${refreshedToken}`;
+      } else {
+        delete refreshedHeaders["Authorization"];
+      }
+      res = await fetch(`${config.apiBaseUrl}${path}`, {
+        ...options,
+        headers: refreshedHeaders,
+      });
+    }
+  }
 
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);


### PR DESCRIPTION
### Summary
Fixes #851.

When web player requests returned 401 (e.g. after pausing video longer than access token expiry), \playerFetch\ had no token refresh handler and failed immediately. Additionally, \describePlaybackTransportError\ mapped 401 and 403 to the same permissions error message (\You do not have permission to play this item.\).\
\
### Changes\
- Added optional \efreshToken?: () => Promise<boolean>\ callback to \PlayerConfig\ in \web/src/player/context/PlayerConfigContext.tsx\.\
- Exported \ttemptRefresh\ in \web/src/api/client.ts\ and wired \efreshToken: () => attemptRefresh()\ into \playerConfig\ in \web/src/playback/WatchPlaybackChrome.tsx\.\
- Intercepted 401 responses in \playerFetch\ to automatically invoke \config.refreshToken()\ and replay the request once on success.\
- Updated \describePlaybackTransportError\ in \web/src/player/playback-errors.ts\ to present 401 as \Authentication required\ / \Your playback session has expired...\ and 403 as \Playback unavailable\.\
- Added unit tests in \web/src/player/player-fetch.test.ts\ and \web/src/player/playback-errors.test.ts\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Playback now automatically refreshes expired access tokens and retries requests once when authentication expires.
  - Added support for playback environments to provide token-refresh behavior.

- **Bug Fixes**
  - Improved playback error messaging by distinguishing authentication-required errors from permission-denied errors.
  - Users are prompted to restart playback or sign in when authentication is required.
  - Playback requests now correctly retry with refreshed authentication details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->