### PR TITLE
fix(metadata): fall back down artwork ladder when large rungs or public delivery paths 404 (fixes #825)

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +22,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by

--- a/internal/metadata/image_ladder_fallback.go
+++ b/internal/metadata/image_ladder_fallback.go
@@ -109,9 +109,10 @@ func (p imageAvailabilityPolicy) withBatchFailureCircuit() imageAvailabilityPoli
 // from artworkkey.VariantWidths. Revisit both this set and that assumption
 // whenever LadderVersion is bumped.
 var ladderTypesWithAddedRung = map[string]bool{
-	ImageCacheImagePoster: true,
-	ImageCacheImageStill:  true,
-	ImageCacheImageLogo:   true,
+	ImageCacheImagePoster:   true,
+	ImageCacheImageStill:    true,
+	ImageCacheImageLogo:     true,
+	ImageCacheImageBackdrop: true,
 }
 
 // needsExistenceCheck reports whether a cached artwork key names a rung that

--- a/internal/metadata/image_ladder_fallback_test.go
+++ b/internal/metadata/image_ladder_fallback_test.go
@@ -159,6 +159,17 @@ func TestLadderFallbackWalksLogoLadder(t *testing.T) {
 	}
 }
 
+func TestLadderFallbackWalksBackdropLadder(t *testing.T) {
+	const requested = "tmdb/movies/550/backdrop/w1920.rev.webp"
+	const present = "tmdb/movies/550/backdrop/w1280.rev.webp"
+	store := newFakeS3ImageStore(present)
+	resolver := newResolverWithStore(t, store)
+
+	if got := resolvedKey(t, resolver, requested); got != present {
+		t.Fatalf("resolved key = %q, want %q", got, present)
+	}
+}
+
 // A storage HEAD is not proof that a separately authenticated public URL is
 // fetchable. The ladder must check the same delivery path the client will use.
 func TestLadderFallbackUsesClientDeliveryAvailability(t *testing.T) {
@@ -181,6 +192,11 @@ func TestLadderFallbackUsesClientDeliveryAvailability(t *testing.T) {
 			name:      "logo",
 			requested: "tmdb/series/1396/logo/w1280.rev.webp",
 			present:   "tmdb/series/1396/logo/w500.rev.webp",
+		},
+		{
+			name:      "backdrop",
+			requested: "tmdb/movies/550/backdrop/w1920.rev.webp",
+			present:   "tmdb/movies/550/backdrop/w1280.rev.webp",
 		},
 	}
 
@@ -318,7 +334,7 @@ func TestLadderFallbackSkipsEstablishedRungs(t *testing.T) {
 	for _, key := range []string{
 		"tmdb/movies/550/poster/w500.abc123.webp",
 		"tmdb/movies/550/poster/w300.abc123.webp",
-		"tmdb/movies/550/backdrop/w1920.abc123.webp",
+		"tmdb/movies/550/backdrop/w1280.abc123.webp",
 		"tmdb/movies/550/poster/original.abc123.webp",
 		"tmdb/series/1396/logo/w500.rev.webp",
 	} {

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -349,7 +349,7 @@ func (c *Client) UsesExternalAuth() bool {
 // separately configured public or token-authenticated endpoint. An auth mode
 // without its endpoint still falls back to standard S3 presigning.
 func (c *Client) UsesExternalDelivery() bool {
-	return c.publicEndpoint != "" && c.UsesExternalAuth()
+	return c.publicEndpoint != ""
 }
 
 // PublicURL returns the deterministic public URL for an object based on the


### PR DESCRIPTION
Fixes #825.

### Summary
When clients (such as tvOS, iOS, or Android) request `image_size=large`, signed URLs can return HTTP 404 when newly added top-rung variants (`w780`, `w1280`, or `w1920`) are absent or when public CDN delivery paths have not propagated.

### Changes
1. **`internal/metadata/image_ladder_fallback.go`**: Added `ImageCacheImageBackdrop` (`"backdrop"`) to `ladderTypesWithAddedRung`. In `LadderVersion = 2`, `backdrop` gained `w1920` as its top width rung. Because `backdrop` was omitted from `ladderTypesWithAddedRung`, `needsExistenceCheck` returned `false` for `w1920` backdrops, presigning unverified `w1920` URLs that return 404 when absent.
2. **`internal/s3client/client.go`**: Updated `UsesExternalDelivery()` to check `c.publicEndpoint != ""`. When a public endpoint (CDN / custom domain) is configured for reads, client requests fetch artwork via the public endpoint. Probing internal S3 `HeadObject` (`ObjectExists`) was insufficient when public CDN delivery returned 404. Checking `publicEndpoint != ""` ensures `ObjectAvailable` probes the actual client-facing URL delivery path.
3. **`internal/metadata/image_ladder_fallback_test.go`**: Added unit test coverage for `backdrop` ladder fallback walking down from `w1920` to `w1280` and verified client delivery availability probe handling for poster, still, logo, and backdrop roles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backdrop artwork delivery by automatically falling back to the next available image size when the requested version is unavailable.
  - Ensured configured public delivery endpoints are consistently recognized, including when presigned access is selected.
  - Improved image delivery reliability across standard and client-specific delivery paths, including cached backdrop artwork.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->