### PR TITLE
fix(web): scope realtime query invalidation to itemId to prevent buffering (fixes #796)

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +23,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by

--- a/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.test.ts
@@ -392,4 +392,24 @@ describe("invalidateMediaSurfaceQueries", () => {
       },
     });
   });
+
+  it("does not invalidate detail queries for a different item ID when itemId is specified", async () => {
+    const queryClient = new QueryClient();
+    const item1DetailKey = itemKeys.detail("item-1");
+    const item2DetailKey = itemKeys.detail("item-2");
+    const item1WatchKey = itemKeys.watchDetail("item-1");
+    const item2WatchKey = itemKeys.watchDetail("item-2");
+
+    queryClient.setQueryData(item1DetailKey, { content_id: "item-1" });
+    queryClient.setQueryData(item2DetailKey, { content_id: "item-2" });
+    queryClient.setQueryData(item1WatchKey, { content_id: "item-1" });
+    queryClient.setQueryData(item2WatchKey, { content_id: "item-2" });
+
+    await invalidateMediaSurfaceQueries(queryClient, { itemId: "item-1" });
+
+    expect(queryClient.getQueryState(item1DetailKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(item1WatchKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(item2DetailKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(item2WatchKey)?.isInvalidated).toBe(false);
+  });
 });

--- a/web/src/hooks/queries/mediaSurfaceRefresh.ts
+++ b/web/src/hooks/queries/mediaSurfaceRefresh.ts
@@ -154,12 +154,37 @@ function queryKeyStartsWith(queryKey: readonly unknown[], prefix: readonly unkno
   );
 }
 
+export function getQueryKeyItemId(queryKey: readonly unknown[]): string | undefined {
+  if (!Array.isArray(queryKey) || queryKey.length < 2) return undefined;
+  if (
+    queryKey[0] === "items" &&
+    (queryKey[1] === "detail" || queryKey[1] === "watchDetail" || queryKey[1] === "markers") &&
+    typeof queryKey[2] === "string"
+  ) {
+    return queryKey[2];
+  }
+  if (queryKey[0] === "catalog" && queryKey[1] === "items" && typeof queryKey[2] === "string") {
+    return queryKey[2];
+  }
+  if (queryKey[0] === "ratings" && typeof queryKey[1] === "string") {
+    return queryKey[1];
+  }
+  return undefined;
+}
+
 function shouldInvalidateMediaSurfaceQuery(
   queryKey: readonly unknown[],
   options: InvalidateMediaSurfaceOptions,
 ) {
   if (options.skipItemDetail && options.itemId && isItemDetailQueryKey(queryKey, options.itemId)) {
     return false;
+  }
+
+  if (options.itemId) {
+    const targetItemId = getQueryKeyItemId(queryKey);
+    if (targetItemId && targetItemId !== options.itemId) {
+      return false;
+    }
   }
 
   if (queryKeyStartsWith(queryKey, catalogKeys.all)) {


### PR DESCRIPTION
Fixes #796.

### Summary
During playback in the web UI, routine WebSocket events (`catalog.item.changed`, `user_state.changed`) triggered `invalidateMediaSurfaceQueries`, which matched `itemKeys.all` (`["items"]`) and invalidated all open item queries (watch detail, seasons, episodes) across all items. This caused active player metadata query bursts that competed with HLS video buffering.

### Changes
- Exported `getQueryKeyItemId` in `web/src/hooks/queries/mediaSurfaceRefresh.ts` to extract item IDs from query keys.
- Updated `shouldInvalidateMediaSurfaceQuery` so that when `options.itemId` is specified, query keys for different item IDs return `false` instead of triggering global invalidation.
- Added unit tests in `web/src/hooks/queries/mediaSurfaceRefresh.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited media refreshes to the specified item, preventing unrelated item details and watch details from being refreshed.
  * Standardized season-not-found handling in internal test coverage.

* **Tests**
  * Added coverage confirming that targeted refreshes leave other items unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->