### PR TITLE
feat(playback): route remux through transcode and proxy nodes

### DIFF
--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -86,7 +86,7 @@ advertises the supported contract:
 {
   "features": ["playback_node_routing_v1"],
   "workloads": ["direct_play", "remux", "video_transcode"],
-  "execution_preferences": ["prefer_worker", "worker_only", "prefer_api", "api_only"],
+  "execution_preferences": ["prefer_worker", "prefer_transcode", "worker_only", "prefer_api", "api_only"],
   "egress_preferences": ["prefer_proxy", "proxy_only", "prefer_api", "api_only"]
 }
 ```
@@ -96,15 +96,30 @@ The existing atomic admin settings update writes the five primitive policies:
 | Setting | Default |
 |---|---|
 | `playback.routing.direct_play_egress` | `prefer_proxy` |
-| `playback.routing.remux_execution` | `prefer_worker` |
+| `playback.routing.remux_execution` | `prefer_transcode` |
 | `playback.routing.remux_egress` | `prefer_proxy` |
-| `playback.routing.video_transcode_execution` | `prefer_worker` |
+| `playback.routing.video_transcode_execution` | `prefer_transcode` |
 | `playback.routing.video_transcode_egress` | `prefer_proxy` |
 
 `prefer_*` permits fallback; `*_only` is a hard boundary. An atomic update is
 rejected when API-only execution is combined with proxy-only egress for remux
 or video transcode, because no implemented transport can satisfy that shape.
 The policy is read as one immutable snapshot for each playback start or replan.
+
+A **worker** is either a proxy node or a transcode node; the selected route says
+which kind executes the work. Progressive remux can run on a proxy, on the API
+process, or on a transcode node that streams its output through a proxy. HLS
+remux and video transcode can run on a transcode node (or the API process).
+`prefer_transcode` ranks a legal transcode-node shape first, then another worker,
+then the API without changing the delivery selected for the client. For video
+transcode, `prefer_transcode` and `prefer_worker` currently choose the same kind
+of worker because only transcode nodes can execute that workload. Egress is
+selected independently, and a proxy used only for egress does not run FFmpeg.
+
+Jellyfin-compatible clients select progressive or HLS transport through their
+protocol request. Routing does not rewrite a Jellyfin client's requested
+transport; progressive Jellyfin remux retains its existing proxy/API execution
+path.
 
 `GET /api/v1/admin/sessions/capabilities` advertises `node_routing: true`.
 Rows from `GET /api/v1/admin/sessions` may then include

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -550,11 +550,20 @@ selected proxy. The execution choice remains independent of egress—a proxy
 origin can serve bytes produced by a transcode node without becoming the
 executor itself.
 
-Both halves advertise this transport contract through `/hw-capabilities`:
-transcode nodes publish `progressive_remux_execution_v1`, and proxies publish
-`progressive_remux_relay_v1`. Route selection requires both markers. During a
-rolling upgrade, an older node is therefore excluded before a client receives
-a URL rather than failing the stream on its first request.
+Both halves of the transcode-node-to-proxy transport advertise their contract
+through `/hw-capabilities`: transcode nodes publish
+`progressive_remux_execution_v1`, and proxies publish
+`progressive_remux_relay_v1`. That route requires both markers. A
+proxy-executed progressive remux requires only the proxy's execution capability
+and remains eligible when relay capability is absent. During a rolling upgrade,
+an older node is therefore excluded from only the shapes it cannot serve before
+a client receives a URL rather than failing the stream on its first request.
+The transcode-executed shape also requires the shared node-recipe store. The API
+writes the plan-scoped transport record before publishing the proxy URL; the
+transcode node validates it before starting each progressive response, and stop
+or force reload deletes it. This durable authority prevents a signed URL whose
+token remains valid after a node replacement from resurrecting stopped FFmpeg
+work. When the store is unavailable, route selection excludes only this shape.
 
 **Authorized media origins.** A client that also sends
 `authorized_media_origins_v1` promises something further: it will fetch media

--- a/docs/architecture/playback-protocol-v3.md
+++ b/docs/architecture/playback-protocol-v3.md
@@ -540,6 +540,22 @@ execute that recipe while the API remains the media origin. A progressive-only
 client receives a non-retryable `local_transcode_disabled` terminal because
 retrying cannot create a legal route.
 
+In routing policy, **worker** means either a proxy node or a transcode node.
+Progressive remux has proxy-worker, API, and transcode-node-to-proxy execution
+shapes; HLS remux has transcode-worker and API execution shapes. Consequently,
+`remux_execution=prefer_transcode` ranks the transcode-node shape first without
+changing the delivery selected for the client. A progressive remux can run
+FFmpeg on the transcode node and relay its single chunked response through the
+selected proxy. The execution choice remains independent of egress—a proxy
+origin can serve bytes produced by a transcode node without becoming the
+executor itself.
+
+Both halves advertise this transport contract through `/hw-capabilities`:
+transcode nodes publish `progressive_remux_execution_v1`, and proxies publish
+`progressive_remux_relay_v1`. Route selection requires both markers. During a
+rolling upgrade, an older node is therefore excluded before a client receives
+a URL rather than failing the stream on its first request.
+
 **Authorized media origins.** A client that also sends
 `authorized_media_origins_v1` promises something further: it will fetch media
 from absolute URLs the plan returns on origins the server designates, attaching
@@ -559,7 +575,7 @@ playback immediately, exactly as it stops API playback. A server with no proxy
 pool, or one that cannot record the handoff, simply keeps the attempt on the API
 origin — the URLs above are an addition a plan may make, never one a client may
 assume. The escalation described just above therefore applies only when no proxy
-origin is available to run the remux.
+origin is available to serve the remux.
 
 Only the primary audio/video transport moves. Start, replan, route events,
 progress and every other control-plane call stay on the API origin, and the

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -203,11 +203,10 @@ type PlaybackHandler struct {
 	ProxyGrantStore recipeCardStoreV3
 	// NodeRecipeStore hands a transcode node the recipe it rebuilds a
 	// header-authenticated remote transcode from after its own restart, keyed by
-	// the transport id the node serves it under. A legacy attempt needs none —
-	// its client URL carries the recipe in a stream token — but a tokenless
-	// relayed request has nothing to reconstruct from. Optional and best effort:
-	// without it (or without Redis behind it) such a session replans instead of
-	// recovering, exactly as before.
+	// the transport id the node serves it under. It is also the active authority
+	// for transcode-executed progressive remuxes, whose signed tokens otherwise
+	// outlive a node's in-memory stop fence. Without a usable store those remuxes
+	// use another legal route; tokenless HLS sessions replan instead of recovering.
 	NodeRecipeStore    recipeCardStoreV3
 	ItemAccess         PlaybackItemAccessChecker // optional; enables file authorization checks
 	EpisodeLookup      PlaybackEpisodeLookup     // optional; resolves episode files to their series

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -236,11 +236,14 @@ type PlaybackHandler struct {
 	// hwaccel, transcode dir). Wired to the live config in integrated mode
 	// so admin changes apply to newly started transcodes. Read it through
 	// playbackConfig(), which falls back to defaults when unset.
-	PlaybackConfig    func() config.PlaybackConfig
-	FFmpegLogSink     playback.FFmpegLogSink
-	copySeekAnchor    copySeekAnchorResolver
-	realtimeCommandMu sync.Mutex
-	realtimeCommands  map[string]playbackCommandRecord
+	PlaybackConfig func() config.PlaybackConfig
+	FFmpegLogSink  playback.FFmpegLogSink
+	copySeekAnchor copySeekAnchorResolver
+	// beforeIdentityLifecycleLockV3 is a test seam for proving that identity
+	// route authority remains unpublished until the shared lifecycle boundary.
+	beforeIdentityLifecycleLockV3 func()
+	realtimeCommandMu             sync.Mutex
+	realtimeCommands              map[string]playbackCommandRecord
 	// tm owns the transcode-session lifecycle (live map, recipe cards, and
 	// restart reconstruct) shared with the jellycompat handler. The handler
 	// delegates all transcode-session and recipe operations to it.

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -780,6 +780,7 @@ func identityRecipeCard(s *playback.Session) playback.RecipeCard {
 	card.OriginalStartedAt = s.StartedAt
 	card.RoutingWorkload = s.RoutingWorkload
 	card.RoutingExecution = s.RoutingExecution
+	card.RoutingExecutionNodeID = s.RoutingExecutionNodeID
 	card.RoutingEgress = s.RoutingEgress
 	card.RoutingEgressNodeID = s.RoutingEgressNodeID
 	card.TranscodeNodeURL = s.TranscodeNodeURL

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -783,6 +783,8 @@ func identityRecipeCard(s *playback.Session) playback.RecipeCard {
 	card.RoutingExecution = s.RoutingExecution
 	card.RoutingEgress = s.RoutingEgress
 	card.RoutingEgressNodeID = s.RoutingEgressNodeID
+	card.TranscodeNodeURL = s.TranscodeNodeURL
+	card.TranscodeTransportID = s.TranscodeTransportID
 	return card
 }
 

--- a/internal/api/handlers/playback_realtime.go
+++ b/internal/api/handlers/playback_realtime.go
@@ -22,6 +22,18 @@ func (h *PlaybackHandler) stopPlaybackSession(ctx context.Context, session *play
 	if h == nil || session == nil || session.ID == "" {
 		return playback.ErrSessionNotFound
 	}
+	// Replacement preparation holds this lifecycle lock until its new live
+	// session state and durable plan are committed (or rolled back). Wait for
+	// that boundary, then reload the route: callers commonly hold a copy taken
+	// before the replacement started, and deleting authority from that stale
+	// copy would leave the successor transport playable after a successful stop.
+	unlock := h.tm.LockSessionLifecycle(session.ID)
+	defer unlock()
+	current, err := h.sessionMgr.GetSession(session.ID)
+	if err != nil {
+		return err
+	}
+	session = current
 	if userInitiated {
 		if err := h.deleteRequiredProgressiveRemuxAuthorityV3(ctx, session); err != nil {
 			return fmt.Errorf("persist progressive remux stop: %w", err)

--- a/internal/api/handlers/playback_realtime.go
+++ b/internal/api/handlers/playback_realtime.go
@@ -38,6 +38,11 @@ func (h *PlaybackHandler) stopPlaybackSession(ctx context.Context, session *play
 		if err := h.deleteRequiredProgressiveRemuxAuthorityV3(ctx, session); err != nil {
 			return fmt.Errorf("persist progressive remux stop: %w", err)
 		}
+		if requiresProgressiveRemuxAuthorityV3(session) {
+			if err := h.tm.CancelRemoteTranscode(ctx, remoteTransportID(session), session.TranscodeNodeURL); err != nil {
+				return fmt.Errorf("cancel progressive remux transport: %w", err)
+			}
+		}
 	}
 
 	if err := h.sessionMgr.StopSession(session.ID); err != nil {

--- a/internal/api/handlers/playback_realtime.go
+++ b/internal/api/handlers/playback_realtime.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/Silo-Server/silo-server/internal/playback"
@@ -20,6 +21,11 @@ type playbackCommandRecord struct {
 func (h *PlaybackHandler) stopPlaybackSession(ctx context.Context, session *playback.Session, userInitiated bool) error {
 	if h == nil || session == nil || session.ID == "" {
 		return playback.ErrSessionNotFound
+	}
+	if userInitiated {
+		if err := h.deleteRequiredProgressiveRemuxAuthorityV3(ctx, session); err != nil {
+			return fmt.Errorf("persist progressive remux stop: %w", err)
+		}
 	}
 
 	if err := h.sessionMgr.StopSession(session.ID); err != nil {

--- a/internal/api/handlers/playback_sessions.go
+++ b/internal/api/handlers/playback_sessions.go
@@ -157,7 +157,7 @@ func (h *AdminHandler) HandleGetPlaybackRoutingCapabilities(w http.ResponseWrite
 	writeJSON(w, http.StatusOK, playbackRoutingCapabilitiesResponse{
 		Features:             []string{"playback_node_routing_v1"},
 		Workloads:            []string{"direct_play", "remux", "video_transcode"},
-		ExecutionPreferences: []string{"prefer_worker", "worker_only", "prefer_api", "api_only"},
+		ExecutionPreferences: []string{"prefer_worker", "prefer_transcode", "worker_only", "prefer_api", "api_only"},
 		EgressPreferences:    []string{"prefer_proxy", "proxy_only", "prefer_api", "api_only"},
 	})
 }

--- a/internal/api/handlers/playback_sessions_test.go
+++ b/internal/api/handlers/playback_sessions_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"unicode"
@@ -102,8 +103,11 @@ func TestPlaybackRoutingCapabilitiesAdvertisePolicyVocabulary(t *testing.T) {
 	if len(response.Features) != 1 || response.Features[0] != "playback_node_routing_v1" {
 		t.Fatalf("features = %v", response.Features)
 	}
-	if len(response.Workloads) != 3 || len(response.ExecutionPreferences) != 4 || len(response.EgressPreferences) != 4 {
+	if len(response.Workloads) != 3 || len(response.ExecutionPreferences) != 5 || len(response.EgressPreferences) != 4 {
 		t.Fatalf("capabilities = %+v", response)
+	}
+	if !slices.Contains(response.ExecutionPreferences, "prefer_transcode") {
+		t.Fatalf("execution preferences = %v, want prefer_transcode", response.ExecutionPreferences)
 	}
 }
 

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2451,12 +2451,15 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	}
 	proxyNode := decision.Plan.ProxyNode
 	transcodeNode := decision.Plan.TranscodeNode
+	releaseReservation := func() {
+		if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
+			releaser.ReleaseSession(session.ID)
+		}
+	}
 	if transcodeNode != nil {
 		transcodeCapabilities, capabilityErr := h.lookupRemoteCapabilitiesV3(r.Context(), transcodeNode.URL, false)
 		if capabilityErr != nil || !slices.Contains(transcodeCapabilities.transportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
-			if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
-				releaser.ReleaseSession(session.ID)
-			}
+			releaseReservation()
 			return preparedTransportV3{}, &transportErrorV3{
 				reason: routeCapabilityUnavailableReasonV3, message: "The selected transcode node cannot execute a progressive remux.",
 				retryable: true, cause: capabilityErr,
@@ -2466,9 +2469,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	if transcodeNode != nil && proxyNode != nil {
 		proxyCapabilities, capabilityErr := h.lookupRemoteCapabilitiesV3(r.Context(), proxyNode.URL, false)
 		if capabilityErr != nil || !slices.Contains(proxyCapabilities.transportFeatures, playback.TransportFeatureProgressiveRemuxRelayV1) {
-			if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
-				releaser.ReleaseSession(session.ID)
-			}
+			releaseReservation()
 			return preparedTransportV3{}, &transportErrorV3{
 				reason: routeCapabilityUnavailableReasonV3, message: "The selected proxy cannot relay a progressive remux from a transcode node.",
 				retryable: true, cause: capabilityErr,
@@ -2488,9 +2489,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			capabilityErr = validateAdvertisedTransformationsV3(result.Plan, advertised)
 		}
 		if capabilityErr != nil {
-			if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
-				releaser.ReleaseSession(session.ID)
-			}
+			releaseReservation()
 			return preparedTransportV3{}, &transportErrorV3{
 				reason: routeCapabilityUnavailableReasonV3, message: "The selected node cannot execute the progressive-remux recipe.",
 				retryable: true, cause: capabilityErr,
@@ -2512,6 +2511,18 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		routeSession.TranscodeNodeURL = transcodeNode.URL
 		routeSession.TranscodeTransportID = transportID
 	}
+	if transcodeNode != nil {
+		card := identityRecipeCard(&routeSession)
+		card.InputPath = file.FilePath
+		card.DVProfile = file.PrimaryDVProfile()
+		card.AudioOnly = file.IsAudioOnly()
+		if err := h.putRequiredNodeRecipeV3(r.Context(), transportID, card); err != nil {
+			releaseReservation()
+			return preparedTransportV3{}, &transportErrorV3{
+				reason: string(noderouting.OutcomeCapacityUnavailable), message: "The transcode remux authority is temporarily unavailable.", retryable: true, cause: err,
+			}
+		}
+	}
 	streamURL := fmt.Sprintf("/stream/%s", routeSession.ID)
 	servedByProxy := false
 	// priorGrant is the egress authority this attempt overwrote, if any. A
@@ -2524,11 +2535,6 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		streamURL, servedByProxy = h.identityStreamURLV3(&routeSession, file, proxyNode)
 	case mode.proxyEgress:
 		streamURL, servedByProxy, priorGrant = h.identityGrantStreamURLV3(r.Context(), &routeSession, file, proxyNode)
-	}
-	releaseProxyReservation := func() {
-		if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
-			releaser.ReleaseSession(session.ID)
-		}
 	}
 	reservationReleased := false
 	if proxyNode != nil && !servedByProxy {
@@ -2548,9 +2554,10 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		// it is reported as such: the HLS path classifies the identical
 		// proxy-authority failure retryable, and a non-retryable answer would
 		// make a client give up on a route the next attempt can take.
-		releaseProxyReservation()
+		releaseReservation()
 		reservationReleased = true
 		if transcodeNode != nil {
+			h.deleteNodeRecipeV3(r.Context(), transportID)
 			return preparedTransportV3{}, &transportErrorV3{
 				reason: string(noderouting.OutcomeCapacityUnavailable), message: "The transcode-to-proxy remux route is temporarily unavailable.", retryable: true,
 			}
@@ -2643,9 +2650,10 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			// reservation ages out — nor keep an egress grant for a transport
 			// that was never committed.
 			if servedByProxy && !reservationReleased {
-				releaseProxyReservation()
+				releaseReservation()
 				h.restoreProxyGrantV3(r.Context(), session.ID, priorGrant)
 			}
+			h.deleteNodeRecipeV3(r.Context(), transportID)
 			unlock()
 		},
 	}, nil
@@ -2786,6 +2794,20 @@ func (h *PlaybackHandler) putNodeRecipeV3(ctx context.Context, transportID strin
 	}
 }
 
+// putRequiredNodeRecipeV3 persists the active authority for a progressive
+// remux executed by a transcode node. Unlike the reconstruction-only write
+// above, this one is part of route admission: the node checks the record before
+// every new remux request, and stop deletes it, so a still-valid stream token
+// cannot resurrect FFmpeg after a node replacement.
+func (h *PlaybackHandler) putRequiredNodeRecipeV3(ctx context.Context, transportID string, card playback.RecipeCard) error {
+	if h == nil || h.NodeRecipeStore == nil || !h.NodeRecipeStore.Enabled() || transportID == "" {
+		return errors.New("node recipe store unavailable")
+	}
+	putCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), nodeRecipeWriteTimeoutV3)
+	defer cancel()
+	return h.NodeRecipeStore.Put(putCtx, transportID, card)
+}
+
 // deleteNodeRecipeV3 drops a transport's stored recipe so a buffered or retrying
 // request cannot resurrect a transcode the server has replaced or ended. The
 // store's TTL is only the backstop for the paths that never run (a crashed API
@@ -2812,7 +2834,14 @@ func (h *PlaybackHandler) resolveIdentityRouteV3(r *http.Request, sessionID stri
 	excludedShapes := make(map[string]struct{})
 	if result.Plan != nil && result.Plan.Delivery == playback.DeliveryRemuxProgressiveV3 &&
 		h.validateLocalProgressiveCapabilitiesV3(r.Context(), result) != nil {
-		excludedShapes["progressive_remux_api"] = struct{}{}
+		excludedShapes[noderouting.ShapeProgressiveRemuxAPI] = struct{}{}
+	}
+	if delivery == noderouting.DeliveryProgressiveRemux &&
+		(h.NodeRecipeStore == nil || !h.NodeRecipeStore.Enabled()) {
+		// A signed stream token can outlive a transcode-node process by 24 hours.
+		// Without durable active-transport authority, a stopped remux could be
+		// replayed after that node restarts and start FFmpeg again.
+		excludedShapes[noderouting.ShapeProgressiveRemuxTranscodeProxy] = struct{}{}
 	}
 	var relayEligible func(*nodepool.Node) bool
 	if delivery == noderouting.DeliveryProgressiveRemux {

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -71,6 +72,8 @@ const (
 	playbackStartSideEffectsQueueSizeV3 = 256
 	playbackCapabilityWarmupWorkersV3   = 4
 	requestIDLogKeyV3                   = "request_id"
+	bandwidthEstimateLogKeyV3           = "bandwidth_estimate_kbps"
+	linkDownstreamLogKeyV3              = "link_downstream_kbps"
 	playbackLogValueV3                  = "playback"
 	playbackRemoteOutcomeFailedV3       = "failed"
 	routeCapabilityUnavailableReasonV3  = "route_capability_unavailable"
@@ -80,6 +83,7 @@ var errSubtitleStoreUnavailableV3 = errors.New("subtitle store unavailable")
 
 type v3NodeCapabilityCache struct {
 	transformations     []playback.TransformationV3
+	transportFeatures   []string
 	toneMapCapabilities tonemap.Capabilities
 	err                 error
 	expiresAt           time.Time
@@ -514,6 +518,7 @@ func (h *PlaybackHandler) lookupRemoteCapabilitiesV3(ctx context.Context, nodeUR
 	}
 	entry = v3NodeCapabilityCache{
 		transformations:     append([]playback.TransformationV3(nil), info.Transformations...),
+		transportFeatures:   append([]string(nil), info.TransportFeatures...),
 		toneMapCapabilities: append(tonemap.Capabilities(nil), info.ToneMapCapabilities...),
 		expiresAt:           completedAt.Add(v3NodeCapabilityTTL),
 	}
@@ -827,38 +832,51 @@ func (h *PlaybackHandler) hlsPlanningRegistryWithInputsV3(
 
 // progressiveRemuxPlanningRegistryWithInputsV3 reports only the remux
 // transformations executable by policy-eligible progressive routes. The API
-// and proxy pools are kept separate from HLS transcode nodes: capability in
-// one pool must not authorize a recipe on another delivery.
+// proxy, and transcode pools are admitted only when policy leaves a legal
+// progressive route through that executor.
 func (h *PlaybackHandler) progressiveRemuxPlanningRegistryWithInputsV3(
 	ctx context.Context,
 	local *playback.TransformationRegistryV3,
 	proxyAllowed bool,
 ) *playback.TransformationRegistryV3 {
 	local = local.OnlyAdvertised(progressiveRemuxTransformationsV3(local.Advertised()))
-	localAllowed, proxyExecutionAllowed := progressiveRemuxExecutorAvailabilityV3(
+	localAllowed, proxyExecutionAllowed, transcodeExecutionAllowed := progressiveRemuxExecutorAvailabilityV3(
 		h.playbackRoutingPolicyForContextV3(ctx), proxyAllowed,
 	)
-	if !proxyExecutionAllowed {
-		if !localAllowed {
-			return local.OnlyAdvertised(nil)
-		}
-		return local
-	}
-	enumerator, ok := h.NodePlanner.(proxyNodeEnumeratorV3)
-	if !ok {
-		if !localAllowed {
-			return local.OnlyAdvertised(nil)
-		}
-		return local
-	}
 	var merged []playback.TransformationV3
-	for _, transformations := range h.pooledNodeTransformationsV3(ctx, enumerator.ProxyNodeURLs()) {
-		merged = append(merged, progressiveRemuxTransformationsV3(transformations)...)
+	if proxyExecutionAllowed {
+		if enumerator, ok := h.NodePlanner.(proxyNodeEnumeratorV3); ok {
+			for _, transformations := range h.pooledNodeTransformationsV3(ctx, enumerator.ProxyNodeURLs()) {
+				merged = append(merged, progressiveRemuxTransformationsV3(transformations)...)
+			}
+		}
+	}
+	if transcodeExecutionAllowed && h.progressiveRemuxRelayAvailableV3(ctx) {
+		if enumerator, ok := h.NodePlanner.(transcodeNodeEnumeratorV3); ok {
+			for _, entry := range h.pooledNodeCapabilitiesV3(ctx, enumerator.TranscodeNodeURLs()) {
+				if slices.Contains(entry.transportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
+					merged = append(merged, progressiveRemuxTransformationsV3(entry.transformations)...)
+				}
+			}
+		}
 	}
 	if !localAllowed {
 		return local.OnlyAdvertised(merged)
 	}
 	return local.WithAdvertised(merged)
+}
+
+func (h *PlaybackHandler) progressiveRemuxRelayAvailableV3(ctx context.Context) bool {
+	enumerator, ok := h.NodePlanner.(proxyNodeEnumeratorV3)
+	if !ok {
+		return false
+	}
+	for _, entry := range h.pooledNodeCapabilitiesV3(ctx, enumerator.ProxyNodeURLs()) {
+		if slices.Contains(entry.transportFeatures, playback.TransportFeatureProgressiveRemuxRelayV1) {
+			return true
+		}
+	}
+	return false
 }
 
 func progressiveRemuxTransformationsV3(transformations []playback.TransformationV3) []playback.TransformationV3 {
@@ -873,20 +891,21 @@ func progressiveRemuxTransformationsV3(transformations []playback.Transformation
 	return result
 }
 
-func progressiveRemuxExecutorAvailabilityV3(policy config.PlaybackRoutingPolicy, proxyAllowed bool) (bool, bool) {
+func progressiveRemuxExecutorAvailabilityV3(policy config.PlaybackRoutingPolicy, proxyAllowed bool) (bool, bool, bool) {
 	routes, err := noderouting.Candidates(noderouting.Request{
 		Workload: noderouting.WorkloadRemux, Delivery: noderouting.DeliveryProgressiveRemux,
 		Policy: policy, ProxyAllowed: proxyAllowed,
 	})
 	if err != nil {
-		return false, false
+		return false, false, false
 	}
-	var localAllowed, proxyExecutionAllowed bool
+	var localAllowed, proxyExecutionAllowed, transcodeExecutionAllowed bool
 	for _, candidate := range routes.Candidates {
 		localAllowed = localAllowed || candidate.Execution == noderouting.ExecutionAPI
 		proxyExecutionAllowed = proxyExecutionAllowed || candidate.Execution == noderouting.ExecutionProxy
+		transcodeExecutionAllowed = transcodeExecutionAllowed || candidate.Execution == noderouting.ExecutionTranscode
 	}
-	return localAllowed, proxyExecutionAllowed
+	return localAllowed, proxyExecutionAllowed, transcodeExecutionAllowed
 }
 
 // hlsCapabilityRegistryWithInputsV3 reports the union of transformations that
@@ -1229,27 +1248,38 @@ func (h *PlaybackHandler) planPlaybackWithCapabilitiesV3(ctx context.Context, in
 // contribute nothing (their failures are negatively cached), so planning
 // degrades toward the local registry instead of blocking the start path.
 func (h *PlaybackHandler) pooledNodeTransformationsV3(ctx context.Context, nodeURLs []string) map[string][]playback.TransformationV3 {
+	capabilities := h.pooledNodeCapabilitiesV3(ctx, nodeURLs)
+	byURL := make(map[string][]playback.TransformationV3, len(capabilities))
+	for nodeURL, entry := range capabilities {
+		byURL[nodeURL] = append([]playback.TransformationV3(nil), entry.transformations...)
+	}
+	return byURL
+}
+
+func (h *PlaybackHandler) pooledNodeCapabilitiesV3(ctx context.Context, nodeURLs []string) map[string]v3NodeCapabilityCache {
 	fetchCtx, cancel := context.WithTimeout(ctx, v3NodeCapabilityPlanTimeout)
 	defer cancel()
-	results := make([][]playback.TransformationV3, len(nodeURLs))
+	results := make([]v3NodeCapabilityCache, len(nodeURLs))
+	available := make([]bool, len(nodeURLs))
 	var wg sync.WaitGroup
 	for i, nodeURL := range nodeURLs {
 		wg.Add(1)
 		go func(i int, nodeURL string) {
 			defer wg.Done()
-			transformations, err := h.remoteTransformationsPlanningV3(fetchCtx, nodeURL)
+			entry, err := h.lookupRemoteCapabilitiesV3(fetchCtx, nodeURL, true)
 			if err != nil {
 				slog.DebugContext(ctx, "protocol v3 node capability unavailable for planning", "component", "api", "node", logredact.SanitizeURL(nodeURL), "error", err)
 				return
 			}
-			results[i] = transformations
+			results[i] = entry
+			available[i] = true
 		}(i, nodeURL)
 	}
 	wg.Wait()
-	byURL := make(map[string][]playback.TransformationV3, len(nodeURLs))
-	for i, transformations := range results {
-		if transformations != nil {
-			byURL[nodeURLs[i]] = transformations
+	byURL := make(map[string]v3NodeCapabilityCache, len(nodeURLs))
+	for i, entry := range results {
+		if available[i] {
+			byURL[nodeURLs[i]] = entry
 		}
 	}
 	return byURL
@@ -1375,10 +1405,15 @@ func (h *PlaybackHandler) transcodeEligibilityV3(ctx context.Context, result pla
 	// round of capability lookups on a filter nothing reads.
 	_, exactPlanner := h.NodePlanner.(nodepool.RoutePlanner)
 	_, predicatePlanner := h.NodePlanner.(predicateSessionPlannerV3)
-	if enumerator, ok := h.NodePlanner.(transcodeNodeEnumeratorV3); ok && (exactPlanner || predicatePlanner) && planRequiresServerTransformationsV3(result.Plan) {
+	requiresProgressiveRemux := result.Plan != nil && result.Plan.Delivery == playback.DeliveryRemuxProgressiveV3
+	if enumerator, ok := h.NodePlanner.(transcodeNodeEnumeratorV3); ok && (exactPlanner || predicatePlanner) &&
+		(planRequiresServerTransformationsV3(result.Plan) || requiresProgressiveRemux) {
 		capable := make(map[string]struct{})
-		for nodeURL, advertised := range h.pooledNodeTransformationsV3(ctx, enumerator.TranscodeNodeURLs()) {
-			if validateAdvertisedTransformationsV3(result.Plan, advertised) != nil {
+		for nodeURL, entry := range h.pooledNodeCapabilitiesV3(ctx, enumerator.TranscodeNodeURLs()) {
+			if requiresProgressiveRemux && !slices.Contains(entry.transportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
+				continue
+			}
+			if validateAdvertisedTransformationsV3(result.Plan, entry.transformations) != nil {
 				continue
 			}
 			if planRequiresToneMapV3(result.Plan) {
@@ -1696,26 +1731,7 @@ func (h *PlaybackHandler) handleStartPlaybackV3(w http.ResponseWriter, r *http.R
 	}
 	result = escalated
 	timings.mark("remux_escalation")
-	// One line per plan decision so route selection is reconstructible from
-	// server logs alone (finding a mis-planned route previously required
-	// correlating client logcat, ffmpeg commands, and session rows).
-	slog.InfoContext(r.Context(), "playback plan decided", append([]any{
-		logComponentKey, playbackLogValueV3,
-		requestIDLogKeyV3, chimw.GetReqID(r.Context()),
-		"outcome", "plan",
-		"decision_reason", result.Plan.DecisionReason,
-		"delivery", result.Plan.Delivery,
-		"play_method", string(result.PlayMethod),
-		"requested_file_id", requestedFile.ID,
-		"effective_file_id", effectiveFile.ID,
-		"dv_profile", result.Plan.Source.DVProfile,
-		"dynamic_range", result.Plan.Source.DynamicRange,
-		"target_resolution", result.TargetResolution,
-		"target_bitrate_kbps", result.TargetBitrateKbps,
-		"quality_preference", req.QualityPreference,
-		"bandwidth_estimate_kbps", intOrZeroHandlerV3(req.BandwidthEstimateKbps),
-	}, clientInfo.LogAttrs()...)...)
-	result.Plan.DegradationWarnings = append(result.Plan.DegradationWarnings, warnings...)
+	appendStartWarningsV3(&result, warnings)
 	response, statusErr := h.startPlannedPlaybackV3(r, userID, profileID, req, requestDigests, requestedFile, effectiveFile, audioIndex, result, clientInfo)
 	timings.mark("session_transport_commit")
 	if statusErr != nil {
@@ -1843,21 +1859,21 @@ func (d playbackStartRequestDigestsV3) matches(stored string) bool {
 	return stored == "" || stored == d.current || stored == d.legacy
 }
 
+func appendStartWarningsV3(result *playback.PlannerResultV3, warnings []playback.DegradationWarningV3) {
+	if result == nil || len(warnings) == 0 {
+		return
+	}
+	if result.Plan != nil {
+		result.Plan.DegradationWarnings = append(result.Plan.DegradationWarnings, warnings...)
+	}
+}
+
 // startPlannedPlaybackV3 creates a session and transport for an accepted plan.
 func (h *PlaybackHandler) startPlannedPlaybackV3(r *http.Request, userID int, profileID string, req playback.StartRequestV3, requestDigests playbackStartRequestDigestsV3, requestedFile, effectiveFile *models.MediaFile, audioIndex int, result playback.PlannerResultV3, clientInfo playback.ClientInfo) (playback.DecisionResponseV3, *transportErrorV3) {
 	if result.Plan == nil {
 		return playback.DecisionResponseV3{}, &transportErrorV3{reason: "internal_error", message: "The server produced no playback plan."}
 	}
 	mode := headerAuthenticatedMediaV3(req.ClientFeatures)
-	if checker, ok := h.sessionMgr.(transcodePermissionChecker); ok && (result.PlayMethod == playback.PlayTranscode || result.TranscodeAudio) {
-		if err := checker.CheckTranscodingAllowed(r.Context(), userID, result.PlayMethod == playback.PlayTranscode); err != nil {
-			reason := "transcoding_disabled"
-			if errors.Is(err, playback.ErrAudioTranscodingDisabled) {
-				reason = "audio_transcoding_disabled"
-			}
-			return playback.DecisionResponseV3{}, &transportErrorV3{reason: reason, message: "The selected server adaptation is disabled for this user."}
-		}
-	}
 	ctx := playback.WithClientInfo(r.Context(), clientInfo)
 	session, err := h.sessionMgr.StartSessionWithFilesContext(ctx, userID, profileID, effectiveFile.ID, requestedFile.ID, result.PlayMethod, result.TranscodeAudio)
 	if err != nil {
@@ -1897,6 +1913,24 @@ func (h *PlaybackHandler) startPlannedPlaybackV3(r *http.Request, userID int, pr
 		abort()
 		return playback.DecisionResponseV3{}, transportErr
 	}
+	// One line per final plan decision so route selection is reconstructible
+	// from server logs.
+	slog.InfoContext(r.Context(), "playback plan decided", append([]any{
+		logComponentKey, playbackLogValueV3,
+		requestIDLogKeyV3, chimw.GetReqID(r.Context()),
+		"outcome", "plan",
+		"decision_reason", result.Plan.DecisionReason,
+		"delivery", result.Plan.Delivery,
+		"play_method", string(result.PlayMethod),
+		"requested_file_id", requestedFile.ID,
+		"effective_file_id", effectiveFile.ID,
+		"dv_profile", result.Plan.Source.DVProfile,
+		"dynamic_range", result.Plan.Source.DynamicRange,
+		"target_resolution", result.TargetResolution,
+		"target_bitrate_kbps", result.TargetBitrateKbps,
+		"quality_preference", req.QualityPreference,
+		bandwidthEstimateLogKeyV3, intOrZeroHandlerV3(req.BandwidthEstimateKbps),
+	}, clientInfo.LogAttrs()...)...)
 	applyTransportToneMapModeV3(&result, transport)
 	frozenRecipe, frozenErr := h.freezeExecutableRecipeV3(r.Context(), effectiveFile, result)
 	if frozenErr != nil {
@@ -2117,6 +2151,18 @@ func (h *PlaybackHandler) prepareTransportV3(r *http.Request, session *playback.
 }
 
 func (h *PlaybackHandler) prepareTransportWithPolicyV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy) (preparedTransportV3, *transportErrorV3) {
+	return h.prepareTransportWithPolicyAndExclusionsV3(r, session, file, result, mode, policy, nil)
+}
+
+func (h *PlaybackHandler) prepareTransportWithPolicyAndExclusionsV3(
+	r *http.Request,
+	session *playback.Session,
+	file *models.MediaFile,
+	result playback.PlannerResultV3,
+	mode mediaAuthModeV3,
+	policy config.PlaybackRoutingPolicy,
+	initialExcludedShapes map[string]struct{},
+) (preparedTransportV3, *transportErrorV3) {
 	timeline, timelineErr := h.prepareTransportTimelineV3(r.Context(), session, file, result)
 	if timelineErr != nil {
 		return preparedTransportV3{}, timelineErr
@@ -2126,7 +2172,10 @@ func (h *PlaybackHandler) prepareTransportWithPolicyV3(r *http.Request, session 
 	}
 	proxyAllowed := mode.proxyEgress || (!mode.headerAuth && h.JWTSecret != "")
 	excludedNodes := make(map[string]struct{})
-	excludedShapes := make(map[string]struct{})
+	excludedShapes := make(map[string]struct{}, len(initialExcludedShapes))
+	for shapeID := range initialExcludedShapes {
+		excludedShapes[shapeID] = struct{}{}
+	}
 	var lastErr *transportErrorV3
 	for attempts := 0; attempts < 32; attempts++ {
 		decision := h.resolveHLSRouteWithPolicyV3(r.Context(), session, result, policy, proxyAllowed, excludedNodes, excludedShapes)
@@ -2222,6 +2271,29 @@ func (h *PlaybackHandler) prepareTransportWithPolicyV3(r *http.Request, session 
 		lastErr = combineTransportErrorsV3(lastErr, transportErr)
 	}
 	return preparedTransportV3{}, &transportErrorV3{reason: "route_preparation_failed", message: "Playback route preparation exhausted every candidate.", retryable: true, cause: lastErr}
+}
+
+func (h *PlaybackHandler) checkReplacementAdmissionV3(
+	ctx context.Context,
+	session *playback.Session,
+	result playback.PlannerResultV3,
+) *transportErrorV3 {
+	if session == nil {
+		return &transportErrorV3{reason: "internal_error", message: "Playback route admission has no live session."}
+	}
+	if checker, ok := h.sessionMgr.(replacementAdmissionCheckerV3); ok {
+		if err := checker.CheckReplacementAllowed(ctx, session.ID, result.PlayMethod, result.TranscodeAudio); err != nil {
+			return sessionStartErrorV3(err)
+		}
+		return nil
+	}
+	if checker, ok := h.sessionMgr.(transcodePermissionChecker); ok &&
+		(result.PlayMethod == playback.PlayTranscode || result.TranscodeAudio) {
+		if err := checker.CheckTranscodingAllowed(ctx, session.UserID, result.PlayMethod == playback.PlayTranscode); err != nil {
+			return sessionStartErrorV3(err)
+		}
+	}
+	return nil
 }
 
 // canRetrySoftwareToneMapV3 permits a software retry only for an initial
@@ -2373,12 +2445,45 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	// The shared resolver removes proxy shapes when this client cannot address
 	// an authorized origin, then applies the same policy ordering as every HLS
 	// path. Legacy and authorized-origin attempts differ only in URL authority.
-	proxyNode, proxyErr := h.planIdentityProxyV3(r, session.ID, result, mode, policy)
-	if proxyErr != nil {
-		return preparedTransportV3{}, proxyErr
+	decision, routeErr := h.resolveIdentityRouteV3(r, session.ID, result, mode, policy)
+	if routeErr != nil {
+		return preparedTransportV3{}, routeErr
 	}
-	if proxyNode != nil && planRequiresServerTransformationsV3(result.Plan) {
-		advertised, capabilityErr := h.remoteTransformationsV3(r.Context(), proxyNode.URL)
+	proxyNode := decision.Plan.ProxyNode
+	transcodeNode := decision.Plan.TranscodeNode
+	if transcodeNode != nil {
+		transcodeCapabilities, capabilityErr := h.lookupRemoteCapabilitiesV3(r.Context(), transcodeNode.URL, false)
+		if capabilityErr != nil || !slices.Contains(transcodeCapabilities.transportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
+			if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
+				releaser.ReleaseSession(session.ID)
+			}
+			return preparedTransportV3{}, &transportErrorV3{
+				reason: routeCapabilityUnavailableReasonV3, message: "The selected transcode node cannot execute a progressive remux.",
+				retryable: true, cause: capabilityErr,
+			}
+		}
+	}
+	if transcodeNode != nil && proxyNode != nil {
+		proxyCapabilities, capabilityErr := h.lookupRemoteCapabilitiesV3(r.Context(), proxyNode.URL, false)
+		if capabilityErr != nil || !slices.Contains(proxyCapabilities.transportFeatures, playback.TransportFeatureProgressiveRemuxRelayV1) {
+			if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
+				releaser.ReleaseSession(session.ID)
+			}
+			return preparedTransportV3{}, &transportErrorV3{
+				reason: routeCapabilityUnavailableReasonV3, message: "The selected proxy cannot relay a progressive remux from a transcode node.",
+				retryable: true, cause: capabilityErr,
+			}
+		}
+	}
+	var executorNode *nodepool.Node
+	switch decision.Shape.Execution {
+	case noderouting.ExecutionProxy:
+		executorNode = proxyNode
+	case noderouting.ExecutionTranscode:
+		executorNode = transcodeNode
+	}
+	if executorNode != nil && planRequiresServerTransformationsV3(result.Plan) {
+		advertised, capabilityErr := h.remoteTransformationsV3(r.Context(), executorNode.URL)
 		if capabilityErr == nil {
 			capabilityErr = validateAdvertisedTransformationsV3(result.Plan, advertised)
 		}
@@ -2387,24 +2492,25 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 				releaser.ReleaseSession(session.ID)
 			}
 			return preparedTransportV3{}, &transportErrorV3{
-				reason: routeCapabilityUnavailableReasonV3, message: "The selected proxy cannot execute the progressive-remux recipe.",
+				reason: routeCapabilityUnavailableReasonV3, message: "The selected node cannot execute the progressive-remux recipe.",
 				retryable: true, cause: capabilityErr,
 			}
 		}
 	}
 	routeSession.RoutingWorkload = string(routingWorkloadV3(result))
-	routeSession.RoutingExecution = string(noderouting.ExecutionNone)
-	if routeSession.RoutingWorkload == string(noderouting.WorkloadRemux) {
-		routeSession.RoutingExecution = string(noderouting.ExecutionAPI)
-	}
-	routeSession.RoutingEgress = string(noderouting.EgressAPI)
+	routeSession.RoutingExecution = string(decision.Shape.Execution)
+	routeSession.RoutingEgress = string(decision.Shape.Egress)
 	if proxyNode != nil {
-		routeSession.RoutingEgress = string(noderouting.EgressProxy)
 		routeSession.RoutingEgressNodeID = proxyNode.ID
 		routeSession.RoutingEgressNodeURL = proxyNode.URL
-		if routeSession.RoutingWorkload == string(noderouting.WorkloadRemux) {
-			routeSession.RoutingExecution = string(noderouting.ExecutionProxy)
-		}
+	}
+	transportID := ""
+	routeSession.TranscodeNodeURL = ""
+	routeSession.TranscodeTransportID = ""
+	if transcodeNode != nil {
+		transportID = transportGenerationV3(session.ID, result.Plan.PlanID)
+		routeSession.TranscodeNodeURL = transcodeNode.URL
+		routeSession.TranscodeTransportID = transportID
 	}
 	streamURL := fmt.Sprintf("/stream/%s", routeSession.ID)
 	servedByProxy := false
@@ -2424,6 +2530,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			releaser.ReleaseSession(session.ID)
 		}
 	}
+	reservationReleased := false
 	if proxyNode != nil && !servedByProxy {
 		// A planned proxy that could not be addressed (no signable token, no
 		// file record, no writable grant) falls back to the local path, so its
@@ -2442,6 +2549,12 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		// proxy-authority failure retryable, and a non-retryable answer would
 		// make a client give up on a route the next attempt can take.
 		releaseProxyReservation()
+		reservationReleased = true
+		if transcodeNode != nil {
+			return preparedTransportV3{}, &transportErrorV3{
+				reason: string(noderouting.OutcomeCapacityUnavailable), message: "The transcode-to-proxy remux route is temporarily unavailable.", retryable: true,
+			}
+		}
 		if !identityLocalFallbackAllowedV3(result, policy) || h.validateLocalProgressiveCapabilitiesV3(r.Context(), result) != nil {
 			return preparedTransportV3{}, &transportErrorV3{
 				reason:    string(noderouting.OutcomeCapacityUnavailable),
@@ -2461,20 +2574,22 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		}
 	}
 	workload := routingWorkloadV3(result)
-	routingExecution := noderouting.ExecutionNone
-	if workload == noderouting.WorkloadRemux {
-		routingExecution = noderouting.ExecutionAPI
-		if servedByProxy {
-			routingExecution = noderouting.ExecutionProxy
-		}
-	}
+	routingExecution := decision.Shape.Execution
 	routingEgress := noderouting.EgressAPI
 	egressNodeID := 0
 	egressNodeURL := ""
 	if servedByProxy {
-		routingEgress = noderouting.EgressProxy
+		routingEgress = decision.Shape.Egress
 		egressNodeID = proxyNode.ID
 		egressNodeURL = proxyNode.URL
+	} else {
+		transcodeNode = nil
+		transportID = ""
+		if workload == noderouting.WorkloadRemux {
+			routingExecution = noderouting.ExecutionAPI
+		} else {
+			routingExecution = noderouting.ExecutionNone
+		}
 	}
 	// Only a proxy that actually runs the remux is this route's executor. Direct
 	// play executes nothing, so naming the proxy there would report an execution
@@ -2485,9 +2600,18 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	if routingExecution == noderouting.ExecutionProxy {
 		executorID = egressNodeID
 		executorURL = egressNodeURL
+	} else if routingExecution == noderouting.ExecutionTranscode && transcodeNode != nil {
+		executorID = transcodeNode.ID
+		executorURL = transcodeNode.URL
+	}
+	nodeURL := ""
+	if transcodeNode != nil {
+		nodeURL = transcodeNode.URL
 	}
 	return preparedTransportV3{
 		url:                streamURL,
+		nodeURL:            nodeURL,
+		transportID:        transportID,
 		routingWorkload:    workload,
 		routingExecution:   routingExecution,
 		routingExecutorID:  executorID,
@@ -2518,7 +2642,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			// must not keep consuming that node's job/bandwidth budget until the
 			// reservation ages out — nor keep an egress grant for a transport
 			// that was never committed.
-			if servedByProxy {
+			if servedByProxy && !reservationReleased {
 				releaseProxyReservation()
 				h.restoreProxyGrantV3(r.Context(), session.ID, priorGrant)
 			}
@@ -2676,13 +2800,13 @@ func (h *PlaybackHandler) deleteNodeRecipeV3(ctx context.Context, transportID st
 	}
 }
 
-// planIdentityProxyV3 resolves direct and progressive routes through the same
-// policy compiler as HLS. A nil proxy with no error is an explicitly selected
-// API route, not an implicit handler-local fallback.
-func (h *PlaybackHandler) planIdentityProxyV3(r *http.Request, sessionID string, result playback.PlannerResultV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy) (*nodepool.Node, *transportErrorV3) {
+// resolveIdentityRouteV3 resolves direct and progressive routes through the
+// same policy compiler as HLS, including the transcode-execution/proxy-egress
+// progressive route.
+func (h *PlaybackHandler) resolveIdentityRouteV3(r *http.Request, sessionID string, result playback.PlannerResultV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy) (noderouting.Decision, *transportErrorV3) {
 	workload, delivery, ok := routingClassV3(result)
 	if !ok {
-		return nil, &transportErrorV3{reason: string(noderouting.OutcomePolicyUnsatisfied), message: "The playback delivery has no legal node route.", retryable: false}
+		return noderouting.Decision{}, &transportErrorV3{reason: string(noderouting.OutcomePolicyUnsatisfied), message: "The playback delivery has no legal node route.", retryable: false}
 	}
 	proxyAllowed := mode.proxyEgress || (!mode.headerAuth && h.JWTSecret != "")
 	excludedShapes := make(map[string]struct{})
@@ -2690,22 +2814,47 @@ func (h *PlaybackHandler) planIdentityProxyV3(r *http.Request, sessionID string,
 		h.validateLocalProgressiveCapabilitiesV3(r.Context(), result) != nil {
 		excludedShapes["progressive_remux_api"] = struct{}{}
 	}
+	var relayEligible func(*nodepool.Node) bool
+	if delivery == noderouting.DeliveryProgressiveRemux {
+		relayEligible = h.identityProxyRelayEligibilityV3(r.Context())
+	}
 	decision, err := noderouting.Resolve(noderouting.AdaptSessionPlanner(h.NodePlanner), noderouting.ResolveRequest{
 		Request: noderouting.Request{
 			Workload: workload, Delivery: delivery,
 			Policy: policy, ProxyAllowed: proxyAllowed,
 		},
 		SessionID: sessionID, EstimatedBitrateKbps: identityStreamBitrateKbpsV3(result),
-		ProxyEligible: h.identityProxyEligibilityV3(r.Context(), result), ExcludedShapeIDs: excludedShapes,
+		TranscodeEligible: h.transcodeEligibilityV3(r.Context(), result, nil), ProxyEligible: relayEligible,
+		ProxyExecutionEligible: h.identityProxyEligibilityV3(r.Context(), result), ExcludedShapeIDs: excludedShapes,
 	})
 	if err != nil {
-		return nil, &transportErrorV3{reason: string(noderouting.OutcomePolicyUnsatisfied), message: "The playback routing policy is invalid.", retryable: false, cause: err}
+		return noderouting.Decision{}, &transportErrorV3{reason: string(noderouting.OutcomePolicyUnsatisfied), message: "The playback routing policy is invalid.", retryable: false, cause: err}
 	}
 	if !decision.Selected() {
 		retryable := decision.Outcome == noderouting.OutcomeCapacityUnavailable
-		return nil, &transportErrorV3{reason: string(decision.Outcome), message: "No playback route satisfies the configured policy and current node availability.", retryable: retryable}
+		return noderouting.Decision{}, &transportErrorV3{reason: string(decision.Outcome), message: "No playback route satisfies the configured policy and current node availability.", retryable: retryable}
 	}
-	return decision.Plan.ProxyNode, nil
+	return decision, nil
+}
+
+func (h *PlaybackHandler) identityProxyRelayEligibilityV3(ctx context.Context) func(*nodepool.Node) bool {
+	enumerator, ok := h.NodePlanner.(proxyNodeEnumeratorV3)
+	if !ok {
+		return func(*nodepool.Node) bool { return false }
+	}
+	capable := make(map[string]struct{})
+	for nodeURL, entry := range h.pooledNodeCapabilitiesV3(ctx, enumerator.ProxyNodeURLs()) {
+		if slices.Contains(entry.transportFeatures, playback.TransportFeatureProgressiveRemuxRelayV1) {
+			capable[nodeURL] = struct{}{}
+		}
+	}
+	return func(node *nodepool.Node) bool {
+		if node == nil {
+			return false
+		}
+		_, supported := capable[node.URL]
+		return supported
+	}
 }
 
 // applyRemoteTransportMarkV3 records whether the committed route's media bytes
@@ -4435,19 +4584,11 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	if !ok {
 		return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{reason: "internal_error", message: "The live session manager does not support atomic replacement."}
 	}
-	if checker, ok := h.sessionMgr.(replacementAdmissionCheckerV3); ok {
-		if err := checker.CheckReplacementAllowed(r.Context(), session.ID, result.PlayMethod, result.TranscodeAudio); err != nil {
-			mapped := sessionStartErrorV3(err)
-			return playback.DecisionResponseV3{}, *record, nil, mapped
-		}
-		_, reservationHeld = h.sessionMgr.(replacementReservationCancellerV3)
+	admissionErr := h.checkReplacementAdmissionV3(r.Context(), session, result)
+	if admissionErr != nil {
+		return playback.DecisionResponseV3{}, *record, nil, admissionErr
 	}
-	if checker, ok := h.sessionMgr.(transcodePermissionChecker); ok && (result.PlayMethod == playback.PlayTranscode || result.TranscodeAudio) {
-		if err := checker.CheckTranscodingAllowed(r.Context(), session.UserID, result.PlayMethod == playback.PlayTranscode); err != nil {
-			mapped := sessionStartErrorV3(err)
-			return playback.DecisionResponseV3{}, *record, nil, mapped
-		}
-	}
+	_, reservationHeld = h.sessionMgr.(replacementReservationCancellerV3)
 	result.Plan.SessionID = session.ID
 	artifactRecipe := record.FrozenRecipe
 	if !seekReanchor {
@@ -5531,7 +5672,9 @@ func sessionStartErrorV3(err error) *transportErrorV3 {
 	switch {
 	case errors.Is(err, playback.ErrTooManyStreams), errors.Is(err, playback.ErrTooManyTranscodes):
 		return &transportErrorV3{reason: "capacity_unavailable", message: "Playback capacity is currently unavailable.", retryable: true}
-	case errors.Is(err, playback.ErrTranscodingDisabled), errors.Is(err, playback.ErrAudioTranscodingDisabled):
+	case errors.Is(err, playback.ErrAudioTranscodingDisabled):
+		return &transportErrorV3{reason: "audio_transcoding_disabled", message: "The selected audio adaptation is disabled."}
+	case errors.Is(err, playback.ErrTranscodingDisabled):
 		return &transportErrorV3{reason: "transcoding_disabled", message: "The selected server adaptation is disabled."}
 	case errors.Is(err, playback.ErrPlaybackNotAllowed):
 		return &transportErrorV3{reason: "policy_denied", message: "Playback is denied by server policy."}
@@ -5874,7 +6017,7 @@ var diagnosticKeysV3 = map[string]struct{}{
 	"audio_output_mode": {}, "audio_mime": {}, "audio_channels": {}, "audio_decoder_name": {},
 	"correction_id": {}, "correction_stage": {},
 	"network_transport": {}, "network_metered": {}, "network_validated": {},
-	"bandwidth_estimate_kbps": {}, "link_downstream_kbps": {},
+	bandwidthEstimateLogKeyV3: {}, linkDownstreamLogKeyV3: {},
 	"target_source_position_seconds": {}, "reason": {},
 }
 

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2570,9 +2570,19 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		reservationReleased = true
 		if transcodeNode != nil {
 			h.deleteNodeRecipeV3(r.Context(), transportID)
-			return preparedTransportV3{}, &transportErrorV3{
+			grantErr := &transportErrorV3{
 				reason: string(noderouting.OutcomeCapacityUnavailable), message: "The transcode-to-proxy remux route is temporarily unavailable.", retryable: true,
 			}
+			fallbackExclusions := maps.Clone(excludedShapes)
+			if fallbackExclusions == nil {
+				fallbackExclusions = make(map[string]struct{})
+			}
+			fallbackExclusions[decision.Shape.ID] = struct{}{}
+			fallback, fallbackErr := h.prepareIdentityTransportV3(r, session, file, result, timeline, mode, policy, fallbackExclusions)
+			if fallbackErr == nil {
+				return fallback, nil
+			}
+			return preparedTransportV3{}, combineTransportErrorsV3(grantErr, fallbackErr)
 		}
 		if !identityLocalFallbackAllowedV3(result, policy) || h.validateLocalProgressiveCapabilitiesV3(r.Context(), result) != nil {
 			return preparedTransportV3{}, &transportErrorV3{

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -852,7 +852,8 @@ func (h *PlaybackHandler) progressiveRemuxPlanningRegistryWithInputsV3(
 			}
 		}
 	}
-	if transcodeExecutionAllowed && h.progressiveRemuxRelayAvailableV3(ctx) {
+	if transcodeExecutionAllowed && h.NodeRecipeStore != nil && h.NodeRecipeStore.Enabled() &&
+		h.progressiveRemuxRelayAvailableV3(ctx) {
 		if enumerator, ok := h.NodePlanner.(transcodeNodeEnumeratorV3); ok {
 			for _, entry := range h.pooledNodeCapabilitiesV3(ctx, enumerator.TranscodeNodeURLs()) {
 				if slices.Contains(entry.transportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
@@ -2664,6 +2665,9 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 				return
 			}
 			committed = true
+			if nodeURL != "" && transportID != "" {
+				h.tm.StopRemoteTranscode(transportID, nodeURL)
+			}
 			// The session never reached the client, so a proxy admitted for it
 			// must not keep consuming that node's job/bandwidth budget until the
 			// reservation ages out — nor keep an egress grant for a transport

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -4339,7 +4339,11 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 		var err error
 		rollbackSession, err = transport.applySession()
 		if err != nil {
-			transport.rollback()
+			if rollbackErr, _ := rollbackFailedReplanV3(transport, nil); rollbackErr != nil {
+				slog.ErrorContext(r.Context(), "protocol v3 unapplied replacement transport cancellation failed", "session", sessionID, "error", rollbackErr)
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to cancel the unapplied replacement transport")
+				return
+			}
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to commit the live replacement session")
 			return
 		}
@@ -4773,6 +4777,28 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		}
 		artifactRecipe = frozenRecipe
 	}
+	// Resolve every fallible subtitle and frozen-route check before transport
+	// preparation publishes a stable proxy grant. An existing client can issue
+	// a GET against that grant immediately, even though this replan response has
+	// not returned yet, so errors after publication would require canceling an
+	// already admitted successor.
+	if err := h.attachSubtitleArtifactV3(r.Context(), session.ID, effectiveFile, result.Plan, result.SubtitleTrackIndex, &artifactRecipe); err != nil {
+		return playback.DecisionResponseV3{}, *record, nil, subtitleArtifactErrorV3("Failed to prepare the selected subtitle artifact.", err)
+	}
+	if seekReanchor {
+		if err := validateSeekReanchorPlanV3(record, result.Plan); err != nil {
+			changedFields := seekReanchorIdentityChangesV3(record, result.Plan)
+			slog.ErrorContext(r.Context(), "protocol v3 seek reanchor changed route identity",
+				"session", record.SessionID,
+				"playback_attempt_id", record.PlaybackAttemptID,
+				"changed_fields", changedFields,
+			)
+			return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{
+				reason:  "seek_reanchor_route_changed",
+				message: err.Error(),
+			}
+		}
+	}
 	transportReused := false
 	if trackChange && h.hasActiveHLSTransportV3(session) {
 		proxyAllowed := mode.proxyEgress || (!mode.headerAuth && h.JWTSecret != "")
@@ -4812,35 +4838,13 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 			return playback.DecisionResponseV3{}, *record, nil, transportErr
 		}
 		applyTransportToneMapModeV3(&result, transport)
-		if !seekReanchor {
-			frozenRecipe, frozenErr := h.freezeExecutableRecipeV3(r.Context(), effectiveFile, result)
-			if frozenErr != nil {
-				transport.rollback()
-				return playback.DecisionResponseV3{}, *record, nil, subtitleArtifactErrorV3("Failed to freeze the selected subtitle identity.", frozenErr)
-			}
-			artifactRecipe = frozenRecipe
-		}
+		// Transport preparation can only attest the executor's tone-map mode;
+		// every other frozen identity field was validated above. Copy that one
+		// receipt into the already validated recipe instead of rerunning a
+		// fallible subtitle-identity freeze after authority publication.
+		artifactRecipe.ToneMapMode = result.ToneMapMode
 	}
 	result.Plan.Stream.URL = transport.url
-	if err := h.attachSubtitleArtifactV3(r.Context(), session.ID, effectiveFile, result.Plan, result.SubtitleTrackIndex, &artifactRecipe); err != nil {
-		transport.rollback()
-		return playback.DecisionResponseV3{}, *record, nil, subtitleArtifactErrorV3("Failed to prepare the selected subtitle artifact.", err)
-	}
-	if seekReanchor {
-		if err := validateSeekReanchorPlanV3(record, result.Plan); err != nil {
-			changedFields := seekReanchorIdentityChangesV3(record, result.Plan)
-			slog.ErrorContext(r.Context(), "protocol v3 seek reanchor changed route identity",
-				"session", record.SessionID,
-				"playback_attempt_id", record.PlaybackAttemptID,
-				"changed_fields", changedFields,
-			)
-			transport.rollback()
-			return playback.DecisionResponseV3{}, *record, nil, &transportErrorV3{
-				reason:  "seek_reanchor_route_changed",
-				message: err.Error(),
-			}
-		}
-	}
 	response := playback.DecisionResponseV3{ProtocolVersion: playback.ProtocolV3, ServerFeatures: playback.ServerFeaturesV3(), Outcome: playback.OutcomePlayableV3, SessionID: session.ID, PlaybackPlan: result.Plan}
 	updated := *record
 	updated.CurrentPlanID = result.Plan.PlanID

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -105,6 +105,7 @@ type preparedTransportV3 struct {
 	routingEgressURL   string
 	commit             func()
 	rollback           func()
+	rollbackRequired   func() error
 	applySession       func() (func() error, error)
 	afterDurableCommit func()
 }
@@ -2674,6 +2675,46 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	if transcodeNode != nil {
 		nodeURL = transcodeNode.URL
 	}
+	adoptSuccessor := func() {
+		h.tm.CloseTranscodeSession(session.ID, "")
+		if previousNodeURL != "" {
+			h.tm.StopRemoteTranscode(previousTransportID, previousNodeURL)
+			h.deleteNodeRecipeV3(r.Context(), previousTransportID)
+		}
+		h.revokeStaleProxyGrantOnCommitV3(r.Context(), session.ID, mode, servedByProxy)
+		h.applyRemoteTransportMarkV3(r.Context(), session.ID, servedByProxy)
+	}
+	rollbackTransport := func(requireCancellation bool) error {
+		if committed {
+			return nil
+		}
+		if requireCancellation && nodeURL != "" && transportID != "" {
+			if err := h.tm.CancelRemoteTranscode(r.Context(), transportID, nodeURL); err != nil {
+				// applySession has already made this the live route. Keep its
+				// authority and reservation intact so a later stop can retry the
+				// cancellation instead of orphaning an admitted remote stream.
+				committed = true
+				adoptSuccessor()
+				releaseLifecycle()
+				return err
+			}
+		}
+		committed = true
+		if !requireCancellation && nodeURL != "" && transportID != "" {
+			h.tm.StopRemoteTranscode(transportID, nodeURL)
+		}
+		// The session never reached the client, so a proxy admitted for it
+		// must not keep consuming that node's job/bandwidth budget until the
+		// reservation ages out — nor keep an egress grant for a transport
+		// that was never committed.
+		if servedByProxy && !reservationReleased {
+			releaseReservation()
+			h.restoreProxyGrantV3(r.Context(), session.ID, priorGrant)
+		}
+		h.deleteNodeRecipeV3(r.Context(), transportID)
+		releaseLifecycle()
+		return nil
+	}
 	return preparedTransportV3{
 		url:                streamURL,
 		nodeURL:            nodeURL,
@@ -2690,34 +2731,13 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 				return
 			}
 			committed = true
-			h.tm.CloseTranscodeSession(session.ID, "")
-			if previousNodeURL != "" {
-				h.tm.StopRemoteTranscode(previousTransportID, previousNodeURL)
-				h.deleteNodeRecipeV3(r.Context(), previousTransportID)
-			}
-			h.revokeStaleProxyGrantOnCommitV3(r.Context(), session.ID, mode, servedByProxy)
-			h.applyRemoteTransportMarkV3(r.Context(), session.ID, servedByProxy)
+			adoptSuccessor()
 			releaseLifecycle()
 		},
 		rollback: func() {
-			if committed {
-				return
-			}
-			committed = true
-			if nodeURL != "" && transportID != "" {
-				h.tm.StopRemoteTranscode(transportID, nodeURL)
-			}
-			// The session never reached the client, so a proxy admitted for it
-			// must not keep consuming that node's job/bandwidth budget until the
-			// reservation ages out — nor keep an egress grant for a transport
-			// that was never committed.
-			if servedByProxy && !reservationReleased {
-				releaseReservation()
-				h.restoreProxyGrantV3(r.Context(), session.ID, priorGrant)
-			}
-			h.deleteNodeRecipeV3(r.Context(), transportID)
-			releaseLifecycle()
+			_ = rollbackTransport(false)
 		},
+		rollbackRequired: func() error { return rollbackTransport(true) },
 	}, nil
 }
 
@@ -3780,6 +3800,52 @@ func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *pla
 		egressNodeID = nodePlan.ProxyNode.ID
 		egressNodeURL = nodePlan.ProxyNode.URL
 	}
+	adoptSuccessor := func() {
+		h.tm.CloseTranscodeSession(session.ID, "")
+		if previousNodeURL != "" {
+			h.tm.StopRemoteTranscode(previousTransportID, previousNodeURL)
+			h.deleteNodeRecipeV3(r.Context(), previousTransportID)
+		}
+		h.revokeStaleProxyGrantOnCommitV3(r.Context(), session.ID, mode, servedByProxy)
+		h.applyRemoteTransportMarkV3(r.Context(), session.ID, servedByProxy)
+	}
+	rollbackTransport := func(requireCancellation bool) error {
+		if committed {
+			return nil
+		}
+		if requireCancellation {
+			if err := h.tm.CancelRemoteTranscode(r.Context(), transportID, node.URL); err != nil {
+				// Preserve the admitted successor route for a retryable stop. Its
+				// live session, authority, and reservation must continue to agree.
+				committed = true
+				adoptSuccessor()
+				unlock()
+				return err
+			}
+		} else {
+			h.tm.StopRemoteTranscode(transportID, node.URL)
+		}
+		committed = true
+		// The node job this recipe rebuilds is gone, so the recipe must go too.
+		h.deleteNodeRecipeV3(r.Context(), transportID)
+		// The accepted node job is gone; drop the planner reservation too so
+		// repeated failed starts cannot pin the node's max-job or bandwidth
+		// budget until the reservation ages out.
+		if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
+			releaser.ReleaseSession(session.ID)
+		}
+		// An egress grant written for a transport that never committed would
+		// point a proxy at a transcode that no longer exists.
+		if servedByProxy {
+			h.restoreProxyGrantV3(r.Context(), session.ID, priorGrant)
+		}
+		unlock()
+		return nil
+	}
+	var rollbackRequired func() error
+	if routingWorkloadV3(result) == noderouting.WorkloadRemux {
+		rollbackRequired = func() error { return rollbackTransport(true) }
+	}
 	return preparedTransportV3{url: url, nodeURL: node.URL, transportID: transportID, hwAccel: confirmedHWAccel, toneMapMode: confirmedToneMapMode,
 		routingWorkload: routingWorkloadV3(result), routingExecution: noderouting.ExecutionTranscode, routingExecutorID: node.ID, routingExecutorURL: node.URL,
 		routingEgress: routingEgress, routingEgressID: egressNodeID, routingEgressURL: egressNodeURL, commit: func() {
@@ -3787,35 +3853,11 @@ func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *pla
 				return
 			}
 			committed = true
-			h.tm.CloseTranscodeSession(session.ID, "")
-			if previousNodeURL != "" {
-				h.tm.StopRemoteTranscode(previousTransportID, previousNodeURL)
-				h.deleteNodeRecipeV3(r.Context(), previousTransportID)
-			}
-			h.revokeStaleProxyGrantOnCommitV3(r.Context(), session.ID, mode, servedByProxy)
-			h.applyRemoteTransportMarkV3(r.Context(), session.ID, servedByProxy)
+			adoptSuccessor()
 			unlock()
 		}, rollback: func() {
-			if committed {
-				return
-			}
-			committed = true
-			h.tm.StopRemoteTranscode(transportID, node.URL)
-			// The node job this recipe rebuilds is gone, so the recipe must go too.
-			h.deleteNodeRecipeV3(r.Context(), transportID)
-			// The accepted node job is gone; drop the planner reservation too so
-			// repeated failed starts cannot pin the node's max-job or bandwidth
-			// budget until the reservation ages out.
-			if releaser, ok := h.NodePlanner.(sessionReservationReleaserV3); ok {
-				releaser.ReleaseSession(session.ID)
-			}
-			// An egress grant written for a transport that never committed would
-			// point a proxy at a transcode that no longer exists.
-			if servedByProxy {
-				h.restoreProxyGrantV3(r.Context(), session.ID, priorGrant)
-			}
-			unlock()
-		}}, nil
+			_ = rollbackTransport(false)
+		}, rollbackRequired: rollbackRequired}, nil
 }
 
 // remoteTranscodeRecipeCardV3 captures the byte-affecting recipe of a started
@@ -4303,17 +4345,14 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 		}
 	}
 	if err := h.PlanStoreV3.CompleteReplan(r.Context(), sessionID, req.ReplanRequestID, lease.LeaseToken, record.CurrentReplanRequestID, encoded, updated); err != nil {
-		rollbackFailed := false
-		if rollbackSession != nil {
-			if rollbackErr := rollbackSession(); rollbackErr != nil {
-				rollbackFailed = true
-				slog.ErrorContext(r.Context(), "protocol v3 replacement rollback failed", "session", sessionID, "error", rollbackErr)
-			}
+		transportRollbackErr, sessionRollbackErr := rollbackFailedReplanV3(transport, rollbackSession)
+		if transportRollbackErr != nil {
+			slog.ErrorContext(r.Context(), "protocol v3 replacement transport cancellation failed", "session", sessionID, "error", transportRollbackErr)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to cancel the replacement transport")
+			return
 		}
-		if transport != nil {
-			transport.rollback()
-		}
-		if rollbackFailed {
+		if sessionRollbackErr != nil {
+			slog.ErrorContext(r.Context(), "protocol v3 replacement rollback failed", "session", sessionID, "error", sessionRollbackErr)
 			_ = h.stopPlaybackSessionByID(context.WithoutCancel(r.Context()), sessionID, false)
 		}
 		if errors.Is(err, playback.ErrReplanSupersededV3) {
@@ -4332,6 +4371,25 @@ func (h *PlaybackHandler) HandleReplanPlaybackV3(w http.ResponseWriter, r *http.
 	}
 	h.raceCopySafetyV3(updated.EffectiveMediaFileID, response.PlaybackPlan)
 	writeJSON(w, http.StatusOK, response)
+}
+
+// rollbackFailedReplanV3 cancels a remotely admitted replacement before it
+// restores the predecessor session. If cancellation cannot be confirmed, the
+// successor remains live and authoritative so a later stop can retry it.
+func rollbackFailedReplanV3(transport *preparedTransportV3, rollbackSession func() error) (transportErr, sessionErr error) {
+	if transport != nil {
+		if transport.rollbackRequired != nil {
+			if err := transport.rollbackRequired(); err != nil {
+				return err, nil
+			}
+		} else {
+			transport.rollback()
+		}
+	}
+	if rollbackSession != nil {
+		return nil, rollbackSession()
+	}
+	return nil, nil
 }
 
 // raceCopySafetyV3 resolves an unknown H.264 copy-safety verdict behind a plan
@@ -4805,6 +4863,7 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 		}
 	}
 	originalRollback := transport.rollback
+	originalRollbackRequired := transport.rollbackRequired
 	replacement := playback.SessionReplacement{
 		EffectiveMediaFileID: effectiveFile.ID,
 		StreamState:          h.v3SessionStreamState(r.Context(), session, effectiveFile, result, transport, mode),
@@ -4842,6 +4901,15 @@ func (h *PlaybackHandler) executeReplanV3(r *http.Request, record *playback.Atte
 	transport.rollback = func() {
 		originalRollback()
 		cancelReservation()
+	}
+	if originalRollbackRequired != nil {
+		transport.rollbackRequired = func() error {
+			if err := originalRollbackRequired(); err != nil {
+				return err
+			}
+			cancelReservation()
+			return nil
+		}
 	}
 	reservationHandedOff = true
 	return response, updated, &transport, nil

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2890,9 +2890,7 @@ func (h *PlaybackHandler) deleteNodeRecipeV3(ctx context.Context, transportID st
 // stop, not a best-effort cleanup: the caller must retain the session and let
 // the client retry.
 func (h *PlaybackHandler) deleteRequiredProgressiveRemuxAuthorityV3(ctx context.Context, session *playback.Session) error {
-	if session == nil || session.TranscodeTransportID == "" || session.TranscodeNodeURL == "" ||
-		session.RoutingWorkload != string(noderouting.WorkloadRemux) ||
-		session.RoutingExecution != string(noderouting.ExecutionTranscode) {
+	if !requiresProgressiveRemuxAuthorityV3(session) {
 		return nil
 	}
 	if h == nil || h.NodeRecipeStore == nil || !h.NodeRecipeStore.Enabled() {
@@ -2901,6 +2899,12 @@ func (h *PlaybackHandler) deleteRequiredProgressiveRemuxAuthorityV3(ctx context.
 	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), nodeRecipeWriteTimeoutV3)
 	defer cancel()
 	return h.NodeRecipeStore.Delete(deleteCtx, session.TranscodeTransportID)
+}
+
+func requiresProgressiveRemuxAuthorityV3(session *playback.Session) bool {
+	return session != nil && session.TranscodeTransportID != "" && session.TranscodeNodeURL != "" &&
+		session.RoutingWorkload == string(noderouting.WorkloadRemux) &&
+		session.RoutingExecution == string(noderouting.ExecutionTranscode)
 }
 
 // resolveIdentityRouteV3 resolves direct and progressive routes through the

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2844,6 +2844,25 @@ func (h *PlaybackHandler) deleteNodeRecipeV3(ctx context.Context, transportID st
 	}
 }
 
+// deleteRequiredProgressiveRemuxAuthorityV3 makes a user-visible stop durable
+// before the session and its retry path disappear. A progressive remux token
+// can remain valid for 24 hours, so an unavailable authority store is a failed
+// stop, not a best-effort cleanup: the caller must retain the session and let
+// the client retry.
+func (h *PlaybackHandler) deleteRequiredProgressiveRemuxAuthorityV3(ctx context.Context, session *playback.Session) error {
+	if session == nil || session.TranscodeTransportID == "" || session.TranscodeNodeURL == "" ||
+		session.RoutingWorkload != string(noderouting.WorkloadRemux) ||
+		session.RoutingExecution != string(noderouting.ExecutionTranscode) {
+		return nil
+	}
+	if h == nil || h.NodeRecipeStore == nil || !h.NodeRecipeStore.Enabled() {
+		return errors.New("node recipe store unavailable")
+	}
+	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), nodeRecipeWriteTimeoutV3)
+	defer cancel()
+	return h.NodeRecipeStore.Delete(deleteCtx, session.TranscodeTransportID)
+}
+
 // resolveIdentityRouteV3 resolves direct and progressive routes through the
 // same policy compiler as HLS, including the transcode-execution/proxy-egress
 // progressive route.

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2424,26 +2424,6 @@ func planRequiresServerTransformationsV3(plan *playback.PlanV3) bool {
 }
 
 func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, timeline preparedTimelineV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy, excludedShapes map[string]struct{}) (preparedTransportV3, *transportErrorV3) {
-	routeSession := *session
-	// The URL builders below refuse to mint a stream token for a session that
-	// requires media authorization. The live session only learns the mode when
-	// its stream state is committed, so stamp the route copy the builders see.
-	routeSession.RequireMediaAuthorization = mode.headerAuth
-	routeSession.PlayMethod = result.PlayMethod
-	routeSession.BasePlayMethod = result.PlayMethod
-	routeSession.MediaFileID = result.Plan.EffectiveMediaFileID
-	routeSession.AudioTrackIndex = plannedAudioTrackIndexV3(result, session.AudioTrackIndex)
-	routeSession.TranscodeAudio = result.TranscodeAudio
-	routeSession.TargetAudioCodec = result.TargetAudioCodec
-	routeSession.SourceAudioChannels = result.SourceAudioChannels
-	routeSession.TargetAudioChannels = result.TargetAudioChannels
-	routeSession.TargetAudioBitrateKbps = result.TargetAudioBitrateKbps
-	routeSession.RemuxDVMode = remuxDVModeForPlanV3(result.Plan)
-	// A replan starts without an egress identity. Do not let the previous
-	// proxy's row or internal URL leak into an API-served replacement route.
-	routeSession.RoutingEgressNodeID = 0
-	routeSession.RoutingEgressNodeURL = ""
-
 	// The shared resolver removes proxy shapes when this client cannot address
 	// an authorized origin, then applies the same policy ordering as every HLS
 	// path. Legacy and authorized-origin attempts differ only in URL authority.
@@ -2458,7 +2438,16 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			releaser.ReleaseSession(session.ID)
 		}
 	}
+	var unlockLifecycle func()
+	releaseLifecycle := func() {
+		if unlockLifecycle == nil {
+			return
+		}
+		unlockLifecycle()
+		unlockLifecycle = nil
+	}
 	fallbackFromSelectedRoute := func(routeErr *transportErrorV3) (preparedTransportV3, *transportErrorV3) {
+		releaseLifecycle()
 		releaseReservation()
 		fallbackExclusions := maps.Clone(excludedShapes)
 		if fallbackExclusions == nil {
@@ -2508,6 +2497,56 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			})
 		}
 	}
+
+	// A stop and a replacement must agree on the exact moment a progressive
+	// authority becomes externally usable. Re-read the session after entering
+	// their shared lifecycle boundary: if stop won, fail before publishing the
+	// successor recipe or proxy grant; if replacement won, stop waits until its
+	// commit or rollback has made that authority match the live session.
+	if h.beforeIdentityLifecycleLockV3 != nil {
+		h.beforeIdentityLifecycleLockV3()
+	}
+	unlockLifecycle = h.tm.LockSessionLifecycle(session.ID)
+	// Accepted start/replan plans always carry their live session ID. Low-level
+	// transport tests deliberately omit it so they can exercise route assembly
+	// without reconstructing the surrounding request transaction.
+	if result.Plan.SessionID != "" {
+		if result.Plan.SessionID != session.ID {
+			releaseLifecycle()
+			releaseReservation()
+			return preparedTransportV3{}, &transportErrorV3{
+				reason: "internal_error", message: "The playback plan does not belong to the session being prepared.",
+			}
+		}
+		currentSession, err := h.sessionMgr.GetSession(session.ID)
+		if err != nil {
+			releaseLifecycle()
+			releaseReservation()
+			return preparedTransportV3{}, &transportErrorV3{
+				reason: "session_expired", message: "The playback session ended before its route could be prepared.", retryable: true, cause: err,
+			}
+		}
+		session = currentSession
+	}
+	routeSession := *session
+	// The URL builders below refuse to mint a stream token for a session that
+	// requires media authorization. The live session only learns the mode when
+	// its stream state is committed, so stamp the route copy the builders see.
+	routeSession.RequireMediaAuthorization = mode.headerAuth
+	routeSession.PlayMethod = result.PlayMethod
+	routeSession.BasePlayMethod = result.PlayMethod
+	routeSession.MediaFileID = result.Plan.EffectiveMediaFileID
+	routeSession.AudioTrackIndex = plannedAudioTrackIndexV3(result, session.AudioTrackIndex)
+	routeSession.TranscodeAudio = result.TranscodeAudio
+	routeSession.TargetAudioCodec = result.TargetAudioCodec
+	routeSession.SourceAudioChannels = result.SourceAudioChannels
+	routeSession.TargetAudioChannels = result.TargetAudioChannels
+	routeSession.TargetAudioBitrateKbps = result.TargetAudioBitrateKbps
+	routeSession.RemuxDVMode = remuxDVModeForPlanV3(result.Plan)
+	// A replan starts without an egress identity. Do not let the previous
+	// proxy's row or internal URL leak into an API-served replacement route.
+	routeSession.RoutingEgressNodeID = 0
+	routeSession.RoutingEgressNodeURL = ""
 	routeSession.RoutingWorkload = string(routingWorkloadV3(result))
 	routeSession.RoutingExecution = string(decision.Shape.Execution)
 	routeSession.RoutingEgress = string(decision.Shape.Egress)
@@ -2583,6 +2622,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		}
 		releaseReservation()
 		if !identityLocalFallbackAllowedV3(result, policy) || h.validateLocalProgressiveCapabilitiesV3(r.Context(), result) != nil {
+			releaseLifecycle()
 			return preparedTransportV3{}, &transportErrorV3{
 				reason:    string(noderouting.OutcomeCapacityUnavailable),
 				message:   "The proxy egress route is temporarily unavailable.",
@@ -2593,7 +2633,6 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 
 	previousNodeURL := session.TranscodeNodeURL
 	previousTransportID := remoteTransportID(session)
-	unlock := h.tm.LockSessionLifecycle(session.ID)
 	committed := false
 	if result.Plan != nil && result.Plan.Delivery == playback.DeliveryRemuxProgressiveV3 {
 		if seek := timeline.seekSeconds; seek > 0 {
@@ -2658,7 +2697,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			}
 			h.revokeStaleProxyGrantOnCommitV3(r.Context(), session.ID, mode, servedByProxy)
 			h.applyRemoteTransportMarkV3(r.Context(), session.ID, servedByProxy)
-			unlock()
+			releaseLifecycle()
 		},
 		rollback: func() {
 			if committed {
@@ -2677,7 +2716,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 				h.restoreProxyGrantV3(r.Context(), session.ID, priorGrant)
 			}
 			h.deleteNodeRecipeV3(r.Context(), transportID)
-			unlock()
+			releaseLifecycle()
 		},
 	}, nil
 }

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2500,6 +2500,12 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	routeSession.RoutingWorkload = string(routingWorkloadV3(result))
 	routeSession.RoutingExecution = string(decision.Shape.Execution)
 	routeSession.RoutingEgress = string(decision.Shape.Egress)
+	routeSession.RoutingExecutionNodeID = 0
+	routeSession.RoutingExecutionNodeURL = ""
+	if executorNode != nil {
+		routeSession.RoutingExecutionNodeID = executorNode.ID
+		routeSession.RoutingExecutionNodeURL = executorNode.URL
+	}
 	if proxyNode != nil {
 		routeSession.RoutingEgressNodeID = proxyNode.ID
 		routeSession.RoutingEgressNodeURL = proxyNode.URL

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -2457,24 +2457,35 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			releaser.ReleaseSession(session.ID)
 		}
 	}
+	fallbackFromSelectedRoute := func(routeErr *transportErrorV3) (preparedTransportV3, *transportErrorV3) {
+		releaseReservation()
+		fallbackExclusions := maps.Clone(excludedShapes)
+		if fallbackExclusions == nil {
+			fallbackExclusions = make(map[string]struct{})
+		}
+		fallbackExclusions[decision.Shape.ID] = struct{}{}
+		fallback, fallbackErr := h.prepareIdentityTransportV3(r, session, file, result, timeline, mode, policy, fallbackExclusions)
+		if fallbackErr == nil {
+			return fallback, nil
+		}
+		return preparedTransportV3{}, combineTransportErrorsV3(routeErr, fallbackErr)
+	}
 	if transcodeNode != nil {
 		transcodeCapabilities, capabilityErr := h.lookupRemoteCapabilitiesV3(r.Context(), transcodeNode.URL, false)
 		if capabilityErr != nil || !slices.Contains(transcodeCapabilities.transportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
-			releaseReservation()
-			return preparedTransportV3{}, &transportErrorV3{
+			return fallbackFromSelectedRoute(&transportErrorV3{
 				reason: routeCapabilityUnavailableReasonV3, message: "The selected transcode node cannot execute a progressive remux.",
 				retryable: true, cause: capabilityErr,
-			}
+			})
 		}
 	}
 	if transcodeNode != nil && proxyNode != nil {
 		proxyCapabilities, capabilityErr := h.lookupRemoteCapabilitiesV3(r.Context(), proxyNode.URL, false)
 		if capabilityErr != nil || !slices.Contains(proxyCapabilities.transportFeatures, playback.TransportFeatureProgressiveRemuxRelayV1) {
-			releaseReservation()
-			return preparedTransportV3{}, &transportErrorV3{
+			return fallbackFromSelectedRoute(&transportErrorV3{
 				reason: routeCapabilityUnavailableReasonV3, message: "The selected proxy cannot relay a progressive remux from a transcode node.",
 				retryable: true, cause: capabilityErr,
-			}
+			})
 		}
 	}
 	var executorNode *nodepool.Node
@@ -2490,11 +2501,10 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 			capabilityErr = validateAdvertisedTransformationsV3(result.Plan, advertised)
 		}
 		if capabilityErr != nil {
-			releaseReservation()
-			return preparedTransportV3{}, &transportErrorV3{
+			return fallbackFromSelectedRoute(&transportErrorV3{
 				reason: routeCapabilityUnavailableReasonV3, message: "The selected node cannot execute the progressive-remux recipe.",
 				retryable: true, cause: capabilityErr,
-			}
+			})
 		}
 	}
 	routeSession.RoutingWorkload = string(routingWorkloadV3(result))
@@ -2524,21 +2534,11 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		card.DVProfile = file.PrimaryDVProfile()
 		card.AudioOnly = file.IsAudioOnly()
 		if err := h.putRequiredNodeRecipeV3(r.Context(), transportID, card); err != nil {
-			releaseReservation()
 			h.deleteNodeRecipeV3(r.Context(), transportID)
 			authorityErr := &transportErrorV3{
 				reason: string(noderouting.OutcomeCapacityUnavailable), message: "The transcode remux authority is temporarily unavailable.", retryable: true, cause: err,
 			}
-			fallbackExclusions := maps.Clone(excludedShapes)
-			if fallbackExclusions == nil {
-				fallbackExclusions = make(map[string]struct{})
-			}
-			fallbackExclusions[decision.Shape.ID] = struct{}{}
-			fallback, fallbackErr := h.prepareIdentityTransportV3(r, session, file, result, timeline, mode, policy, fallbackExclusions)
-			if fallbackErr == nil {
-				return fallback, nil
-			}
-			return fallback, combineTransportErrorsV3(authorityErr, fallbackErr)
+			return fallbackFromSelectedRoute(authorityErr)
 		}
 	}
 	streamURL := fmt.Sprintf("/stream/%s", routeSession.ID)
@@ -2572,24 +2572,15 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		// it is reported as such: the HLS path classifies the identical
 		// proxy-authority failure retryable, and a non-retryable answer would
 		// make a client give up on a route the next attempt can take.
-		releaseReservation()
 		reservationReleased = true
 		if transcodeNode != nil {
 			h.deleteNodeRecipeV3(r.Context(), transportID)
 			grantErr := &transportErrorV3{
 				reason: string(noderouting.OutcomeCapacityUnavailable), message: "The transcode-to-proxy remux route is temporarily unavailable.", retryable: true,
 			}
-			fallbackExclusions := maps.Clone(excludedShapes)
-			if fallbackExclusions == nil {
-				fallbackExclusions = make(map[string]struct{})
-			}
-			fallbackExclusions[decision.Shape.ID] = struct{}{}
-			fallback, fallbackErr := h.prepareIdentityTransportV3(r, session, file, result, timeline, mode, policy, fallbackExclusions)
-			if fallbackErr == nil {
-				return fallback, nil
-			}
-			return preparedTransportV3{}, combineTransportErrorsV3(grantErr, fallbackErr)
+			return fallbackFromSelectedRoute(grantErr)
 		}
+		releaseReservation()
 		if !identityLocalFallbackAllowedV3(result, policy) || h.validateLocalProgressiveCapabilitiesV3(r.Context(), result) != nil {
 			return preparedTransportV3{}, &transportErrorV3{
 				reason:    string(noderouting.OutcomeCapacityUnavailable),

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -2168,7 +2169,7 @@ func (h *PlaybackHandler) prepareTransportWithPolicyAndExclusionsV3(
 		return preparedTransportV3{}, timelineErr
 	}
 	if result.Plan.Delivery != playback.DeliveryTranscodeHLSV3 && result.Plan.Delivery != playback.DeliveryRemuxHLSV3 {
-		return h.prepareIdentityTransportV3(r, session, file, result, timeline, mode, policy)
+		return h.prepareIdentityTransportV3(r, session, file, result, timeline, mode, policy, initialExcludedShapes)
 	}
 	proxyAllowed := mode.proxyEgress || (!mode.headerAuth && h.JWTSecret != "")
 	excludedNodes := make(map[string]struct{})
@@ -2421,7 +2422,7 @@ func planRequiresServerTransformationsV3(plan *playback.PlanV3) bool {
 	return false
 }
 
-func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, timeline preparedTimelineV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy) (preparedTransportV3, *transportErrorV3) {
+func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *playback.Session, file *models.MediaFile, result playback.PlannerResultV3, timeline preparedTimelineV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy, excludedShapes map[string]struct{}) (preparedTransportV3, *transportErrorV3) {
 	routeSession := *session
 	// The URL builders below refuse to mint a stream token for a session that
 	// requires media authorization. The live session only learns the mode when
@@ -2445,7 +2446,7 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 	// The shared resolver removes proxy shapes when this client cannot address
 	// an authorized origin, then applies the same policy ordering as every HLS
 	// path. Legacy and authorized-origin attempts differ only in URL authority.
-	decision, routeErr := h.resolveIdentityRouteV3(r, session.ID, result, mode, policy)
+	decision, routeErr := h.resolveIdentityRouteV3(r, session.ID, result, mode, policy, excludedShapes)
 	if routeErr != nil {
 		return preparedTransportV3{}, routeErr
 	}
@@ -2518,9 +2519,20 @@ func (h *PlaybackHandler) prepareIdentityTransportV3(r *http.Request, session *p
 		card.AudioOnly = file.IsAudioOnly()
 		if err := h.putRequiredNodeRecipeV3(r.Context(), transportID, card); err != nil {
 			releaseReservation()
-			return preparedTransportV3{}, &transportErrorV3{
+			h.deleteNodeRecipeV3(r.Context(), transportID)
+			authorityErr := &transportErrorV3{
 				reason: string(noderouting.OutcomeCapacityUnavailable), message: "The transcode remux authority is temporarily unavailable.", retryable: true, cause: err,
 			}
+			fallbackExclusions := maps.Clone(excludedShapes)
+			if fallbackExclusions == nil {
+				fallbackExclusions = make(map[string]struct{})
+			}
+			fallbackExclusions[decision.Shape.ID] = struct{}{}
+			fallback, fallbackErr := h.prepareIdentityTransportV3(r, session, file, result, timeline, mode, policy, fallbackExclusions)
+			if fallbackErr == nil {
+				return fallback, nil
+			}
+			return fallback, combineTransportErrorsV3(authorityErr, fallbackErr)
 		}
 	}
 	streamURL := fmt.Sprintf("/stream/%s", routeSession.ID)
@@ -2825,13 +2837,16 @@ func (h *PlaybackHandler) deleteNodeRecipeV3(ctx context.Context, transportID st
 // resolveIdentityRouteV3 resolves direct and progressive routes through the
 // same policy compiler as HLS, including the transcode-execution/proxy-egress
 // progressive route.
-func (h *PlaybackHandler) resolveIdentityRouteV3(r *http.Request, sessionID string, result playback.PlannerResultV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy) (noderouting.Decision, *transportErrorV3) {
+func (h *PlaybackHandler) resolveIdentityRouteV3(r *http.Request, sessionID string, result playback.PlannerResultV3, mode mediaAuthModeV3, policy config.PlaybackRoutingPolicy, initialExcludedShapes map[string]struct{}) (noderouting.Decision, *transportErrorV3) {
 	workload, delivery, ok := routingClassV3(result)
 	if !ok {
 		return noderouting.Decision{}, &transportErrorV3{reason: string(noderouting.OutcomePolicyUnsatisfied), message: "The playback delivery has no legal node route.", retryable: false}
 	}
 	proxyAllowed := mode.proxyEgress || (!mode.headerAuth && h.JWTSecret != "")
-	excludedShapes := make(map[string]struct{})
+	excludedShapes := maps.Clone(initialExcludedShapes)
+	if excludedShapes == nil {
+		excludedShapes = make(map[string]struct{})
+	}
 	if result.Plan != nil && result.Plan.Delivery == playback.DeliveryRemuxProgressiveV3 &&
 		h.validateLocalProgressiveCapabilitiesV3(r.Context(), result) != nil {
 		excludedShapes[noderouting.ShapeProgressiveRemuxAPI] = struct{}{}

--- a/internal/api/handlers/playback_v3_node_recipe_test.go
+++ b/internal/api/handlers/playback_v3_node_recipe_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -483,6 +484,77 @@ func TestStopPlaybackWaitsForReplacementAndRevokesItsCurrentAuthority(t *testing
 	}
 	if _, err := manager.GetSession(session.ID); !errors.Is(err, playback.ErrSessionNotFound) {
 		t.Fatalf("session after stop = %v, want not found", err)
+	}
+}
+
+func TestPrepareProgressiveTransportPublishesAuthorityInsideLifecycleBoundary(t *testing.T) {
+	manager := playback.NewSessionManager(0, 0)
+	session, err := manager.StartSession(7, "profile-1", 42, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy := capableProxyStubV3(t)
+	transcode := progressiveRemuxExecutionStubV3(t)
+	handler := NewPlaybackHandler(manager)
+	handler.NodePlanner = &recordingNodePlannerV3{plan: nodepool.Plan{
+		ProxyNode:     &nodepool.Node{ID: 42, URL: proxy.URL},
+		TranscodeNode: &nodepool.Node{ID: 84, URL: transcode.URL},
+	}}
+	recipes := &recordingRecipeCardStoreV3{}
+	grants := &recordingRecipeCardStoreV3{}
+	handler.NodeRecipeStore = recipes
+	handler.ProxyGrantStore = grants
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	reachedLifecycle := make(chan struct{})
+	handler.beforeIdentityLifecycleLockV3 = sync.OnceFunc(func() { close(reachedLifecycle) })
+	unlockStop := handler.tm.LockSessionLifecycle(session.ID)
+	locked := true
+	defer func() {
+		if locked {
+			unlockStop()
+		}
+	}()
+
+	plan := identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3)
+	plan.SessionID = session.ID
+	result := playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux, TargetAudioCodec: "aac"}
+	prepared := make(chan *transportErrorV3, 1)
+	go func() {
+		_, transportErr := handler.prepareTransportV3(
+			httptest.NewRequest(http.MethodPost, "/", nil), session, v3HandlerFixtureFile(t), result, authorizedOriginsModeV3())
+		prepared <- transportErr
+	}()
+
+	select {
+	case <-reachedLifecycle:
+	case <-time.After(2 * time.Second):
+		t.Fatal("transport preparation did not reach the lifecycle boundary")
+	}
+	if len(recipes.cards) != 0 || len(grants.cards) != 0 {
+		t.Fatalf("authority published before lifecycle lock: recipes=%v grants=%v", recipes.cards, grants.cards)
+	}
+	// Model stop after it acquired this boundary: the session disappears before
+	// the waiting replacement can enter and publish its successor authority.
+	if err := manager.StopSession(session.ID); err != nil {
+		t.Fatal(err)
+	}
+	unlockStop()
+	locked = false
+
+	select {
+	case transportErr := <-prepared:
+		if transportErr == nil || transportErr.reason != "session_expired" || !transportErr.retryable {
+			t.Fatalf("transport error = %#v, want retryable session_expired", transportErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("transport preparation did not resume after stop released the lifecycle boundary")
+	}
+	if len(recipes.cards) != 0 || len(grants.cards) != 0 {
+		t.Fatalf("stopped session retained successor authority: recipes=%v grants=%v", recipes.cards, grants.cards)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_node_recipe_test.go
+++ b/internal/api/handlers/playback_v3_node_recipe_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -403,6 +404,71 @@ func TestStopPlaybackRetainsProgressiveSessionUntilAuthorityRevocationSucceeds(t
 	}
 	if _, err := manager.GetSession(session.ID); !errors.Is(err, playback.ErrSessionNotFound) {
 		t.Fatalf("session after successful retry = %v, want not found", err)
+	}
+}
+
+func TestStopPlaybackRetainsProgressiveSessionUntilRemoteCancellationSucceeds(t *testing.T) {
+	requests := 0
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		switch requests {
+		case 1:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case 2:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer node.Close()
+
+	manager := playback.NewSessionManager(0, 0)
+	session, err := manager.StartSession(7, "profile-1", 42, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const transportID = "session-required-cancel-plan0001-aaaabbbb"
+	if err := manager.SetTranscodeRoute(session.ID, playback.TranscodeRoute{NodeURL: node.URL, TransportID: transportID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SetNodeRoutingAssignment(session.ID, playback.NodeRoutingAssignment{
+		Workload: string(noderouting.WorkloadRemux), Execution: string(noderouting.ExecutionTranscode),
+		Egress: string(noderouting.EgressProxy),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	session, err = manager.GetSession(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewPlaybackHandler(manager)
+	recipes := &recordingRecipeCardStoreV3{cards: map[string]playback.RecipeCard{
+		transportID: {SessionID: session.ID, TranscodeTransportID: transportID},
+	}}
+	handler.NodeRecipeStore = recipes
+	stopErr := handler.stopPlaybackSession(t.Context(), session, true)
+	if stopErr == nil || !strings.Contains(stopErr.Error(), "cancel progressive remux transport") {
+		t.Fatalf("stop error = %v, want remote cancellation failure", stopErr)
+	}
+	if _, err := manager.GetSession(session.ID); err != nil {
+		t.Fatalf("failed cancellation removed the retryable playback session: %v", err)
+	}
+	if _, ok := recipes.cards[transportID]; ok {
+		t.Fatal("failed cancellation left authority that could admit another remote process")
+	}
+	if requests != 1 {
+		t.Fatalf("remote cancellation requests = %d, want 1", requests)
+	}
+
+	if err := handler.stopPlaybackSession(t.Context(), session, true); err != nil {
+		t.Fatalf("retry stop after node recovery: %v", err)
+	}
+	if _, err := manager.GetSession(session.ID); !errors.Is(err, playback.ErrSessionNotFound) {
+		t.Fatalf("session after successful retry = %v, want not found", err)
+	}
+	if requests != 3 {
+		t.Fatalf("remote cancellation requests = %d, want required retry plus idempotent final cleanup", requests)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_node_recipe_test.go
+++ b/internal/api/handlers/playback_v3_node_recipe_test.go
@@ -275,6 +275,98 @@ func TestPrepareProgressiveTransportRollbackStopsAdmittedRemoteJob(t *testing.T)
 	}
 }
 
+func TestPrepareProgressiveTransportRequiredRollbackPreservesRetryableRoute(t *testing.T) {
+	deleteRequests := 0
+	predecessorDeleteRequests := 0
+	predecessor := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/transcode/predecessor-transport" {
+			predecessorDeleteRequests++
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(predecessor.Close)
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/hw-capabilities":
+			writeJSON(w, http.StatusOK, playback.HWAccelInfo{
+				TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxExecutionV1},
+				Transformations: []playback.TransformationV3{{
+					Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3,
+					RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3,
+				}},
+			})
+		case r.Method == http.MethodDelete:
+			deleteRequests++
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(node.Close)
+	proxy := capableProxyStubV3(t)
+	recipes := &recordingRecipeCardStoreV3{cards: map[string]playback.RecipeCard{
+		"predecessor-transport": {},
+	}}
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	handler.NodeRecipeStore = recipes
+	handler.NodePlanner = &recordingNodePlannerV3{plan: nodepool.Plan{
+		TranscodeNode: &nodepool.Node{ID: 84, URL: node.URL},
+		ProxyNode:     &nodepool.Node{ID: 42, URL: proxy.URL},
+	}}
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	plan := identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3, playback.TransformationV3{
+		Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3,
+		RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3,
+	})
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{
+			ID: "session-progressive-required-rollback", UserID: 7, ProfileID: "profile-1",
+			TranscodeNodeURL: predecessor.URL, TranscodeTransportID: "predecessor-transport",
+		},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux, TranscodeAudio: true, SourceAudioChannels: 6, TargetAudioChannels: 2, TargetAudioCodec: "aac"},
+		mediaAuthModeV3{},
+	)
+	if transportErr != nil {
+		t.Fatalf("prepare progressive transport: %v", transportErr)
+	}
+	if transport.rollbackRequired == nil {
+		t.Fatal("remote progressive transport has no required rollback")
+	}
+
+	if err := transport.rollbackRequired(); err == nil {
+		t.Fatal("required rollback succeeded despite the node rejecting cancellation")
+	}
+	if deleteRequests != 1 {
+		t.Fatalf("delete requests = %d, want one synchronous cancellation", deleteRequests)
+	}
+	if slices.Contains(recipes.deleted, transport.transportID) {
+		t.Fatal("failed cancellation deleted the authority needed by the retryable live route")
+	}
+	if _, ok := recipes.cards[transport.transportID]; !ok {
+		t.Fatal("failed cancellation did not preserve the node recipe authority")
+	}
+	if predecessorDeleteRequests != 1 {
+		t.Fatalf("predecessor delete requests = %d, want one best-effort teardown", predecessorDeleteRequests)
+	}
+	if _, ok := recipes.cards["predecessor-transport"]; ok {
+		t.Fatal("retained successor left the displaced predecessor recipe authoritative")
+	}
+
+	// A cancellation failure must still release the lifecycle boundary so the
+	// retrying stop can acquire it instead of deadlocking behind this request.
+	unlock := handler.tm.LockSessionLifecycle("session-progressive-required-rollback")
+	unlock()
+}
+
 // A legacy attempt carries its whole recipe in the client's stream token, which
 // the relay forwards to the node. It needs no stored copy, and writing one would
 // put a media path in Redis for no reason.

--- a/internal/api/handlers/playback_v3_node_recipe_test.go
+++ b/internal/api/handlers/playback_v3_node_recipe_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
+	"github.com/Silo-Server/silo-server/internal/noderouting"
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/transcodenode"
 )
@@ -293,6 +294,54 @@ func TestFinalizeSessionStopDropsTheNodeRecipe(t *testing.T) {
 
 	if len(recipes.deleted) != 1 || recipes.deleted[0] != transportID {
 		t.Fatalf("recipes deleted on stop = %v, want the session's transport recipe dropped", recipes.deleted)
+	}
+}
+
+func TestStopPlaybackRetainsProgressiveSessionUntilAuthorityRevocationSucceeds(t *testing.T) {
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer node.Close()
+
+	manager := playback.NewSessionManager(0, 0)
+	session, err := manager.StartSession(7, "profile-1", 42, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const transportID = "session-required-stop-plan0001-aaaabbbb"
+	if err := manager.SetTranscodeRoute(session.ID, playback.TranscodeRoute{NodeURL: node.URL, TransportID: transportID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SetNodeRoutingAssignment(session.ID, playback.NodeRoutingAssignment{
+		Workload: string(noderouting.WorkloadRemux), Execution: string(noderouting.ExecutionTranscode),
+		Egress: string(noderouting.EgressProxy),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	session, err = manager.GetSession(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewPlaybackHandler(manager)
+	recipes := &recordingRecipeCardStoreV3{deleteErr: errors.New("redis is down")}
+	handler.NodeRecipeStore = recipes
+	if err := handler.stopPlaybackSession(t.Context(), session, true); err == nil {
+		t.Fatal("stop succeeded without durable progressive authority revocation")
+	}
+	if _, err := manager.GetSession(session.ID); err != nil {
+		t.Fatalf("failed stop removed the retryable playback session: %v", err)
+	}
+	if len(recipes.deleted) != 1 || recipes.deleted[0] != transportID {
+		t.Fatalf("authority deletion attempts = %v, want [%q]", recipes.deleted, transportID)
+	}
+
+	recipes.deleteErr = nil
+	if err := handler.stopPlaybackSession(t.Context(), session, true); err != nil {
+		t.Fatalf("retry stop after authority recovery: %v", err)
+	}
+	if _, err := manager.GetSession(session.ID); !errors.Is(err, playback.ErrSessionNotFound) {
+		t.Fatalf("session after successful retry = %v, want not found", err)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_node_recipe_test.go
+++ b/internal/api/handlers/playback_v3_node_recipe_test.go
@@ -213,6 +213,64 @@ func TestPrepareTransportV3HeaderAuthStoresTheNodeRecipeForRestartRecovery(t *te
 	}
 }
 
+func TestPrepareProgressiveTransportRollbackStopsAdmittedRemoteJob(t *testing.T) {
+	var stoppedPath string
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/hw-capabilities":
+			writeJSON(w, http.StatusOK, playback.HWAccelInfo{
+				TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxExecutionV1},
+				Transformations: []playback.TransformationV3{{
+					Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3,
+					RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3,
+				}},
+			})
+		case r.Method == http.MethodDelete:
+			stoppedPath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(node.Close)
+	proxy := capableProxyStubV3(t)
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	handler.NodeRecipeStore = &recordingRecipeCardStoreV3{}
+	handler.NodePlanner = &recordingNodePlannerV3{plan: nodepool.Plan{
+		TranscodeNode: &nodepool.Node{ID: 84, URL: node.URL},
+		ProxyNode:     &nodepool.Node{ID: 42, URL: proxy.URL},
+	}}
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	plan := identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3, playback.TransformationV3{
+		Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3,
+		RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3,
+	})
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-progressive-rollback", UserID: 7, ProfileID: "profile-1"},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux, TranscodeAudio: true, SourceAudioChannels: 6, TargetAudioChannels: 2, TargetAudioCodec: "aac"},
+		mediaAuthModeV3{},
+	)
+	if transportErr != nil {
+		t.Fatalf("prepare progressive transport: %v", transportErr)
+	}
+	if transport.routingExecution != noderouting.ExecutionTranscode {
+		t.Fatalf("routing execution = %q, want transcode", transport.routingExecution)
+	}
+
+	transport.rollback()
+
+	if want := "/transcode/" + transport.transportID; stoppedPath != want {
+		t.Fatalf("remote stop path = %q, want %q", stoppedPath, want)
+	}
+}
+
 // A legacy attempt carries its whole recipe in the client's stream token, which
 // the relay forwards to the node. It needs no stored copy, and writing one would
 // put a media path in Redis for no reason.

--- a/internal/api/handlers/playback_v3_node_recipe_test.go
+++ b/internal/api/handlers/playback_v3_node_recipe_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
@@ -400,6 +402,87 @@ func TestStopPlaybackRetainsProgressiveSessionUntilAuthorityRevocationSucceeds(t
 	}
 	if _, err := manager.GetSession(session.ID); !errors.Is(err, playback.ErrSessionNotFound) {
 		t.Fatalf("session after successful retry = %v, want not found", err)
+	}
+}
+
+func TestStopPlaybackWaitsForReplacementAndRevokesItsCurrentAuthority(t *testing.T) {
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer node.Close()
+
+	manager := playback.NewSessionManager(0, 0)
+	session, err := manager.StartSession(7, "profile-1", 42, playback.PlayRemux, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const oldTransportID = "session-stop-race-old-plan"
+	const newTransportID = "session-stop-race-new-plan"
+	if err := manager.SetTranscodeRoute(session.ID, playback.TranscodeRoute{NodeURL: node.URL, TransportID: oldTransportID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.SetNodeRoutingAssignment(session.ID, playback.NodeRoutingAssignment{
+		Workload: string(noderouting.WorkloadRemux), Execution: string(noderouting.ExecutionTranscode),
+		Egress: string(noderouting.EgressProxy),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	staleSession, err := manager.GetSession(session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := NewPlaybackHandler(manager)
+	recipes := &recordingRecipeCardStoreV3{cards: map[string]playback.RecipeCard{
+		oldTransportID: {SessionID: session.ID, TranscodeTransportID: oldTransportID},
+		newTransportID: {SessionID: session.ID, TranscodeTransportID: newTransportID},
+	}}
+	handler.NodeRecipeStore = recipes
+
+	// Model a replan after it has installed its successor in the session manager
+	// but before it has committed the durable plan and released the lifecycle
+	// boundary. The stop receives the intentionally stale predecessor copy.
+	unlockReplacement := handler.tm.LockSessionLifecycle(session.ID)
+	locked := true
+	defer func() {
+		if locked {
+			unlockReplacement()
+		}
+	}()
+	if _, err := manager.ApplyReplacement(session.ID, playback.SessionReplacement{
+		EffectiveMediaFileID: 42,
+		StreamState: playback.SessionStreamState{
+			PlayMethod: playback.PlayRemux, TranscodeNodeURL: node.URL, TranscodeTransportID: newTransportID, TranscodeRouteSet: true,
+			RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode), RoutingEgress: string(noderouting.EgressProxy),
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- handler.stopPlaybackSession(t.Context(), staleSession, true)
+	}()
+	select {
+	case stopErr := <-stopDone:
+		t.Fatalf("stop crossed the in-flight replacement boundary: %v", stopErr)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	unlockReplacement()
+	locked = false
+	select {
+	case stopErr := <-stopDone:
+		if stopErr != nil {
+			t.Fatal(stopErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("stop did not resume after the replacement committed")
+	}
+	if !slices.Equal(recipes.deleted, []string{newTransportID, newTransportID}) {
+		t.Fatalf("deleted recipe authorities = %v, want only the current replacement transport", recipes.deleted)
+	}
+	if _, err := manager.GetSession(session.ID); !errors.Is(err, playback.ErrSessionNotFound) {
+		t.Fatalf("session after stop = %v, want not found", err)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_origins_test.go
+++ b/internal/api/handlers/playback_v3_origins_test.go
@@ -344,8 +344,8 @@ func TestPrepareTransportV3AuthorizedOriginsDoNotFallBackToAnIncapableAPI(t *tes
 	if transportErr.reason != string(noderouting.OutcomeCapacityUnavailable) || !transportErr.retryable {
 		t.Fatalf("transport error = %#v, want a retryable proxy-egress capacity failure", transportErr)
 	}
-	if len(planner.released) != 1 {
-		t.Fatalf("planner releases = %v, want the unusable proxy reservation released", planner.released)
+	if len(planner.released) != 2 {
+		t.Fatalf("planner releases = %v, want the unusable transcode and proxy reservations released", planner.released)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_origins_test.go
+++ b/internal/api/handlers/playback_v3_origins_test.go
@@ -325,6 +325,7 @@ func TestPrepareTransportV3AuthorizedOriginsDoNotFallBackToAnIncapableAPI(t *tes
 	planner := &recordingNodePlannerV3{plan: nodepool.Plan{ProxyNode: &nodepool.Node{URL: proxy.URL}}}
 	handler.NodePlanner = planner
 	handler.ProxyGrantStore = &recordingRecipeCardStoreV3{putErr: errors.New("redis is down")}
+	handler.NodeRecipeStore = &recordingRecipeCardStoreV3{}
 
 	transport, transportErr := handler.prepareTransportV3(
 		httptest.NewRequest(http.MethodPost, "/", nil),

--- a/internal/api/handlers/playback_v3_origins_test.go
+++ b/internal/api/handlers/playback_v3_origins_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
 	"github.com/Silo-Server/silo-server/internal/noderouting"
 	"github.com/Silo-Server/silo-server/internal/playback"
@@ -311,6 +312,51 @@ func TestPrepareTransportV3AuthorizedOriginsRefuseLocalRemuxWhenTheGrantFails(t 
 	}
 	if len(planner.released) != 1 {
 		t.Fatalf("planner releases = %v, want the unusable proxy reservation released", planner.released)
+	}
+}
+
+func TestPrepareTransportV3AuthorizedOriginsFallsBackWhenTranscodeProxyGrantFails(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	stubCopySeekAnchorV3(handler)
+	proxyServer := capableProxyStubV3(t)
+	transcodeServer := progressiveRemuxExecutionStubV3(t)
+	planner := &progressiveFallbackPlannerV3{
+		proxy:     &nodepool.Node{ID: 42, URL: proxyServer.URL},
+		transcode: &nodepool.Node{ID: 84, URL: transcodeServer.URL},
+	}
+	handler.NodePlanner = planner
+	recipes := &recordingRecipeCardStoreV3{}
+	handler.NodeRecipeStore = recipes
+	handler.ProxyGrantStore = &recordingRecipeCardStoreV3{putErr: errors.New("redis is down")}
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-origin-grant-fallback", UserID: 7, ProfileID: "profile-1"},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3), PlayMethod: playback.PlayRemux},
+		authorizedOriginsModeV3())
+	if transportErr != nil {
+		t.Fatalf("prepare identity transport: %v", transportErr)
+	}
+	defer transport.rollback()
+
+	if transport.url != "/stream/session-origin-grant-fallback" ||
+		transport.routingExecution != noderouting.ExecutionAPI || transport.nodeURL != "" {
+		t.Fatalf("fallback transport = %#v, want API-executed remux", transport)
+	}
+	if len(planner.requests) != 2 || !planner.requests[0].NeedsTranscode || !planner.requests[0].NeedsProxy ||
+		planner.requests[1].NeedsTranscode || !planner.requests[1].NeedsProxy {
+		t.Fatalf("route requests = %#v, want transcode+proxy then proxy-only", planner.requests)
+	}
+	if len(planner.released) != 2 {
+		t.Fatalf("released reservations = %v, want both unusable proxy routes released", planner.released)
+	}
+	if len(recipes.deleted) != 1 {
+		t.Fatalf("node authority cleanup = %v, want failed transport deleted", recipes.deleted)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_origins_test.go
+++ b/internal/api/handlers/playback_v3_origins_test.go
@@ -21,10 +21,11 @@ import (
 // restarted transcode node would rebuild from, so a test can assert on the
 // authority the URL depends on rather than only on the URL's shape.
 type recordingRecipeCardStoreV3 struct {
-	disabled bool
-	putErr   error
-	cards    map[string]playback.RecipeCard
-	deleted  []string
+	disabled  bool
+	putErr    error
+	deleteErr error
+	cards     map[string]playback.RecipeCard
+	deleted   []string
 	// ops is the ordered call log ("get", "put", "delete"), so a test can
 	// assert that a replan read the grant it displaced before overwriting it.
 	ops []string
@@ -56,6 +57,9 @@ func (s *recordingRecipeCardStoreV3) Put(_ context.Context, sessionID string, ca
 func (s *recordingRecipeCardStoreV3) Delete(_ context.Context, sessionID string) error {
 	s.ops = append(s.ops, "delete")
 	s.deleted = append(s.deleted, sessionID)
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
 	delete(s.cards, sessionID)
 	return nil
 }

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -5266,11 +5266,12 @@ func TestPrepareTransportV3RunsProgressiveRemuxOnTranscodeNodeThroughProxy(t *te
 		t.Fatal(err)
 	}
 	if claims.TranscodeNode != transcode.URL || claims.TranscodeTransportID != transport.transportID ||
-		claims.RoutingExecution != string(noderouting.ExecutionTranscode) || claims.RoutingEgressNodeID != proxy.ID {
+		claims.RoutingExecution != string(noderouting.ExecutionTranscode) || claims.RoutingExecutionNodeID != transcode.ID ||
+		claims.RoutingEgressNodeID != proxy.ID {
 		t.Fatalf("claims = %#v, want bound transcode-to-proxy route", claims)
 	}
 	stored, ok := recipes.cards[transport.transportID]
-	if !ok || stored.TranscodeTransportID != transport.transportID || stored.InputPath == "" {
+	if !ok || stored.TranscodeTransportID != transport.transportID || stored.RoutingExecutionNodeID != transcode.ID || stored.InputPath == "" {
 		t.Fatalf("durable remux authority = %#v, want active transport %q", stored, transport.transportID)
 	}
 }

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -5194,6 +5194,8 @@ func TestPrepareTransportV3RunsProgressiveRemuxOnTranscodeNodeThroughProxy(t *te
 	proxy := &nodepool.Node{ID: 42, URL: proxyServer.URL}
 	transcode := &nodepool.Node{ID: 84, URL: transcodeServer.URL}
 	handler.NodePlanner = &recordingNodePlannerV3{plan: nodepool.Plan{ProxyNode: proxy, TranscodeNode: transcode}}
+	recipes := &recordingRecipeCardStoreV3{}
+	handler.NodeRecipeStore = recipes
 	policy := config.DefaultPlaybackRoutingPolicy()
 	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
 	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
@@ -5225,6 +5227,38 @@ func TestPrepareTransportV3RunsProgressiveRemuxOnTranscodeNodeThroughProxy(t *te
 	if claims.TranscodeNode != transcode.URL || claims.TranscodeTransportID != transport.transportID ||
 		claims.RoutingExecution != string(noderouting.ExecutionTranscode) || claims.RoutingEgressNodeID != proxy.ID {
 		t.Fatalf("claims = %#v, want bound transcode-to-proxy route", claims)
+	}
+	stored, ok := recipes.cards[transport.transportID]
+	if !ok || stored.TranscodeTransportID != transport.transportID || stored.InputPath == "" {
+		t.Fatalf("durable remux authority = %#v, want active transport %q", stored, transport.transportID)
+	}
+}
+
+func TestPrepareTransportV3ExcludesTranscodeRemuxWithoutDurableAuthority(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	stubCopySeekAnchorV3(handler)
+	proxyServer := capableProxyStubV3(t)
+	transcodeServer := progressiveRemuxExecutionStubV3(t)
+	proxy := &nodepool.Node{ID: 42, URL: proxyServer.URL}
+	transcode := &nodepool.Node{ID: 84, URL: transcodeServer.URL}
+	handler.NodePlanner = &recordingNodePlannerV3{plan: nodepool.Plan{ProxyNode: proxy, TranscodeNode: transcode}}
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-remux-no-authority", UserID: 7, ProfileID: "profile-1"},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3), PlayMethod: playback.PlayRemux}, mediaAuthModeV3{})
+	if transportErr != nil {
+		t.Fatalf("prepare identity transport: %v", transportErr)
+	}
+	defer transport.rollback()
+
+	if transport.routingExecution == noderouting.ExecutionTranscode || transport.nodeURL != "" || transport.transportID != "" {
+		t.Fatalf("prepared route = %#v, want no transcode execution without a durable node authority store", transport)
 	}
 }
 
@@ -5463,6 +5497,7 @@ func TestPrepareTransportV3KeepsBoostedDownmixLocalWhenProxyHasOldRecipe(t *test
 	}}))
 	planner := &recordingNodePlannerV3{plan: nodepool.Plan{ProxyNode: &nodepool.Node{URL: proxy.URL}}}
 	handler.NodePlanner = planner
+	handler.NodeRecipeStore = &recordingRecipeCardStoreV3{}
 
 	transport, transportErr := handler.prepareTransportV3(
 		httptest.NewRequest(http.MethodPost, "/", nil),

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -5038,6 +5038,7 @@ type progressiveFallbackPlannerV3 struct {
 	proxy     *nodepool.Node
 	requests  []nodepool.RouteRequest
 	released  []string
+	onPlan    func(nodepool.RouteRequest)
 }
 
 func (*progressiveFallbackPlannerV3) PlanSession(string, string, bool, int) nodepool.Plan {
@@ -5046,6 +5047,9 @@ func (*progressiveFallbackPlannerV3) PlanSession(string, string, bool, int) node
 
 func (p *progressiveFallbackPlannerV3) PlanRoute(request nodepool.RouteRequest) nodepool.Plan {
 	p.requests = append(p.requests, request)
+	if p.onPlan != nil {
+		p.onPlan(request)
+	}
 	if request.NeedsTranscode && (p.transcode == nil || request.TranscodeEligible != nil && !request.TranscodeEligible(p.transcode)) {
 		return nodepool.Plan{}
 	}
@@ -5317,6 +5321,65 @@ func TestPrepareTransportV3FallsBackWhenTranscodeRemuxAuthorityWriteFails(t *tes
 	}
 	if len(recipes.deleted) != 1 {
 		t.Fatalf("ambiguous authority cleanup = %v, want failed transport deleted", recipes.deleted)
+	}
+}
+
+func TestPrepareTransportV3FallsBackWhenSelectedRemuxNodeLosesCapability(t *testing.T) {
+	var transcodeCapable atomic.Bool
+	transcodeCapable.Store(true)
+	transcodeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hw-capabilities" || !transcodeCapable.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writeJSON(w, http.StatusOK, playback.HWAccelInfo{
+			TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxExecutionV1},
+		})
+	}))
+	defer transcodeServer.Close()
+
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	stubCopySeekAnchorV3(handler)
+	proxyServer := capableProxyStubV3(t)
+	planner := &progressiveFallbackPlannerV3{
+		proxy:     &nodepool.Node{ID: 42, URL: proxyServer.URL},
+		transcode: &nodepool.Node{ID: 84, URL: transcodeServer.URL},
+	}
+	planner.onPlan = func(request nodepool.RouteRequest) {
+		if !request.NeedsTranscode || !transcodeCapable.Swap(false) {
+			return
+		}
+		handler.v3NodeCapabilitiesMu.Lock()
+		delete(handler.v3NodeCapabilities, transcodeServer.URL)
+		handler.v3NodeCapabilitiesMu.Unlock()
+	}
+	handler.NodePlanner = planner
+	handler.NodeRecipeStore = &recordingRecipeCardStoreV3{}
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-capability-fallback", UserID: 7, ProfileID: "profile-1"},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3), PlayMethod: playback.PlayRemux},
+		mediaAuthModeV3{})
+	if transportErr != nil {
+		t.Fatalf("prepare identity transport: %v", transportErr)
+	}
+	defer transport.rollback()
+
+	if !strings.HasPrefix(transport.url, proxyServer.URL+"/stream/remux/") ||
+		transport.routingExecution != noderouting.ExecutionProxy || transport.nodeURL != "" {
+		t.Fatalf("fallback transport = %#v, want proxy-executed remux", transport)
+	}
+	if len(planner.requests) != 2 || !planner.requests[0].NeedsTranscode || planner.requests[1].NeedsTranscode {
+		t.Fatalf("route requests = %#v, want failed transcode route followed by proxy-only fallback", planner.requests)
+	}
+	if len(planner.released) != 1 || planner.released[0] != "session-capability-fallback" {
+		t.Fatalf("released reservations = %v, want failed transcode route released", planner.released)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -5033,6 +5033,47 @@ type recordingNodePlannerV3 struct {
 	releasedProxy []string
 }
 
+type progressiveFallbackPlannerV3 struct {
+	transcode *nodepool.Node
+	proxy     *nodepool.Node
+	requests  []nodepool.RouteRequest
+	released  []string
+}
+
+func (*progressiveFallbackPlannerV3) PlanSession(string, string, bool, int) nodepool.Plan {
+	return nodepool.Plan{}
+}
+
+func (p *progressiveFallbackPlannerV3) PlanRoute(request nodepool.RouteRequest) nodepool.Plan {
+	p.requests = append(p.requests, request)
+	if request.NeedsTranscode && (p.transcode == nil || request.TranscodeEligible != nil && !request.TranscodeEligible(p.transcode)) {
+		return nodepool.Plan{}
+	}
+	if request.NeedsProxy && (p.proxy == nil || request.ProxyEligible != nil && !request.ProxyEligible(p.proxy)) {
+		return nodepool.Plan{}
+	}
+	plan := nodepool.Plan{}
+	if request.NeedsTranscode {
+		plan.TranscodeNode = p.transcode
+	}
+	if request.NeedsProxy {
+		plan.ProxyNode = p.proxy
+	}
+	return plan
+}
+
+func (p *progressiveFallbackPlannerV3) ReleaseSession(sessionID string) {
+	p.released = append(p.released, sessionID)
+}
+
+func (p *progressiveFallbackPlannerV3) ProxyNodeURLs() []string {
+	return []string{p.proxy.URL}
+}
+
+func (p *progressiveFallbackPlannerV3) TranscodeNodeURLs() []string {
+	return []string{p.transcode.URL}
+}
+
 func (p *recordingNodePlannerV3) PlanSession(sessionID, _ string, needsTranscode bool, estBitrateKbps int) nodepool.Plan {
 	p.plannedSessionID = sessionID
 	p.needsTranscode = needsTranscode
@@ -5231,6 +5272,50 @@ func TestPrepareTransportV3RunsProgressiveRemuxOnTranscodeNodeThroughProxy(t *te
 	stored, ok := recipes.cards[transport.transportID]
 	if !ok || stored.TranscodeTransportID != transport.transportID || stored.InputPath == "" {
 		t.Fatalf("durable remux authority = %#v, want active transport %q", stored, transport.transportID)
+	}
+}
+
+func TestPrepareTransportV3FallsBackWhenTranscodeRemuxAuthorityWriteFails(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	stubCopySeekAnchorV3(handler)
+	proxyServer := capableProxyStubV3(t)
+	transcodeServer := progressiveRemuxExecutionStubV3(t)
+	planner := &progressiveFallbackPlannerV3{
+		proxy:     &nodepool.Node{ID: 42, URL: proxyServer.URL},
+		transcode: &nodepool.Node{ID: 84, URL: transcodeServer.URL},
+	}
+	handler.NodePlanner = planner
+	recipes := &recordingRecipeCardStoreV3{putErr: errors.New("redis is down")}
+	handler.NodeRecipeStore = recipes
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-authority-fallback", UserID: 7, ProfileID: "profile-1"},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3), PlayMethod: playback.PlayRemux},
+		mediaAuthModeV3{})
+	if transportErr != nil {
+		t.Fatalf("prepare identity transport: %v", transportErr)
+	}
+	defer transport.rollback()
+
+	if !strings.HasPrefix(transport.url, proxyServer.URL+"/stream/remux/") ||
+		transport.routingExecution != noderouting.ExecutionProxy || transport.nodeURL != "" {
+		t.Fatalf("fallback transport = %#v, want proxy-executed remux", transport)
+	}
+	if len(planner.requests) != 2 || !planner.requests[0].NeedsTranscode || !planner.requests[0].NeedsProxy ||
+		planner.requests[1].NeedsTranscode || !planner.requests[1].NeedsProxy {
+		t.Fatalf("route requests = %#v, want transcode+proxy then proxy-only", planner.requests)
+	}
+	if len(planner.released) != 1 || planner.released[0] != "session-authority-fallback" {
+		t.Fatalf("released reservations = %v, want failed transcode route released", planner.released)
+	}
+	if len(recipes.deleted) != 1 {
+		t.Fatalf("ambiguous authority cleanup = %v, want failed transport deleted", recipes.deleted)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -1654,6 +1654,33 @@ func TestHandleReplanPlaybackV3RollsBackLiveSessionWhenPersistenceFails(t *testi
 	}
 }
 
+func TestRollbackFailedReplanV3KeepsSuccessorWhenCancellationFails(t *testing.T) {
+	cancelErr := errors.New("node unavailable")
+	normalRollbackCalled := false
+	sessionRollbackCalled := false
+	transport := &preparedTransportV3{
+		rollback: func() { normalRollbackCalled = true },
+		rollbackRequired: func() error {
+			return cancelErr
+		},
+	}
+
+	transportErr, sessionErr := rollbackFailedReplanV3(transport, func() error {
+		sessionRollbackCalled = true
+		return nil
+	})
+
+	if !errors.Is(transportErr, cancelErr) || sessionErr != nil {
+		t.Fatalf("rollback errors = transport %v session %v, want cancellation failure only", transportErr, sessionErr)
+	}
+	if normalRollbackCalled {
+		t.Fatal("required rollback failure fell through to best-effort cleanup")
+	}
+	if sessionRollbackCalled {
+		t.Fatal("predecessor session was restored while the successor transport remained active")
+	}
+}
+
 func TestHandleReplanPlaybackV3SeekReanchorKeepsCurrentRecipeEligible(t *testing.T) {
 	file := v3HandlerFixtureFile(t)
 	file.SubtitleTracks = []models.SubtitleTrack{{Index: 0, Codec: "ass", Language: "eng"}}

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -5185,6 +5185,49 @@ func TestPrepareTransportV3RoutesProgressiveRemuxThroughProxyNodeWithSeekAndDV(t
 	}
 }
 
+func TestPrepareTransportV3RunsProgressiveRemuxOnTranscodeNodeThroughProxy(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.JWTSecret = "test-secret"
+	stubCopySeekAnchorV3(handler)
+	proxyServer := capableProxyStubV3(t)
+	transcodeServer := progressiveRemuxExecutionStubV3(t)
+	proxy := &nodepool.Node{ID: 42, URL: proxyServer.URL}
+	transcode := &nodepool.Node{ID: 84, URL: transcodeServer.URL}
+	handler.NodePlanner = &recordingNodePlannerV3{plan: nodepool.Plan{ProxyNode: proxy, TranscodeNode: transcode}}
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	plan := identityProxyPlanV3(playback.DeliveryRemuxProgressiveV3)
+	transport, transportErr := handler.prepareTransportV3(
+		httptest.NewRequest(http.MethodPost, "/", nil),
+		&playback.Session{ID: "session-remote-remux", UserID: 7, ProfileID: "profile-1"},
+		v3HandlerFixtureFile(t),
+		playback.PlannerResultV3{Plan: plan, PlayMethod: playback.PlayRemux, TargetAudioCodec: "aac"}, mediaAuthModeV3{})
+	if transportErr != nil {
+		t.Fatalf("prepare identity transport: %v", transportErr)
+	}
+	defer transport.rollback()
+
+	prefix := proxy.URL + "/stream/remux/"
+	if !strings.HasPrefix(transport.url, prefix) {
+		t.Fatalf("stream URL = %q, want proxy remux URL", transport.url)
+	}
+	if transport.nodeURL != transcode.URL || transport.transportID == "" ||
+		transport.routingExecution != noderouting.ExecutionTranscode || transport.routingExecutorID != transcode.ID ||
+		transport.routingEgress != noderouting.EgressProxy || transport.routingEgressID != proxy.ID {
+		t.Fatalf("prepared route = %#v, want transcode execution through proxy", transport)
+	}
+	claims, err := streamtoken.Verify(strings.TrimPrefix(transport.url, prefix), handler.JWTSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claims.TranscodeNode != transcode.URL || claims.TranscodeTransportID != transport.transportID ||
+		claims.RoutingExecution != string(noderouting.ExecutionTranscode) || claims.RoutingEgressNodeID != proxy.ID {
+		t.Fatalf("claims = %#v, want bound transcode-to-proxy route", claims)
+	}
+}
+
 func TestIdentityStreamURLV3VersionsOnlyBoostedRemuxRoutes(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.JWTSecret = "test-secret"
@@ -5318,6 +5361,13 @@ func TestPrepareTransportV3RefusesLocalRemuxWhenFallbackDisabled(t *testing.T) {
 	}
 }
 
+func TestSessionStartErrorV3PreservesAudioTranscodingReason(t *testing.T) {
+	got := sessionStartErrorV3(playback.ErrAudioTranscodingDisabled)
+	if got.reason != "audio_transcoding_disabled" {
+		t.Fatalf("reason = %q, want audio_transcoding_disabled", got.reason)
+	}
+}
+
 func TestPrepareTransportV3AllowsLocalDirectPlayWhenFallbackDisabled(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.JWTSecret = "test-secret"
@@ -5367,10 +5417,28 @@ func capableProxyStubV3(t *testing.T) *httptest.Server {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		writeJSON(w, http.StatusOK, playback.HWAccelInfo{Transformations: []playback.TransformationV3{
-			{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3},
-			{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"},
-		}})
+		writeJSON(w, http.StatusOK, playback.HWAccelInfo{
+			TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxRelayV1},
+			Transformations: []playback.TransformationV3{
+				{Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3, RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3},
+				{Name: playback.TransformationServerDV7HDR10V3, Executor: playback.ExecutorServerV3, RecipeVersion: "1"},
+			},
+		})
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func progressiveRemuxExecutionStubV3(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hw-capabilities" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, playback.HWAccelInfo{
+			TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxExecutionV1},
+		})
 	}))
 	t.Cleanup(server.Close)
 	return server
@@ -5415,10 +5483,11 @@ func TestPrepareTransportV3KeepsBoostedDownmixLocalWhenProxyHasOldRecipe(t *test
 	if strings.HasPrefix(transport.url, proxy.URL) {
 		t.Fatalf("stream url = %q, want local fallback when the proxy only has audio recipe v1", transport.url)
 	}
-	// Narrowing happens before selection, so no reservation is made against an
-	// incapable proxy in the first place and none needs releasing.
-	if len(planner.released) != 0 {
-		t.Fatalf("released = %v, want no reservation taken on an incapable proxy", planner.released)
+	// The proxy-execution shape is narrowed before selection. The legacy planner
+	// double then returns that same proxy as a partial transcode+proxy plan; the
+	// adapter must release the unusable half-reservation before falling local.
+	if len(planner.released) != 1 || planner.released[0] != "session-incapable-proxy" {
+		t.Fatalf("released = %v, want the partial legacy route released", planner.released)
 	}
 }
 

--- a/internal/api/handlers/playback_v3_union_test.go
+++ b/internal/api/handlers/playback_v3_union_test.go
@@ -664,6 +664,33 @@ func TestProgressivePlanningCapabilitiesV3RequireAddressableProxy(t *testing.T) 
 	}
 }
 
+func TestProgressivePlanningCapabilitiesV3RequireRelayForTranscodeExecutor(t *testing.T) {
+	transcode := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, playback.HWAccelInfo{
+			TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxExecutionV1},
+			Transformations: []playback.TransformationV3{{
+				Name: playback.TransformationAudioToAACV3, Executor: playback.ExecutorServerV3,
+				RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3,
+			}},
+		})
+	}))
+	t.Cleanup(transcode.Close)
+
+	local := playback.NewTransformationRegistryV3([]playback.TransformationSpecV3{{
+		Name: playback.TransformationAudioToAACV3, RecipeVersion: playback.TransformationAudioToAACRecipeVersionV3,
+	}})
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.NodePlanner = enumeratingNodePlannerV3{urls: []string{transcode.URL}}
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionWorkerOnly
+	handler.PlaybackConfig = func() config.PlaybackConfig { return config.PlaybackConfig{Routing: policy} }
+
+	registry := handler.progressiveRemuxPlanningRegistryWithInputsV3(t.Context(), local, true)
+	if registry.Available(playback.TransformationAudioToAACV3) {
+		t.Fatal("transcode capability without a relay-capable proxy widened progressive planning")
+	}
+}
+
 func TestHandlePlaybackCapabilityV3UnionsWorkloadRegistries(t *testing.T) {
 	var remoteProbes atomic.Int32
 	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/handlers/playback_v3_union_test.go
+++ b/internal/api/handlers/playback_v3_union_test.go
@@ -664,7 +664,7 @@ func TestProgressivePlanningCapabilitiesV3RequireAddressableProxy(t *testing.T) 
 	}
 }
 
-func TestProgressivePlanningCapabilitiesV3RequireRelayForTranscodeExecutor(t *testing.T) {
+func TestProgressivePlanningCapabilitiesV3RequireRelayAndAuthorityForTranscodeExecutor(t *testing.T) {
 	transcode := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, playback.HWAccelInfo{
 			TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxExecutionV1},
@@ -688,6 +688,24 @@ func TestProgressivePlanningCapabilitiesV3RequireRelayForTranscodeExecutor(t *te
 	registry := handler.progressiveRemuxPlanningRegistryWithInputsV3(t.Context(), local, true)
 	if registry.Available(playback.TransformationAudioToAACV3) {
 		t.Fatal("transcode capability without a relay-capable proxy widened progressive planning")
+	}
+
+	relay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, playback.HWAccelInfo{
+			TransportFeatures: []string{playback.TransportFeatureProgressiveRemuxRelayV1},
+		})
+	}))
+	t.Cleanup(relay.Close)
+	handler.NodePlanner = enumeratingNodePlannerV3{urls: []string{transcode.URL}, proxyURLs: []string{relay.URL}}
+	registry = handler.progressiveRemuxPlanningRegistryWithInputsV3(t.Context(), local, true)
+	if registry.Available(playback.TransformationAudioToAACV3) {
+		t.Fatal("transcode capability without a durable authority store widened progressive planning")
+	}
+
+	handler.NodeRecipeStore = &recordingRecipeCardStoreV3{}
+	registry = handler.progressiveRemuxPlanningRegistryWithInputsV3(t.Context(), local, true)
+	if !registry.Available(playback.TransformationAudioToAACV3) {
+		t.Fatal("eligible transcode capability with relay and authority store was omitted")
 	}
 }
 

--- a/internal/config/admin_settings.go
+++ b/internal/config/admin_settings.go
@@ -91,9 +91,9 @@ var adminSettingDefaults = map[string]string{
 	"playback.hw_accel":                              "auto",
 	"playback.transcode_enabled":                     "true",
 	PlaybackRoutingDirectPlayEgressSettingKey:        string(PlaybackEgressPreferProxy),
-	PlaybackRoutingRemuxExecutionSettingKey:          string(PlaybackExecutionPreferWorker),
+	PlaybackRoutingRemuxExecutionSettingKey:          string(PlaybackExecutionPreferTranscode),
 	PlaybackRoutingRemuxEgressSettingKey:             string(PlaybackEgressPreferProxy),
-	PlaybackRoutingVideoTranscodeExecutionSettingKey: string(PlaybackExecutionPreferWorker),
+	PlaybackRoutingVideoTranscodeExecutionSettingKey: string(PlaybackExecutionPreferTranscode),
 	PlaybackRoutingVideoTranscodeEgressSettingKey:    string(PlaybackEgressPreferProxy),
 	"playback.chapter_thumbnail_workers":             "1",
 	"playback.chapter_thumbnail_execution":           "local",
@@ -461,7 +461,8 @@ func NormalizeAdminSetting(key, raw string) (string, error) {
 		return normalizeAdminEnum(key, value, "auto", "qsv", "vaapi", "nvenc", "videotoolbox", "none")
 	case PlaybackRoutingRemuxExecutionSettingKey, PlaybackRoutingVideoTranscodeExecutionSettingKey:
 		return normalizeAdminEnum(key, value,
-			string(PlaybackExecutionPreferWorker), string(PlaybackExecutionWorkerOnly),
+			string(PlaybackExecutionPreferWorker), string(PlaybackExecutionPreferTranscode),
+			string(PlaybackExecutionWorkerOnly),
 			string(PlaybackExecutionPreferAPI), string(PlaybackExecutionAPIOnly))
 	case PlaybackRoutingDirectPlayEgressSettingKey, PlaybackRoutingRemuxEgressSettingKey,
 		PlaybackRoutingVideoTranscodeEgressSettingKey:

--- a/internal/config/admin_settings_test.go
+++ b/internal/config/admin_settings_test.go
@@ -303,7 +303,7 @@ func TestNormalizeAdminSettingAcceptsVideoToolbox(t *testing.T) {
 
 func TestNormalizeAdminSettingAcceptsPlaybackRoutingEnums(t *testing.T) {
 	tests := map[string]string{
-		PlaybackRoutingRemuxExecutionSettingKey:          "worker_only",
+		PlaybackRoutingRemuxExecutionSettingKey:          "prefer_transcode",
 		PlaybackRoutingVideoTranscodeExecutionSettingKey: "prefer_api",
 		PlaybackRoutingDirectPlayEgressSettingKey:        "proxy_only",
 		PlaybackRoutingRemuxEgressSettingKey:             "api_only",
@@ -326,14 +326,23 @@ func TestNormalizeAdminSettingAcceptsPlaybackRoutingEnums(t *testing.T) {
 	}
 }
 
-func TestPlaybackRoutingDefaultsMatchCurrentClusterBehavior(t *testing.T) {
+func TestPlaybackRoutingDefaultsPreferTranscodeExecutionAndProxyEgress(t *testing.T) {
 	cfg, err := LoadFromDB(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := DefaultPlaybackRoutingPolicy()
+	want := PlaybackRoutingPolicy{
+		DirectPlayEgress:        PlaybackEgressPreferProxy,
+		RemuxExecution:          PlaybackExecutionPreferTranscode,
+		RemuxEgress:             PlaybackEgressPreferProxy,
+		VideoTranscodeExecution: PlaybackExecutionPreferTranscode,
+		VideoTranscodeEgress:    PlaybackEgressPreferProxy,
+	}
 	if cfg.Playback.Routing != want {
 		t.Fatalf("routing = %#v, want %#v", cfg.Playback.Routing, want)
+	}
+	if defaults := DefaultPlaybackRoutingPolicy(); defaults != want {
+		t.Fatalf("runtime defaults = %#v, want %#v", defaults, want)
 	}
 }
 

--- a/internal/config/playback_routing.go
+++ b/internal/config/playback_routing.go
@@ -11,15 +11,17 @@ const (
 )
 
 // PlaybackExecutionPreference controls whether server-side media work should
-// run on a worker or on the integrated API process. A preference permits
-// fallback; an "only" value is a hard routing constraint.
+// run on a worker or on the integrated API process. A worker is either a proxy
+// node or a transcode node, depending on the delivery's legal route shapes. A
+// preference permits fallback; an "only" value is a hard routing constraint.
 type PlaybackExecutionPreference string
 
 const (
-	PlaybackExecutionPreferWorker PlaybackExecutionPreference = "prefer_worker"
-	PlaybackExecutionWorkerOnly   PlaybackExecutionPreference = "worker_only"
-	PlaybackExecutionPreferAPI    PlaybackExecutionPreference = "prefer_api"
-	PlaybackExecutionAPIOnly      PlaybackExecutionPreference = "api_only"
+	PlaybackExecutionPreferWorker    PlaybackExecutionPreference = "prefer_worker"
+	PlaybackExecutionPreferTranscode PlaybackExecutionPreference = "prefer_transcode"
+	PlaybackExecutionWorkerOnly      PlaybackExecutionPreference = "worker_only"
+	PlaybackExecutionPreferAPI       PlaybackExecutionPreference = "prefer_api"
+	PlaybackExecutionAPIOnly         PlaybackExecutionPreference = "api_only"
 )
 
 // PlaybackEgressPreference controls which Silo process is the client-facing
@@ -47,9 +49,9 @@ type PlaybackRoutingPolicy struct {
 func DefaultPlaybackRoutingPolicy() PlaybackRoutingPolicy {
 	return PlaybackRoutingPolicy{
 		DirectPlayEgress:        PlaybackEgressPreferProxy,
-		RemuxExecution:          PlaybackExecutionPreferWorker,
+		RemuxExecution:          PlaybackExecutionPreferTranscode,
 		RemuxEgress:             PlaybackEgressPreferProxy,
-		VideoTranscodeExecution: PlaybackExecutionPreferWorker,
+		VideoTranscodeExecution: PlaybackExecutionPreferTranscode,
 		VideoTranscodeEgress:    PlaybackEgressPreferProxy,
 	}
 }
@@ -103,7 +105,7 @@ func validatePlaybackRoutingPolicy(policy PlaybackRoutingPolicy) error {
 		{PlaybackRoutingVideoTranscodeExecutionSettingKey, policy.VideoTranscodeExecution},
 	} {
 		switch setting.value {
-		case PlaybackExecutionPreferWorker, PlaybackExecutionWorkerOnly,
+		case PlaybackExecutionPreferWorker, PlaybackExecutionPreferTranscode, PlaybackExecutionWorkerOnly,
 			PlaybackExecutionPreferAPI, PlaybackExecutionAPIOnly:
 		default:
 			return fmt.Errorf("%s has invalid execution preference %q", setting.key, setting.value)

--- a/internal/httpstream/rolling_deadline.go
+++ b/internal/httpstream/rolling_deadline.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -74,8 +75,10 @@ type RollingDeadlineWriter struct {
 	rc       *http.ResponseController
 	window   time.Duration
 	step     time.Duration
+	deadline sync.Mutex
 	lastBump time.Time
 	disabled bool
+	aborted  bool
 
 	statusCode    int
 	bytesWritten  int64
@@ -99,13 +102,15 @@ func newRollingDeadlineWriter(w http.ResponseWriter, window, step time.Duration)
 }
 
 func (s *RollingDeadlineWriter) bump() {
-	if s.disabled {
+	s.deadline.Lock()
+	defer s.deadline.Unlock()
+	if s.disabled || s.aborted {
 		return
 	}
 	if !s.lastBump.IsZero() && time.Since(s.lastBump) < s.step {
 		return
 	}
-	s.forceBump()
+	s.forceBumpLocked()
 }
 
 // forceBump sets the deadline unconditionally, ignoring the step throttle.
@@ -118,7 +123,13 @@ func (s *RollingDeadlineWriter) bump() {
 // reaps healthy slow clients. Every slice therefore gets a full window, which is
 // what the pre-CopyChunked loop did.
 func (s *RollingDeadlineWriter) forceBump() {
-	if s.disabled {
+	s.deadline.Lock()
+	defer s.deadline.Unlock()
+	s.forceBumpLocked()
+}
+
+func (s *RollingDeadlineWriter) forceBumpLocked() {
+	if s.disabled || s.aborted {
 		return
 	}
 	now := time.Now()
@@ -127,6 +138,16 @@ func (s *RollingDeadlineWriter) forceBump() {
 		return
 	}
 	s.lastBump = now
+}
+
+// Abort interrupts an in-flight response write and prevents a later rolling
+// deadline bump from reviving it. Session stops use this to withdraw a
+// progressive response even when its client has stopped reading.
+func (s *RollingDeadlineWriter) Abort() error {
+	s.deadline.Lock()
+	defer s.deadline.Unlock()
+	s.aborted = true
+	return s.rc.SetWriteDeadline(time.Now())
 }
 
 func (s *RollingDeadlineWriter) Header() http.Header { return s.w.Header() }

--- a/internal/httpstream/rolling_deadline_test.go
+++ b/internal/httpstream/rolling_deadline_test.go
@@ -3,6 +3,7 @@ package httpstream
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -11,9 +12,42 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+type deadlineBlockingResponseWriter struct {
+	header          http.Header
+	writeStarted    chan struct{}
+	deadlineExpired chan struct{}
+	startOnce       sync.Once
+	expireOnce      sync.Once
+}
+
+func newDeadlineBlockingResponseWriter() *deadlineBlockingResponseWriter {
+	return &deadlineBlockingResponseWriter{
+		header:          make(http.Header),
+		writeStarted:    make(chan struct{}),
+		deadlineExpired: make(chan struct{}),
+	}
+}
+
+func (w *deadlineBlockingResponseWriter) Header() http.Header { return w.header }
+func (*deadlineBlockingResponseWriter) WriteHeader(int)       {}
+
+func (w *deadlineBlockingResponseWriter) Write([]byte) (int, error) {
+	w.startOnce.Do(func() { close(w.writeStarted) })
+	<-w.deadlineExpired
+	return 0, os.ErrDeadlineExceeded
+}
+
+func (w *deadlineBlockingResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	if !deadline.After(time.Now()) {
+		w.expireOnce.Do(func() { close(w.deadlineExpired) })
+	}
+	return nil
+}
 
 func TestClassifyOutcome(t *testing.T) {
 	tests := []struct {
@@ -33,6 +67,33 @@ func TestClassifyOutcome(t *testing.T) {
 				t.Fatalf("ClassifyOutcome() = %q, want %q", got, test.want)
 			}
 		})
+	}
+}
+
+func TestRollingDeadlineWriterAbortInterruptsBlockedWrite(t *testing.T) {
+	w := newDeadlineBlockingResponseWriter()
+	stream := newRollingDeadlineWriter(w, time.Hour, 0)
+	writeResult := make(chan error, 1)
+	go func() {
+		_, err := stream.Write([]byte("blocked"))
+		writeResult <- err
+	}()
+
+	select {
+	case <-w.writeStarted:
+	case <-t.Context().Done():
+		t.Fatal("stream write did not start")
+	}
+	if err := stream.Abort(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-writeResult:
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("write error = %v, want deadline exceeded", err)
+		}
+	case <-t.Context().Done():
+		t.Fatal("aborted stream write remained blocked")
 	}
 }
 

--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -626,6 +626,10 @@ func (h *PlaybackHandler) resolveCompatIdentityRouteWithPolicy(
 		},
 		SessionID: sessionID, EstimatedBitrateKbps: bitrateKbps,
 		ProxyEligible: h.compatProxyEligibility(ctx, requiresAudioBoost),
+		// The progressive transcode-to-proxy relay is a native-v3 token/grant
+		// contract. Compatibility redirects keep their existing proxy/API remux
+		// executor until that protocol can describe the two-node route.
+		ExcludedShapeIDs: map[string]struct{}{"progressive_remux_transcode_proxy": {}},
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "compile Jellyfin-compatible playback route", "component", "noderouting", "error", err)

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -619,17 +619,19 @@ func (h *PlaybackHandler) resolveCompatIdentityRouteWithPolicy(
 		workload = noderouting.WorkloadRemux
 		delivery = noderouting.DeliveryProgressiveRemux
 	}
+	proxyEligible := h.compatProxyEligibility(ctx, requiresAudioBoost)
 	decision, err := noderouting.Resolve(noderouting.AdaptSessionPlanner(h.NodePlanner), noderouting.ResolveRequest{
 		Request: noderouting.Request{
 			Workload: workload, Delivery: delivery,
 			Policy: policy, ProxyAllowed: h.JWTSecret != "",
 		},
 		SessionID: sessionID, EstimatedBitrateKbps: bitrateKbps,
-		ProxyEligible: h.compatProxyEligibility(ctx, requiresAudioBoost),
+		ProxyEligible:          proxyEligible,
+		ProxyExecutionEligible: proxyEligible,
 		// The progressive transcode-to-proxy relay is a native-v3 token/grant
 		// contract. Compatibility redirects keep their existing proxy/API remux
 		// executor until that protocol can describe the two-node route.
-		ExcludedShapeIDs: map[string]struct{}{"progressive_remux_transcode_proxy": {}},
+		ExcludedShapeIDs: map[string]struct{}{noderouting.ShapeProgressiveRemuxTranscodeProxy: {}},
 	})
 	if err != nil {
 		slog.ErrorContext(ctx, "compile Jellyfin-compatible playback route", "component", "noderouting", "error", err)

--- a/internal/jellycompat/routing_policy_test.go
+++ b/internal/jellycompat/routing_policy_test.go
@@ -108,6 +108,11 @@ func TestBuildPlaybackSourceHonorsProgressiveRemuxRoutingPolicy(t *testing.T) {
 			wantDirectStream: true,
 		},
 		{
+			name:      "transcode preference does not rewrite the requested Jellyfin transport",
+			execution: config.PlaybackExecutionPreferTranscode, egress: config.PlaybackEgressPreferProxy,
+			wantDirectStream: true,
+		},
+		{
 			name:      "worker execution with API egress falls back to HLS",
 			execution: config.PlaybackExecutionWorkerOnly, egress: config.PlaybackEgressAPIOnly,
 			wantDirectStream: false,

--- a/internal/nodeconfig/watcher.go
+++ b/internal/nodeconfig/watcher.go
@@ -79,9 +79,11 @@ type Watcher struct {
 	missingRowLogged    bool
 	duplicateRowLogged  bool
 	ambiguousNameLogged bool
-	// nodeRowID is the row this worker has resolved to, kept so a later rename
-	// or repoint cannot sever the association. Zero until a lookup succeeds.
-	nodeRowID int
+	// nodeRowID and nodeRegisteredURL are the row this worker has resolved to,
+	// kept so a later rename or repoint cannot sever the association. Zero and
+	// empty until a lookup succeeds.
+	nodeRowID         int
+	nodeRegisteredURL string
 
 	// reloadMu makes one reload atomic from the read of server_settings through
 	// the config swap and its callbacks; see reload.
@@ -92,13 +94,13 @@ type Watcher struct {
 	fetchSettingsFn func(context.Context) (map[string]string, error)
 }
 
-// rememberNodeRowID records the row a lookup resolved to.
-func (w *Watcher) rememberNodeRowID(id int) {
-	if id <= 0 {
+func (w *Watcher) rememberNodeRegistration(id int, registeredURL string) {
+	if id <= 0 || registeredURL == "" {
 		return
 	}
 	w.mu.Lock()
 	w.nodeRowID = id
+	w.nodeRegisteredURL = registeredURL
 	w.mu.Unlock()
 }
 
@@ -119,10 +121,23 @@ func (w *Watcher) NodeRowID() (int, bool) {
 	return w.rememberedNodeRowID()
 }
 
+// NodeRegisteredURL returns the route URL stored on the stream_nodes row this
+// worker resolved. It may differ from the process-local NODE_URL in a
+// split-horizon deployment.
+func (w *Watcher) NodeRegisteredURL() (string, bool) {
+	if w == nil {
+		return "", false
+	}
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.nodeRegisteredURL, w.nodeRowID > 0 && w.nodeRegisteredURL != ""
+}
+
 // forgetNodeRowID drops a remembered row that no longer exists.
 func (w *Watcher) forgetNodeRowID() {
 	w.mu.Lock()
 	w.nodeRowID = 0
+	w.nodeRegisteredURL = ""
 	w.mu.Unlock()
 }
 
@@ -445,6 +460,7 @@ func (w *Watcher) queryNodeHWOverrides(ctx context.Context, nodeURL, nodeName st
 			return nodeHWOverrides{}, false, err
 		}
 		if len(matched) > 0 {
+			w.rememberNodeRegistration(id, matched[0])
 			return overrides, true, nil
 		}
 		// The row was deleted. Forget it and fall back to the identities, which
@@ -462,7 +478,7 @@ func (w *Watcher) queryNodeHWOverrides(ctx context.Context, nodeURL, nodeName st
 		w.logDuplicateNodeRows(ctx, nodeURL, matched)
 	}
 	if len(matched) > 0 {
-		w.rememberNodeRowID(id)
+		w.rememberNodeRegistration(id, matched[0])
 		return overrides, true, nil
 	}
 
@@ -484,7 +500,7 @@ func (w *Watcher) queryNodeHWOverrides(ctx context.Context, nodeURL, nodeName st
 	case 0:
 		return nodeHWOverrides{}, false, nil
 	case 1:
-		w.rememberNodeRowID(id)
+		w.rememberNodeRegistration(id, matched[0])
 		return overrides, true, nil
 	default:
 		w.logAmbiguousNodeName(ctx, nodeName, matched)

--- a/internal/nodeconfig/watcher_test.go
+++ b/internal/nodeconfig/watcher_test.go
@@ -21,13 +21,19 @@ func TestWatcherNodeRowID(t *testing.T) {
 	if id, ok := w.NodeRowID(); ok || id != 0 {
 		t.Fatalf("unresolved NodeRowID = (%d, %t), want (0, false)", id, ok)
 	}
-	w.rememberNodeRowID(11)
+	w.rememberNodeRegistration(11, "https://registered-node.example")
 	if id, ok := w.NodeRowID(); !ok || id != 11 {
 		t.Fatalf("resolved NodeRowID = (%d, %t), want (11, true)", id, ok)
+	}
+	if registeredURL, ok := w.NodeRegisteredURL(); !ok || registeredURL != "https://registered-node.example" {
+		t.Fatalf("resolved NodeRegisteredURL = (%q, %t)", registeredURL, ok)
 	}
 	w.forgetNodeRowID()
 	if id, ok := w.NodeRowID(); ok || id != 0 {
 		t.Fatalf("forgotten NodeRowID = (%d, %t), want (0, false)", id, ok)
+	}
+	if registeredURL, ok := w.NodeRegisteredURL(); ok || registeredURL != "" {
+		t.Fatalf("forgotten NodeRegisteredURL = (%q, %t), want empty and false", registeredURL, ok)
 	}
 }
 

--- a/internal/noderecipe/store.go
+++ b/internal/noderecipe/store.go
@@ -33,6 +33,7 @@ package noderecipe
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,6 +66,12 @@ const nodeAuthorityGenerationKeyPrefix = "silo:noderecipe-authority-generation:"
 // previous wire format for older transcode nodes during rolling upgrades.
 const nodeAuthorityRecordGenerationKeyPrefix = "silo:noderecipe-authority-record:"
 
+// nodeAuthorityRecordDigestKeyPrefix binds the generation sidecar to the
+// recipe bytes it stamped. An older API may overwrite only the legacy recipe
+// key; the digest lets a current node recognize that the surviving generation
+// belongs to different bytes and validate the overwrite as a legacy write.
+const nodeAuthorityRecordDigestKeyPrefix = "silo:noderecipe-authority-digest:"
+
 // DefaultTTL bounds how long a stored recipe survives. It matches the stream
 // token lifetime (playback.MaxTokenTTL, 24h): past it no surviving token could
 // still drive a reconstruct, so the recipe is safe to lapse.
@@ -89,8 +96,8 @@ type audioRecipeEnvelope struct {
 	Recipe  playback.RecipeCard `json:"audio_recipe"`
 }
 
-// putNodeRecipeScript reads the node generation and writes both the
-// legacy-readable recipe and its generation sidecar in one Redis operation. It
+// putNodeRecipeScript reads the node generation and writes the legacy-readable
+// recipe plus generation and digest sidecars in one Redis operation. It
 // therefore orders a concurrent Put and RevokeNode: a recipe written before
 // the increment is stale, while one written after it carries the new generation.
 var putNodeRecipeScript = redis.NewScript(`
@@ -100,19 +107,27 @@ if not generation then
 end
 redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
 redis.call("SET", KEYS[2], generation, "PX", ARGV[2])
+redis.call("SET", KEYS[4], ARGV[3], "PX", ARGV[2])
 return generation
 `)
 
-// validateLegacyNodeRecipeScript accepts a sidecar-less record only when its
-// Redis expiry proves that an older writer issued it after the latest reload.
-// The exact recipe comparison makes the decision apply to the bytes Get
-// decoded even if another writer updates the key concurrently.
+// validateLegacyNodeRecipeScript accepts a record with missing or mismatched
+// sidecars only when its Redis expiry proves that an older writer issued it
+// after the latest reload. The exact recipe comparison makes the decision
+// apply to the bytes Get decoded even if another writer updates the key
+// concurrently.
 var validateLegacyNodeRecipeScript = redis.NewScript(`
 local recipe = redis.call("GET", KEYS[1])
 if not recipe or recipe ~= ARGV[1] then
   return 0
 end
-if redis.call("EXISTS", KEYS[2]) ~= 0 then
+local binding = redis.call("GET", KEYS[4])
+if binding and binding == ARGV[3] then
+  local stamped_generation = tonumber(redis.call("GET", KEYS[2]))
+  local current_generation = tonumber(redis.call("GET", KEYS[3])) or 0
+  if stamped_generation and stamped_generation == current_generation then
+    return 1
+  end
   return 0
 end
 local generation = tonumber(redis.call("GET", KEYS[3]))
@@ -190,6 +205,14 @@ func nodeAuthorityRecordGenerationKey(sessionID string) string {
 	return nodeAuthorityRecordGenerationKeyPrefix + sessionID
 }
 
+func nodeAuthorityRecordDigestKey(sessionID string) string {
+	return nodeAuthorityRecordDigestKeyPrefix + sessionID
+}
+
+func nodeAuthorityRecordDigest(data []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
 // Put stores the reconstruction recipe for a remote transcode session. Best
 // effort: a write error is returned for the caller to log, never fatal.
 func (s *Store) Put(ctx context.Context, sessionID string, card playback.RecipeCard) error {
@@ -206,7 +229,8 @@ func (s *Store) Put(ctx context.Context, sessionID string, card playback.RecipeC
 			s.key(sessionID),
 			nodeAuthorityRecordGenerationKey(sessionID),
 			nodeAuthorityGenerationKey(card.TranscodeNodeURL),
-		}, data, ttlMillis).Err()
+			nodeAuthorityRecordDigestKey(sessionID),
+		}, data, ttlMillis, nodeAuthorityRecordDigest(data)).Err()
 	}
 	return s.rdb.Set(ctx, s.key(sessionID), data, s.ttl).Err()
 }
@@ -259,7 +283,11 @@ func (s *Store) loadStoredCard(ctx context.Context, sessionID string) ([]byte, i
 		data, err := s.rdb.Get(ctx, s.key(sessionID)).Bytes()
 		return data, 0, false, err
 	}
-	values, err := s.rdb.MGet(ctx, s.key(sessionID), nodeAuthorityRecordGenerationKey(sessionID)).Result()
+	values, err := s.rdb.MGet(ctx,
+		s.key(sessionID),
+		nodeAuthorityRecordGenerationKey(sessionID),
+		nodeAuthorityRecordDigestKey(sessionID),
+	).Result()
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -267,7 +295,11 @@ func (s *Store) loadStoredCard(ctx context.Context, sessionID string) ([]byte, i
 	if !ok {
 		return nil, 0, false, redis.Nil
 	}
-	if values[1] == nil {
+	if values[1] == nil || values[2] == nil {
+		return []byte(recipe), 0, false, nil
+	}
+	recordDigest, ok := values[2].(string)
+	if !ok || recordDigest != nodeAuthorityRecordDigest([]byte(recipe)) {
 		return []byte(recipe), 0, false, nil
 	}
 	rawGeneration, ok := values[1].(string)
@@ -287,7 +319,8 @@ func (s *Store) legacyRecipeIssuedAfterRevocation(ctx context.Context, sessionID
 		s.key(sessionID),
 		nodeAuthorityRecordGenerationKey(sessionID),
 		nodeAuthorityGenerationKey(nodeURL),
-	}, data, ttlMillis).Int()
+		nodeAuthorityRecordDigestKey(sessionID),
+	}, data, ttlMillis, nodeAuthorityRecordDigest(data)).Int()
 	return valid == 1, err
 }
 
@@ -366,7 +399,7 @@ func (s *Store) Delete(ctx context.Context, sessionID string) error {
 	}
 	keys := []string{s.key(sessionID)}
 	if s.prefix == KeyPrefix {
-		keys = append(keys, nodeAuthorityRecordGenerationKey(sessionID))
+		keys = append(keys, nodeAuthorityRecordGenerationKey(sessionID), nodeAuthorityRecordDigestKey(sessionID))
 	}
 	return s.rdb.Del(ctx, keys...).Err()
 }

--- a/internal/noderecipe/store.go
+++ b/internal/noderecipe/store.go
@@ -13,8 +13,10 @@
 // This store bridges that gap over the same shared Redis the offload topology
 // already relies on (the node-session tracker): central writes the recipe keyed
 // by the upstream session id when it starts a remote transcode, and the
-// transcode node reads it on a reconstruct miss. It is
-// off the hot path — written once at start, read only after a node restart.
+// transcode node reads it on a reconstruct miss. Transcode-executed progressive
+// remuxes also use the record as durable active authority: central writes it
+// before publishing the route, the node checks it before each remux response,
+// and deliberate teardown deletes it so a surviving token cannot restart work.
 //
 // The same central→node recipe handoff serves a second, independent purpose
 // under its own key space: a proxy grant. When an attempt negotiates

--- a/internal/noderecipe/store.go
+++ b/internal/noderecipe/store.go
@@ -55,9 +55,9 @@ const KeyPrefix = "silo:noderecipe:"
 // node roles, and a lookup in one must never resolve the other's entry.
 const ProxyGrantKeyPrefix = "silo:proxygrant:"
 
-// nodeAuthorityGenerationKeyPrefix namespaces the per-node generation that
-// force reload advances to revoke every outstanding node recipe, including a
-// progressive-remux URL that has not received its first request yet.
+// nodeAuthorityGenerationKeyPrefix namespaces the per-node Redis timestamp
+// generation that force reload advances to revoke every outstanding node
+// recipe, including a progressive-remux URL with no request yet.
 const nodeAuthorityGenerationKeyPrefix = "silo:noderecipe-authority-generation:"
 
 // nodeAuthorityRecordGenerationKeyPrefix namespaces the generation stamped
@@ -101,6 +101,46 @@ end
 redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
 redis.call("SET", KEYS[2], generation, "PX", ARGV[2])
 return generation
+`)
+
+// validateLegacyNodeRecipeScript accepts a sidecar-less record only when its
+// Redis expiry proves that an older writer issued it after the latest reload.
+// The exact recipe comparison makes the decision apply to the bytes Get
+// decoded even if another writer updates the key concurrently.
+var validateLegacyNodeRecipeScript = redis.NewScript(`
+local recipe = redis.call("GET", KEYS[1])
+if not recipe or recipe ~= ARGV[1] then
+  return 0
+end
+if redis.call("EXISTS", KEYS[2]) ~= 0 then
+  return 0
+end
+local generation = tonumber(redis.call("GET", KEYS[3]))
+if not generation or generation == 0 then
+  return 1
+end
+local ttl = redis.call("PTTL", KEYS[1])
+if ttl < 0 then
+  return 0
+end
+local now = redis.call("TIME")
+local now_ms = now[1] * 1000 + math.floor(now[2] / 1000)
+local issued_at = now_ms - (tonumber(ARGV[2]) - ttl)
+if issued_at > generation then
+  return 1
+end
+return 0
+`)
+
+var revokeNodeScript = redis.NewScript(`
+local now = redis.call("TIME")
+local now_ms = now[1] * 1000 + math.floor(now[2] / 1000)
+local current = tonumber(redis.call("GET", KEYS[1])) or 0
+if now_ms <= current then
+  now_ms = current + 1
+end
+redis.call("SET", KEYS[1], now_ms)
+return now_ms
 `)
 
 // Store is the Redis-backed recipe store shared by central (writer) and the
@@ -178,7 +218,7 @@ func (s *Store) Get(ctx context.Context, sessionID string) (*playback.RecipeCard
 	if s == nil || s.rdb == nil || sessionID == "" {
 		return nil, false
 	}
-	data, generation, err := s.loadStoredCard(ctx, sessionID)
+	data, generation, stamped, err := s.loadStoredCard(ctx, sessionID)
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
 			slog.WarnContext(ctx, "load node recipe failed", "component", "noderecipe", "key_prefix", s.prefix, "error", err, "playback_session_id", sessionID)
@@ -191,43 +231,64 @@ func (s *Store) Get(ctx context.Context, sessionID string) (*playback.RecipeCard
 		return nil, false
 	}
 	if s.prefix == KeyPrefix && strings.TrimSpace(card.TranscodeNodeURL) != "" {
-		currentGeneration, generationErr := s.currentNodeAuthorityGeneration(ctx, card.TranscodeNodeURL)
-		if generationErr != nil {
-			slog.WarnContext(ctx, "load node authority generation failed", "component", "noderecipe", "error", generationErr, "playback_session_id", sessionID)
-			return nil, false
-		}
-		if generation != currentGeneration {
-			return nil, false
+		if stamped {
+			currentGeneration, generationErr := s.currentNodeAuthorityGeneration(ctx, card.TranscodeNodeURL)
+			if generationErr != nil {
+				slog.WarnContext(ctx, "load node authority generation failed", "component", "noderecipe", "error", generationErr, "playback_session_id", sessionID)
+				return nil, false
+			}
+			if generation != currentGeneration {
+				return nil, false
+			}
+		} else {
+			valid, validationErr := s.legacyRecipeIssuedAfterRevocation(ctx, sessionID, data, card.TranscodeNodeURL)
+			if validationErr != nil {
+				slog.WarnContext(ctx, "validate legacy node recipe authority failed", "component", "noderecipe", "error", validationErr, "playback_session_id", sessionID)
+				return nil, false
+			}
+			if !valid {
+				return nil, false
+			}
 		}
 	}
 	return &card, true
 }
 
-func (s *Store) loadStoredCard(ctx context.Context, sessionID string) ([]byte, int64, error) {
+func (s *Store) loadStoredCard(ctx context.Context, sessionID string) ([]byte, int64, bool, error) {
 	if s.prefix != KeyPrefix {
 		data, err := s.rdb.Get(ctx, s.key(sessionID)).Bytes()
-		return data, 0, err
+		return data, 0, false, err
 	}
 	values, err := s.rdb.MGet(ctx, s.key(sessionID), nodeAuthorityRecordGenerationKey(sessionID)).Result()
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 	recipe, ok := values[0].(string)
 	if !ok {
-		return nil, 0, redis.Nil
+		return nil, 0, false, redis.Nil
 	}
 	if values[1] == nil {
-		return []byte(recipe), 0, nil
+		return []byte(recipe), 0, false, nil
 	}
 	rawGeneration, ok := values[1].(string)
 	if !ok {
-		return nil, 0, errors.New("invalid node authority generation type")
+		return nil, 0, false, errors.New("invalid node authority generation type")
 	}
 	generation, err := strconv.ParseInt(rawGeneration, 10, 64)
 	if err != nil {
-		return nil, 0, fmt.Errorf("parse node authority generation: %w", err)
+		return nil, 0, false, fmt.Errorf("parse node authority generation: %w", err)
 	}
-	return []byte(recipe), generation, nil
+	return []byte(recipe), generation, true, nil
+}
+
+func (s *Store) legacyRecipeIssuedAfterRevocation(ctx context.Context, sessionID string, data []byte, nodeURL string) (bool, error) {
+	ttlMillis := max(s.ttl.Milliseconds(), 1)
+	valid, err := validateLegacyNodeRecipeScript.Run(ctx, s.rdb, []string{
+		s.key(sessionID),
+		nodeAuthorityRecordGenerationKey(sessionID),
+		nodeAuthorityGenerationKey(nodeURL),
+	}, data, ttlMillis).Int()
+	return valid == 1, err
 }
 
 func (s *Store) currentNodeAuthorityGeneration(ctx context.Context, nodeURL string) (int64, error) {
@@ -311,12 +372,14 @@ func (s *Store) Delete(ctx context.Context, sessionID string) error {
 }
 
 // RevokeNode invalidates every recipe previously issued for nodeURL. The
-// generation key intentionally outlives individual recipes: it is one bounded
-// key per configured node and prevents a legacy generation-zero record from
-// becoming valid again after recipe TTLs expire.
+// The generation intentionally outlives individual recipes: the Redis-server
+// timestamp is bounded per configured node and distinguishes a pre-reload
+// legacy record from one issued later by an old API.
 func (s *Store) RevokeNode(ctx context.Context, nodeURL string) error {
 	if s == nil || s.rdb == nil || s.prefix != KeyPrefix || strings.TrimSpace(nodeURL) == "" {
 		return nil
 	}
-	return s.rdb.Incr(ctx, nodeAuthorityGenerationKey(nodeURL)).Err()
+	return revokeNodeScript.Run(ctx, s.rdb, []string{
+		nodeAuthorityGenerationKey(nodeURL),
+	}).Err()
 }

--- a/internal/noderecipe/store.go
+++ b/internal/noderecipe/store.go
@@ -201,6 +201,20 @@ func nodeAuthorityGenerationKey(nodeURL string) string {
 	return nodeAuthorityGenerationKeyPrefix + normalized
 }
 
+func nodeAuthorityGenerationKeyForNodeID(nodeID int) string {
+	return nodeAuthorityGenerationKeyPrefix + "node-id:" + strconv.Itoa(nodeID)
+}
+
+func nodeAuthorityGenerationKeyForCard(card playback.RecipeCard) string {
+	if card.RoutingExecutionNodeID > 0 {
+		return nodeAuthorityGenerationKeyForNodeID(card.RoutingExecutionNodeID)
+	}
+	if strings.TrimSpace(card.TranscodeNodeURL) != "" {
+		return nodeAuthorityGenerationKey(card.TranscodeNodeURL)
+	}
+	return ""
+}
+
 func nodeAuthorityRecordGenerationKey(sessionID string) string {
 	return nodeAuthorityRecordGenerationKeyPrefix + sessionID
 }
@@ -223,12 +237,12 @@ func (s *Store) Put(ctx context.Context, sessionID string, card playback.RecipeC
 	if err != nil {
 		return err
 	}
-	if s.prefix == KeyPrefix && strings.TrimSpace(card.TranscodeNodeURL) != "" {
+	if authorityKey := nodeAuthorityGenerationKeyForCard(card); s.prefix == KeyPrefix && authorityKey != "" {
 		ttlMillis := max(s.ttl.Milliseconds(), 1)
 		return putNodeRecipeScript.Run(ctx, s.rdb, []string{
 			s.key(sessionID),
 			nodeAuthorityRecordGenerationKey(sessionID),
-			nodeAuthorityGenerationKey(card.TranscodeNodeURL),
+			authorityKey,
 			nodeAuthorityRecordDigestKey(sessionID),
 		}, data, ttlMillis, nodeAuthorityRecordDigest(data)).Err()
 	}
@@ -254,9 +268,9 @@ func (s *Store) Get(ctx context.Context, sessionID string) (*playback.RecipeCard
 		slog.WarnContext(ctx, "decode node recipe failed", "component", "noderecipe", "key_prefix", s.prefix, "playback_session_id", sessionID)
 		return nil, false
 	}
-	if s.prefix == KeyPrefix && strings.TrimSpace(card.TranscodeNodeURL) != "" {
+	if authorityKey := nodeAuthorityGenerationKeyForCard(card); s.prefix == KeyPrefix && authorityKey != "" {
 		if stamped {
-			currentGeneration, generationErr := s.currentNodeAuthorityGeneration(ctx, card.TranscodeNodeURL)
+			currentGeneration, generationErr := s.currentNodeAuthorityGeneration(ctx, authorityKey)
 			if generationErr != nil {
 				slog.WarnContext(ctx, "load node authority generation failed", "component", "noderecipe", "error", generationErr, "playback_session_id", sessionID)
 				return nil, false
@@ -265,7 +279,7 @@ func (s *Store) Get(ctx context.Context, sessionID string) (*playback.RecipeCard
 				return nil, false
 			}
 		} else {
-			valid, validationErr := s.legacyRecipeIssuedAfterRevocation(ctx, sessionID, data, card.TranscodeNodeURL)
+			valid, validationErr := s.legacyRecipeIssuedAfterRevocation(ctx, sessionID, data, authorityKey)
 			if validationErr != nil {
 				slog.WarnContext(ctx, "validate legacy node recipe authority failed", "component", "noderecipe", "error", validationErr, "playback_session_id", sessionID)
 				return nil, false
@@ -313,19 +327,19 @@ func (s *Store) loadStoredCard(ctx context.Context, sessionID string) ([]byte, i
 	return []byte(recipe), generation, true, nil
 }
 
-func (s *Store) legacyRecipeIssuedAfterRevocation(ctx context.Context, sessionID string, data []byte, nodeURL string) (bool, error) {
+func (s *Store) legacyRecipeIssuedAfterRevocation(ctx context.Context, sessionID string, data []byte, authorityKey string) (bool, error) {
 	ttlMillis := max(s.ttl.Milliseconds(), 1)
 	valid, err := validateLegacyNodeRecipeScript.Run(ctx, s.rdb, []string{
 		s.key(sessionID),
 		nodeAuthorityRecordGenerationKey(sessionID),
-		nodeAuthorityGenerationKey(nodeURL),
+		authorityKey,
 		nodeAuthorityRecordDigestKey(sessionID),
 	}, data, ttlMillis, nodeAuthorityRecordDigest(data)).Int()
 	return valid == 1, err
 }
 
-func (s *Store) currentNodeAuthorityGeneration(ctx context.Context, nodeURL string) (int64, error) {
-	generation, err := s.rdb.Get(ctx, nodeAuthorityGenerationKey(nodeURL)).Int64()
+func (s *Store) currentNodeAuthorityGeneration(ctx context.Context, authorityKey string) (int64, error) {
+	generation, err := s.rdb.Get(ctx, authorityKey).Int64()
 	if errors.Is(err, redis.Nil) {
 		return 0, nil
 	}
@@ -405,7 +419,7 @@ func (s *Store) Delete(ctx context.Context, sessionID string) error {
 }
 
 // RevokeNode invalidates every recipe previously issued for nodeURL. The
-// The generation intentionally outlives individual recipes: the Redis-server
+// generation intentionally outlives individual recipes: the Redis-server
 // timestamp is bounded per configured node and distinguishes a pre-reload
 // legacy record from one issued later by an old API.
 func (s *Store) RevokeNode(ctx context.Context, nodeURL string) error {
@@ -414,5 +428,17 @@ func (s *Store) RevokeNode(ctx context.Context, nodeURL string) error {
 	}
 	return revokeNodeScript.Run(ctx, s.rdb, []string{
 		nodeAuthorityGenerationKey(nodeURL),
+	}).Err()
+}
+
+// RevokeNodeID invalidates current progressive-remux recipes for the stable
+// stream_nodes row. Unlike a route URL, the row identity survives URL repoints
+// and process replacement, so a failed reload can always retry it.
+func (s *Store) RevokeNodeID(ctx context.Context, nodeID int) error {
+	if s == nil || s.rdb == nil || s.prefix != KeyPrefix || nodeID <= 0 {
+		return nil
+	}
+	return revokeNodeScript.Run(ctx, s.rdb, []string{
+		nodeAuthorityGenerationKeyForNodeID(nodeID),
 	}).Err()
 }

--- a/internal/noderecipe/store.go
+++ b/internal/noderecipe/store.go
@@ -35,7 +35,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -58,15 +60,19 @@ const ProxyGrantKeyPrefix = "silo:proxygrant:"
 // progressive-remux URL that has not received its first request yet.
 const nodeAuthorityGenerationKeyPrefix = "silo:noderecipe-authority-generation:"
 
+// nodeAuthorityRecordGenerationKeyPrefix namespaces the generation stamped
+// alongside one node recipe. Keeping it in a sidecar preserves the recipe's
+// previous wire format for older transcode nodes during rolling upgrades.
+const nodeAuthorityRecordGenerationKeyPrefix = "silo:noderecipe-authority-record:"
+
 // DefaultTTL bounds how long a stored recipe survives. It matches the stream
 // token lifetime (playback.MaxTokenTTL, 24h): past it no surviving token could
 // still drive a reconstruct, so the recipe is safe to lapse.
 const DefaultTTL = playback.MaxTokenTTL
 
 const (
-	toneMapEnvelopeVersion       = 1
-	audioRecipeEnvelopeVersion   = 2
-	nodeAuthorityEnvelopeVersion = 3
+	toneMapEnvelopeVersion     = 1
+	audioRecipeEnvelopeVersion = 2
 )
 
 type toneMapEnvelope struct {
@@ -83,23 +89,17 @@ type audioRecipeEnvelope struct {
 	Recipe  playback.RecipeCard `json:"audio_recipe"`
 }
 
-type nodeAuthorityEnvelope struct {
-	Version             int             `json:"version"`
-	AuthorityGeneration int64           `json:"authority_generation"`
-	Recipe              json.RawMessage `json:"node_recipe"`
-}
-
-// putNodeRecipeScript reads the node generation and writes the recipe envelope
-// in one Redis operation. It therefore orders a concurrent Put and RevokeNode:
-// a recipe written before the increment is stale, while one written after it
-// carries the new generation.
+// putNodeRecipeScript reads the node generation and writes both the
+// legacy-readable recipe and its generation sidecar in one Redis operation. It
+// therefore orders a concurrent Put and RevokeNode: a recipe written before
+// the increment is stale, while one written after it carries the new generation.
 var putNodeRecipeScript = redis.NewScript(`
-local generation = redis.call("GET", KEYS[2])
+local generation = redis.call("GET", KEYS[3])
 if not generation then
   generation = "0"
 end
-local envelope = '{"version":' .. ARGV[3] .. ',"authority_generation":' .. generation .. ',"node_recipe":' .. ARGV[1] .. '}'
-redis.call("SET", KEYS[1], envelope, "PX", ARGV[2])
+redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])
+redis.call("SET", KEYS[2], generation, "PX", ARGV[2])
 return generation
 `)
 
@@ -146,6 +146,10 @@ func nodeAuthorityGenerationKey(nodeURL string) string {
 	return nodeAuthorityGenerationKeyPrefix + normalized
 }
 
+func nodeAuthorityRecordGenerationKey(sessionID string) string {
+	return nodeAuthorityRecordGenerationKeyPrefix + sessionID
+}
+
 // Put stores the reconstruction recipe for a remote transcode session. Best
 // effort: a write error is returned for the caller to log, never fatal.
 func (s *Store) Put(ctx context.Context, sessionID string, card playback.RecipeCard) error {
@@ -160,8 +164,9 @@ func (s *Store) Put(ctx context.Context, sessionID string, card playback.RecipeC
 		ttlMillis := max(s.ttl.Milliseconds(), 1)
 		return putNodeRecipeScript.Run(ctx, s.rdb, []string{
 			s.key(sessionID),
+			nodeAuthorityRecordGenerationKey(sessionID),
 			nodeAuthorityGenerationKey(card.TranscodeNodeURL),
-		}, data, ttlMillis, nodeAuthorityEnvelopeVersion).Err()
+		}, data, ttlMillis).Err()
 	}
 	return s.rdb.Set(ctx, s.key(sessionID), data, s.ttl).Err()
 }
@@ -173,14 +178,14 @@ func (s *Store) Get(ctx context.Context, sessionID string) (*playback.RecipeCard
 	if s == nil || s.rdb == nil || sessionID == "" {
 		return nil, false
 	}
-	data, err := s.rdb.Get(ctx, s.key(sessionID)).Bytes()
+	data, generation, err := s.loadStoredCard(ctx, sessionID)
 	if err != nil {
 		if !errors.Is(err, redis.Nil) {
 			slog.WarnContext(ctx, "load node recipe failed", "component", "noderecipe", "key_prefix", s.prefix, "error", err, "playback_session_id", sessionID)
 		}
 		return nil, false
 	}
-	card, generation, ok := unmarshalStoredCard(data, s.prefix == KeyPrefix)
+	card, ok := unmarshalCard(data)
 	if !ok {
 		slog.WarnContext(ctx, "decode node recipe failed", "component", "noderecipe", "key_prefix", s.prefix, "playback_session_id", sessionID)
 		return nil, false
@@ -198,29 +203,39 @@ func (s *Store) Get(ctx context.Context, sessionID string) (*playback.RecipeCard
 	return &card, true
 }
 
+func (s *Store) loadStoredCard(ctx context.Context, sessionID string) ([]byte, int64, error) {
+	if s.prefix != KeyPrefix {
+		data, err := s.rdb.Get(ctx, s.key(sessionID)).Bytes()
+		return data, 0, err
+	}
+	values, err := s.rdb.MGet(ctx, s.key(sessionID), nodeAuthorityRecordGenerationKey(sessionID)).Result()
+	if err != nil {
+		return nil, 0, err
+	}
+	recipe, ok := values[0].(string)
+	if !ok {
+		return nil, 0, redis.Nil
+	}
+	if values[1] == nil {
+		return []byte(recipe), 0, nil
+	}
+	rawGeneration, ok := values[1].(string)
+	if !ok {
+		return nil, 0, errors.New("invalid node authority generation type")
+	}
+	generation, err := strconv.ParseInt(rawGeneration, 10, 64)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parse node authority generation: %w", err)
+	}
+	return []byte(recipe), generation, nil
+}
+
 func (s *Store) currentNodeAuthorityGeneration(ctx context.Context, nodeURL string) (int64, error) {
 	generation, err := s.rdb.Get(ctx, nodeAuthorityGenerationKey(nodeURL)).Int64()
 	if errors.Is(err, redis.Nil) {
 		return 0, nil
 	}
 	return generation, err
-}
-
-func unmarshalStoredCard(data []byte, nodeRecipe bool) (playback.RecipeCard, int64, bool) {
-	if !nodeRecipe {
-		card, ok := unmarshalCard(data)
-		return card, 0, ok
-	}
-	var envelope nodeAuthorityEnvelope
-	if err := json.Unmarshal(data, &envelope); err != nil {
-		return playback.RecipeCard{}, 0, false
-	}
-	if envelope.Version != nodeAuthorityEnvelopeVersion || len(envelope.Recipe) == 0 {
-		card, ok := unmarshalCard(data)
-		return card, 0, ok
-	}
-	card, ok := unmarshalCard(envelope.Recipe)
-	return card, envelope.AuthorityGeneration, ok
 }
 
 func marshalCard(card playback.RecipeCard) ([]byte, error) {
@@ -288,7 +303,11 @@ func (s *Store) Delete(ctx context.Context, sessionID string) error {
 	if s == nil || s.rdb == nil || sessionID == "" {
 		return nil
 	}
-	return s.rdb.Del(ctx, s.key(sessionID)).Err()
+	keys := []string{s.key(sessionID)}
+	if s.prefix == KeyPrefix {
+		keys = append(keys, nodeAuthorityRecordGenerationKey(sessionID))
+	}
+	return s.rdb.Del(ctx, keys...).Err()
 }
 
 // RevokeNode invalidates every recipe previously issued for nodeURL. The

--- a/internal/noderecipe/store.go
+++ b/internal/noderecipe/store.go
@@ -17,6 +17,9 @@
 // remuxes also use the record as durable active authority: central writes it
 // before publishing the route, the node checks it before each remux response,
 // and deliberate teardown deletes it so a surviving token cannot restart work.
+// Each node record is stamped with a per-node authority generation; destructive
+// force reload advances that generation so even a published remux URL which has
+// not received its first request is revoked without enumerating recipe keys.
 //
 // The same central→node recipe handoff serves a second, independent purpose
 // under its own key space: a proxy grant. When an attempt negotiates
@@ -24,7 +27,8 @@
 // URL, so the proxy has no token to serve from — central writes the session's
 // recipe here at plan time and the proxy reads it after authenticating the
 // caller's own login session. NewStore and NewProxyGrantStore are the two key
-// spaces; everything else about them is identical.
+// spaces. Proxy grants deliberately do not participate in the transcode-node
+// authority generation.
 package noderecipe
 
 import (
@@ -32,6 +36,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -48,14 +53,20 @@ const KeyPrefix = "silo:noderecipe:"
 // node roles, and a lookup in one must never resolve the other's entry.
 const ProxyGrantKeyPrefix = "silo:proxygrant:"
 
+// nodeAuthorityGenerationKeyPrefix namespaces the per-node generation that
+// force reload advances to revoke every outstanding node recipe, including a
+// progressive-remux URL that has not received its first request yet.
+const nodeAuthorityGenerationKeyPrefix = "silo:noderecipe-authority-generation:"
+
 // DefaultTTL bounds how long a stored recipe survives. It matches the stream
 // token lifetime (playback.MaxTokenTTL, 24h): past it no surviving token could
 // still drive a reconstruct, so the recipe is safe to lapse.
 const DefaultTTL = playback.MaxTokenTTL
 
 const (
-	toneMapEnvelopeVersion     = 1
-	audioRecipeEnvelopeVersion = 2
+	toneMapEnvelopeVersion       = 1
+	audioRecipeEnvelopeVersion   = 2
+	nodeAuthorityEnvelopeVersion = 3
 )
 
 type toneMapEnvelope struct {
@@ -71,6 +82,26 @@ type audioRecipeEnvelope struct {
 	Version int                 `json:"version"`
 	Recipe  playback.RecipeCard `json:"audio_recipe"`
 }
+
+type nodeAuthorityEnvelope struct {
+	Version             int             `json:"version"`
+	AuthorityGeneration int64           `json:"authority_generation"`
+	Recipe              json.RawMessage `json:"node_recipe"`
+}
+
+// putNodeRecipeScript reads the node generation and writes the recipe envelope
+// in one Redis operation. It therefore orders a concurrent Put and RevokeNode:
+// a recipe written before the increment is stale, while one written after it
+// carries the new generation.
+var putNodeRecipeScript = redis.NewScript(`
+local generation = redis.call("GET", KEYS[2])
+if not generation then
+  generation = "0"
+end
+local envelope = '{"version":' .. ARGV[3] .. ',"authority_generation":' .. generation .. ',"node_recipe":' .. ARGV[1] .. '}'
+redis.call("SET", KEYS[1], envelope, "PX", ARGV[2])
+return generation
+`)
 
 // Store is the Redis-backed recipe store shared by central (writer) and the
 // nodes (readers). One instance owns exactly one key prefix; see NewStore and
@@ -110,6 +141,11 @@ func (s *Store) Enabled() bool { return s != nil && s.rdb != nil }
 
 func (s *Store) key(sessionID string) string { return s.prefix + sessionID }
 
+func nodeAuthorityGenerationKey(nodeURL string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(nodeURL), "/")
+	return nodeAuthorityGenerationKeyPrefix + normalized
+}
+
 // Put stores the reconstruction recipe for a remote transcode session. Best
 // effort: a write error is returned for the caller to log, never fatal.
 func (s *Store) Put(ctx context.Context, sessionID string, card playback.RecipeCard) error {
@@ -119,6 +155,13 @@ func (s *Store) Put(ctx context.Context, sessionID string, card playback.RecipeC
 	data, err := marshalCard(card)
 	if err != nil {
 		return err
+	}
+	if s.prefix == KeyPrefix && strings.TrimSpace(card.TranscodeNodeURL) != "" {
+		ttlMillis := max(s.ttl.Milliseconds(), 1)
+		return putNodeRecipeScript.Run(ctx, s.rdb, []string{
+			s.key(sessionID),
+			nodeAuthorityGenerationKey(card.TranscodeNodeURL),
+		}, data, ttlMillis, nodeAuthorityEnvelopeVersion).Err()
 	}
 	return s.rdb.Set(ctx, s.key(sessionID), data, s.ttl).Err()
 }
@@ -137,12 +180,47 @@ func (s *Store) Get(ctx context.Context, sessionID string) (*playback.RecipeCard
 		}
 		return nil, false
 	}
-	card, ok := unmarshalCard(data)
+	card, generation, ok := unmarshalStoredCard(data, s.prefix == KeyPrefix)
 	if !ok {
 		slog.WarnContext(ctx, "decode node recipe failed", "component", "noderecipe", "key_prefix", s.prefix, "playback_session_id", sessionID)
 		return nil, false
 	}
+	if s.prefix == KeyPrefix && strings.TrimSpace(card.TranscodeNodeURL) != "" {
+		currentGeneration, generationErr := s.currentNodeAuthorityGeneration(ctx, card.TranscodeNodeURL)
+		if generationErr != nil {
+			slog.WarnContext(ctx, "load node authority generation failed", "component", "noderecipe", "error", generationErr, "playback_session_id", sessionID)
+			return nil, false
+		}
+		if generation != currentGeneration {
+			return nil, false
+		}
+	}
 	return &card, true
+}
+
+func (s *Store) currentNodeAuthorityGeneration(ctx context.Context, nodeURL string) (int64, error) {
+	generation, err := s.rdb.Get(ctx, nodeAuthorityGenerationKey(nodeURL)).Int64()
+	if errors.Is(err, redis.Nil) {
+		return 0, nil
+	}
+	return generation, err
+}
+
+func unmarshalStoredCard(data []byte, nodeRecipe bool) (playback.RecipeCard, int64, bool) {
+	if !nodeRecipe {
+		card, ok := unmarshalCard(data)
+		return card, 0, ok
+	}
+	var envelope nodeAuthorityEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return playback.RecipeCard{}, 0, false
+	}
+	if envelope.Version != nodeAuthorityEnvelopeVersion || len(envelope.Recipe) == 0 {
+		card, ok := unmarshalCard(data)
+		return card, 0, ok
+	}
+	card, ok := unmarshalCard(envelope.Recipe)
+	return card, envelope.AuthorityGeneration, ok
 }
 
 func marshalCard(card playback.RecipeCard) ([]byte, error) {
@@ -211,4 +289,15 @@ func (s *Store) Delete(ctx context.Context, sessionID string) error {
 		return nil
 	}
 	return s.rdb.Del(ctx, s.key(sessionID)).Err()
+}
+
+// RevokeNode invalidates every recipe previously issued for nodeURL. The
+// generation key intentionally outlives individual recipes: it is one bounded
+// key per configured node and prevents a legacy generation-zero record from
+// becoming valid again after recipe TTLs expire.
+func (s *Store) RevokeNode(ctx context.Context, nodeURL string) error {
+	if s == nil || s.rdb == nil || s.prefix != KeyPrefix || strings.TrimSpace(nodeURL) == "" {
+		return nil
+	}
+	return s.rdb.Incr(ctx, nodeAuthorityGenerationKey(nodeURL)).Err()
 }

--- a/internal/noderecipe/store_test.go
+++ b/internal/noderecipe/store_test.go
@@ -83,10 +83,13 @@ func TestNodeAuthorityGenerationKeyNormalizesNodeURL(t *testing.T) {
 	}
 }
 
-func TestNodeAuthorityRecordGenerationKeyIsSeparateFromRecipe(t *testing.T) {
+func TestNodeAuthorityRecordSidecarKeysAreSeparate(t *testing.T) {
 	store := NewStore(nil, 0)
 	if got := nodeAuthorityRecordGenerationKey("abc"); got == store.key("abc") {
 		t.Fatalf("record generation key %q collides with recipe key", got)
+	}
+	if got := nodeAuthorityRecordDigestKey("abc"); got == store.key("abc") || got == nodeAuthorityRecordGenerationKey("abc") {
+		t.Fatalf("record digest key %q collides with another authority key", got)
 	}
 }
 
@@ -172,14 +175,18 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	newSessionID := "new-" + unique
 	legacyBeforeSessionID := "legacy-before-" + unique
 	legacyAfterSessionID := "legacy-after-" + unique
+	legacyOverwriteBeforeSessionID := "legacy-overwrite-before-" + unique
+	legacyOverwriteSessionID := "legacy-overwrite-" + unique
 	grantID := "grant-" + unique
 	t.Cleanup(func() {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), time.Second)
 		defer cancel()
 		_ = client.Del(cleanupCtx,
-			store.key(oldSessionID), store.key(newSessionID), store.key(legacyBeforeSessionID), store.key(legacyAfterSessionID),
+			store.key(oldSessionID), store.key(newSessionID), store.key(legacyBeforeSessionID), store.key(legacyAfterSessionID), store.key(legacyOverwriteBeforeSessionID), store.key(legacyOverwriteSessionID),
 			nodeAuthorityRecordGenerationKey(oldSessionID), nodeAuthorityRecordGenerationKey(newSessionID),
-			nodeAuthorityRecordGenerationKey(legacyBeforeSessionID), nodeAuthorityRecordGenerationKey(legacyAfterSessionID),
+			nodeAuthorityRecordGenerationKey(legacyBeforeSessionID), nodeAuthorityRecordGenerationKey(legacyAfterSessionID), nodeAuthorityRecordGenerationKey(legacyOverwriteBeforeSessionID), nodeAuthorityRecordGenerationKey(legacyOverwriteSessionID),
+			nodeAuthorityRecordDigestKey(oldSessionID), nodeAuthorityRecordDigestKey(newSessionID),
+			nodeAuthorityRecordDigestKey(legacyBeforeSessionID), nodeAuthorityRecordDigestKey(legacyAfterSessionID), nodeAuthorityRecordDigestKey(legacyOverwriteBeforeSessionID), nodeAuthorityRecordDigestKey(legacyOverwriteSessionID),
 			grants.key(grantID), nodeAuthorityGenerationKey(nodeURL),
 		).Err()
 	})
@@ -207,6 +214,24 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	if err := client.Set(t.Context(), store.key(legacyBeforeSessionID), legacyBeforeData, time.Minute).Err(); err != nil {
 		t.Fatal(err)
 	}
+	legacyOverwriteCard := card
+	legacyOverwriteCard.SessionID = legacyOverwriteSessionID
+	if err := store.Put(t.Context(), legacyOverwriteSessionID, legacyOverwriteCard); err != nil {
+		t.Fatal(err)
+	}
+	legacyOverwriteBeforeCard := card
+	legacyOverwriteBeforeCard.SessionID = legacyOverwriteBeforeSessionID
+	if err := store.Put(t.Context(), legacyOverwriteBeforeSessionID, legacyOverwriteBeforeCard); err != nil {
+		t.Fatal(err)
+	}
+	legacyOverwriteBeforeCard.InputPath = "/media/stale-legacy-overwrite.mkv"
+	legacyOverwriteBeforeData, err := marshalCard(legacyOverwriteBeforeCard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Set(t.Context(), store.key(legacyOverwriteBeforeSessionID), legacyOverwriteBeforeData, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.RevokeNode(t.Context(), nodeURL); err != nil {
 		t.Fatal(err)
 	}
@@ -224,6 +249,9 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 
 	if _, ok := store.Get(t.Context(), legacyBeforeSessionID); ok {
 		t.Fatal("legacy generation-zero recipe survived node revocation")
+	}
+	if _, ok := store.Get(t.Context(), legacyOverwriteBeforeSessionID); ok {
+		t.Fatal("pre-reload legacy overwrite with stale sidecars survived node revocation")
 	}
 
 	revokedAt, err := client.Get(t.Context(), nodeAuthorityGenerationKey(nodeURL)).Int64()
@@ -251,6 +279,17 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	if _, ok := store.Get(t.Context(), legacyAfterSessionID); !ok {
 		t.Fatal("legacy recipe issued after node revocation was rejected")
 	}
+	legacyOverwriteCard.InputPath = "/media/updated-by-legacy-api.mkv"
+	legacyOverwriteData, err := marshalCard(legacyOverwriteCard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Set(t.Context(), store.key(legacyOverwriteSessionID), legacyOverwriteData, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := store.Get(t.Context(), legacyOverwriteSessionID); !ok || got.InputPath != legacyOverwriteCard.InputPath {
+		t.Fatalf("legacy overwrite with stale sidecars = (%+v, %t), want updated recipe", got, ok)
+	}
 
 	grant := playback.RecipeCard{SessionID: grantID, TranscodeNodeURL: nodeURL, PlayMethod: playback.PlayRemux}
 	if err := grants.Put(t.Context(), grantID, grant); err != nil {
@@ -266,12 +305,16 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	if err := store.Delete(t.Context(), newSessionID); err != nil {
 		t.Fatal(err)
 	}
-	remaining, err := client.Exists(t.Context(), store.key(newSessionID), nodeAuthorityRecordGenerationKey(newSessionID)).Result()
+	remaining, err := client.Exists(t.Context(),
+		store.key(newSessionID),
+		nodeAuthorityRecordGenerationKey(newSessionID),
+		nodeAuthorityRecordDigestKey(newSessionID),
+	).Result()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if remaining != 0 {
-		t.Fatal("node recipe delete left its generation sidecar behind")
+		t.Fatal("node recipe delete left an authority sidecar behind")
 	}
 }
 

--- a/internal/noderecipe/store_test.go
+++ b/internal/noderecipe/store_test.go
@@ -83,6 +83,13 @@ func TestNodeAuthorityGenerationKeyNormalizesNodeURL(t *testing.T) {
 	}
 }
 
+func TestNodeAuthorityRecordGenerationKeyIsSeparateFromRecipe(t *testing.T) {
+	store := NewStore(nil, 0)
+	if got := nodeAuthorityRecordGenerationKey("abc"); got == store.key("abc") {
+		t.Fatalf("record generation key %q collides with recipe key", got)
+	}
+}
+
 // The two key spaces share one implementation, so nothing but the prefix may
 // distinguish them: a proxy grant must never resolve a node recipe, and the
 // transcode node's reconstruct lookup must never resolve a grant.
@@ -130,28 +137,18 @@ func TestDefaultTTLMatchesTokenLifetime(t *testing.T) {
 	}
 }
 
-func TestNodeAuthorityEnvelopePreservesNestedRecipe(t *testing.T) {
+func TestNodeAuthorityKeepsPreviousRecipeWireFormat(t *testing.T) {
 	card := playback.RecipeCard{
 		SessionID: "sid", TranscodeNodeURL: "http://node:8070", PlayMethod: playback.PlayTranscode,
 		TranscodeAudio: true, TargetCodecAudio: "aac", SourceAudioChannels: 6, TargetAudioChannels: 2,
 	}
-	inner, err := marshalCard(card)
+	data, err := marshalCard(card)
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := json.Marshal(nodeAuthorityEnvelope{
-		Version: nodeAuthorityEnvelopeVersion, AuthorityGeneration: 7, Recipe: inner,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	decoded, generation, ok := unmarshalStoredCard(data, true)
-	if !ok || decoded != card || generation != 7 {
-		t.Fatalf("decode = (%+v, %d, %v), want (%+v, 7, true)", decoded, generation, ok, card)
-	}
-	if _, _, ok := unmarshalStoredCard(data, false); ok {
-		t.Fatal("proxy-grant decoder accepted a node-authority envelope")
+	decoded, ok := unmarshalCard(data)
+	if !ok || decoded != card {
+		t.Fatalf("previous node decode = (%+v, %v), want (%+v, true)", decoded, ok, card)
 	}
 }
 
@@ -180,6 +177,8 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 		defer cancel()
 		_ = client.Del(cleanupCtx,
 			store.key(oldSessionID), store.key(newSessionID), store.key(legacySessionID),
+			nodeAuthorityRecordGenerationKey(oldSessionID), nodeAuthorityRecordGenerationKey(newSessionID),
+			nodeAuthorityRecordGenerationKey(legacySessionID),
 			grants.key(grantID), nodeAuthorityGenerationKey(nodeURL),
 		).Err()
 	})
@@ -190,6 +189,13 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	}
 	if _, ok := store.Get(t.Context(), oldSessionID); !ok {
 		t.Fatal("fresh node recipe missed before revocation")
+	}
+	rawRecipe, err := client.Get(t.Context(), store.key(oldSessionID)).Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded, ok := unmarshalCard(rawRecipe); !ok || decoded != card {
+		t.Fatalf("stored recipe is not readable by the previous node: (%+v, %v)", decoded, ok)
 	}
 	if err := store.RevokeNode(t.Context(), nodeURL); err != nil {
 		t.Fatal(err)
@@ -228,6 +234,17 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	}
 	if _, ok := grants.Get(t.Context(), grantID); !ok {
 		t.Fatal("node authority revocation affected proxy-grant key space")
+	}
+
+	if err := store.Delete(t.Context(), newSessionID); err != nil {
+		t.Fatal(err)
+	}
+	remaining, err := client.Exists(t.Context(), store.key(newSessionID), nodeAuthorityRecordGenerationKey(newSessionID)).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 0 {
+		t.Fatal("node recipe delete left its generation sidecar behind")
 	}
 }
 

--- a/internal/noderecipe/store_test.go
+++ b/internal/noderecipe/store_test.go
@@ -170,15 +170,16 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	grants := NewProxyGrantStore(client, time.Minute)
 	oldSessionID := "old-" + unique
 	newSessionID := "new-" + unique
-	legacySessionID := "legacy-" + unique
+	legacyBeforeSessionID := "legacy-before-" + unique
+	legacyAfterSessionID := "legacy-after-" + unique
 	grantID := "grant-" + unique
 	t.Cleanup(func() {
 		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), time.Second)
 		defer cancel()
 		_ = client.Del(cleanupCtx,
-			store.key(oldSessionID), store.key(newSessionID), store.key(legacySessionID),
+			store.key(oldSessionID), store.key(newSessionID), store.key(legacyBeforeSessionID), store.key(legacyAfterSessionID),
 			nodeAuthorityRecordGenerationKey(oldSessionID), nodeAuthorityRecordGenerationKey(newSessionID),
-			nodeAuthorityRecordGenerationKey(legacySessionID),
+			nodeAuthorityRecordGenerationKey(legacyBeforeSessionID), nodeAuthorityRecordGenerationKey(legacyAfterSessionID),
 			grants.key(grantID), nodeAuthorityGenerationKey(nodeURL),
 		).Err()
 	})
@@ -197,6 +198,15 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	if decoded, ok := unmarshalCard(rawRecipe); !ok || decoded != card {
 		t.Fatalf("stored recipe is not readable by the previous node: (%+v, %v)", decoded, ok)
 	}
+	legacyBeforeCard := card
+	legacyBeforeCard.SessionID = legacyBeforeSessionID
+	legacyBeforeData, err := marshalCard(legacyBeforeCard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Set(t.Context(), store.key(legacyBeforeSessionID), legacyBeforeData, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.RevokeNode(t.Context(), nodeURL); err != nil {
 		t.Fatal(err)
 	}
@@ -212,17 +222,34 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 		t.Fatal("recipe issued after node revocation was rejected")
 	}
 
-	legacyCard := card
-	legacyCard.SessionID = legacySessionID
-	legacyData, err := marshalCard(legacyCard)
+	if _, ok := store.Get(t.Context(), legacyBeforeSessionID); ok {
+		t.Fatal("legacy generation-zero recipe survived node revocation")
+	}
+
+	revokedAt, err := client.Get(t.Context(), nodeAuthorityGenerationKey(nodeURL)).Int64()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := client.Set(t.Context(), store.key(legacySessionID), legacyData, time.Minute).Err(); err != nil {
+	for {
+		redisTime, timeErr := client.Time(t.Context()).Result()
+		if timeErr != nil {
+			t.Fatal(timeErr)
+		}
+		if redisTime.UnixMilli() > revokedAt {
+			break
+		}
+	}
+	legacyAfterCard := card
+	legacyAfterCard.SessionID = legacyAfterSessionID
+	legacyAfterData, err := marshalCard(legacyAfterCard)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := store.Get(t.Context(), legacySessionID); ok {
-		t.Fatal("legacy generation-zero recipe survived node revocation")
+	if err := client.Set(t.Context(), store.key(legacyAfterSessionID), legacyAfterData, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.Get(t.Context(), legacyAfterSessionID); !ok {
+		t.Fatal("legacy recipe issued after node revocation was rejected")
 	}
 
 	grant := playback.RecipeCard{SessionID: grantID, TranscodeNodeURL: nodeURL, PlayMethod: playback.PlayRemux}

--- a/internal/noderecipe/store_test.go
+++ b/internal/noderecipe/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -65,6 +66,12 @@ func TestNilStore_RevokeNodeNoop(t *testing.T) {
 	if err := NewStore(nil, 0).RevokeNode(t.Context(), "http://node"); err != nil {
 		t.Fatalf("disabled store RevokeNode returned error: %v", err)
 	}
+	if err := s.RevokeNodeID(t.Context(), 42); err != nil {
+		t.Fatalf("nil store RevokeNodeID returned error: %v", err)
+	}
+	if err := NewStore(nil, 0).RevokeNodeID(t.Context(), 42); err != nil {
+		t.Fatalf("disabled store RevokeNodeID returned error: %v", err)
+	}
 }
 
 func TestKeyNamespacing(t *testing.T) {
@@ -80,6 +87,16 @@ func TestNodeAuthorityGenerationKeyNormalizesNodeURL(t *testing.T) {
 	}
 	if withoutSlash == nodeAuthorityGenerationKey("http://other-node:8070") {
 		t.Fatal("different nodes share an authority generation key")
+	}
+}
+
+func TestNodeAuthorityGenerationKeyUsesStableNodeIDWhenAvailable(t *testing.T) {
+	card := playback.RecipeCard{TranscodeNodeURL: "http://node:8070", RoutingExecutionNodeID: 42}
+	if got, want := nodeAuthorityGenerationKeyForCard(card), nodeAuthorityGenerationKeyForNodeID(42); got != want {
+		t.Fatalf("card authority key = %q, want stable ID key %q", got, want)
+	}
+	if nodeAuthorityGenerationKeyForNodeID(42) == nodeAuthorityGenerationKey("http://node-id:42") {
+		t.Fatal("stable node ID and route URL share an authority key")
 	}
 }
 
@@ -168,6 +185,11 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	t.Cleanup(func() { _ = client.Close() })
 
 	unique := uuid.NewString()
+	parsedNodeID, err := strconv.ParseInt(unique[:8], 16, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nodeID := int(parsedNodeID%2_000_000_000) + 1
 	nodeURL := "http://node-" + unique
 	store := NewStore(client, time.Minute)
 	grants := NewProxyGrantStore(client, time.Minute)
@@ -187,11 +209,14 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 			nodeAuthorityRecordGenerationKey(legacyBeforeSessionID), nodeAuthorityRecordGenerationKey(legacyAfterSessionID), nodeAuthorityRecordGenerationKey(legacyOverwriteBeforeSessionID), nodeAuthorityRecordGenerationKey(legacyOverwriteSessionID),
 			nodeAuthorityRecordDigestKey(oldSessionID), nodeAuthorityRecordDigestKey(newSessionID),
 			nodeAuthorityRecordDigestKey(legacyBeforeSessionID), nodeAuthorityRecordDigestKey(legacyAfterSessionID), nodeAuthorityRecordDigestKey(legacyOverwriteBeforeSessionID), nodeAuthorityRecordDigestKey(legacyOverwriteSessionID),
-			grants.key(grantID), nodeAuthorityGenerationKey(nodeURL),
+			grants.key(grantID), nodeAuthorityGenerationKey(nodeURL), nodeAuthorityGenerationKeyForNodeID(nodeID),
 		).Err()
 	})
 
-	card := playback.RecipeCard{SessionID: oldSessionID, TranscodeNodeURL: nodeURL, PlayMethod: playback.PlayRemux}
+	card := playback.RecipeCard{
+		SessionID: oldSessionID, TranscodeNodeURL: nodeURL, PlayMethod: playback.PlayRemux,
+		RoutingExecutionNodeID: nodeID,
+	}
 	if err := store.Put(t.Context(), oldSessionID, card); err != nil {
 		t.Fatal(err)
 	}
@@ -232,11 +257,14 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 	if err := client.Set(t.Context(), store.key(legacyOverwriteBeforeSessionID), legacyOverwriteBeforeData, time.Minute).Err(); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RevokeNode(t.Context(), nodeURL); err != nil {
+	if err := store.RevokeNodeID(t.Context(), nodeID); err != nil {
 		t.Fatal(err)
 	}
 	if _, ok := store.Get(t.Context(), oldSessionID); ok {
 		t.Fatal("recipe issued before node revocation remained valid")
+	}
+	if _, ok := NewStore(client, time.Minute).Get(t.Context(), oldSessionID); ok {
+		t.Fatal("fresh store instance forgot the stable node revocation")
 	}
 
 	card.SessionID = newSessionID
@@ -254,7 +282,7 @@ func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
 		t.Fatal("pre-reload legacy overwrite with stale sidecars survived node revocation")
 	}
 
-	revokedAt, err := client.Get(t.Context(), nodeAuthorityGenerationKey(nodeURL)).Int64()
+	revokedAt, err := client.Get(t.Context(), nodeAuthorityGenerationKeyForNodeID(nodeID)).Int64()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/noderecipe/store_test.go
+++ b/internal/noderecipe/store_test.go
@@ -3,7 +3,12 @@ package noderecipe
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/tonemap"
@@ -52,9 +57,29 @@ func TestNilStore_DeleteNoop(t *testing.T) {
 	}
 }
 
+func TestNilStore_RevokeNodeNoop(t *testing.T) {
+	var s *Store
+	if err := s.RevokeNode(t.Context(), "http://node"); err != nil {
+		t.Fatalf("nil store RevokeNode returned error: %v", err)
+	}
+	if err := NewStore(nil, 0).RevokeNode(t.Context(), "http://node"); err != nil {
+		t.Fatalf("disabled store RevokeNode returned error: %v", err)
+	}
+}
+
 func TestKeyNamespacing(t *testing.T) {
 	if got := NewStore(nil, 0).key("abc"); got != "silo:noderecipe:abc" {
 		t.Fatalf("key(abc) = %q, want silo:noderecipe:abc", got)
+	}
+}
+
+func TestNodeAuthorityGenerationKeyNormalizesNodeURL(t *testing.T) {
+	withoutSlash := nodeAuthorityGenerationKey("http://node:8070")
+	if withSlash := nodeAuthorityGenerationKey(" http://node:8070/ "); withSlash != withoutSlash {
+		t.Fatalf("generation keys differ: %q != %q", withSlash, withoutSlash)
+	}
+	if withoutSlash == nodeAuthorityGenerationKey("http://other-node:8070") {
+		t.Fatal("different nodes share an authority generation key")
 	}
 }
 
@@ -102,6 +127,107 @@ func TestDefaultTTLMatchesTokenLifetime(t *testing.T) {
 	}
 	if NewStore(nil, 0).ttl != DefaultTTL {
 		t.Fatal("NewStore with ttl<=0 did not default to DefaultTTL")
+	}
+}
+
+func TestNodeAuthorityEnvelopePreservesNestedRecipe(t *testing.T) {
+	card := playback.RecipeCard{
+		SessionID: "sid", TranscodeNodeURL: "http://node:8070", PlayMethod: playback.PlayTranscode,
+		TranscodeAudio: true, TargetCodecAudio: "aac", SourceAudioChannels: 6, TargetAudioChannels: 2,
+	}
+	inner, err := marshalCard(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(nodeAuthorityEnvelope{
+		Version: nodeAuthorityEnvelopeVersion, AuthorityGeneration: 7, Recipe: inner,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decoded, generation, ok := unmarshalStoredCard(data, true)
+	if !ok || decoded != card || generation != 7 {
+		t.Fatalf("decode = (%+v, %d, %v), want (%+v, 7, true)", decoded, generation, ok, card)
+	}
+	if _, _, ok := unmarshalStoredCard(data, false); ok {
+		t.Fatal("proxy-grant decoder accepted a node-authority envelope")
+	}
+}
+
+func TestNodeAuthorityGenerationRevokesDormantRecipes(t *testing.T) {
+	rawURL := os.Getenv("SILO_TEST_REDIS_URL")
+	if rawURL == "" {
+		t.Skip("SILO_TEST_REDIS_URL not set")
+	}
+	options, err := redis.ParseURL(rawURL)
+	if err != nil {
+		t.Fatalf("parse SILO_TEST_REDIS_URL: %v", err)
+	}
+	client := redis.NewClient(options)
+	t.Cleanup(func() { _ = client.Close() })
+
+	unique := uuid.NewString()
+	nodeURL := "http://node-" + unique
+	store := NewStore(client, time.Minute)
+	grants := NewProxyGrantStore(client, time.Minute)
+	oldSessionID := "old-" + unique
+	newSessionID := "new-" + unique
+	legacySessionID := "legacy-" + unique
+	grantID := "grant-" + unique
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), time.Second)
+		defer cancel()
+		_ = client.Del(cleanupCtx,
+			store.key(oldSessionID), store.key(newSessionID), store.key(legacySessionID),
+			grants.key(grantID), nodeAuthorityGenerationKey(nodeURL),
+		).Err()
+	})
+
+	card := playback.RecipeCard{SessionID: oldSessionID, TranscodeNodeURL: nodeURL, PlayMethod: playback.PlayRemux}
+	if err := store.Put(t.Context(), oldSessionID, card); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.Get(t.Context(), oldSessionID); !ok {
+		t.Fatal("fresh node recipe missed before revocation")
+	}
+	if err := store.RevokeNode(t.Context(), nodeURL); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.Get(t.Context(), oldSessionID); ok {
+		t.Fatal("recipe issued before node revocation remained valid")
+	}
+
+	card.SessionID = newSessionID
+	if err := store.Put(t.Context(), newSessionID, card); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.Get(t.Context(), newSessionID); !ok {
+		t.Fatal("recipe issued after node revocation was rejected")
+	}
+
+	legacyCard := card
+	legacyCard.SessionID = legacySessionID
+	legacyData, err := marshalCard(legacyCard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Set(t.Context(), store.key(legacySessionID), legacyData, time.Minute).Err(); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := store.Get(t.Context(), legacySessionID); ok {
+		t.Fatal("legacy generation-zero recipe survived node revocation")
+	}
+
+	grant := playback.RecipeCard{SessionID: grantID, TranscodeNodeURL: nodeURL, PlayMethod: playback.PlayRemux}
+	if err := grants.Put(t.Context(), grantID, grant); err != nil {
+		t.Fatal(err)
+	}
+	if err := grants.RevokeNode(t.Context(), nodeURL); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := grants.Get(t.Context(), grantID); !ok {
+		t.Fatal("node authority revocation affected proxy-grant key space")
 	}
 }
 

--- a/internal/noderouting/resolver.go
+++ b/internal/noderouting/resolver.go
@@ -112,12 +112,13 @@ func (a sessionPlannerAdapter) planSession(request nodepool.RouteRequest, transc
 
 type ResolveRequest struct {
 	Request
-	SessionID            string
-	CurrentTranscodeURL  string
-	EstimatedBitrateKbps int
-	TranscodeEligible    func(*nodepool.Node) bool
-	ProxyEligible        func(*nodepool.Node) bool
-	ExcludedShapeIDs     map[string]struct{}
+	SessionID              string
+	CurrentTranscodeURL    string
+	EstimatedBitrateKbps   int
+	TranscodeEligible      func(*nodepool.Node) bool
+	ProxyEligible          func(*nodepool.Node) bool
+	ProxyExecutionEligible func(*nodepool.Node) bool
+	ExcludedShapeIDs       map[string]struct{}
 }
 
 type Outcome string
@@ -169,6 +170,10 @@ func Resolve(planner nodepool.RoutePlanner, request ResolveRequest) (Decision, e
 			continue
 		}
 		plannerAttempted = true
+		proxyEligible := request.ProxyEligible
+		if shape.Execution == ExecutionProxy {
+			proxyEligible = request.ProxyExecutionEligible
+		}
 		plan := planner.PlanRoute(nodepool.RouteRequest{
 			SessionID:            request.SessionID,
 			CurrentTranscodeURL:  request.CurrentTranscodeURL,
@@ -176,7 +181,7 @@ func Resolve(planner nodepool.RoutePlanner, request ResolveRequest) (Decision, e
 			NeedsTranscode:       shape.NeedsTranscodeNode(),
 			NeedsProxy:           shape.NeedsProxyNode(),
 			TranscodeEligible:    request.TranscodeEligible,
-			ProxyEligible:        request.ProxyEligible,
+			ProxyEligible:        proxyEligible,
 		})
 		if shape.NeedsTranscodeNode() != (plan.TranscodeNode != nil) ||
 			shape.NeedsProxyNode() != (plan.ProxyNode != nil) {

--- a/internal/noderouting/resolver_test.go
+++ b/internal/noderouting/resolver_test.go
@@ -64,6 +64,51 @@ func TestResolveUsesExactWorkerAPIRoute(t *testing.T) {
 	}
 }
 
+func TestResolveUsesTranscodeExecutorWithRelayOnlyProxy(t *testing.T) {
+	proxies := nodepool.NewProxyPool()
+	proxies.SetNodes([]*nodepool.Node{{ID: 2, URL: "http://proxy", Enabled: true, Healthy: true}})
+	transcodes := nodepool.NewTranscodePool()
+	transcodes.SetNodes([]*nodepool.Node{{ID: 1, URL: "http://transcode", Enabled: true, Healthy: true}})
+	planner := nodepool.NewPlanner(proxies, transcodes)
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+
+	decision, err := Resolve(planner, ResolveRequest{
+		Request:                Request{Workload: WorkloadRemux, Delivery: DeliveryProgressiveRemux, Policy: policy, ProxyAllowed: true},
+		SessionID:              "session-1",
+		TranscodeEligible:      func(node *nodepool.Node) bool { return node.URL == "http://transcode" },
+		ProxyExecutionEligible: func(*nodepool.Node) bool { return false },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Shape.ID != "progressive_remux_transcode_proxy" ||
+		decision.Plan.TranscodeNode == nil || decision.Plan.ProxyNode == nil {
+		t.Fatalf("decision = %#v, want transcode execution with proxy egress", decision)
+	}
+}
+
+func TestResolveProxyExecutorDoesNotRequireRelayCapability(t *testing.T) {
+	proxies := nodepool.NewProxyPool()
+	proxies.SetNodes([]*nodepool.Node{{ID: 2, URL: "http://proxy", Enabled: true, Healthy: true}})
+	planner := nodepool.NewPlanner(proxies, nodepool.NewTranscodePool())
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionWorkerOnly
+
+	decision, err := Resolve(planner, ResolveRequest{
+		Request:           Request{Workload: WorkloadRemux, Delivery: DeliveryProgressiveRemux, Policy: policy, ProxyAllowed: true},
+		SessionID:         "session-1",
+		ProxyEligible:     func(*nodepool.Node) bool { return false },
+		TranscodeEligible: func(*nodepool.Node) bool { return false },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Shape.ID != "progressive_remux_proxy" || decision.Plan.ProxyNode == nil {
+		t.Fatalf("decision = %#v, want proxy-executed remux", decision)
+	}
+}
+
 type reservingLegacyPlanner struct {
 	plan          nodepool.Plan
 	released      []string

--- a/internal/noderouting/routes.go
+++ b/internal/noderouting/routes.go
@@ -51,6 +51,11 @@ type Shape struct {
 	Egress    Egress
 }
 
+const (
+	ShapeProgressiveRemuxAPI            = "progressive_remux_api"
+	ShapeProgressiveRemuxTranscodeProxy = "progressive_remux_transcode_proxy"
+)
+
 func (s Shape) NeedsTranscodeNode() bool { return s.Execution == ExecutionTranscode }
 func (s Shape) NeedsProxyNode() bool     { return s.Egress == EgressProxy }
 
@@ -151,9 +156,9 @@ func legalShapes(workload Workload, delivery Delivery) []Shape {
 		}
 	case DeliveryProgressiveRemux:
 		return []Shape{
-			shape("progressive_remux_api", ExecutionAPI, EgressAPI),
+			shape(ShapeProgressiveRemuxAPI, ExecutionAPI, EgressAPI),
 			shape("progressive_remux_proxy", ExecutionProxy, EgressProxy),
-			shape("progressive_remux_transcode_proxy", ExecutionTranscode, EgressProxy),
+			shape(ShapeProgressiveRemuxTranscodeProxy, ExecutionTranscode, EgressProxy),
 		}
 	case DeliveryHLSRemux:
 		return []Shape{

--- a/internal/noderouting/routes.go
+++ b/internal/noderouting/routes.go
@@ -153,6 +153,7 @@ func legalShapes(workload Workload, delivery Delivery) []Shape {
 		return []Shape{
 			shape("progressive_remux_api", ExecutionAPI, EgressAPI),
 			shape("progressive_remux_proxy", ExecutionProxy, EgressProxy),
+			shape("progressive_remux_transcode_proxy", ExecutionTranscode, EgressProxy),
 		}
 	case DeliveryHLSRemux:
 		return []Shape{
@@ -222,6 +223,15 @@ func rank(shape Shape, execution config.PlaybackExecutionPreference, egress conf
 	case config.PlaybackExecutionPreferWorker:
 		if !isWorker(shape.Execution) {
 			executionMiss = 1
+		}
+	case config.PlaybackExecutionPreferTranscode:
+		switch shape.Execution {
+		case ExecutionTranscode:
+			executionMiss = 0
+		case ExecutionProxy:
+			executionMiss = 1
+		default:
+			executionMiss = 2
 		}
 	case config.PlaybackExecutionPreferAPI:
 		if shape.Execution != ExecutionAPI {

--- a/internal/noderouting/routes_test.go
+++ b/internal/noderouting/routes_test.go
@@ -1,12 +1,13 @@
 package noderouting
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/config"
 )
 
-func TestCandidatesPreserveDefaultClusterBehavior(t *testing.T) {
+func TestCandidatesFollowSiloDefaults(t *testing.T) {
 	tests := []struct {
 		name     string
 		workload Workload
@@ -14,7 +15,7 @@ func TestCandidatesPreserveDefaultClusterBehavior(t *testing.T) {
 		want     string
 	}{
 		{"direct", WorkloadDirectPlay, DeliveryDirect, "direct_proxy"},
-		{"progressive remux", WorkloadRemux, DeliveryProgressiveRemux, "progressive_remux_proxy"},
+		{"progressive remux", WorkloadRemux, DeliveryProgressiveRemux, "progressive_remux_transcode_proxy"},
 		{"hls remux", WorkloadRemux, DeliveryHLSRemux, "hls_remux_transcode_proxy"},
 		{"video", WorkloadVideoTranscode, DeliveryHLSVideo, "hls_video_transcode_proxy"},
 	}
@@ -83,6 +84,55 @@ func TestCandidatesKeepExecutionPreferenceAheadOfEgressOnTie(t *testing.T) {
 	}
 	if got := result.Candidates[1].ID; got != "hls_video_transcode_proxy" {
 		t.Fatalf("second candidate = %q, want worker execution before local API", got)
+	}
+}
+
+func TestCandidatesPreferTranscodeNodeBeforeOtherExecutors(t *testing.T) {
+	policy := config.DefaultPlaybackRoutingPolicy()
+	policy.RemuxExecution = config.PlaybackExecutionPreferTranscode
+
+	tests := []struct {
+		name     string
+		delivery Delivery
+		want     []string
+	}{
+		{
+			name:     "HLS remux",
+			delivery: DeliveryHLSRemux,
+			want: []string{
+				"hls_remux_transcode_proxy",
+				"hls_remux_transcode_api",
+				"hls_remux_api",
+			},
+		},
+		{
+			name:     "progressive remux",
+			delivery: DeliveryProgressiveRemux,
+			want: []string{
+				"progressive_remux_transcode_proxy",
+				"progressive_remux_proxy",
+				"progressive_remux_api",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := Candidates(Request{
+				Workload: WorkloadRemux, Delivery: test.delivery,
+				Policy: policy, ProxyAllowed: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := make([]string, len(result.Candidates))
+			for i, candidate := range result.Candidates {
+				got[i] = candidate.ID
+			}
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("candidates = %v, want %v", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/playback/capabilityhash.go
+++ b/internal/playback/capabilityhash.go
@@ -54,6 +54,7 @@ type canonicalCapability struct {
 	ProbeRequestTimeout int64                      `json:"probe_request_timeout_ms"`
 	DetectedBackends    []canonicalDetectedBackend `json:"detected_backends"`
 	Transformations     []canonicalTransformation  `json:"transformations"`
+	TransportFeatures   []string                   `json:"transport_features"`
 	ToneMapCapabilities []canonicalToneMap         `json:"tone_map_capabilities"`
 }
 
@@ -100,6 +101,7 @@ func canonicalCapabilities(info HWAccelInfo) canonicalCapability {
 		ProbeRequestTimeout: info.ProbeRequestTimeoutMillis,
 		DetectedBackends:    canonicalDetectedBackends(info.DetectedBackends),
 		Transformations:     canonicalTransformations(info.Transformations),
+		TransportFeatures:   sortedStrings(info.TransportFeatures),
 		ToneMapCapabilities: canonicalToneMaps(info.ToneMapCapabilities),
 	}
 }

--- a/internal/playback/capabilityhash_test.go
+++ b/internal/playback/capabilityhash_test.go
@@ -25,6 +25,7 @@ func sampleCapabilityInfo() HWAccelInfo {
 			{Name: "tone_map", Executor: "node", RecipeVersion: "v2", ValidatedClaims: []string{"hdr10", "hlg"}},
 			{Name: "audio_to_aac", Executor: "node", RecipeVersion: "v1"},
 		},
+		TransportFeatures: []string{"feature-b", "feature-a"},
 		ToneMapCapabilities: tonemap.Capabilities{
 			{Mode: tonemap.ModeHardware, Backend: "nvenc", Filter: "tonemap_cuda", SourceKinds: []tonemap.SourceKind{"hdr10", "hlg"}},
 			{Mode: tonemap.ModeSoftware, Backend: "software", Filter: "tonemap", SourceKinds: []tonemap.SourceKind{"hdr10"}},
@@ -45,6 +46,7 @@ func TestComputeCapabilityHashIgnoresSliceOrder(t *testing.T) {
 	shuffled.DetectedBackends[0].Devices = []string{"/dev/dri/renderD128", "/dev/dri/renderD129"}
 	shuffled.Transformations = []TransformationV3{shuffled.Transformations[1], shuffled.Transformations[0]}
 	shuffled.Transformations[1].ValidatedClaims = []string{"hlg", "hdr10"}
+	shuffled.TransportFeatures = []string{"feature-a", "feature-b"}
 	shuffled.ToneMapCapabilities = tonemap.Capabilities{shuffled.ToneMapCapabilities[1], shuffled.ToneMapCapabilities[0]}
 	shuffled.ToneMapCapabilities[1].SourceKinds = []tonemap.SourceKind{"hlg", "hdr10"}
 
@@ -116,6 +118,7 @@ func TestComputeCapabilityHashDetectsRealChanges(t *testing.T) {
 		{"verified device", func(i *HWAccelInfo) { i.DetectedBackends[0].Device = "/dev/dri/renderD129" }},
 		{"transformation recipe version", func(i *HWAccelInfo) { i.Transformations[0].RecipeVersion = "v3" }},
 		{"validated claims", func(i *HWAccelInfo) { i.Transformations[0].ValidatedClaims = []string{"hdr10"} }},
+		{"transport feature", func(i *HWAccelInfo) { i.TransportFeatures = []string{"feature-a"} }},
 		{"tone map filter", func(i *HWAccelInfo) { i.ToneMapCapabilities[0].Filter = "tonemap_opencl" }},
 		{"tone map source kinds", func(i *HWAccelInfo) {
 			i.ToneMapCapabilities[0].SourceKinds = []tonemap.SourceKind{"hdr10"}

--- a/internal/playback/gpudetect.go
+++ b/internal/playback/gpudetect.go
@@ -164,6 +164,7 @@ type HWAccelInfo struct {
 	Source              string               `json:"source"`
 	NodeURL             string               `json:"node_url,omitempty"`
 	Transformations     []TransformationV3   `json:"transformations,omitempty"`
+	TransportFeatures   []string             `json:"transport_features,omitempty"`
 	ToneMapCapabilities tonemap.Capabilities `json:"tone_map_capabilities,omitempty"`
 	// BootID is this host's kernel boot identity (Linux only). Paired with a
 	// render device's PCI address it distinguishes "same GPU, same boot" from

--- a/internal/playback/protocol_v3.go
+++ b/internal/playback/protocol_v3.go
@@ -76,6 +76,14 @@ const (
 	DeviceQuirkRegistryRevisionV3    = "2026-07-13.1"
 )
 
+// Worker transport features are protocol capabilities rather than media
+// transformations. They let route planning exclude an older worker before a
+// client is handed a URL that worker cannot serve.
+const (
+	TransportFeatureProgressiveRemuxExecutionV1 = "progressive_remux_execution_v1"
+	TransportFeatureProgressiveRemuxRelayV1     = "progressive_remux_relay_v1"
+)
+
 // Degradation warning codes reported by playback plans.
 const DegradationWarningHDRToneMappedV3 = "hdr_tone_mapped"
 

--- a/internal/playback/recipecard.go
+++ b/internal/playback/recipecard.go
@@ -29,13 +29,14 @@ type RecipeCard struct {
 	OriginalStartedAt    time.Time `json:"original_started_at,omitempty"`
 	// Routing fields freeze the committed media-serving boundary so a token or
 	// stored card cannot lose a proxy-only assignment when it reconstructs a
-	// session on another process. The stable egress node identity binds a
-	// proxy-served artifact to the node whose capacity the planner reserved;
-	// internal URLs stay out of the portable recipe.
-	RoutingWorkload     string `json:"routing_workload,omitempty"`
-	RoutingExecution    string `json:"routing_execution,omitempty"`
-	RoutingEgress       string `json:"routing_egress,omitempty"`
-	RoutingEgressNodeID int    `json:"routing_egress_node_id,omitempty"`
+	// session on another process. Stable execution and egress identities bind
+	// the artifact to the nodes whose capacity the planner reserved; internal
+	// URLs stay out of the portable recipe.
+	RoutingWorkload        string `json:"routing_workload,omitempty"`
+	RoutingExecution       string `json:"routing_execution,omitempty"`
+	RoutingExecutionNodeID int    `json:"routing_execution_node_id,omitzero"`
+	RoutingEgress          string `json:"routing_egress,omitempty"`
+	RoutingEgressNodeID    int    `json:"routing_egress_node_id,omitempty"`
 
 	// PlayMethod discriminates which serve path reconstructs this session
 	// (direct / remux / transcode). Empty decodes as PlayTranscode for
@@ -345,26 +346,27 @@ func (c RecipeCard) ToClaims() streamtoken.Claims {
 		playMethod = streamtoken.PlayMethodToneMapTranscode
 	}
 	return streamtoken.Claims{
-		SessionID:            c.SessionID,
-		MediaPath:            c.InputPath,
-		OutputSubdir:         c.OutputSubdir,
-		DVProfile:            c.DVProfile,
-		AudioOnly:            c.AudioOnly,
-		PlayMethod:           playMethod,
-		TranscodeAudio:       c.TranscodeAudio,
-		RemuxDVMode:          string(c.RemuxDVMode),
-		TranscodeNode:        c.TranscodeNodeURL,
-		TranscodeTransportID: c.TranscodeTransportID,
-		RoutingWorkload:      c.RoutingWorkload,
-		RoutingExecution:     c.RoutingExecution,
-		RoutingEgress:        c.RoutingEgress,
-		RoutingEgressNodeID:  c.RoutingEgressNodeID,
-		TargetCodec:          c.TargetCodecVideo,
-		TargetRes:            c.TargetResolution,
-		AudioTrackIndex:      c.AudioTrackIndex,
-		UserID:               c.UserID,
-		ProfileID:            c.ProfileID,
-		MediaFileID:          c.MediaFileID,
+		SessionID:              c.SessionID,
+		MediaPath:              c.InputPath,
+		OutputSubdir:           c.OutputSubdir,
+		DVProfile:              c.DVProfile,
+		AudioOnly:              c.AudioOnly,
+		PlayMethod:             playMethod,
+		TranscodeAudio:         c.TranscodeAudio,
+		RemuxDVMode:            string(c.RemuxDVMode),
+		TranscodeNode:          c.TranscodeNodeURL,
+		TranscodeTransportID:   c.TranscodeTransportID,
+		RoutingWorkload:        c.RoutingWorkload,
+		RoutingExecution:       c.RoutingExecution,
+		RoutingExecutionNodeID: c.RoutingExecutionNodeID,
+		RoutingEgress:          c.RoutingEgress,
+		RoutingEgressNodeID:    c.RoutingEgressNodeID,
+		TargetCodec:            c.TargetCodecVideo,
+		TargetRes:              c.TargetResolution,
+		AudioTrackIndex:        c.AudioTrackIndex,
+		UserID:                 c.UserID,
+		ProfileID:              c.ProfileID,
+		MediaFileID:            c.MediaFileID,
 		OriginalStartedAtUnixNano: func() int64 {
 			if c.OriginalStartedAt.IsZero() {
 				return 0
@@ -443,6 +445,7 @@ func RecipeCardFromClaims(c *streamtoken.Claims) RecipeCard {
 		TranscodeTransportID:       c.TranscodeTransportID,
 		RoutingWorkload:            c.RoutingWorkload,
 		RoutingExecution:           c.RoutingExecution,
+		RoutingExecutionNodeID:     c.RoutingExecutionNodeID,
 		RoutingEgress:              c.RoutingEgress,
 		RoutingEgressNodeID:        c.RoutingEgressNodeID,
 		PlayMethod:                 method,

--- a/internal/playback/recipecard_test.go
+++ b/internal/playback/recipecard_test.go
@@ -154,19 +154,24 @@ func TestRecipeCardPreservesCopyVideoMPEGTS(t *testing.T) {
 	}
 }
 
-func TestRecipeCardPreservesRoutingEgressNodeID(t *testing.T) {
+func TestRecipeCardPreservesRoutingNodeIDs(t *testing.T) {
 	card := NewDirectRecipeCard("route-bound", 42, "profile-1", 77)
 	card.RoutingWorkload = "direct_play"
 	card.RoutingExecution = "none"
+	card.RoutingExecutionNodeID = 7
 	card.RoutingEgress = "proxy"
 	card.RoutingEgressNodeID = 11
 
 	claims := card.ToClaims()
+	if claims.RoutingExecutionNodeID != 7 {
+		t.Fatalf("claims execution node ID = %d, want 7", claims.RoutingExecutionNodeID)
+	}
 	if claims.RoutingEgressNodeID != 11 {
 		t.Fatalf("claims egress node ID = %d, want 11", claims.RoutingEgressNodeID)
 	}
-	if back := RecipeCardFromClaims(&claims); back.RoutingEgressNodeID != 11 {
-		t.Fatalf("round-trip egress node ID = %d, want 11", back.RoutingEgressNodeID)
+	back := RecipeCardFromClaims(&claims)
+	if back.RoutingExecutionNodeID != 7 || back.RoutingEgressNodeID != 11 {
+		t.Fatalf("round-trip node IDs = execution %d, egress %d; want 7 and 11", back.RoutingExecutionNodeID, back.RoutingEgressNodeID)
 	}
 }
 

--- a/internal/playback/remux.go
+++ b/internal/playback/remux.go
@@ -465,7 +465,8 @@ func ServeRemuxWithOptions(w http.ResponseWriter, r *http.Request, filePath, out
 	mode, ffmpegPath := opts.DVMode, opts.FFmpegPath
 	// Remux output streams for the length of the title; roll the write
 	// deadline with progress instead of the server's absolute WriteTimeout.
-	w = httpstream.NewRollingDeadlineWriter(w)
+	streamWriter := httpstream.NewRollingDeadlineWriter(w)
+	w = streamWriter
 	// Check file exists before starting ffmpeg to return a proper 404.
 	// Headers must be written before streaming begins, so we can't detect
 	// ffmpeg errors after WriteHeader(200) has been sent.
@@ -489,10 +490,16 @@ func ServeRemuxWithOptions(w http.ResponseWriter, r *http.Request, filePath, out
 		// Deferred after session.Close, so it runs before it: the watcher is
 		// gone by the time the owner drains and reaps the process.
 		served := make(chan struct{})
-		defer close(served)
+		watcherDone := make(chan struct{})
+		defer func() {
+			close(served)
+			<-watcherDone
+		}()
 		go func() {
+			defer close(watcherDone)
 			select {
 			case <-opts.Abort:
+				_ = streamWriter.Abort()
 				session.Abort()
 			case <-served:
 			}

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -3,6 +3,7 @@ package playback
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -233,7 +234,16 @@ func (m *TranscodeManager) SwapTranscodeSessionIf(
 // leaves the local live-map entry untouched for an atomic remote-to-local v3
 // replacement.
 func (m *TranscodeManager) StopRemoteTranscode(sessionID, transcodeNodeURL string) {
-	m.deleteRemoteTranscode(sessionID, transcodeNodeURL)
+	if err := m.deleteRemoteTranscode(context.Background(), sessionID, transcodeNodeURL); err != nil {
+		slog.Warn("remote transcode delete failed", "error", err, "session", sessionID, "node", transcodeNodeURL, "playback_session_id", sessionID)
+	}
+}
+
+// CancelRemoteTranscode synchronously confirms that a remote process no longer
+// exists. User-visible stop paths use this before removing the playback session
+// so a node partition leaves a live session the caller can retry stopping.
+func (m *TranscodeManager) CancelRemoteTranscode(ctx context.Context, sessionID, transcodeNodeURL string) error {
+	return m.deleteRemoteTranscode(ctx, sessionID, transcodeNodeURL)
 }
 
 // LockSessionLifecycle acquires the per-session lifecycle mutex and returns a
@@ -995,7 +1005,7 @@ func (m *TranscodeManager) CloseTranscodeSession(sessionID, transcodeNodeURL str
 		_ = session.Close()
 	}
 
-	m.deleteRemoteTranscode(sessionID, transcodeNodeURL)
+	m.StopRemoteTranscode(sessionID, transcodeNodeURL)
 }
 
 // CloseTranscodeSessionIf tears down a transcode session only when the live map
@@ -1028,36 +1038,39 @@ func (m *TranscodeManager) CloseTranscodeSessionIf(sessionID string, expected *T
 		_ = expected.Close()
 	}
 
-	m.deleteRemoteTranscode(sessionID, transcodeNodeURL)
+	m.StopRemoteTranscode(sessionID, transcodeNodeURL)
 	return true
 }
 
-// deleteRemoteTranscode sends DELETE to the assigned transcode node if any
-// (synchronous with timeout). A no-op for local/integrated sessions.
-func (m *TranscodeManager) deleteRemoteTranscode(sessionID, transcodeNodeURL string) {
-	if transcodeNodeURL != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		deleteURL := transcodeNodeURL + "/transcode/" + sessionID
-		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, deleteURL, nil)
-		if err != nil {
-			slog.Error("remote transcode delete: build request", "error", err, "session", sessionID, "playback_session_id", sessionID)
-			return
-		}
-		req.Header.Set("Authorization", "Bearer "+m.jwtSecret())
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			slog.Warn("remote transcode delete failed", "error", err, "session", sessionID, "node", transcodeNodeURL, "playback_session_id", sessionID)
-			return
-		}
-		_ = resp.Body.Close()
-		if resp.StatusCode >= http.StatusMultipleChoices {
-			slog.Warn("remote transcode delete returned non-success status",
-				"status", resp.StatusCode, "session", sessionID, "node", transcodeNodeURL, "playback_session_id", sessionID)
-		}
+// deleteRemoteTranscode sends DELETE to the assigned transcode node with a
+// bounded timeout. A missing process is already canceled and therefore
+// succeeds; other transport and HTTP failures remain retryable by the caller.
+func (m *TranscodeManager) deleteRemoteTranscode(ctx context.Context, sessionID, transcodeNodeURL string) error {
+	if transcodeNodeURL == "" {
+		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
+	deleteURL := transcodeNodeURL + "/transcode/" + sessionID
+	req, err := http.NewRequestWithContext(deleteCtx, http.MethodDelete, deleteURL, nil)
+	if err != nil {
+		return fmt.Errorf("build remote transcode delete request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.jwtSecret())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send remote transcode delete: %w", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode != http.StatusNotFound {
+		return fmt.Errorf("remote transcode delete returned status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // CleanupOrphanedTranscodes removes stale per-session temp directories for

--- a/internal/playback/transport_stop_test.go
+++ b/internal/playback/transport_stop_test.go
@@ -19,6 +19,38 @@ type countingResponseWriter struct {
 	written int64
 }
 
+type stalledResponseWriter struct {
+	header          http.Header
+	writeStarted    chan struct{}
+	deadlineExpired chan struct{}
+	startOnce       sync.Once
+	expireOnce      sync.Once
+}
+
+func newStalledResponseWriter() *stalledResponseWriter {
+	return &stalledResponseWriter{
+		header:          make(http.Header),
+		writeStarted:    make(chan struct{}),
+		deadlineExpired: make(chan struct{}),
+	}
+}
+
+func (w *stalledResponseWriter) Header() http.Header { return w.header }
+func (*stalledResponseWriter) WriteHeader(int)       {}
+
+func (w *stalledResponseWriter) Write([]byte) (int, error) {
+	w.startOnce.Do(func() { close(w.writeStarted) })
+	<-w.deadlineExpired
+	return 0, os.ErrDeadlineExceeded
+}
+
+func (w *stalledResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	if !deadline.After(time.Now()) {
+		w.expireOnce.Do(func() { close(w.deadlineExpired) })
+	}
+	return nil
+}
+
 func (w *countingResponseWriter) Header() http.Header {
 	if w.header == nil {
 		w.header = http.Header{}
@@ -107,6 +139,40 @@ func TestServeRemuxAbortEndsTheResponse(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("the remux response outlived the stop that withdrew its session")
+	}
+}
+
+func TestServeRemuxAbortInterruptsBlockedClientWrite(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(source, []byte("not really a movie"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	abort := make(chan struct{})
+	writer := newStalledResponseWriter()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/stream/session-1", nil)
+	ffmpegPath := streamingFakeFFmpegScript(t)
+	served := make(chan error, 1)
+	go func() {
+		served <- ServeRemuxWithOptions(writer, request, source, "mp4", 0, false, 0, 0, RemuxServeOptions{
+			FFmpegPath: ffmpegPath,
+			Abort:      abort,
+		})
+	}()
+
+	select {
+	case <-writer.writeStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("remux never reached the blocked client write")
+	}
+	close(abort)
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Fatalf("ServeRemuxWithOptions after abort = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("remux outlived an abort while its client write was blocked")
 	}
 }
 

--- a/internal/proxy/capability_snapshot_test.go
+++ b/internal/proxy/capability_snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -74,6 +75,9 @@ func TestProxyCapabilitiesPublishCapabilityHash(t *testing.T) {
 	}
 	if info.CapabilityHash == "" {
 		t.Fatal("served capability report carries no capability_hash")
+	}
+	if !slices.Contains(info.TransportFeatures, playback.TransportFeatureProgressiveRemuxRelayV1) {
+		t.Fatalf("transport features = %v, want progressive remux relay", info.TransportFeatures)
 	}
 	served := info
 	served.CapabilityHash = ""

--- a/internal/proxy/media_routes_test.go
+++ b/internal/proxy/media_routes_test.go
@@ -183,6 +183,8 @@ func TestProxyPlaybackEndpointStatusV3BindsRecipeFamily(t *testing.T) {
 		RoutingExecution: string(noderouting.ExecutionProxy), RoutingEgress: string(noderouting.EgressProxy),
 		RoutingEgressNodeID: 11,
 	}
+	remoteRemux := remux
+	remoteRemux.RoutingExecution = string(noderouting.ExecutionTranscode)
 	transcodeRemux := streamtoken.Claims{
 		PlayMethod: string(playback.PlayTranscode), RoutingWorkload: string(noderouting.WorkloadRemux),
 		RoutingExecution: string(noderouting.ExecutionTranscode), RoutingEgress: string(noderouting.EgressProxy),
@@ -200,6 +202,8 @@ func TestProxyPlaybackEndpointStatusV3BindsRecipeFamily(t *testing.T) {
 		{name: "direct", claims: direct, endpoint: proxyPlaybackEndpointDirectV3},
 		{name: "direct on remux", claims: direct, endpoint: proxyPlaybackEndpointRemuxV3, want: http.StatusServiceUnavailable},
 		{name: "remux", claims: remux, endpoint: proxyPlaybackEndpointRemuxV3},
+		{name: "remote remux", claims: remoteRemux, endpoint: proxyPlaybackEndpointRemuxV3},
+		{name: "remote remux identity", claims: remoteRemux, endpoint: proxyPlaybackEndpointIdentityV3},
 		{name: "versioned remux", claims: func() streamtoken.Claims {
 			claims := remux
 			claims.PlayMethod = streamtoken.PlayMethodAudioDownmixRemux

--- a/internal/proxy/mediagrant.go
+++ b/internal/proxy/mediagrant.go
@@ -153,7 +153,14 @@ func (s *Server) handleGrantIdentity(w http.ResponseWriter, r *http.Request) {
 	}
 	switch {
 	case card.PlayMethod == playback.PlayRemux:
-		s.serveRemuxClaims(w, r, &claims)
+		if remuxRunsOnTranscodeNodeV3(&claims) {
+			info := sessionInfo(s.tracker, &claims, "remux")
+			s.tracker.Track(r.Context(), info)
+			defer s.tracker.Remove(r.Context(), claims.SessionID)
+			s.relayGrantToTranscodeNode(w, r, &claims, "/remux/"+transcodeTransportIDFromClaims(&claims))
+		} else {
+			s.serveRemuxClaims(w, r, &claims)
+		}
 	case card.IsTranscodeRecipe():
 		writeGrantError(w, http.StatusBadRequest, "bad_request", "Transcode streams use manifest/segment endpoints")
 	default:

--- a/internal/proxy/mediagrant_test.go
+++ b/internal/proxy/mediagrant_test.go
@@ -301,6 +301,40 @@ func TestProxyGrantTranscodeRelaysToTheNodeWithAProxyMintedToken(t *testing.T) {
 	}
 }
 
+func TestProxyGrantProgressiveRemuxRelaysToTranscodeNode(t *testing.T) {
+	var forwarded, relayPath, relayQuery string
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = r.Header.Get("X-Silo-Stream-Token")
+		relayPath = r.URL.Path
+		relayQuery = r.URL.RawQuery
+		_, _ = w.Write([]byte("remote-remux"))
+	}))
+	t.Cleanup(node.Close)
+
+	card := playback.NewRemuxRecipeCard("session-remux", 7, "profile-1", 42, false, 0, playback.RemuxDVPreserveV3)
+	card.InputPath = "/media/movie.mkv"
+	card.TranscodeNodeURL = node.URL
+	card.TranscodeTransportID = "session-remux-plan-a"
+	card.RoutingWorkload = string(noderouting.WorkloadRemux)
+	card.RoutingExecution = string(noderouting.ExecutionTranscode)
+	card.RoutingEgress = string(noderouting.EgressProxy)
+	card.RoutingEgressNodeID = 11
+	srv := newGrantProxyServer(t, map[string]playback.RecipeCard{card.SessionID: card})
+	srv.nodeRowID = func() (int, bool) { return 11, true }
+
+	rr := grantRequest(t, srv, http.MethodGet, "/stream/v3/session-remux?seek=8", grantAccessToken(t, 7, "login-1"))
+	if rr.Code != http.StatusOK || rr.Body.String() != "remote-remux" {
+		t.Fatalf("response = %d %q", rr.Code, rr.Body.String())
+	}
+	if relayPath != "/remux/session-remux-plan-a" || relayQuery != "seek=8" {
+		t.Fatalf("relay = %q?%s", relayPath, relayQuery)
+	}
+	claims, err := streamtoken.Verify(forwarded, grantTestSecret)
+	if err != nil || claims.TranscodeNode != node.URL || claims.RoutingExecution != string(noderouting.ExecutionTranscode) {
+		t.Fatalf("forwarded claims = %#v, err=%v", claims, err)
+	}
+}
+
 // A transcode session has no progressive body to serve, and answering one from
 // the identity route would hand the client a stream the plan never described.
 func TestProxyGrantIdentityRefusesATranscodeGrant(t *testing.T) {

--- a/internal/proxy/router_socket_test.go
+++ b/internal/proxy/router_socket_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/nodeconfig"
+	"github.com/Silo-Server/silo-server/internal/noderouting"
 	"github.com/Silo-Server/silo-server/internal/nodesessions"
+	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/streamtelemetry"
 	"github.com/Silo-Server/silo-server/internal/streamtoken"
 )
@@ -388,5 +390,41 @@ func TestMountedProxyRouterRelaysToNode(t *testing.T) {
 	forwardedClaims, err := streamtoken.Verify(forwardedToken, secret)
 	if err != nil || forwardedClaims.SessionID != snapshot.Sessions[0].SessionID {
 		t.Fatalf("forwarded claims = %+v, err=%v", forwardedClaims, err)
+	}
+}
+
+func TestMountedProxyRouterRelaysProgressiveRemuxToTranscodeNode(t *testing.T) {
+	const secret = "socket-proxy-remux-secret"
+	const body = "progressive-remux-bytes"
+	var relayPath, relayQuery, forwardedToken string
+	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		relayPath = r.URL.Path
+		relayQuery = r.URL.RawQuery
+		forwardedToken = r.Header.Get("X-Silo-Stream-Token")
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(node.Close)
+
+	claims := streamtoken.Claims{
+		SessionID: "socket-remux-1", PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: node.URL, TranscodeTransportID: "transport-remux-1",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingEgress: string(noderouting.EgressProxy), RoutingEgressNodeID: 11,
+	}
+	token, err := streamtoken.Sign(claims, secret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := newSocketProxyServer(t, secret, nil)
+	srv.nodeRowID = func() (int, bool) { return 11, true }
+	server := httptest.NewServer(srv.Handler())
+	t.Cleanup(server.Close)
+
+	got := socketProxyRequest(t, server.Client(), http.MethodGet, server.URL+"/stream/remux/"+token+"?seek=12.5", nil)
+	if got.status != http.StatusOK || got.body != body {
+		t.Fatalf("relayed remux = %d %q, want 200 %q", got.status, got.body, body)
+	}
+	if relayPath != "/remux/transport-remux-1" || relayQuery != "seek=12.5" || forwardedToken != token {
+		t.Fatalf("relay = %q?%s token-match=%v", relayPath, relayQuery, forwardedToken == token)
 	}
 }

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -288,10 +288,9 @@ func (s *Server) buildCapabilitySnapshotLocked(ctx context.Context) (playback.HW
 	// Hardware acceleration is not probed here, and the report says so rather
 	// than leaving the fields unset by accident. A proxy relays streams and runs
 	// identity/remux recipes on ffmpeg; it never executes a hardware transcode,
-	// and the only field anything reads off this report is Transformations —
-	// planIdentityProxySessionV3 filters proxies by their advertised
-	// transformations and consults nothing else. So there is no inventory to
-	// report and nothing a GPU smoke-encode matrix could tell the planner.
+	// and the only fields planning reads off this report are Transformations and
+	// TransportFeatures. So there is no hardware inventory to report and nothing
+	// a GPU smoke-encode matrix could tell the planner.
 	//
 	// The consequence worth stating: the hash now tracks only what this proxy
 	// can *do*. A reboot, a renumbered render node, or a card appearing on the
@@ -321,6 +320,7 @@ func (s *Server) buildCapabilitySnapshotLocked(ctx context.Context) (playback.HW
 		return playback.HWAccelInfo{}, err
 	}
 	info.Transformations = registry.Advertised()
+	info.TransportFeatures = []string{playback.TransportFeatureProgressiveRemuxRelayV1}
 	// Advertised before the hash is taken, because it is part of what the hash
 	// covers: a build that needs longer reaches the sweep rather than sitting
 	// behind an unchanged identity.
@@ -554,8 +554,10 @@ func proxyPlaybackEndpointStatusV3(claims *streamtoken.Claims, endpoint proxyPla
 		claims.RoutingExecution == string(noderouting.ExecutionNone) &&
 		claims.RoutingEgress == string(noderouting.EgressProxy) &&
 		claims.PlayMethod == string(playback.PlayDirect)
+	remuxExecution := claims.RoutingExecution == string(noderouting.ExecutionProxy) ||
+		claims.RoutingExecution == string(noderouting.ExecutionTranscode)
 	remux := claims.RoutingWorkload == string(noderouting.WorkloadRemux) &&
-		claims.RoutingExecution == string(noderouting.ExecutionProxy) &&
+		remuxExecution &&
 		claims.RoutingEgress == string(noderouting.EgressProxy) &&
 		proxyRemuxPlayMethodV3(claims.PlayMethod)
 	transcode := (claims.RoutingWorkload == string(noderouting.WorkloadRemux) ||
@@ -805,6 +807,10 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if remuxRunsOnTranscodeNodeV3(claims) {
+		s.relayProgressiveRemux(w, r, claims, chi.URLParam(r, "token"))
+		return
+	}
 	s.serveRemuxClaims(w, r, claims)
 }
 
@@ -820,7 +826,23 @@ func (s *Server) handleAudioV2Remux(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	if remuxRunsOnTranscodeNodeV3(claims) {
+		s.relayProgressiveRemux(w, r, claims, chi.URLParam(r, "token"))
+		return
+	}
 	s.serveRemuxClaims(w, r, claims)
+}
+
+func remuxRunsOnTranscodeNodeV3(claims *streamtoken.Claims) bool {
+	return claims != nil && claims.RoutingExecution == string(noderouting.ExecutionTranscode)
+}
+
+func (s *Server) relayProgressiveRemux(w http.ResponseWriter, r *http.Request, claims *streamtoken.Claims, forwardToken string) {
+	attachStream(r.Context(), claims)
+	info := sessionInfo(s.tracker, claims, "remux")
+	s.tracker.Track(r.Context(), info)
+	defer s.tracker.Remove(r.Context(), claims.SessionID)
+	s.proxyToTranscodeNode(w, r, claims, "/remux/"+transcodeTransportIDFromClaims(claims), forwardToken)
 }
 
 // validAudioV2RemuxClaims proves the complete shape consumed by the proxy's

--- a/internal/streamtoken/token.go
+++ b/internal/streamtoken/token.go
@@ -40,22 +40,23 @@ const (
 // (uid/pid/mfid) are lookup keys re-resolved against the authority on
 // reconstruct; they are never trusted on their own.
 type Claims struct {
-	SessionID            string `json:"sid"`
-	MediaPath            string `json:"path"`
-	PlayMethod           string `json:"method"`
-	TranscodeAudio       bool   `json:"ta,omitempty"`
-	TranscodeNode        string `json:"tnode,omitempty"`
-	TranscodeTransportID string `json:"tid,omitempty"`
-	RoutingWorkload      string `json:"rwl,omitempty"`
-	RoutingExecution     string `json:"rex,omitempty"`
-	RoutingEgress        string `json:"reg,omitempty"`
-	RoutingEgressNodeID  int    `json:"renid,omitempty"`
-	TargetCodec          string `json:"tc,omitempty"`
-	TargetRes            string `json:"tres,omitempty"`
-	AudioCodec           string `json:"ac,omitempty"`
-	AudioChannels        int    `json:"ach,omitempty"`
-	AudioTrackIndex      int    `json:"ati,omitempty"`
-	AudioOnly            bool   `json:"ao,omitempty"`
+	SessionID              string `json:"sid"`
+	MediaPath              string `json:"path"`
+	PlayMethod             string `json:"method"`
+	TranscodeAudio         bool   `json:"ta,omitempty"`
+	TranscodeNode          string `json:"tnode,omitempty"`
+	TranscodeTransportID   string `json:"tid,omitempty"`
+	RoutingWorkload        string `json:"rwl,omitempty"`
+	RoutingExecution       string `json:"rex,omitempty"`
+	RoutingExecutionNodeID int    `json:"rxnid,omitzero"`
+	RoutingEgress          string `json:"reg,omitempty"`
+	RoutingEgressNodeID    int    `json:"renid,omitempty"`
+	TargetCodec            string `json:"tc,omitempty"`
+	TargetRes              string `json:"tres,omitempty"`
+	AudioCodec             string `json:"ac,omitempty"`
+	AudioChannels          int    `json:"ach,omitempty"`
+	AudioTrackIndex        int    `json:"ati,omitempty"`
+	AudioOnly              bool   `json:"ao,omitempty"`
 	// DVProfile is the file's Dolby Vision profile (0 = none); remux nodes
 	// use it to strip dangling profile 7 RPUs. Absent in older tokens, which
 	// decodes as 0 (no strip — the pre-existing behavior).

--- a/internal/transcodenode/capability_snapshot_test.go
+++ b/internal/transcodenode/capability_snapshot_test.go
@@ -76,6 +76,7 @@ func TestHealthPublishesStoredCapabilityHashWithoutProbing(t *testing.T) {
 // otherwise the API would refetch a report it already has.
 func TestHWCapabilitiesPublishesCapabilityHash(t *testing.T) {
 	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 42, true }
 
 	request := httptest.NewRequest(http.MethodGet, "/hw-capabilities", nil)
 	request.Header.Set("Authorization", "Bearer "+testSecret)
@@ -106,6 +107,29 @@ func TestHWCapabilitiesPublishesCapabilityHash(t *testing.T) {
 	}
 	if got := decodeHealth(t, server).CapabilitiesHash; got != info.CapabilityHash {
 		t.Fatalf("health capabilities_hash = %q, want the just-served %q", got, info.CapabilityHash)
+	}
+}
+
+func TestHWCapabilitiesWithholdsProgressiveRemuxWithoutNodeIdentity(t *testing.T) {
+	server := newTestServer(t)
+
+	request := httptest.NewRequest(http.MethodGet, "/hw-capabilities", nil)
+	request.Header.Set("Authorization", "Bearer "+testSecret)
+	recorder := httptest.NewRecorder()
+	server.Handler().ServeHTTP(recorder, request)
+
+	if recorder.Code == http.StatusServiceUnavailable {
+		t.Skip("this host's ffmpeg cannot answer a capability probe")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var info playback.HWAccelInfo
+	if err := json.Unmarshal(recorder.Body.Bytes(), &info); err != nil {
+		t.Fatalf("decode capabilities: %v", err)
+	}
+	if slices.Contains(info.TransportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
+		t.Fatalf("transport features = %v, want progressive remux withheld without a resolved node row", info.TransportFeatures)
 	}
 }
 

--- a/internal/transcodenode/capability_snapshot_test.go
+++ b/internal/transcodenode/capability_snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/config"
@@ -93,6 +94,9 @@ func TestHWCapabilitiesPublishesCapabilityHash(t *testing.T) {
 	}
 	if info.CapabilityHash == "" {
 		t.Fatal("served capability report carries no capability_hash")
+	}
+	if !slices.Contains(info.TransportFeatures, playback.TransportFeatureProgressiveRemuxExecutionV1) {
+		t.Fatalf("transport features = %v, want progressive remux execution", info.TransportFeatures)
 	}
 	// The hash must describe this payload, not some earlier one.
 	served := info

--- a/internal/transcodenode/media_routes.go
+++ b/internal/transcodenode/media_routes.go
@@ -10,6 +10,8 @@ import (
 var transcodeNodeMediaRoutes = []streamtelemetry.MediaRoute{
 	nodeRoute(http.MethodGet, "/downloads/artifacts/{artifact_id}", streamtelemetry.ClassTransfer),
 	nodeRoute(http.MethodHead, "/downloads/artifacts/{artifact_id}", streamtelemetry.ClassTransfer),
+	nodeRoute(http.MethodGet, "/remux/{session_id}", streamtelemetry.ClassPlayback),
+	nodeRoute(http.MethodHead, "/remux/{session_id}", streamtelemetry.ClassPlayback),
 	nodeRoute(http.MethodGet, "/transcode/{session_id}/master.m3u8", streamtelemetry.ClassManifest),
 	nodeRoute(http.MethodGet, "/transcode/{session_id}/segment/{name}", streamtelemetry.ClassPlayback),
 }

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -206,6 +206,7 @@ type progressiveRemuxRequest struct {
 // Server is the HTTP handler for transcode mode.
 type Server struct {
 	watcher                   *nodeconfig.Watcher
+	nodeRowID                 func() (int, bool)
 	tracker                   sessionTracker
 	ffmpegSink                playback.FFmpegLogSink
 	inputPaths                InputPathAuthorizer
@@ -429,6 +430,9 @@ func NewServer(watcher *nodeconfig.Watcher, tracker *nodesessions.Tracker) *Serv
 		progressiveRemuxes:        make(map[string]progressiveRemuxRequest),
 		stoppedProgressiveRemuxes: make(map[string]time.Time),
 		lastAccess:                make(map[string]time.Time),
+	}
+	if watcher != nil {
+		s.nodeRowID = watcher.NodeRowID
 	}
 	return s
 }
@@ -1886,7 +1890,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "routing policy unsatisfied", http.StatusServiceUnavailable)
 		return
 	}
-	if s.tracker != nil && strings.TrimRight(claims.TranscodeNode, "/") != strings.TrimRight(s.tracker.NodeURL(), "/") {
+	if !s.progressiveRemuxRunsOnThisNode(claims) {
 		http.Error(w, "routing policy unsatisfied", http.StatusServiceUnavailable)
 		return
 	}
@@ -1997,6 +2001,25 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// progressiveRemuxRunsOnThisNode binds a routed remux to the stable database
+// identity selected by the planner. NODE_URL is only the worker's local
+// address and may intentionally differ from the registered route URL in a
+// split-horizon deployment. The URL check remains for bounded tokens minted by
+// an earlier API that did not carry the additive node ID.
+func (s *Server) progressiveRemuxRunsOnThisNode(claims *streamtoken.Claims) bool {
+	if s == nil || claims == nil {
+		return false
+	}
+	if claims.RoutingExecutionNodeID > 0 {
+		if s.nodeRowID == nil {
+			return false
+		}
+		nodeID, ok := s.nodeRowID()
+		return ok && nodeID == claims.RoutingExecutionNodeID
+	}
+	return s.tracker == nil || strings.TrimRight(claims.TranscodeNode, "/") == strings.TrimRight(s.tracker.NodeURL(), "/")
+}
+
 func transcodeNodeRemuxPlayMethod(method string) bool {
 	return method == string(playback.PlayRemux) || method == streamtoken.PlayMethodAudioDownmixRemux
 }
@@ -2021,6 +2044,7 @@ func (s *Server) progressiveRemuxAuthorityActive(ctx context.Context, transportI
 		stored.TranscodeTransportID == transportID &&
 		stored.RoutingWorkload == claims.RoutingWorkload &&
 		stored.RoutingExecution == claims.RoutingExecution &&
+		stored.RoutingExecutionNodeID == claims.RoutingExecutionNodeID &&
 		stored.RoutingEgress == claims.RoutingEgress &&
 		stored.RoutingEgressNodeID == claims.RoutingEgressNodeID
 }

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -204,9 +204,10 @@ type sessionTracker interface {
 }
 
 type progressiveRemuxRequest struct {
-	id     uint64
-	cancel context.CancelFunc
-	done   <-chan struct{}
+	id                uint64
+	playbackSessionID string
+	cancel            context.CancelFunc
+	done              <-chan struct{}
 }
 
 // Server is the HTTP handler for transcode mode.
@@ -1965,6 +1966,10 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithCancel(r.Context())
 	requestID := s.progressiveRemuxSequence.Add(1)
+	playbackSessionID := claims.SessionID
+	if playbackSessionID == "" {
+		playbackSessionID = transportID
+	}
 	abort := make(chan struct{})
 	stop := sync.OnceFunc(func() {
 		cancel()
@@ -1991,7 +1996,9 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session already active", http.StatusConflict)
 		return
 	}
-	s.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: requestID, cancel: stop, done: done}
+	s.progressiveRemuxes[transportID] = progressiveRemuxRequest{
+		id: requestID, playbackSessionID: playbackSessionID, cancel: stop, done: done,
+	}
 	s.mu.Unlock()
 	unlock()
 	s.reloadMu.RUnlock()
@@ -2013,11 +2020,11 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 			startedAt = time.Now().UTC()
 		}
 		s.tracker.Track(ctx, nodesessions.SessionInfo{
-			SessionID: transportID, NodeURL: s.tracker.NodeURL(), NodeName: s.tracker.NodeName(), Type: "remux",
+			SessionID: playbackSessionID, NodeURL: s.tracker.NodeURL(), NodeName: s.tracker.NodeName(), Type: "remux",
 			CodecAudio: claims.TargetCodecAudio, StartedAt: startedAt.Format(time.RFC3339), StartedAtUnixNano: startedAt.UnixNano(),
 			StartedAtSource: string(source), AuthUserID: claims.UserID, ProfileID: claims.ProfileID, MediaFileID: claims.MediaFileID,
 		})
-		defer s.tracker.Remove(context.WithoutCancel(ctx), transportID)
+		defer s.tracker.Remove(context.WithoutCancel(ctx), playbackSessionID)
 	}
 
 	request := r.WithContext(ctx)
@@ -2098,16 +2105,23 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 
 	durableProgressive := false
 	authorityFound := false
+	playbackSessionID := sessionID
 	if s.recipeStore != nil {
 		card, ok := s.recipeStore.Get(r.Context(), sessionID)
 		authorityFound = ok && card != nil
 		durableProgressive = authorityFound && card.PlayMethod == playback.PlayRemux
+		if authorityFound && card.SessionID != "" {
+			playbackSessionID = card.SessionID
+		}
 	}
 
 	s.mu.Lock()
 	now := time.Now()
 	s.pruneStoppedProgressiveRemuxesLocked(now)
 	progressive, progressiveFound := s.progressiveRemuxes[sessionID]
+	if progressiveFound && progressive.playbackSessionID != "" {
+		playbackSessionID = progressive.playbackSessionID
+	}
 	if progressiveFound || durableProgressive {
 		if s.stoppedProgressiveRemuxes == nil {
 			s.stoppedProgressiveRemuxes = make(map[string]time.Time)
@@ -2151,10 +2165,20 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if s.tracker != nil {
-		s.tracker.Remove(r.Context(), sessionID)
+		s.tracker.Remove(r.Context(), playbackSessionID)
+	}
+	var shutdownErr error
+	if progressiveFound {
+		waitCtx, cancelWait := context.WithTimeout(r.Context(), progressiveRemuxShutdownTimeout)
+		shutdownErr = waitForProgressiveRemuxShutdown(waitCtx, sessionID, progressive)
+		cancelWait()
 	}
 	if authorityErr != nil {
 		http.Error(w, "transcode authority revocation unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if shutdownErr != nil {
+		http.Error(w, "progressive remux shutdown unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	if !found {
@@ -2568,23 +2592,34 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 			}
 		}
 		if s.tracker != nil {
-			s.tracker.Remove(ctx, id)
+			trackerSessionID := request.playbackSessionID
+			if trackerSessionID == "" {
+				trackerSessionID = id
+			}
+			s.tracker.Remove(ctx, trackerSessionID)
 		}
 	}
 
 	waitCtx, cancelWait := context.WithTimeout(ctx, progressiveRemuxShutdownTimeout)
 	defer cancelWait()
 	for id, request := range progressiveVictims {
-		if request.done == nil {
-			continue
-		}
-		select {
-		case <-request.done:
-		case <-waitCtx.Done():
-			return errors.Join(authorityErr, fmt.Errorf("wait for progressive remux %s shutdown: %w", id, waitCtx.Err()))
+		if err := waitForProgressiveRemuxShutdown(waitCtx, id, request); err != nil {
+			return errors.Join(authorityErr, err)
 		}
 	}
 	return authorityErr
+}
+
+func waitForProgressiveRemuxShutdown(ctx context.Context, transportID string, request progressiveRemuxRequest) error {
+	if request.done == nil {
+		return nil
+	}
+	select {
+	case <-request.done:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("wait for progressive remux %s shutdown: %w", transportID, ctx.Err())
+	}
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -658,16 +658,17 @@ func (s *Server) retireGPUSession(close func() error) error {
 	return close()
 }
 
-// recipeStore reads a remote transcode's reconstruction recipe written by central
-// at transcode start, keyed by the transport id this node serves the job under.
-// It is the reconstruct source for every flow whose request cannot carry a
-// complete recipe itself: the jellycompat node-hop token is identity-only by
+// recipeStore reads a remote transport record written by central, keyed by the
+// transport id this node serves the job under. It is the reconstruct source for
+// every flow whose request cannot carry a complete recipe itself: the
+// jellycompat node-hop token is identity-only by
 // design — not because a Jellyfin client can't round-trip it, but because the
 // recipe is mutated in place and the client can't be driven to refresh a stale
 // token — and a header-authenticated (tokenless) attempt publishes no credential
 // at all, so the relayed request carries nothing to rebuild from (see
 // internal/noderecipe). On a node restart the node fetches the recipe here
-// instead of 404ing. *noderecipe.Store implements it.
+// instead of 404ing. Progressive remux uses the same record as durable active
+// authority before spawning FFmpeg. *noderecipe.Store implements it.
 type recipeStore interface {
 	Get(ctx context.Context, sessionID string) (*playback.RecipeCard, bool)
 	// Delete drops a session's recipe so a buffered/retrying request after a node
@@ -677,9 +678,9 @@ type recipeStore interface {
 }
 
 // SetRecipeStore wires the control-plane recipe store so this node can rebuild a
-// jellycompat or header-authenticated transcode after its own restart. Optional;
-// without it a request that carries no complete recipe of its own cannot
-// reconstruct and 404s as before.
+// jellycompat or header-authenticated transcode after its own restart and
+// validate active progressive-remux transports. Optional for reconstruction;
+// transcode-executed progressive remux is not routed to a node without it.
 func (s *Server) SetRecipeStore(store recipeStore) {
 	s.recipeStore = store
 }
@@ -1881,6 +1882,10 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "routing policy unsatisfied", http.StatusServiceUnavailable)
 		return
 	}
+	if !s.progressiveRemuxAuthorityActive(r.Context(), transportID, claims) {
+		http.Error(w, "session stopped", http.StatusGone)
+		return
+	}
 	if claims.PlayMethod == streamtoken.PlayMethodAudioDownmixRemux &&
 		(!claims.TranscodeAudio || claims.TargetAudioChannels != 2 ||
 			!playback.IsAudioToAACStereoDownmixV3(claims.SourceAudioChannels, claims.TargetCodecAudio, claims.TargetAudioChannels)) {
@@ -1900,6 +1905,17 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		seekSeconds = parsed
 	}
 
+	// Admit against one stable configuration generation. Force reload takes the
+	// exclusive side, then cancels every request registered below before it
+	// returns; a request that waited through a reload must retry with a fresh
+	// route instead of starting FFmpeg from the stale cfg pointer above.
+	s.reloadMu.RLock()
+	if s.watcher.Config() != cfg {
+		s.reloadMu.RUnlock()
+		http.Error(w, "node configuration changed", http.StatusServiceUnavailable)
+		return
+	}
+
 	ctx, cancel := context.WithCancel(r.Context())
 	requestID := s.progressiveRemuxSequence.Add(1)
 	unlock := s.lockSessionLifecycle(transportID)
@@ -1909,6 +1925,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	if s.stoppedProgressiveRemuxes[transportID].After(now) {
 		s.mu.Unlock()
 		unlock()
+		s.reloadMu.RUnlock()
 		cancel()
 		http.Error(w, "session stopped", http.StatusGone)
 		return
@@ -1921,6 +1938,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	requests[requestID] = cancel
 	s.mu.Unlock()
 	unlock()
+	s.reloadMu.RUnlock()
 	defer func() {
 		cancel()
 		s.mu.Lock()
@@ -1965,6 +1983,30 @@ func transcodeNodeRemuxPlayMethod(method string) bool {
 	return method == string(playback.PlayRemux) || method == streamtoken.PlayMethodAudioDownmixRemux
 }
 
+// progressiveRemuxAuthorityActive checks the durable transport record written
+// before central publishes this node route. Stop and force reload delete the
+// record, so a signed token that remains cryptographically valid cannot start a
+// new FFmpeg process after this node's in-memory stop fence is lost on restart.
+func (s *Server) progressiveRemuxAuthorityActive(ctx context.Context, transportID string, claims *streamtoken.Claims) bool {
+	if s.recipeStore == nil || claims == nil {
+		return false
+	}
+	card, ok := s.recipeStore.Get(ctx, transportID)
+	if !ok || card == nil {
+		return false
+	}
+	stored := card.ToClaims()
+	return stored.SessionID == claims.SessionID &&
+		stored.MediaPath == claims.MediaPath &&
+		stored.PlayMethod == claims.PlayMethod &&
+		stored.TranscodeNode == claims.TranscodeNode &&
+		stored.TranscodeTransportID == transportID &&
+		stored.RoutingWorkload == claims.RoutingWorkload &&
+		stored.RoutingExecution == claims.RoutingExecution &&
+		stored.RoutingEgress == claims.RoutingEgress &&
+		stored.RoutingEgressNodeID == claims.RoutingEgressNodeID
+}
+
 func (s *Server) pruneStoppedProgressiveRemuxesLocked(now time.Time) {
 	for id, expiresAt := range s.stoppedProgressiveRemuxes {
 		if !expiresAt.After(now) {
@@ -1995,11 +2037,7 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	progressive := s.progressiveRemuxes[sessionID]
 	delete(s.progressiveRemuxes, sessionID)
 	session, ok := s.sessions[sessionID]
-	if !ok && len(progressive) == 0 {
-		s.mu.Unlock()
-		http.Error(w, "session not found", http.StatusNotFound)
-		return
-	}
+	found := ok || len(progressive) > 0
 	if ok {
 		delete(s.sessions, sessionID)
 		delete(s.lastAccess, sessionID)
@@ -2032,6 +2070,10 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 
 	if s.tracker != nil {
 		s.tracker.Remove(r.Context(), sessionID)
+	}
+	if !found {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
@@ -2292,6 +2334,13 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "reload failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	s.teardownForForceReload(r.Context())
+
+	slog.InfoContext(r.Context(), "transcode force reload completed", slog.String("component", "transcodenode"))
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) teardownForForceReload(ctx context.Context) {
 	type forceReloadVictim struct {
 		id      string
 		session *playback.TranscodeSession
@@ -2318,7 +2367,7 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 
 		_ = s.closeSessionOffGPU(victim.session)
 		if err := os.RemoveAll(s.sessionOutputDir(victim.id)); err != nil {
-			slog.WarnContext(r.Context(), "remove transcode session directory during reload", "component", "transcodenode", "session", victim.id, "error", err)
+			slog.WarnContext(ctx, "remove transcode session directory during reload", "component", "transcodenode", "session", victim.id, "error", err)
 		}
 
 		// A force-reload tears this session down for good, so drop its recipe too:
@@ -2327,20 +2376,48 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 		// concurrent same-ID start cannot have its newly written recipe removed.
 		if s.recipeStore != nil {
 			id := victim.id
-			if err := s.recipeStore.Delete(r.Context(), id); err != nil {
-				slog.WarnContext(r.Context(), "delete transcode recipe on force reload", "component", "transcodenode", "error", err, "session", id, "playback_session_id", id)
+			if err := s.recipeStore.Delete(ctx, id); err != nil {
+				slog.WarnContext(ctx, "delete transcode recipe on force reload", "component", "transcodenode", "error", err, "session", id, "playback_session_id", id)
 			}
 		}
 
 		// Drop only this victim from the tracker. A blanket Cleanup here would
 		// also wipe unrelated tracker-only work, such as an active download
 		// preparation, even though force reload does not stop that job.
-		s.tracker.Remove(r.Context(), victim.id)
+		if s.tracker != nil {
+			s.tracker.Remove(ctx, victim.id)
+		}
 		unlock()
 	}
 
-	slog.InfoContext(r.Context(), "transcode force reload completed", slog.String("component", "transcodenode"))
-	w.WriteHeader(http.StatusNoContent)
+	s.mu.Lock()
+	now := time.Now()
+	s.pruneStoppedProgressiveRemuxesLocked(now)
+	progressiveVictims := make(map[string][]context.CancelFunc, len(s.progressiveRemuxes))
+	for id, requests := range s.progressiveRemuxes {
+		cancels := make([]context.CancelFunc, 0, len(requests))
+		for _, cancel := range requests {
+			cancels = append(cancels, cancel)
+		}
+		progressiveVictims[id] = cancels
+		s.stoppedProgressiveRemuxes[id] = now.Add(playback.MaxTokenTTL)
+		delete(s.progressiveRemuxes, id)
+	}
+	s.mu.Unlock()
+
+	for id, cancels := range progressiveVictims {
+		for _, cancel := range cancels {
+			cancel()
+		}
+		if s.recipeStore != nil {
+			if err := s.recipeStore.Delete(ctx, id); err != nil {
+				slog.WarnContext(ctx, "delete progressive remux authority on force reload", "component", "transcodenode", "error", err, "session", id, "playback_session_id", id)
+			}
+		}
+		if s.tracker != nil {
+			s.tracker.Remove(ctx, id)
+		}
+	}
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1965,6 +1965,11 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithCancel(r.Context())
 	requestID := s.progressiveRemuxSequence.Add(1)
+	abort := make(chan struct{})
+	stop := sync.OnceFunc(func() {
+		cancel()
+		close(abort)
+	})
 	done := make(chan struct{})
 	unlock := s.lockSessionLifecycle(transportID)
 	s.mu.Lock()
@@ -1986,7 +1991,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session already active", http.StatusConflict)
 		return
 	}
-	s.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: requestID, cancel: cancel, done: done}
+	s.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: requestID, cancel: stop, done: done}
 	s.mu.Unlock()
 	unlock()
 	s.reloadMu.RUnlock()
@@ -2022,6 +2027,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		ContentType: playback.RemuxContentType(claims.AudioOnly), AudioOnly: claims.AudioOnly,
 		SourceAudioChannels: claims.SourceAudioChannels, TargetAudioChannels: claims.TargetAudioChannels,
 		TargetAudioBitrateKbps: claims.TargetAudioBitrateKbps,
+		Abort:                  abort,
 	}); err != nil && !errors.Is(err, context.Canceled) {
 		slog.WarnContext(ctx, "progressive remux ended with an error", "component", "transcodenode", "error", err,
 			"session", transportID, "playback_session_id", claims.SessionID)
@@ -2108,7 +2114,6 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 		}
 		s.stoppedProgressiveRemuxes[sessionID] = now.Add(playback.MaxTokenTTL)
 	}
-	delete(s.progressiveRemuxes, sessionID)
 	session, ok := s.sessions[sessionID]
 	found := ok || progressiveFound || authorityFound
 	if ok {
@@ -2545,11 +2550,13 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 	s.mu.Lock()
 	now := time.Now()
 	s.pruneStoppedProgressiveRemuxesLocked(now)
+	if s.stoppedProgressiveRemuxes == nil {
+		s.stoppedProgressiveRemuxes = make(map[string]time.Time)
+	}
 	progressiveVictims := make(map[string]progressiveRemuxRequest, len(s.progressiveRemuxes))
 	for id, request := range s.progressiveRemuxes {
 		progressiveVictims[id] = request
 		s.stoppedProgressiveRemuxes[id] = now.Add(playback.MaxTokenTTL)
-		delete(s.progressiveRemuxes, id)
 	}
 	s.mu.Unlock()
 

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1904,10 +1904,6 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "routing policy unsatisfied", http.StatusServiceUnavailable)
 		return
 	}
-	if !s.progressiveRemuxAuthorityActive(r.Context(), transportID, claims) {
-		http.Error(w, "session stopped", http.StatusGone)
-		return
-	}
 	if claims.PlayMethod == streamtoken.PlayMethodAudioDownmixRemux &&
 		(!claims.TranscodeAudio || claims.TargetAudioChannels != 2 ||
 			!playback.IsAudioToAACStereoDownmixV3(claims.SourceAudioChannels, claims.TargetCodecAudio, claims.TargetAudioChannels)) {
@@ -1945,6 +1941,11 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	if s.watcher.Config() != cfg {
 		s.reloadMu.RUnlock()
 		http.Error(w, "node configuration changed", http.StatusServiceUnavailable)
+		return
+	}
+	if !s.progressiveRemuxAuthorityActive(r.Context(), transportID, claims) {
+		s.reloadMu.RUnlock()
+		http.Error(w, "session stopped", http.StatusGone)
 		return
 	}
 

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -198,6 +198,11 @@ type sessionTracker interface {
 	NodeName() string
 }
 
+type progressiveRemuxRequest struct {
+	id     uint64
+	cancel context.CancelFunc
+}
+
 // Server is the HTTP handler for transcode mode.
 type Server struct {
 	watcher                   *nodeconfig.Watcher
@@ -208,7 +213,7 @@ type Server struct {
 	artifactRoot              string
 	telemetry                 *streamtelemetry.Registry
 	sessions                  map[string]*playback.TranscodeSession
-	progressiveRemuxes        map[string]map[uint64]context.CancelFunc
+	progressiveRemuxes        map[string]progressiveRemuxRequest
 	stoppedProgressiveRemuxes map[string]time.Time
 	progressiveRemuxSequence  atomic.Uint64
 	// lastAccess records, per registered session id, when a manifest or segment
@@ -421,7 +426,7 @@ func NewServer(watcher *nodeconfig.Watcher, tracker *nodesessions.Tracker) *Serv
 		transcodeDir:              transcodeDir,
 		artifactRoot:              artifactRoot,
 		sessions:                  make(map[string]*playback.TranscodeSession),
-		progressiveRemuxes:        make(map[string]map[uint64]context.CancelFunc),
+		progressiveRemuxes:        make(map[string]progressiveRemuxRequest),
 		stoppedProgressiveRemuxes: make(map[string]time.Time),
 		lastAccess:                make(map[string]time.Time),
 	}
@@ -675,6 +680,9 @@ type recipeStore interface {
 	// restart cannot reconstruct a brand-new ffmpeg for an already-stopped session.
 	// Called only on deliberate teardown; nil-safe and a missing key is a no-op.
 	Delete(ctx context.Context, sessionID string) error
+	// RevokeNode invalidates all recipes issued for a node before a destructive
+	// reload, including transports that have not received their first request.
+	RevokeNode(ctx context.Context, nodeURL string) error
 }
 
 // SetRecipeStore wires the control-plane recipe store so this node can rebuild a
@@ -1930,23 +1938,23 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session stopped", http.StatusGone)
 		return
 	}
-	requests := s.progressiveRemuxes[transportID]
-	if requests == nil {
-		requests = make(map[uint64]context.CancelFunc)
-		s.progressiveRemuxes[transportID] = requests
+	if _, active := s.progressiveRemuxes[transportID]; active {
+		s.mu.Unlock()
+		unlock()
+		s.reloadMu.RUnlock()
+		cancel()
+		http.Error(w, "session already active", http.StatusConflict)
+		return
 	}
-	requests[requestID] = cancel
+	s.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: requestID, cancel: cancel}
 	s.mu.Unlock()
 	unlock()
 	s.reloadMu.RUnlock()
 	defer func() {
 		cancel()
 		s.mu.Lock()
-		if current := s.progressiveRemuxes[transportID]; current != nil {
-			delete(current, requestID)
-			if len(current) == 0 {
-				delete(s.progressiveRemuxes, transportID)
-			}
+		if current, ok := s.progressiveRemuxes[transportID]; ok && current.id == requestID {
+			delete(s.progressiveRemuxes, transportID)
 		}
 		s.mu.Unlock()
 	}()
@@ -2034,17 +2042,17 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
 	s.pruneStoppedProgressiveRemuxesLocked(now)
 	s.stoppedProgressiveRemuxes[sessionID] = now.Add(playback.MaxTokenTTL)
-	progressive := s.progressiveRemuxes[sessionID]
+	progressive, progressiveFound := s.progressiveRemuxes[sessionID]
 	delete(s.progressiveRemuxes, sessionID)
 	session, ok := s.sessions[sessionID]
-	found := ok || len(progressive) > 0
+	found := ok || progressiveFound
 	if ok {
 		delete(s.sessions, sessionID)
 		delete(s.lastAccess, sessionID)
 	}
 	s.mu.Unlock()
-	for _, cancel := range progressive {
-		cancel()
+	if progressiveFound {
+		progressive.cancel()
 	}
 
 	if ok {
@@ -2334,13 +2342,25 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "reload failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	s.teardownForForceReload(r.Context())
+	if err := s.teardownForForceReload(r.Context()); err != nil {
+		http.Error(w, "force reload authority revocation failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	slog.InfoContext(r.Context(), "transcode force reload completed", slog.String("component", "transcodenode"))
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s *Server) teardownForForceReload(ctx context.Context) {
+func (s *Server) teardownForForceReload(ctx context.Context) error {
+	var authorityErr error
+	if s.recipeStore != nil {
+		if s.tracker == nil || strings.TrimSpace(s.tracker.NodeURL()) == "" {
+			authorityErr = errors.New("transcode node URL unavailable")
+		} else {
+			authorityErr = s.recipeStore.RevokeNode(ctx, s.tracker.NodeURL())
+		}
+	}
+
 	type forceReloadVictim struct {
 		id      string
 		session *playback.TranscodeSession
@@ -2393,22 +2413,16 @@ func (s *Server) teardownForForceReload(ctx context.Context) {
 	s.mu.Lock()
 	now := time.Now()
 	s.pruneStoppedProgressiveRemuxesLocked(now)
-	progressiveVictims := make(map[string][]context.CancelFunc, len(s.progressiveRemuxes))
-	for id, requests := range s.progressiveRemuxes {
-		cancels := make([]context.CancelFunc, 0, len(requests))
-		for _, cancel := range requests {
-			cancels = append(cancels, cancel)
-		}
-		progressiveVictims[id] = cancels
+	progressiveVictims := make(map[string]context.CancelFunc, len(s.progressiveRemuxes))
+	for id, request := range s.progressiveRemuxes {
+		progressiveVictims[id] = request.cancel
 		s.stoppedProgressiveRemuxes[id] = now.Add(playback.MaxTokenTTL)
 		delete(s.progressiveRemuxes, id)
 	}
 	s.mu.Unlock()
 
-	for id, cancels := range progressiveVictims {
-		for _, cancel := range cancels {
-			cancel()
-		}
+	for id, cancel := range progressiveVictims {
+		cancel()
 		if s.recipeStore != nil {
 			if err := s.recipeStore.Delete(ctx, id); err != nil {
 				slog.WarnContext(ctx, "delete progressive remux authority on force reload", "component", "transcodenode", "error", err, "session", id, "playback_session_id", id)
@@ -2418,6 +2432,7 @@ func (s *Server) teardownForForceReload(ctx context.Context) {
 			s.tracker.Remove(ctx, id)
 		}
 	}
+	return authorityErr
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -2045,17 +2045,27 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	unlock := s.lockSessionLifecycle(sessionID)
 	defer unlock()
 
-	s.mu.Lock()
-	if s.stoppedProgressiveRemuxes == nil {
-		s.stoppedProgressiveRemuxes = make(map[string]time.Time)
+	durableProgressive := false
+	authorityFound := false
+	if s.recipeStore != nil {
+		card, ok := s.recipeStore.Get(r.Context(), sessionID)
+		authorityFound = ok && card != nil
+		durableProgressive = authorityFound && card.PlayMethod == playback.PlayRemux
 	}
+
+	s.mu.Lock()
 	now := time.Now()
 	s.pruneStoppedProgressiveRemuxesLocked(now)
-	s.stoppedProgressiveRemuxes[sessionID] = now.Add(playback.MaxTokenTTL)
 	progressive, progressiveFound := s.progressiveRemuxes[sessionID]
+	if progressiveFound || durableProgressive {
+		if s.stoppedProgressiveRemuxes == nil {
+			s.stoppedProgressiveRemuxes = make(map[string]time.Time)
+		}
+		s.stoppedProgressiveRemuxes[sessionID] = now.Add(playback.MaxTokenTTL)
+	}
 	delete(s.progressiveRemuxes, sessionID)
 	session, ok := s.sessions[sessionID]
-	found := ok || progressiveFound
+	found := ok || progressiveFound || authorityFound
 	if ok {
 		delete(s.sessions, sessionID)
 		delete(s.lastAccess, sessionID)
@@ -2078,16 +2088,24 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Drop the recipe so a buffered/retrying request after a node restart cannot
-	// reconstruct a new ffmpeg for this now-stopped session. Best-effort: a stop
-	// must still succeed even if the recipe store is briefly unavailable.
+	// reconstruct a new ffmpeg for this now-stopped session. A failed deletion
+	// must be visible to the caller: the in-memory fence cannot survive a node
+	// replacement, so reporting success would make the stop revocable only until
+	// this process exits.
+	var authorityErr error
 	if s.recipeStore != nil {
-		if err := s.recipeStore.Delete(r.Context(), sessionID); err != nil {
-			slog.WarnContext(r.Context(), "delete transcode recipe on stop", "component", "transcodenode", "error", err, "session", sessionID, "playback_session_id", sessionID)
+		authorityErr = s.recipeStore.Delete(r.Context(), sessionID)
+		if authorityErr != nil {
+			slog.WarnContext(r.Context(), "delete transcode recipe on stop", "component", "transcodenode", "error", authorityErr, "session", sessionID, "playback_session_id", sessionID)
 		}
 	}
 
 	if s.tracker != nil {
 		s.tracker.Remove(r.Context(), sessionID)
+	}
+	if authorityErr != nil {
+		http.Error(w, "transcode authority revocation unavailable", http.StatusServiceUnavailable)
+		return
 	}
 	if !found {
 		http.Error(w, "session not found", http.StatusNotFound)

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -691,8 +691,11 @@ type recipeStore interface {
 	// Called only on deliberate teardown; nil-safe and a missing key is a no-op.
 	Delete(ctx context.Context, sessionID string) error
 	// RevokeNode invalidates all recipes issued for a node before a destructive
-	// reload, including transports that have not received their first request.
+	// reload under its legacy URL identity.
 	RevokeNode(ctx context.Context, nodeURL string) error
+	// RevokeNodeID invalidates current progressive-remux authority under the
+	// stable stream_nodes identity, which survives URL repoints and restarts.
+	RevokeNodeID(ctx context.Context, nodeID int) error
 }
 
 // SetRecipeStore wires the control-plane recipe store so this node can rebuild a
@@ -2020,20 +2023,14 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 // progressiveRemuxRunsOnThisNode binds a routed remux to the stable database
 // identity selected by the planner. NODE_URL is only the worker's local
 // address and may intentionally differ from the registered route URL in a
-// split-horizon deployment. The URL check remains for bounded tokens minted by
-// an earlier API that did not carry the additive node ID.
+// split-horizon deployment. A transcode-executed progressive route has never
+// shipped without the additive row ID, so an ID-less token fails closed.
 func (s *Server) progressiveRemuxRunsOnThisNode(claims *streamtoken.Claims) bool {
-	if s == nil || claims == nil {
+	if s == nil || claims == nil || claims.RoutingExecutionNodeID <= 0 || s.nodeRowID == nil {
 		return false
 	}
-	if claims.RoutingExecutionNodeID > 0 {
-		if s.nodeRowID == nil {
-			return false
-		}
-		nodeID, ok := s.nodeRowID()
-		return ok && nodeID == claims.RoutingExecutionNodeID
-	}
-	return s.tracker == nil || strings.TrimRight(claims.TranscodeNode, "/") == strings.TrimRight(s.tracker.NodeURL(), "/")
+	nodeID, ok := s.nodeRowID()
+	return ok && nodeID == claims.RoutingExecutionNodeID
 }
 
 func transcodeNodeRemuxPlayMethod(method string) bool {
@@ -2407,14 +2404,18 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 	s.reloadMu.Lock()
 	defer s.reloadMu.Unlock()
 	previousRegisteredURL := ""
+	previousNodeID := 0
 	if s.registeredNodeURL != nil {
 		previousRegisteredURL, _ = s.registeredNodeURL()
+	}
+	if s.nodeRowID != nil {
+		previousNodeID, _ = s.nodeRowID()
 	}
 	if err := s.watcher.ForceReload(r.Context()); err != nil {
 		http.Error(w, "reload failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if err := s.teardownForForceReload(r.Context(), previousRegisteredURL); err != nil {
+	if err := s.teardownForForceReload(r.Context(), previousRegisteredURL, previousNodeID); err != nil {
 		http.Error(w, "force reload authority revocation failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -2423,9 +2424,30 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredURL string) error {
+func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredURL string, previousNodeID int) error {
 	var authorityErr error
 	if s.recipeStore != nil {
+		var revokeErrs []error
+		nodeIDs := []int{previousNodeID}
+		if s.nodeRowID != nil {
+			if nodeID, ok := s.nodeRowID(); ok {
+				nodeIDs = append(nodeIDs, nodeID)
+			}
+		}
+		seenNodeIDs := make(map[int]struct{}, len(nodeIDs))
+		for _, nodeID := range nodeIDs {
+			if nodeID <= 0 {
+				continue
+			}
+			if _, duplicate := seenNodeIDs[nodeID]; duplicate {
+				continue
+			}
+			seenNodeIDs[nodeID] = struct{}{}
+			if err := s.recipeStore.RevokeNodeID(ctx, nodeID); err != nil {
+				revokeErrs = append(revokeErrs, fmt.Errorf("revoke node id %d: %w", nodeID, err))
+			}
+		}
+
 		nodeURLs := append([]string(nil), s.pendingAuthorityRevocations...)
 		nodeURLs = append(nodeURLs, previousRegisteredURL)
 		registeredURLResolved := false
@@ -2440,7 +2462,6 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 			nodeURLs = append(nodeURLs, s.tracker.NodeURL())
 		}
 		seen := make(map[string]struct{}, len(nodeURLs))
-		var revokeErrs []error
 		failedURLs := make([]string, 0, len(s.pendingAuthorityRevocations))
 		for _, nodeURL := range nodeURLs {
 			nodeURL = strings.TrimRight(strings.TrimSpace(nodeURL), "/")
@@ -2457,7 +2478,7 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 			}
 		}
 		s.pendingAuthorityRevocations = failedURLs
-		if len(seen) == 0 {
+		if len(seenNodeIDs) == 0 && len(seen) == 0 {
 			authorityErr = errors.New("transcode node URL unavailable")
 		} else {
 			authorityErr = errors.Join(revokeErrs...)

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1903,6 +1903,16 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	if !s.requireApprovedInputPath(w, r, claims.MediaPath) {
 		return
 	}
+	if r.Method == http.MethodHead {
+		contentType := playback.RemuxContentType(claims.AudioOnly)
+		if contentType == "" {
+			contentType = "video/mp4"
+		}
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Cache-Control", "no-store, max-age=0")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 	seekSeconds := 0.0
 	if rawSeek := r.URL.Query().Get("seek"); rawSeek != "" {
 		parsed, parseErr := strconv.ParseFloat(rawSeek, 64)

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/httpstream"
 	"github.com/Silo-Server/silo-server/internal/nodeconfig"
 	"github.com/Silo-Server/silo-server/internal/nodemetrics"
+	"github.com/Silo-Server/silo-server/internal/noderouting"
 	"github.com/Silo-Server/silo-server/internal/nodesessions"
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/streamtelemetry"
@@ -199,14 +200,17 @@ type sessionTracker interface {
 
 // Server is the HTTP handler for transcode mode.
 type Server struct {
-	watcher      *nodeconfig.Watcher
-	tracker      sessionTracker
-	ffmpegSink   playback.FFmpegLogSink
-	inputPaths   InputPathAuthorizer
-	transcodeDir string
-	artifactRoot string
-	telemetry    *streamtelemetry.Registry
-	sessions     map[string]*playback.TranscodeSession
+	watcher                   *nodeconfig.Watcher
+	tracker                   sessionTracker
+	ffmpegSink                playback.FFmpegLogSink
+	inputPaths                InputPathAuthorizer
+	transcodeDir              string
+	artifactRoot              string
+	telemetry                 *streamtelemetry.Registry
+	sessions                  map[string]*playback.TranscodeSession
+	progressiveRemuxes        map[string]map[uint64]context.CancelFunc
+	stoppedProgressiveRemuxes map[string]time.Time
+	progressiveRemuxSequence  atomic.Uint64
 	// lastAccess records, per registered session id, when a manifest or segment
 	// request last touched the job (registration counts as the first access).
 	// Guarded by mu alongside sessions; the idle reaper closes jobs whose entry
@@ -412,12 +416,14 @@ func NewServer(watcher *nodeconfig.Watcher, tracker *nodesessions.Tracker) *Serv
 		artifactRoot = config.EffectiveDownloadArtifactDir(artifactDir, transcodeDir)
 	}
 	s := &Server{
-		watcher:      watcher,
-		tracker:      trackerImpl,
-		transcodeDir: transcodeDir,
-		artifactRoot: artifactRoot,
-		sessions:     make(map[string]*playback.TranscodeSession),
-		lastAccess:   make(map[string]time.Time),
+		watcher:                   watcher,
+		tracker:                   trackerImpl,
+		transcodeDir:              transcodeDir,
+		artifactRoot:              artifactRoot,
+		sessions:                  make(map[string]*playback.TranscodeSession),
+		progressiveRemuxes:        make(map[string]map[uint64]context.CancelFunc),
+		stoppedProgressiveRemuxes: make(map[string]time.Time),
+		lastAccess:                make(map[string]time.Time),
 	}
 	return s
 }
@@ -711,6 +717,8 @@ func (s *Server) Handler() http.Handler {
 		r.Delete("/downloads/artifacts/{artifact_id}", s.handleDeleteDownloadArtifact)
 		r.Post("/transcode/start", s.handleStart)
 		r.Delete("/transcode/{session_id}", s.handleStop)
+		r.Head("/remux/{session_id}", observeNode(s.telemetry, http.MethodHead, "/remux/{session_id}", s.handleRemux))
+		r.Get("/remux/{session_id}", observeNode(s.telemetry, http.MethodGet, "/remux/{session_id}", s.handleRemux))
 		r.Get("/transcode/{session_id}/master.m3u8", observeNode(s.telemetry, http.MethodGet, "/transcode/{session_id}/master.m3u8", s.handleManifest))
 		r.Get("/transcode/{session_id}/segment/{name}", observeNode(s.telemetry, http.MethodGet, "/transcode/{session_id}/segment/{name}", s.handleSegment))
 		r.Post("/transcode/{session_id}/segment/{name}/downloaded", s.handleSegmentDownloaded)
@@ -1153,6 +1161,7 @@ func (s *Server) buildCapabilitySnapshotLocked(ctx context.Context) (playback.HW
 		return playback.HWAccelInfo{}, err
 	}
 	info.Transformations = registry.Advertised()
+	info.TransportFeatures = []string{playback.TransportFeatureProgressiveRemuxExecutionV1}
 	info.CapabilityHash = playback.ComputeCapabilityHash(info)
 	return info, nil
 }
@@ -1840,6 +1849,130 @@ func (s *Server) acquireReconstructSlot(ctx context.Context) (func(), bool) {
 	}
 }
 
+// handleRemux executes a progressive remux on demand. The static bearer
+// authenticates the proxy process; the independently verified stream token
+// binds the media recipe and the exact transcode-execution/proxy-egress route.
+func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
+	cfg := s.watcher.Config()
+	if cfg == nil || cfg.Auth.JWTSecret == "" {
+		http.Error(w, "node not configured", http.StatusServiceUnavailable)
+		return
+	}
+	token := strings.TrimSpace(r.Header.Get("X-Silo-Stream-Token"))
+	claims, err := streamtoken.Verify(token, cfg.Auth.JWTSecret)
+	if err != nil {
+		http.Error(w, "invalid stream token", http.StatusUnauthorized)
+		return
+	}
+	transportID := claims.TranscodeTransportID
+	if transportID == "" {
+		transportID = claims.SessionID
+	}
+	if transportID == "" || transportID != chi.URLParam(r, "session_id") ||
+		claims.TranscodeNode == "" ||
+		claims.RoutingWorkload != string(noderouting.WorkloadRemux) ||
+		claims.RoutingExecution != string(noderouting.ExecutionTranscode) ||
+		claims.RoutingEgress != string(noderouting.EgressProxy) ||
+		!transcodeNodeRemuxPlayMethod(claims.PlayMethod) {
+		http.Error(w, "routing policy unsatisfied", http.StatusServiceUnavailable)
+		return
+	}
+	if s.tracker != nil && strings.TrimRight(claims.TranscodeNode, "/") != strings.TrimRight(s.tracker.NodeURL(), "/") {
+		http.Error(w, "routing policy unsatisfied", http.StatusServiceUnavailable)
+		return
+	}
+	if claims.PlayMethod == streamtoken.PlayMethodAudioDownmixRemux &&
+		(!claims.TranscodeAudio || claims.TargetAudioChannels != 2 ||
+			!playback.IsAudioToAACStereoDownmixV3(claims.SourceAudioChannels, claims.TargetCodecAudio, claims.TargetAudioChannels)) {
+		http.NotFound(w, r)
+		return
+	}
+	if !s.requireApprovedInputPath(w, r, claims.MediaPath) {
+		return
+	}
+	seekSeconds := 0.0
+	if rawSeek := r.URL.Query().Get("seek"); rawSeek != "" {
+		parsed, parseErr := strconv.ParseFloat(rawSeek, 64)
+		if parseErr != nil || parsed < 0 {
+			http.Error(w, "invalid seek", http.StatusBadRequest)
+			return
+		}
+		seekSeconds = parsed
+	}
+
+	ctx, cancel := context.WithCancel(r.Context())
+	requestID := s.progressiveRemuxSequence.Add(1)
+	unlock := s.lockSessionLifecycle(transportID)
+	s.mu.Lock()
+	now := time.Now()
+	s.pruneStoppedProgressiveRemuxesLocked(now)
+	if s.stoppedProgressiveRemuxes[transportID].After(now) {
+		s.mu.Unlock()
+		unlock()
+		cancel()
+		http.Error(w, "session stopped", http.StatusGone)
+		return
+	}
+	requests := s.progressiveRemuxes[transportID]
+	if requests == nil {
+		requests = make(map[uint64]context.CancelFunc)
+		s.progressiveRemuxes[transportID] = requests
+	}
+	requests[requestID] = cancel
+	s.mu.Unlock()
+	unlock()
+	defer func() {
+		cancel()
+		s.mu.Lock()
+		if current := s.progressiveRemuxes[transportID]; current != nil {
+			delete(current, requestID)
+			if len(current) == 0 {
+				delete(s.progressiveRemuxes, transportID)
+			}
+		}
+		s.mu.Unlock()
+	}()
+
+	s.activeJobs.Add(1)
+	defer s.activeJobs.Add(-1)
+	if s.tracker != nil {
+		startedAt, source := claims.StartedAt()
+		if source == streamtoken.StartedAtSourceNone {
+			startedAt = time.Now().UTC()
+		}
+		s.tracker.Track(ctx, nodesessions.SessionInfo{
+			SessionID: transportID, NodeURL: s.tracker.NodeURL(), NodeName: s.tracker.NodeName(), Type: "remux",
+			CodecAudio: claims.TargetCodecAudio, StartedAt: startedAt.Format(time.RFC3339), StartedAtUnixNano: startedAt.UnixNano(),
+			StartedAtSource: string(source), AuthUserID: claims.UserID, ProfileID: claims.ProfileID, MediaFileID: claims.MediaFileID,
+		})
+		defer s.tracker.Remove(context.WithoutCancel(ctx), transportID)
+	}
+
+	request := r.WithContext(ctx)
+	s.attachTelemetrySession(request, transportID)
+	if err := playback.ServeRemuxWithOptions(w, request, claims.MediaPath, "mp4", seekSeconds, claims.TranscodeAudio, claims.AudioTrackIndex, claims.DVProfile, playback.RemuxServeOptions{
+		DVMode: playback.RemuxDVMode(claims.RemuxDVMode), FFmpegPath: cfg.Playback.FFmpegPath,
+		ContentType: playback.RemuxContentType(claims.AudioOnly), AudioOnly: claims.AudioOnly,
+		SourceAudioChannels: claims.SourceAudioChannels, TargetAudioChannels: claims.TargetAudioChannels,
+		TargetAudioBitrateKbps: claims.TargetAudioBitrateKbps,
+	}); err != nil && !errors.Is(err, context.Canceled) {
+		slog.WarnContext(ctx, "progressive remux ended with an error", "component", "transcodenode", "error", err,
+			"session", transportID, "playback_session_id", claims.SessionID)
+	}
+}
+
+func transcodeNodeRemuxPlayMethod(method string) bool {
+	return method == string(playback.PlayRemux) || method == streamtoken.PlayMethodAudioDownmixRemux
+}
+
+func (s *Server) pruneStoppedProgressiveRemuxesLocked(now time.Time) {
+	for id, expiresAt := range s.stoppedProgressiveRemuxes {
+		if !expiresAt.After(now) {
+			delete(s.stoppedProgressiveRemuxes, id)
+		}
+	}
+}
+
 func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	sessionID := chi.URLParam(r, "session_id")
 
@@ -1853,22 +1986,39 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 	defer unlock()
 
 	s.mu.Lock()
+	if s.stoppedProgressiveRemuxes == nil {
+		s.stoppedProgressiveRemuxes = make(map[string]time.Time)
+	}
+	now := time.Now()
+	s.pruneStoppedProgressiveRemuxesLocked(now)
+	s.stoppedProgressiveRemuxes[sessionID] = now.Add(playback.MaxTokenTTL)
+	progressive := s.progressiveRemuxes[sessionID]
+	delete(s.progressiveRemuxes, sessionID)
 	session, ok := s.sessions[sessionID]
-	if !ok {
+	if !ok && len(progressive) == 0 {
 		s.mu.Unlock()
 		http.Error(w, "session not found", http.StatusNotFound)
 		return
 	}
-	delete(s.sessions, sessionID)
-	delete(s.lastAccess, sessionID)
+	if ok {
+		delete(s.sessions, sessionID)
+		delete(s.lastAccess, sessionID)
+	}
 	s.mu.Unlock()
-
-	if err := s.closeSessionOffGPU(session); err != nil {
-		slog.ErrorContext(r.Context(), "close transcode session", "component", "transcodenode", "error", err, "session", sessionID, "playback_session_id", sessionID)
+	for _, cancel := range progressive {
+		cancel()
 	}
 
-	if err := os.RemoveAll(s.sessionOutputDir(sessionID)); err != nil {
-		slog.WarnContext(r.Context(), "remove transcode session directory", "component", "transcodenode", "session", sessionID, "error", err)
+	if ok {
+		if err := s.closeSessionOffGPU(session); err != nil {
+			slog.ErrorContext(r.Context(), "close transcode session", "component", "transcodenode", "error", err, "session", sessionID, "playback_session_id", sessionID)
+		}
+	}
+
+	if ok {
+		if err := os.RemoveAll(s.sessionOutputDir(sessionID)); err != nil {
+			slog.WarnContext(r.Context(), "remove transcode session directory", "component", "transcodenode", "session", sessionID, "error", err)
+		}
 	}
 
 	// Drop the recipe so a buffered/retrying request after a node restart cannot
@@ -1880,7 +2030,9 @@ func (s *Server) handleStop(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.tracker.Remove(r.Context(), sessionID)
+	if s.tracker != nil {
+		s.tracker.Remove(r.Context(), sessionID)
+	}
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -2193,9 +2345,14 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
-	sessionIDs := make([]string, 0, len(s.sessions))
+	sessionIDs := make([]string, 0, len(s.sessions)+len(s.progressiveRemuxes))
 	for id := range s.sessions {
 		sessionIDs = append(sessionIDs, id)
+	}
+	for id := range s.progressiveRemuxes {
+		if _, exists := s.sessions[id]; !exists {
+			sessionIDs = append(sessionIDs, id)
+		}
 	}
 	s.mu.RUnlock()
 

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -190,6 +190,11 @@ const sessionTrackingOperationTimeout = 2 * time.Second
 // TranscodeStartReadinessTimeout is the node-side RequireReady manifest budget.
 const TranscodeStartReadinessTimeout = 8 * time.Second
 
+// progressiveRemuxShutdownTimeout bounds a destructive reload when a canceled
+// FFmpeg process does not exit. A timed-out reload must fail rather than report
+// completion while the old-config process is still live.
+const progressiveRemuxShutdownTimeout = 10 * time.Second
+
 type sessionTracker interface {
 	Track(context.Context, nodesessions.SessionInfo)
 	Remove(context.Context, string)
@@ -201,6 +206,7 @@ type sessionTracker interface {
 type progressiveRemuxRequest struct {
 	id     uint64
 	cancel context.CancelFunc
+	done   <-chan struct{}
 }
 
 // Server is the HTTP handler for transcode mode.
@@ -1959,6 +1965,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithCancel(r.Context())
 	requestID := s.progressiveRemuxSequence.Add(1)
+	done := make(chan struct{})
 	unlock := s.lockSessionLifecycle(transportID)
 	s.mu.Lock()
 	now := time.Now()
@@ -1979,7 +1986,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session already active", http.StatusConflict)
 		return
 	}
-	s.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: requestID, cancel: cancel}
+	s.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: requestID, cancel: cancel, done: done}
 	s.mu.Unlock()
 	unlock()
 	s.reloadMu.RUnlock()
@@ -1990,6 +1997,7 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 			delete(s.progressiveRemuxes, transportID)
 		}
 		s.mu.Unlock()
+		close(done)
 	}()
 
 	s.activeJobs.Add(1)
@@ -2416,7 +2424,7 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.teardownForForceReload(r.Context(), previousRegisteredURL, previousNodeID); err != nil {
-		http.Error(w, "force reload authority revocation failed: "+err.Error(), http.StatusInternalServerError)
+		http.Error(w, "force reload teardown failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -2537,16 +2545,16 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 	s.mu.Lock()
 	now := time.Now()
 	s.pruneStoppedProgressiveRemuxesLocked(now)
-	progressiveVictims := make(map[string]context.CancelFunc, len(s.progressiveRemuxes))
+	progressiveVictims := make(map[string]progressiveRemuxRequest, len(s.progressiveRemuxes))
 	for id, request := range s.progressiveRemuxes {
-		progressiveVictims[id] = request.cancel
+		progressiveVictims[id] = request
 		s.stoppedProgressiveRemuxes[id] = now.Add(playback.MaxTokenTTL)
 		delete(s.progressiveRemuxes, id)
 	}
 	s.mu.Unlock()
 
-	for id, cancel := range progressiveVictims {
-		cancel()
+	for id, request := range progressiveVictims {
+		request.cancel()
 		if s.recipeStore != nil {
 			if err := s.recipeStore.Delete(ctx, id); err != nil {
 				slog.WarnContext(ctx, "delete progressive remux authority on force reload", "component", "transcodenode", "error", err, "session", id, "playback_session_id", id)
@@ -2554,6 +2562,19 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 		}
 		if s.tracker != nil {
 			s.tracker.Remove(ctx, id)
+		}
+	}
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, progressiveRemuxShutdownTimeout)
+	defer cancelWait()
+	for id, request := range progressiveVictims {
+		if request.done == nil {
+			continue
+		}
+		select {
+		case <-request.done:
+		case <-waitCtx.Done():
+			return errors.Join(authorityErr, fmt.Errorf("wait for progressive remux %s shutdown: %w", id, waitCtx.Err()))
 		}
 	}
 	return authorityErr

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -207,6 +207,7 @@ type progressiveRemuxRequest struct {
 type Server struct {
 	watcher                   *nodeconfig.Watcher
 	nodeRowID                 func() (int, bool)
+	registeredNodeURL         func() (string, bool)
 	tracker                   sessionTracker
 	ffmpegSink                playback.FFmpegLogSink
 	inputPaths                InputPathAuthorizer
@@ -433,6 +434,7 @@ func NewServer(watcher *nodeconfig.Watcher, tracker *nodesessions.Tracker) *Serv
 	}
 	if watcher != nil {
 		s.nodeRowID = watcher.NodeRowID
+		s.registeredNodeURL = watcher.NodeRegisteredURL
 	}
 	return s
 }
@@ -2406,10 +2408,19 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 func (s *Server) teardownForForceReload(ctx context.Context) error {
 	var authorityErr error
 	if s.recipeStore != nil {
-		if s.tracker == nil || strings.TrimSpace(s.tracker.NodeURL()) == "" {
+		nodeURL := ""
+		if s.registeredNodeURL != nil {
+			registeredURL, ok := s.registeredNodeURL()
+			if ok {
+				nodeURL = registeredURL
+			}
+		} else if s.tracker != nil {
+			nodeURL = s.tracker.NodeURL()
+		}
+		if strings.TrimSpace(nodeURL) == "" {
 			authorityErr = errors.New("transcode node URL unavailable")
 		} else {
-			authorityErr = s.recipeStore.RevokeNode(ctx, s.tracker.NodeURL())
+			authorityErr = s.recipeStore.RevokeNode(ctx, nodeURL)
 		}
 	}
 

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -1176,7 +1176,15 @@ func (s *Server) buildCapabilitySnapshotLocked(ctx context.Context) (playback.HW
 		return playback.HWAccelInfo{}, err
 	}
 	info.Transformations = registry.Advertised()
-	info.TransportFeatures = []string{playback.TransportFeatureProgressiveRemuxExecutionV1}
+	// Progressive remux tokens bind execution to the stable stream_nodes row.
+	// Do not let central commit work to this node until the watcher can resolve
+	// that identity; otherwise every committed GET would fail closed at serve
+	// time with no different route for a replan to choose.
+	if s.nodeRowID != nil {
+		if nodeID, ok := s.nodeRowID(); ok && nodeID > 0 {
+			info.TransportFeatures = []string{playback.TransportFeatureProgressiveRemuxExecutionV1}
+		}
+	}
 	info.CapabilityHash = playback.ComputeCapabilityHash(info)
 	return info, nil
 }

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -2422,12 +2422,15 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 	var authorityErr error
 	if s.recipeStore != nil {
 		nodeURLs := []string{previousRegisteredURL}
+		registeredURLResolved := false
 		if s.registeredNodeURL != nil {
 			registeredURL, ok := s.registeredNodeURL()
 			if ok {
 				nodeURLs = append(nodeURLs, registeredURL)
+				registeredURLResolved = true
 			}
-		} else if s.tracker != nil {
+		}
+		if !registeredURLResolved && s.tracker != nil {
 			nodeURLs = append(nodeURLs, s.tracker.NodeURL())
 		}
 		seen := make(map[string]struct{}, len(nodeURLs))

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -2392,11 +2392,15 @@ func (s *Server) handleReloadConfig(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 	s.reloadMu.Lock()
 	defer s.reloadMu.Unlock()
+	previousRegisteredURL := ""
+	if s.registeredNodeURL != nil {
+		previousRegisteredURL, _ = s.registeredNodeURL()
+	}
 	if err := s.watcher.ForceReload(r.Context()); err != nil {
 		http.Error(w, "reload failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if err := s.teardownForForceReload(r.Context()); err != nil {
+	if err := s.teardownForForceReload(r.Context(), previousRegisteredURL); err != nil {
 		http.Error(w, "force reload authority revocation failed: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -2405,22 +2409,37 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s *Server) teardownForForceReload(ctx context.Context) error {
+func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredURL string) error {
 	var authorityErr error
 	if s.recipeStore != nil {
-		nodeURL := ""
+		nodeURLs := []string{previousRegisteredURL}
 		if s.registeredNodeURL != nil {
 			registeredURL, ok := s.registeredNodeURL()
 			if ok {
-				nodeURL = registeredURL
+				nodeURLs = append(nodeURLs, registeredURL)
 			}
 		} else if s.tracker != nil {
-			nodeURL = s.tracker.NodeURL()
+			nodeURLs = append(nodeURLs, s.tracker.NodeURL())
 		}
-		if strings.TrimSpace(nodeURL) == "" {
+		seen := make(map[string]struct{}, len(nodeURLs))
+		var revokeErrs []error
+		for _, nodeURL := range nodeURLs {
+			nodeURL = strings.TrimRight(strings.TrimSpace(nodeURL), "/")
+			if nodeURL == "" {
+				continue
+			}
+			if _, duplicate := seen[nodeURL]; duplicate {
+				continue
+			}
+			seen[nodeURL] = struct{}{}
+			if err := s.recipeStore.RevokeNode(ctx, nodeURL); err != nil {
+				revokeErrs = append(revokeErrs, fmt.Errorf("revoke %s: %w", nodeURL, err))
+			}
+		}
+		if len(seen) == 0 {
 			authorityErr = errors.New("transcode node URL unavailable")
 		} else {
-			authorityErr = s.recipeStore.RevokeNode(ctx, nodeURL)
+			authorityErr = errors.Join(revokeErrs...)
 		}
 	}
 

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -227,8 +227,12 @@ type Server struct {
 	mu         sync.RWMutex
 	// reloadMu keeps force-reload teardown atomic with session creation and
 	// reconstruction. It is always acquired before lifecycleMu or mu.
-	reloadMu   sync.RWMutex
-	activeJobs atomic.Int32
+	reloadMu sync.RWMutex
+	// pendingAuthorityRevocations retains normalized node URLs whose generation
+	// bump failed during a force reload. Guarded by reloadMu; the next operator
+	// retry must revisit them even if the watcher has already adopted a new URL.
+	pendingAuthorityRevocations []string
+	activeJobs                  atomic.Int32
 
 	// reconstructGroup single-flights node-side session reconstruction per session
 	// id so a post-restart wave of concurrent manifest/segment requests for the same
@@ -1913,16 +1917,6 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	if !s.requireApprovedInputPath(w, r, claims.MediaPath) {
 		return
 	}
-	if r.Method == http.MethodHead {
-		contentType := playback.RemuxContentType(claims.AudioOnly)
-		if contentType == "" {
-			contentType = "video/mp4"
-		}
-		w.Header().Set("Content-Type", contentType)
-		w.Header().Set("Cache-Control", "no-store, max-age=0")
-		w.WriteHeader(http.StatusOK)
-		return
-	}
 	seekSeconds := 0.0
 	if rawSeek := r.URL.Query().Get("seek"); rawSeek != "" {
 		parsed, parseErr := strconv.ParseFloat(rawSeek, 64)
@@ -1946,6 +1940,17 @@ func (s *Server) handleRemux(w http.ResponseWriter, r *http.Request) {
 	if !s.progressiveRemuxAuthorityActive(r.Context(), transportID, claims) {
 		s.reloadMu.RUnlock()
 		http.Error(w, "session stopped", http.StatusGone)
+		return
+	}
+	if r.Method == http.MethodHead {
+		s.reloadMu.RUnlock()
+		contentType := playback.RemuxContentType(claims.AudioOnly)
+		if contentType == "" {
+			contentType = "video/mp4"
+		}
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Cache-Control", "no-store, max-age=0")
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 
@@ -2421,7 +2426,8 @@ func (s *Server) handleForceReload(w http.ResponseWriter, r *http.Request) {
 func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredURL string) error {
 	var authorityErr error
 	if s.recipeStore != nil {
-		nodeURLs := []string{previousRegisteredURL}
+		nodeURLs := append([]string(nil), s.pendingAuthorityRevocations...)
+		nodeURLs = append(nodeURLs, previousRegisteredURL)
 		registeredURLResolved := false
 		if s.registeredNodeURL != nil {
 			registeredURL, ok := s.registeredNodeURL()
@@ -2435,6 +2441,7 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 		}
 		seen := make(map[string]struct{}, len(nodeURLs))
 		var revokeErrs []error
+		failedURLs := make([]string, 0, len(s.pendingAuthorityRevocations))
 		for _, nodeURL := range nodeURLs {
 			nodeURL = strings.TrimRight(strings.TrimSpace(nodeURL), "/")
 			if nodeURL == "" {
@@ -2445,9 +2452,11 @@ func (s *Server) teardownForForceReload(ctx context.Context, previousRegisteredU
 			}
 			seen[nodeURL] = struct{}{}
 			if err := s.recipeStore.RevokeNode(ctx, nodeURL); err != nil {
+				failedURLs = append(failedURLs, nodeURL)
 				revokeErrs = append(revokeErrs, fmt.Errorf("revoke %s: %w", nodeURL, err))
 			}
 		}
+		s.pendingAuthorityRevocations = failedURLs
 		if len(seen) == 0 {
 			authorityErr = errors.New("transcode node URL unavailable")
 		} else {

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -1865,6 +1865,50 @@ func TestHandleProgressiveRemuxExecutesSignedTranscodeRoute(t *testing.T) {
 	}
 }
 
+func TestHandleProgressiveRemuxHeadDoesNotStartFFmpeg(t *testing.T) {
+	server := newTestServer(t)
+	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ffmpegMarker := filepath.Join(t.TempDir(), "ffmpeg-ran")
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg.sh")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\ntouch \""+ffmpegMarker+"\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	claims := streamtoken.Claims{
+		SessionID: "playback-head", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-head",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingEgress: string(noderouting.EgressProxy),
+	}
+	card := playback.RecipeCardFromClaims(&claims)
+	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
+	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodHead, "/remux/transport-head", nil)
+	request.Header.Set("X-Silo-Stream-Token", token)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", "transport-head")
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+	recorder := httptest.NewRecorder()
+
+	server.handleRemux(recorder, request)
+
+	if recorder.Code != http.StatusOK || recorder.Header().Get("Content-Type") != "video/mp4" {
+		t.Fatalf("response = %d content-type %q", recorder.Code, recorder.Header().Get("Content-Type"))
+	}
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs = %d, want no FFmpeg start", got)
+	}
+	if _, err := os.Stat(ffmpegMarker); !os.IsNotExist(err) {
+		t.Fatalf("HEAD invoked ffmpeg: %v", err)
+	}
+}
+
 func TestHandleProgressiveRemuxRejectsConcurrentRequest(t *testing.T) {
 	server := newTestServer(t)
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -2236,6 +2236,7 @@ func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	server := newTestServer(t)
 	server.tracker = newBlockingSessionTracker()
+	server.registeredNodeURL = func() (string, bool) { return "", false }
 	const transportID = "transport-force-reload"
 	ctx, cancel := context.WithCancel(t.Context())
 	server.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: 1, cancel: cancel}

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -1842,6 +1842,8 @@ func TestHandleProgressiveRemuxExecutesSignedTranscodeRoute(t *testing.T) {
 		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
 		RoutingEgress: string(noderouting.EgressProxy),
 	}
+	card := playback.RecipeCardFromClaims(&claims)
+	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
 	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
 	if err != nil {
 		t.Fatal(err)
@@ -1914,7 +1916,7 @@ func TestHandleStopCancelsProgressiveRemux(t *testing.T) {
 	}
 }
 
-func TestHandleProgressiveRemuxRefusesStoppedTransport(t *testing.T) {
+func TestHandleProgressiveRemuxRefusesStoppedTransportAfterRestart(t *testing.T) {
 	server := newTestServer(t)
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
@@ -1925,20 +1927,26 @@ func TestHandleProgressiveRemuxRefusesStoppedTransport(t *testing.T) {
 	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nprintf invoked > \""+ffmpegLog+"\"\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
-
-	stopRequest := httptest.NewRequest(http.MethodDelete, "/transcode/transport-1", nil)
-	stopRouteContext := chi.NewRouteContext()
-	stopRouteContext.URLParams.Add("session_id", "transport-1")
-	stopRequest = stopRequest.WithContext(context.WithValue(stopRequest.Context(), chi.RouteCtxKey, stopRouteContext))
-	server.handleStop(httptest.NewRecorder(), stopRequest)
-
 	claims := streamtoken.Claims{
 		SessionID: "playback-1", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
 		TranscodeNode: "http://node", TranscodeTransportID: "transport-1",
 		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
 		RoutingEgress: string(noderouting.EgressProxy),
 	}
+	card := playback.RecipeCardFromClaims(&claims)
+	store := &stubRecipeStore{card: &card, ok: true}
+	server.SetRecipeStore(store)
+	stopRequest := httptest.NewRequest(http.MethodDelete, "/transcode/transport-1", nil)
+	stopRouteContext := chi.NewRouteContext()
+	stopRouteContext.URLParams.Add("session_id", "transport-1")
+	stopRequest = stopRequest.WithContext(context.WithValue(stopRequest.Context(), chi.RouteCtxKey, stopRouteContext))
+	server.handleStop(httptest.NewRecorder(), stopRequest)
+
+	// A replacement process has no in-memory stop fence. The deleted durable
+	// authority must still reject the old token before FFmpeg can start.
+	restarted := newTestServer(t)
+	restarted.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	restarted.SetRecipeStore(store)
 	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
 	if err != nil {
 		t.Fatal(err)
@@ -1950,13 +1958,107 @@ func TestHandleProgressiveRemuxRefusesStoppedTransport(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
 	recorder := httptest.NewRecorder()
 
-	server.handleRemux(recorder, request)
+	restarted.handleRemux(recorder, request)
 
 	if recorder.Code != http.StatusGone {
 		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
 	if _, err := os.Stat(ffmpegLog); !os.IsNotExist(err) {
 		t.Fatalf("stopped transport invoked ffmpeg: %v", err)
+	}
+}
+
+func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
+	server := newTestServer(t)
+	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg.sh")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nprintf node-remux-bytes\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	claims := streamtoken.Claims{
+		SessionID: "playback-reload-gate", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-reload-gate",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingEgress: string(noderouting.EgressProxy),
+	}
+	card := playback.RecipeCardFromClaims(&claims)
+	storeHit := make(chan struct{}, 1)
+	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true, getHit: storeHit})
+	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/remux/transport-reload-gate", nil)
+	request.Header.Set("X-Silo-Stream-Token", token)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", "transport-reload-gate")
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+	recorder := httptest.NewRecorder()
+	done := make(chan struct{})
+	waitCtx, waitCancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer waitCancel()
+
+	server.reloadMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			server.reloadMu.Unlock()
+		}
+	}()
+	go func() {
+		server.handleRemux(recorder, request)
+		close(done)
+	}()
+	select {
+	case <-storeHit:
+	case <-waitCtx.Done():
+		t.Fatal("remux did not reach durable authority validation")
+	}
+	select {
+	case <-done:
+		t.Fatal("remux completed while force-reload gate was held")
+	default:
+	}
+	server.reloadMu.Unlock()
+	locked = false
+	select {
+	case <-done:
+	case <-waitCtx.Done():
+		t.Fatal("remux did not resume after force-reload gate was released")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
+	server := newTestServer(t)
+	const transportID = "transport-force-reload"
+	ctx, cancel := context.WithCancel(t.Context())
+	server.progressiveRemuxes[transportID] = map[uint64]context.CancelFunc{1: cancel}
+	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: transportID}}
+	server.SetRecipeStore(store)
+
+	server.teardownForForceReload(t.Context())
+
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("force reload did not cancel the progressive remux")
+	}
+	server.mu.RLock()
+	_, active := server.progressiveRemuxes[transportID]
+	fenced := server.stoppedProgressiveRemuxes[transportID].After(time.Now())
+	server.mu.RUnlock()
+	if active || !fenced {
+		t.Fatalf("force-reload state = active %t, fenced %t; want removed and fenced", active, fenced)
+	}
+	if len(store.deletes) != 1 || store.deletes[0] != transportID {
+		t.Fatalf("durable authority deletes = %v, want [%q]", store.deletes, transportID)
 	}
 }
 
@@ -2076,16 +2178,28 @@ type stubRecipeStore struct {
 	hits    int
 	deletes []string
 	delErr  error
+	getHit  chan struct{}
 }
 
 func (s *stubRecipeStore) Get(context.Context, string) (*playback.RecipeCard, bool) {
 	s.hits++
+	if s.getHit != nil {
+		select {
+		case s.getHit <- struct{}{}:
+		default:
+		}
+	}
 	return s.card, s.ok
 }
 
 func (s *stubRecipeStore) Delete(_ context.Context, sessionID string) error {
 	s.deletes = append(s.deletes, sessionID)
-	return s.delErr
+	if s.delErr != nil {
+		return s.delErr
+	}
+	s.card = nil
+	s.ok = false
+	return nil
 }
 
 // When the forwarded token is recipe-less (jellycompat), the node consults the

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -2040,6 +2040,60 @@ func TestHandleStopCancelsProgressiveRemux(t *testing.T) {
 	}
 }
 
+func TestHandleStopReturnsUnavailableWhenProgressiveAuthorityDeleteFails(t *testing.T) {
+	const transportID = "transport-delete-failure"
+	server := newTestServer(t)
+	server.SetRecipeStore(&stubRecipeStore{
+		card: &playback.RecipeCard{SessionID: "playback-1", TranscodeTransportID: transportID, PlayMethod: playback.PlayRemux},
+		ok:   true, delErr: errors.New("redis is down"),
+	})
+	req := httptest.NewRequest(http.MethodDelete, "/transcode/"+transportID, nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", transportID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+	rr := httptest.NewRecorder()
+
+	server.handleStop(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, body = %s; want durable revocation failure", rr.Code, rr.Body.String())
+	}
+	server.mu.RLock()
+	fenced := server.stoppedProgressiveRemuxes[transportID].After(time.Now())
+	server.mu.RUnlock()
+	if !fenced {
+		t.Fatal("failed durable revocation did not retain the process-local stop fence")
+	}
+}
+
+func TestHandleStopDoesNotFenceOrdinaryHLSSession(t *testing.T) {
+	const sessionID = "hls-session"
+	server := newTestServer(t)
+	server.sessions[sessionID] = &playback.TranscodeSession{}
+	server.activeJobs.Store(1)
+	server.SetRecipeStore(&stubRecipeStore{
+		card: &playback.RecipeCard{SessionID: sessionID, PlayMethod: playback.PlayTranscode},
+		ok:   true,
+	})
+	req := httptest.NewRequest(http.MethodDelete, "/transcode/"+sessionID, nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", sessionID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+	rr := httptest.NewRecorder()
+
+	server.handleStop(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	server.mu.RLock()
+	_, fenced := server.stoppedProgressiveRemuxes[sessionID]
+	server.mu.RUnlock()
+	if fenced {
+		t.Fatal("ordinary HLS teardown was retained in the progressive-remux fence map")
+	}
+}
+
 func TestHandleProgressiveRemuxRefusesStoppedTransportAfterRestart(t *testing.T) {
 	server := newTestServer(t)
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -1828,6 +1828,7 @@ func signCard(t *testing.T, card playback.RecipeCard) string {
 
 func TestHandleProgressiveRemuxExecutesSignedTranscodeRoute(t *testing.T) {
 	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 11, true }
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
@@ -1841,7 +1842,7 @@ func TestHandleProgressiveRemuxExecutesSignedTranscodeRoute(t *testing.T) {
 		SessionID: "playback-1", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
 		TranscodeNode: "http://node", TranscodeTransportID: "transport-1",
 		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
-		RoutingEgress: string(noderouting.EgressProxy),
+		RoutingExecutionNodeID: 11, RoutingEgress: string(noderouting.EgressProxy),
 	}
 	card := playback.RecipeCardFromClaims(&claims)
 	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
@@ -1939,10 +1940,15 @@ func TestProgressiveRemuxRunsOnThisNodeRejectsDifferentNodeID(t *testing.T) {
 	if server.progressiveRemuxRunsOnThisNode(claims) {
 		t.Fatal("progressive remux accepted a token bound to a different node ID")
 	}
+	claims.RoutingExecutionNodeID = 0
+	if server.progressiveRemuxRunsOnThisNode(claims) {
+		t.Fatal("progressive remux accepted a token without a stable node ID")
+	}
 }
 
 func TestHandleProgressiveRemuxRejectsConcurrentRequest(t *testing.T) {
 	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 11, true }
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
@@ -1960,7 +1966,7 @@ func TestHandleProgressiveRemuxRejectsConcurrentRequest(t *testing.T) {
 		SessionID: "playback-concurrent", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
 		TranscodeNode: "http://node", TranscodeTransportID: "transport-concurrent",
 		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
-		RoutingEgress: string(noderouting.EgressProxy),
+		RoutingExecutionNodeID: 11, RoutingEgress: string(noderouting.EgressProxy),
 	}
 	card := playback.RecipeCardFromClaims(&claims)
 	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
@@ -2128,6 +2134,7 @@ func TestHandleStopDoesNotFenceOrdinaryHLSSession(t *testing.T) {
 
 func TestHandleProgressiveRemuxRefusesStoppedTransportAfterRestart(t *testing.T) {
 	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 11, true }
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
@@ -2141,7 +2148,7 @@ func TestHandleProgressiveRemuxRefusesStoppedTransportAfterRestart(t *testing.T)
 		SessionID: "playback-1", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
 		TranscodeNode: "http://node", TranscodeTransportID: "transport-1",
 		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
-		RoutingEgress: string(noderouting.EgressProxy),
+		RoutingExecutionNodeID: 11, RoutingEgress: string(noderouting.EgressProxy),
 	}
 	card := playback.RecipeCardFromClaims(&claims)
 	store := &stubRecipeStore{card: &card, ok: true}
@@ -2155,6 +2162,7 @@ func TestHandleProgressiveRemuxRefusesStoppedTransportAfterRestart(t *testing.T)
 	// A replacement process has no in-memory stop fence. The deleted durable
 	// authority must still reject the old token before FFmpeg can start.
 	restarted := newTestServer(t)
+	restarted.nodeRowID = func() (int, bool) { return 11, true }
 	restarted.watcher.Config().Playback.FFmpegPath = ffmpegPath
 	restarted.SetRecipeStore(store)
 	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
@@ -2180,6 +2188,7 @@ func TestHandleProgressiveRemuxRefusesStoppedTransportAfterRestart(t *testing.T)
 
 func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 11, true }
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
@@ -2193,7 +2202,7 @@ func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 		SessionID: "playback-reload-gate", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
 		TranscodeNode: "http://node", TranscodeTransportID: "transport-reload-gate",
 		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
-		RoutingEgress: string(noderouting.EgressProxy),
+		RoutingExecutionNodeID: 11, RoutingEgress: string(noderouting.EgressProxy),
 	}
 	card := playback.RecipeCardFromClaims(&claims)
 	storeHit := make(chan struct{}, 1)
@@ -2260,7 +2269,7 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: transportID}}
 	server.SetRecipeStore(store)
 
-	if err := server.teardownForForceReload(t.Context(), ""); err != nil {
+	if err := server.teardownForForceReload(t.Context(), "", 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2287,12 +2296,16 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 func TestForceReloadTeardownRevokesDormantProgressiveAuthorities(t *testing.T) {
 	server := newTestServer(t)
 	server.tracker = newBlockingSessionTracker()
+	server.nodeRowID = func() (int, bool) { return 84, true }
 	server.registeredNodeURL = func() (string, bool) { return "https://new-registered-node.example", true }
 	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: "dormant-transport"}}
 	server.SetRecipeStore(store)
 
-	if err := server.teardownForForceReload(t.Context(), "https://old-registered-node.example"); err != nil {
+	if err := server.teardownForForceReload(t.Context(), "https://old-registered-node.example", 84); err != nil {
 		t.Fatal(err)
+	}
+	if !slices.Equal(store.revokedNodeIDs, []int{84}) {
+		t.Fatalf("stable node authority revocations = %v, want [84]", store.revokedNodeIDs)
 	}
 
 	wantRevoked := []string{"https://old-registered-node.example", "https://new-registered-node.example"}
@@ -2311,11 +2324,11 @@ func TestForceReloadTeardownRetriesFailedPreviousURLRevocation(t *testing.T) {
 	store := &stubRecipeStore{revokeErrs: map[string]error{oldURL: errors.New("redis unavailable")}}
 	server.SetRecipeStore(store)
 
-	if err := server.teardownForForceReload(t.Context(), oldURL); err == nil {
+	if err := server.teardownForForceReload(t.Context(), oldURL, 0); err == nil {
 		t.Fatal("partial authority revocation unexpectedly succeeded")
 	}
 	delete(store.revokeErrs, oldURL)
-	if err := server.teardownForForceReload(t.Context(), "https://new-registered-node.example"); err != nil {
+	if err := server.teardownForForceReload(t.Context(), "https://new-registered-node.example", 0); err != nil {
 		t.Fatalf("retry authority revocation: %v", err)
 	}
 
@@ -2328,6 +2341,31 @@ func TestForceReloadTeardownRetriesFailedPreviousURLRevocation(t *testing.T) {
 	}
 	if len(server.pendingAuthorityRevocations) != 0 {
 		t.Fatalf("pending authority revocations = %v, want none after retry", server.pendingAuthorityRevocations)
+	}
+}
+
+func TestForceReloadTeardownRetriesStableNodeIDAfterProcessRestart(t *testing.T) {
+	const nodeID = 84
+	store := &stubRecipeStore{revokeNodeIDErr: errors.New("redis unavailable")}
+	first := newTestServer(t)
+	first.nodeRowID = func() (int, bool) { return nodeID, true }
+	first.SetRecipeStore(store)
+
+	if err := first.teardownForForceReload(t.Context(), "", nodeID); err == nil {
+		t.Fatal("failed stable authority revocation unexpectedly succeeded")
+	}
+
+	// A replacement process has no pending in-memory revocations. Resolving the
+	// same stream_nodes row must nevertheless retry the durable generation.
+	store.revokeNodeIDErr = nil
+	restarted := newTestServer(t)
+	restarted.nodeRowID = func() (int, bool) { return nodeID, true }
+	restarted.SetRecipeStore(store)
+	if err := restarted.teardownForForceReload(t.Context(), "", nodeID); err != nil {
+		t.Fatalf("retry stable authority revocation after restart: %v", err)
+	}
+	if !slices.Equal(store.revokedNodeIDs, []int{nodeID, nodeID}) {
+		t.Fatalf("stable node authority revocations = %v, want [%d %d]", store.revokedNodeIDs, nodeID, nodeID)
 	}
 }
 
@@ -2442,15 +2480,17 @@ func TestReconstructionEndpointsClassifyExecutorDiscoveryFailure(t *testing.T) {
 
 // stubRecipeStore is a recipeStore for the jellycompat node-restart fetch path.
 type stubRecipeStore struct {
-	card         *playback.RecipeCard
-	ok           bool
-	hits         int
-	deletes      []string
-	revokedNodes []string
-	delErr       error
-	revokeErr    error
-	revokeErrs   map[string]error
-	getHit       chan struct{}
+	card            *playback.RecipeCard
+	ok              bool
+	hits            int
+	deletes         []string
+	revokedNodes    []string
+	revokedNodeIDs  []int
+	delErr          error
+	revokeErr       error
+	revokeErrs      map[string]error
+	revokeNodeIDErr error
+	getHit          chan struct{}
 }
 
 func (s *stubRecipeStore) Get(context.Context, string) (*playback.RecipeCard, bool) {
@@ -2480,6 +2520,11 @@ func (s *stubRecipeStore) RevokeNode(_ context.Context, nodeURL string) error {
 		return err
 	}
 	return s.revokeErr
+}
+
+func (s *stubRecipeStore) RevokeNodeID(_ context.Context, nodeID int) error {
+	s.revokedNodeIDs = append(s.revokedNodeIDs, nodeID)
+	return s.revokeNodeIDErr
 }
 
 // When the forwarded token is recipe-less (jellycompat), the node consults the

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -126,7 +126,7 @@ func newTestServer(t *testing.T) *Server {
 		transcodeDir:              cfg.Playback.TranscodeDir,
 		artifactRoot:              filepath.Join(cfg.Playback.TranscodeDir, downloadprepare.ArtifactDirectoryName),
 		sessions:                  make(map[string]*playback.TranscodeSession),
-		progressiveRemuxes:        make(map[string]map[uint64]context.CancelFunc),
+		progressiveRemuxes:        make(map[string]progressiveRemuxRequest),
 		stoppedProgressiveRemuxes: make(map[string]time.Time),
 		lastAccess:                make(map[string]time.Time),
 	}
@@ -1865,6 +1865,86 @@ func TestHandleProgressiveRemuxExecutesSignedTranscodeRoute(t *testing.T) {
 	}
 }
 
+func TestHandleProgressiveRemuxRejectsConcurrentRequest(t *testing.T) {
+	server := newTestServer(t)
+	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ffmpegLog := filepath.Join(t.TempDir(), "ffmpeg.log")
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg.sh")
+	ffmpegScript := "#!/bin/sh\n" +
+		"case \" $* \" in *\" -i " + mediaPath + " \"*) printf 'invoked\\n' >> \"" + ffmpegLog + "\";; esac\n" +
+		"printf node-remux-bytes\n"
+	if err := os.WriteFile(ffmpegPath, []byte(ffmpegScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	claims := streamtoken.Claims{
+		SessionID: "playback-concurrent", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-concurrent",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingEgress: string(noderouting.EgressProxy),
+	}
+	card := playback.RecipeCardFromClaims(&claims)
+	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
+	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/remux/"+claims.TranscodeTransportID, nil)
+	request.Header.Set("X-Silo-Stream-Token", token)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", claims.TranscodeTransportID)
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+	firstWriter := newBlockingResponseWriter()
+	released := false
+	defer func() {
+		if !released {
+			close(firstWriter.releaseWrite)
+		}
+	}()
+	firstDone := make(chan struct{})
+	go func() {
+		server.handleRemux(firstWriter, request.Clone(request.Context()))
+		close(firstDone)
+	}()
+	waitCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	select {
+	case <-firstWriter.writeStarted:
+	case <-waitCtx.Done():
+		t.Fatal("first remux did not reach its response")
+	}
+
+	recorder := httptest.NewRecorder()
+	server.handleRemux(recorder, request.Clone(request.Context()))
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if got := server.activeJobs.Load(); got != 1 {
+		t.Fatalf("active jobs = %d, want only the first remux", got)
+	}
+	close(firstWriter.releaseWrite)
+	released = true
+	select {
+	case <-firstDone:
+	case <-waitCtx.Done():
+		t.Fatal("first remux did not finish after response release")
+	}
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs after response = %d, want 0", got)
+	}
+	invocations, err := os.ReadFile(ffmpegLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(invocations), "invoked\n"); got != 1 {
+		t.Fatalf("ffmpeg invocations = %d, want 1; log = %q", got, invocations)
+	}
+}
+
 func TestHandleProgressiveRemuxRejectsProxyExecutionToken(t *testing.T) {
 	server := newTestServer(t)
 	claims := streamtoken.Claims{
@@ -1897,7 +1977,7 @@ func TestHandleProgressiveRemuxRejectsProxyExecutionToken(t *testing.T) {
 func TestHandleStopCancelsProgressiveRemux(t *testing.T) {
 	server := newTestServer(t)
 	ctx, cancel := context.WithCancel(t.Context())
-	server.progressiveRemuxes["transport-1"] = map[uint64]context.CancelFunc{1: cancel}
+	server.progressiveRemuxes["transport-1"] = progressiveRemuxRequest{id: 1, cancel: cancel}
 	req := httptest.NewRequest(http.MethodDelete, "/transcode/transport-1", nil)
 	routeContext := chi.NewRouteContext()
 	routeContext.URLParams.Add("session_id", "transport-1")
@@ -2037,13 +2117,16 @@ func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 
 func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	server := newTestServer(t)
+	server.tracker = newBlockingSessionTracker()
 	const transportID = "transport-force-reload"
 	ctx, cancel := context.WithCancel(t.Context())
-	server.progressiveRemuxes[transportID] = map[uint64]context.CancelFunc{1: cancel}
+	server.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: 1, cancel: cancel}
 	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: transportID}}
 	server.SetRecipeStore(store)
 
-	server.teardownForForceReload(t.Context())
+	if err := server.teardownForForceReload(t.Context()); err != nil {
+		t.Fatal(err)
+	}
 
 	select {
 	case <-ctx.Done():
@@ -2059,6 +2142,27 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	}
 	if len(store.deletes) != 1 || store.deletes[0] != transportID {
 		t.Fatalf("durable authority deletes = %v, want [%q]", store.deletes, transportID)
+	}
+	if len(store.revokedNodes) != 1 || store.revokedNodes[0] != server.tracker.NodeURL() {
+		t.Fatalf("node authority revocations = %v, want [%q]", store.revokedNodes, server.tracker.NodeURL())
+	}
+}
+
+func TestForceReloadTeardownRevokesDormantProgressiveAuthorities(t *testing.T) {
+	server := newTestServer(t)
+	server.tracker = newBlockingSessionTracker()
+	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: "dormant-transport"}}
+	server.SetRecipeStore(store)
+
+	if err := server.teardownForForceReload(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(store.revokedNodes) != 1 || store.revokedNodes[0] != server.tracker.NodeURL() {
+		t.Fatalf("node authority revocations = %v, want [%q]", store.revokedNodes, server.tracker.NodeURL())
+	}
+	if len(store.deletes) != 0 {
+		t.Fatalf("dormant authority was unexpectedly enumerated: deletes = %v", store.deletes)
 	}
 }
 
@@ -2173,12 +2277,14 @@ func TestReconstructionEndpointsClassifyExecutorDiscoveryFailure(t *testing.T) {
 
 // stubRecipeStore is a recipeStore for the jellycompat node-restart fetch path.
 type stubRecipeStore struct {
-	card    *playback.RecipeCard
-	ok      bool
-	hits    int
-	deletes []string
-	delErr  error
-	getHit  chan struct{}
+	card         *playback.RecipeCard
+	ok           bool
+	hits         int
+	deletes      []string
+	revokedNodes []string
+	delErr       error
+	revokeErr    error
+	getHit       chan struct{}
 }
 
 func (s *stubRecipeStore) Get(context.Context, string) (*playback.RecipeCard, bool) {
@@ -2200,6 +2306,11 @@ func (s *stubRecipeStore) Delete(_ context.Context, sessionID string) error {
 	s.card = nil
 	s.ok = false
 	return nil
+}
+
+func (s *stubRecipeStore) RevokeNode(_ context.Context, nodeURL string) error {
+	s.revokedNodes = append(s.revokedNodes, nodeURL)
+	return s.revokeErr
 }
 
 // When the forwarded token is recipe-less (jellycompat), the node consults the

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -1909,6 +1909,23 @@ func TestHandleProgressiveRemuxHeadDoesNotStartFFmpeg(t *testing.T) {
 	if _, err := os.Stat(ffmpegMarker); !os.IsNotExist(err) {
 		t.Fatalf("HEAD invoked ffmpeg: %v", err)
 	}
+
+	server.SetRecipeStore(&stubRecipeStore{})
+	stoppedRequest := httptest.NewRequest(http.MethodHead, "/remux/transport-head", nil)
+	stoppedRequest.Header.Set("X-Silo-Stream-Token", token)
+	stoppedRouteContext := chi.NewRouteContext()
+	stoppedRouteContext.URLParams.Add("session_id", "transport-head")
+	stoppedRequest = stoppedRequest.WithContext(context.WithValue(stoppedRequest.Context(), chi.RouteCtxKey, stoppedRouteContext))
+	stoppedRecorder := httptest.NewRecorder()
+
+	server.handleRemux(stoppedRecorder, stoppedRequest)
+
+	if stoppedRecorder.Code != http.StatusGone {
+		t.Fatalf("stopped HEAD status = %d, want 410", stoppedRecorder.Code)
+	}
+	if _, err := os.Stat(ffmpegMarker); !os.IsNotExist(err) {
+		t.Fatalf("stopped HEAD invoked ffmpeg: %v", err)
+	}
 }
 
 func TestProgressiveRemuxRunsOnThisNodeRejectsDifferentNodeID(t *testing.T) {
@@ -2287,6 +2304,33 @@ func TestForceReloadTeardownRevokesDormantProgressiveAuthorities(t *testing.T) {
 	}
 }
 
+func TestForceReloadTeardownRetriesFailedPreviousURLRevocation(t *testing.T) {
+	server := newTestServer(t)
+	server.registeredNodeURL = func() (string, bool) { return "https://new-registered-node.example", true }
+	oldURL := "https://old-registered-node.example"
+	store := &stubRecipeStore{revokeErrs: map[string]error{oldURL: errors.New("redis unavailable")}}
+	server.SetRecipeStore(store)
+
+	if err := server.teardownForForceReload(t.Context(), oldURL); err == nil {
+		t.Fatal("partial authority revocation unexpectedly succeeded")
+	}
+	delete(store.revokeErrs, oldURL)
+	if err := server.teardownForForceReload(t.Context(), "https://new-registered-node.example"); err != nil {
+		t.Fatalf("retry authority revocation: %v", err)
+	}
+
+	wantRevoked := []string{
+		oldURL, "https://new-registered-node.example",
+		oldURL, "https://new-registered-node.example",
+	}
+	if !slices.Equal(store.revokedNodes, wantRevoked) {
+		t.Fatalf("node authority revocations = %v, want %v", store.revokedNodes, wantRevoked)
+	}
+	if len(server.pendingAuthorityRevocations) != 0 {
+		t.Fatalf("pending authority revocations = %v, want none after retry", server.pendingAuthorityRevocations)
+	}
+}
+
 func requestWithToken(sessionID, token string) *http.Request {
 	r := httptest.NewRequest(http.MethodGet, "/transcode/"+sessionID+"/master.m3u8", nil)
 	if token != "" {
@@ -2405,6 +2449,7 @@ type stubRecipeStore struct {
 	revokedNodes []string
 	delErr       error
 	revokeErr    error
+	revokeErrs   map[string]error
 	getHit       chan struct{}
 }
 
@@ -2431,6 +2476,9 @@ func (s *stubRecipeStore) Delete(_ context.Context, sessionID string) error {
 
 func (s *stubRecipeStore) RevokeNode(_ context.Context, nodeURL string) error {
 	s.revokedNodes = append(s.revokedNodes, nodeURL)
+	if err := s.revokeErrs[nodeURL]; err != nil {
+		return err
+	}
 	return s.revokeErr
 }
 

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -1867,6 +1867,7 @@ func TestHandleProgressiveRemuxExecutesSignedTranscodeRoute(t *testing.T) {
 
 func TestHandleProgressiveRemuxHeadDoesNotStartFFmpeg(t *testing.T) {
 	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 11, true }
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
@@ -1879,9 +1880,9 @@ func TestHandleProgressiveRemuxHeadDoesNotStartFFmpeg(t *testing.T) {
 	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
 	claims := streamtoken.Claims{
 		SessionID: "playback-head", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
-		TranscodeNode: "http://node", TranscodeTransportID: "transport-head",
+		TranscodeNode: "http://registered-node", TranscodeTransportID: "transport-head",
 		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
-		RoutingEgress: string(noderouting.EgressProxy),
+		RoutingExecutionNodeID: 11, RoutingEgress: string(noderouting.EgressProxy),
 	}
 	card := playback.RecipeCardFromClaims(&claims)
 	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
@@ -1906,6 +1907,19 @@ func TestHandleProgressiveRemuxHeadDoesNotStartFFmpeg(t *testing.T) {
 	}
 	if _, err := os.Stat(ffmpegMarker); !os.IsNotExist(err) {
 		t.Fatalf("HEAD invoked ffmpeg: %v", err)
+	}
+}
+
+func TestProgressiveRemuxRunsOnThisNodeRejectsDifferentNodeID(t *testing.T) {
+	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 12, true }
+
+	claims := &streamtoken.Claims{
+		TranscodeNode:          "http://same-node-url",
+		RoutingExecutionNodeID: 11,
+	}
+	if server.progressiveRemuxRunsOnThisNode(claims) {
+		t.Fatal("progressive remux accepted a token bound to a different node ID")
 	}
 }
 

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/mediaprobe"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/nodeconfig"
+	"github.com/Silo-Server/silo-server/internal/noderouting"
 	"github.com/Silo-Server/silo-server/internal/nodesessions"
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/streamtoken"
@@ -120,12 +121,14 @@ func newTestServer(t *testing.T) *Server {
 	cfg.Download.ArtifactDir = filepath.Join(cfg.Playback.TranscodeDir, downloadprepare.ArtifactDirectoryName)
 	w.SetConfigForTest(cfg)
 	return &Server{
-		watcher:      w,
-		inputPaths:   allowInputPaths{},
-		transcodeDir: cfg.Playback.TranscodeDir,
-		artifactRoot: filepath.Join(cfg.Playback.TranscodeDir, downloadprepare.ArtifactDirectoryName),
-		sessions:     make(map[string]*playback.TranscodeSession),
-		lastAccess:   make(map[string]time.Time),
+		watcher:                   w,
+		inputPaths:                allowInputPaths{},
+		transcodeDir:              cfg.Playback.TranscodeDir,
+		artifactRoot:              filepath.Join(cfg.Playback.TranscodeDir, downloadprepare.ArtifactDirectoryName),
+		sessions:                  make(map[string]*playback.TranscodeSession),
+		progressiveRemuxes:        make(map[string]map[uint64]context.CancelFunc),
+		stoppedProgressiveRemuxes: make(map[string]time.Time),
+		lastAccess:                make(map[string]time.Time),
 	}
 }
 
@@ -1820,6 +1823,141 @@ func signCard(t *testing.T, card playback.RecipeCard) string {
 		t.Fatalf("sign card: %v", err)
 	}
 	return tok
+}
+
+func TestHandleProgressiveRemuxExecutesSignedTranscodeRoute(t *testing.T) {
+	server := newTestServer(t)
+	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg.sh")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nprintf node-remux-bytes\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	claims := streamtoken.Claims{
+		SessionID: "playback-1", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-1",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingEgress: string(noderouting.EgressProxy),
+	}
+	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/remux/transport-1?seek=2", nil)
+	req.Header.Set("X-Silo-Stream-Token", token)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", "transport-1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+	rr := httptest.NewRecorder()
+
+	server.handleRemux(rr, req)
+
+	if rr.Code != http.StatusOK || rr.Body.String() != "node-remux-bytes" {
+		t.Fatalf("response = %d %q, want remux bytes", rr.Code, rr.Body.String())
+	}
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs after response = %d, want 0", got)
+	}
+}
+
+func TestHandleProgressiveRemuxRejectsProxyExecutionToken(t *testing.T) {
+	server := newTestServer(t)
+	claims := streamtoken.Claims{
+		SessionID: "playback-1", MediaPath: "/media/movie.mkv", PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-1",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionProxy),
+		RoutingEgress: string(noderouting.EgressProxy),
+	}
+	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/remux/transport-1", nil)
+	req.Header.Set("X-Silo-Stream-Token", token)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", "transport-1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+	rr := httptest.NewRecorder()
+
+	server.handleRemux(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs = %d, want no FFmpeg start", got)
+	}
+}
+
+func TestHandleStopCancelsProgressiveRemux(t *testing.T) {
+	server := newTestServer(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	server.progressiveRemuxes["transport-1"] = map[uint64]context.CancelFunc{1: cancel}
+	req := httptest.NewRequest(http.MethodDelete, "/transcode/transport-1", nil)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", "transport-1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+	rr := httptest.NewRecorder()
+
+	server.handleStop(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	select {
+	case <-ctx.Done():
+	default:
+		t.Fatal("progressive remux was not canceled")
+	}
+}
+
+func TestHandleProgressiveRemuxRefusesStoppedTransport(t *testing.T) {
+	server := newTestServer(t)
+	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ffmpegLog := filepath.Join(t.TempDir(), "ffmpeg.log")
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg.sh")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nprintf invoked > \""+ffmpegLog+"\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+
+	stopRequest := httptest.NewRequest(http.MethodDelete, "/transcode/transport-1", nil)
+	stopRouteContext := chi.NewRouteContext()
+	stopRouteContext.URLParams.Add("session_id", "transport-1")
+	stopRequest = stopRequest.WithContext(context.WithValue(stopRequest.Context(), chi.RouteCtxKey, stopRouteContext))
+	server.handleStop(httptest.NewRecorder(), stopRequest)
+
+	claims := streamtoken.Claims{
+		SessionID: "playback-1", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-1",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingEgress: string(noderouting.EgressProxy),
+	}
+	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/remux/transport-1", nil)
+	request.Header.Set("X-Silo-Stream-Token", token)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", "transport-1")
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+	recorder := httptest.NewRecorder()
+
+	server.handleRemux(recorder, request)
+
+	if recorder.Code != http.StatusGone {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if _, err := os.Stat(ffmpegLog); !os.IsNotExist(err) {
+		t.Fatalf("stopped transport invoked ffmpeg: %v", err)
+	}
 }
 
 func requestWithToken(sessionID, token string) *http.Request {

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -59,6 +59,38 @@ type blockingResponseWriter struct {
 	startOnce    sync.Once
 }
 
+type abortableBlockingResponseWriter struct {
+	header          http.Header
+	writeStarted    chan struct{}
+	deadlineExpired chan struct{}
+	startOnce       sync.Once
+	expireOnce      sync.Once
+}
+
+func newAbortableBlockingResponseWriter() *abortableBlockingResponseWriter {
+	return &abortableBlockingResponseWriter{
+		header:          make(http.Header),
+		writeStarted:    make(chan struct{}),
+		deadlineExpired: make(chan struct{}),
+	}
+}
+
+func (w *abortableBlockingResponseWriter) Header() http.Header { return w.header }
+func (*abortableBlockingResponseWriter) WriteHeader(int)       {}
+
+func (w *abortableBlockingResponseWriter) Write([]byte) (int, error) {
+	w.startOnce.Do(func() { close(w.writeStarted) })
+	<-w.deadlineExpired
+	return 0, os.ErrDeadlineExceeded
+}
+
+func (w *abortableBlockingResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	if !deadline.After(time.Now()) {
+		w.expireOnce.Do(func() { close(w.deadlineExpired) })
+	}
+	return nil
+}
+
 func newBlockingResponseWriter() *blockingResponseWriter {
 	return &blockingResponseWriter{
 		header:       make(http.Header),
@@ -2076,6 +2108,12 @@ func TestHandleStopCancelsProgressiveRemux(t *testing.T) {
 	default:
 		t.Fatal("progressive remux was not canceled")
 	}
+	server.mu.RLock()
+	_, retained := server.progressiveRemuxes["transport-1"]
+	server.mu.RUnlock()
+	if !retained {
+		t.Fatal("stop discarded the progressive remux completion handle before its handler exited")
+	}
 }
 
 func TestHandleStopReturnsUnavailableWhenProgressiveAuthorityDeleteFails(t *testing.T) {
@@ -2257,6 +2295,15 @@ func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs after remux handler return = %d, want 0", got)
+	}
+	server.mu.RLock()
+	_, active := server.progressiveRemuxes[claims.TranscodeTransportID]
+	server.mu.RUnlock()
+	if active {
+		t.Fatal("completed remux handler remained registered")
+	}
 }
 
 func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
@@ -2277,6 +2324,9 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 		<-ctx.Done()
 		<-releaseHandler
 		server.activeJobs.Add(-1)
+		server.mu.Lock()
+		delete(server.progressiveRemuxes, transportID)
+		server.mu.Unlock()
 		close(done)
 	}()
 	waitCtx, cancelWait := context.WithTimeout(t.Context(), time.Second)
@@ -2293,6 +2343,12 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	}
 	if got := server.activeJobs.Load(); got != 1 {
 		t.Fatalf("active jobs before handler exit = %d, want 1", got)
+	}
+	server.mu.RLock()
+	_, draining := server.progressiveRemuxes[transportID]
+	server.mu.RUnlock()
+	if !draining {
+		t.Fatal("force reload discarded the completion handle before the remux handler exited")
 	}
 	select {
 	case err := <-teardownResult:
@@ -2324,6 +2380,155 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	}
 	if len(store.revokedNodes) != 1 || store.revokedNodes[0] != server.tracker.NodeURL() {
 		t.Fatalf("node authority revocations = %v, want [%q]", store.revokedNodes, server.tracker.NodeURL())
+	}
+}
+
+func TestForceReloadTeardownRetainsUndrainedProgressiveRemuxForRetry(t *testing.T) {
+	server := newTestServer(t)
+	const transportID = "transport-force-reload-retry"
+	requestCtx, cancelRequest := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	cancelCalls := make(chan struct{}, 2)
+	server.progressiveRemuxes[transportID] = progressiveRemuxRequest{
+		id: 2,
+		cancel: func() {
+			cancelRequest()
+			cancelCalls <- struct{}{}
+		},
+		done: done,
+	}
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), time.Second)
+	defer cancelWait()
+
+	firstCtx, cancelFirst := context.WithCancel(waitCtx)
+	firstResult := make(chan error, 1)
+	go func() {
+		firstResult <- server.teardownForForceReload(firstCtx, "", 0)
+	}()
+	select {
+	case <-cancelCalls:
+	case <-waitCtx.Done():
+		t.Fatal("first force reload did not cancel the remux")
+	}
+	cancelFirst()
+	select {
+	case err := <-firstResult:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("first force reload error = %v, want context canceled", err)
+		}
+	case <-waitCtx.Done():
+		t.Fatal("first force reload did not return after its wait was canceled")
+	}
+	server.mu.RLock()
+	_, retained := server.progressiveRemuxes[transportID]
+	server.mu.RUnlock()
+	if !retained {
+		t.Fatal("timed-out force reload discarded the remux completion handle")
+	}
+
+	retryResult := make(chan error, 1)
+	go func() {
+		retryResult <- server.teardownForForceReload(waitCtx, "", 0)
+	}()
+	select {
+	case <-cancelCalls:
+	case <-waitCtx.Done():
+		t.Fatal("force reload retry did not recapture the draining remux")
+	}
+	select {
+	case err := <-retryResult:
+		t.Fatalf("force reload retry returned before the remux drained: %v", err)
+	default:
+	}
+	server.mu.Lock()
+	delete(server.progressiveRemuxes, transportID)
+	server.mu.Unlock()
+	close(done)
+	select {
+	case err := <-retryResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-waitCtx.Done():
+		t.Fatal("force reload retry did not return after the remux drained")
+	}
+	select {
+	case <-requestCtx.Done():
+	default:
+		t.Fatal("force reload never canceled the remux request")
+	}
+}
+
+func TestForceReloadTeardownDrainsRealProgressiveRemuxWithBlockedClient(t *testing.T) {
+	server := newTestServer(t)
+	server.nodeRowID = func() (int, bool) { return 11, true }
+	server.registeredNodeURL = func() (string, bool) { return "http://node", true }
+	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg.sh")
+	ffmpegScript := "#!/bin/sh\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$arg\" = \"pipe:1\" ]; then\n" +
+		"    while :; do printf node-remux-bytes; sleep 0.01; done\n" +
+		"  fi\n" +
+		"done\n" +
+		"exit 0\n"
+	if err := os.WriteFile(ffmpegPath, []byte(ffmpegScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	server.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	claims := streamtoken.Claims{
+		SessionID: "playback-force-reload", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-force-reload-real",
+		RoutingWorkload: string(noderouting.WorkloadRemux), RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingExecutionNodeID: 11, RoutingEgress: string(noderouting.EgressProxy),
+	}
+	card := playback.RecipeCardFromClaims(&claims)
+	server.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
+	token, err := streamtoken.Sign(claims, testSecret, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodGet, "/remux/"+claims.TranscodeTransportID, nil)
+	request.Header.Set("X-Silo-Stream-Token", token)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", claims.TranscodeTransportID)
+	request = request.WithContext(context.WithValue(request.Context(), chi.RouteCtxKey, routeContext))
+	writer := newAbortableBlockingResponseWriter()
+	handlerDone := make(chan struct{})
+	go func() {
+		server.handleRemux(writer, request)
+		close(handlerDone)
+	}()
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancelWait()
+	select {
+	case <-writer.writeStarted:
+	case <-waitCtx.Done():
+		t.Fatal("progressive remux did not reach the blocked client write")
+	}
+	if got := server.activeJobs.Load(); got != 1 {
+		t.Fatalf("active jobs before force reload = %d, want 1", got)
+	}
+
+	if err := server.teardownForForceReload(waitCtx, "http://node", 11); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-handlerDone:
+	case <-waitCtx.Done():
+		t.Fatal("force reload returned without draining the progressive remux handler")
+	}
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs after force reload = %d, want 0", got)
+	}
+	server.mu.RLock()
+	_, active := server.progressiveRemuxes[claims.TranscodeTransportID]
+	server.mu.RUnlock()
+	if active {
+		t.Fatal("force reload left the drained remux registered")
 	}
 }
 

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -2263,6 +2263,7 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 func TestForceReloadTeardownRevokesDormantProgressiveAuthorities(t *testing.T) {
 	server := newTestServer(t)
 	server.tracker = newBlockingSessionTracker()
+	server.registeredNodeURL = func() (string, bool) { return "https://registered-node.example", true }
 	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: "dormant-transport"}}
 	server.SetRecipeStore(store)
 
@@ -2270,8 +2271,8 @@ func TestForceReloadTeardownRevokesDormantProgressiveAuthorities(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(store.revokedNodes) != 1 || store.revokedNodes[0] != server.tracker.NodeURL() {
-		t.Fatalf("node authority revocations = %v, want [%q]", store.revokedNodes, server.tracker.NodeURL())
+	if len(store.revokedNodes) != 1 || store.revokedNodes[0] != "https://registered-node.example" {
+		t.Fatalf("node authority revocations = %v, want registered route URL", store.revokedNodes)
 	}
 	if len(store.deletes) != 0 {
 		t.Fatalf("dormant authority was unexpectedly enumerated: deletes = %v", store.deletes)

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -2265,18 +2265,52 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	server.registeredNodeURL = func() (string, bool) { return "", false }
 	const transportID = "transport-force-reload"
 	ctx, cancel := context.WithCancel(t.Context())
-	server.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: 1, cancel: cancel}
+	done := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	server.activeJobs.Add(1)
+	server.progressiveRemuxes[transportID] = progressiveRemuxRequest{id: 1, cancel: cancel, done: done}
 	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: transportID}}
 	server.SetRecipeStore(store)
-
-	if err := server.teardownForForceReload(t.Context(), "", 0); err != nil {
-		t.Fatal(err)
-	}
+	handlerExited := make(chan struct{})
+	go func() {
+		defer close(handlerExited)
+		<-ctx.Done()
+		<-releaseHandler
+		server.activeJobs.Add(-1)
+		close(done)
+	}()
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), time.Second)
+	defer cancelWait()
+	teardownResult := make(chan error, 1)
+	go func() {
+		teardownResult <- server.teardownForForceReload(waitCtx, "", 0)
+	}()
 
 	select {
 	case <-ctx.Done():
-	default:
+	case <-waitCtx.Done():
 		t.Fatal("force reload did not cancel the progressive remux")
+	}
+	if got := server.activeJobs.Load(); got != 1 {
+		t.Fatalf("active jobs before handler exit = %d, want 1", got)
+	}
+	select {
+	case err := <-teardownResult:
+		t.Fatalf("force reload returned before the progressive remux handler exited: %v", err)
+	default:
+	}
+	close(releaseHandler)
+	select {
+	case err := <-teardownResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-waitCtx.Done():
+		t.Fatal("force reload did not return after the progressive remux handler exited")
+	}
+	<-handlerExited
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs after force reload = %d, want 0", got)
 	}
 	server.mu.RLock()
 	_, active := server.progressiveRemuxes[transportID]

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -52,6 +52,28 @@ type blockingSessionTracker struct {
 	removeHasDeadline bool
 }
 
+type recordingSessionTracker struct {
+	mu      sync.Mutex
+	tracked []nodesessions.SessionInfo
+	removed []string
+}
+
+func (t *recordingSessionTracker) Track(_ context.Context, info nodesessions.SessionInfo) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tracked = append(t.tracked, info)
+}
+
+func (t *recordingSessionTracker) Remove(_ context.Context, sessionID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.removed = append(t.removed, sessionID)
+}
+
+func (*recordingSessionTracker) Cleanup(context.Context) {}
+func (*recordingSessionTracker) NodeURL() string         { return "http://node" }
+func (*recordingSessionTracker) NodeName() string        { return "node" }
+
 type blockingResponseWriter struct {
 	header       http.Header
 	writeStarted chan struct{}
@@ -2091,21 +2113,37 @@ func TestHandleProgressiveRemuxRejectsProxyExecutionToken(t *testing.T) {
 func TestHandleStopCancelsProgressiveRemux(t *testing.T) {
 	server := newTestServer(t)
 	ctx, cancel := context.WithCancel(t.Context())
-	server.progressiveRemuxes["transport-1"] = progressiveRemuxRequest{id: 1, cancel: cancel}
+	done := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	server.activeJobs.Add(1)
+	server.progressiveRemuxes["transport-1"] = progressiveRemuxRequest{
+		id: 1, playbackSessionID: "playback-1", cancel: cancel, done: done,
+	}
 	req := httptest.NewRequest(http.MethodDelete, "/transcode/transport-1", nil)
 	routeContext := chi.NewRouteContext()
 	routeContext.URLParams.Add("session_id", "transport-1")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
 	rr := httptest.NewRecorder()
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), time.Second)
+	defer cancelWait()
+	go func() {
+		<-ctx.Done()
+		<-releaseHandler
+		server.activeJobs.Add(-1)
+		server.mu.Lock()
+		delete(server.progressiveRemuxes, "transport-1")
+		server.mu.Unlock()
+		close(done)
+	}()
+	stopDone := make(chan struct{})
+	go func() {
+		server.handleStop(rr, req)
+		close(stopDone)
+	}()
 
-	server.handleStop(rr, req)
-
-	if rr.Code != http.StatusNoContent {
-		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
-	}
 	select {
 	case <-ctx.Done():
-	default:
+	case <-waitCtx.Done():
 		t.Fatal("progressive remux was not canceled")
 	}
 	server.mu.RLock()
@@ -2114,6 +2152,65 @@ func TestHandleStopCancelsProgressiveRemux(t *testing.T) {
 	if !retained {
 		t.Fatal("stop discarded the progressive remux completion handle before its handler exited")
 	}
+	select {
+	case <-stopDone:
+		t.Fatal("stop returned before the progressive remux handler exited")
+	default:
+	}
+	close(releaseHandler)
+	select {
+	case <-stopDone:
+	case <-waitCtx.Done():
+		t.Fatal("stop did not return after the progressive remux handler exited")
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	if got := server.activeJobs.Load(); got != 0 {
+		t.Fatalf("active jobs after stop = %d, want 0", got)
+	}
+}
+
+func TestHandleStopReturnsUnavailableWhileProgressiveHandlerIsStuck(t *testing.T) {
+	server := newTestServer(t)
+	remuxCanceled := make(chan struct{})
+	done := make(chan struct{})
+	server.progressiveRemuxes["transport-stuck"] = progressiveRemuxRequest{
+		id: 1, playbackSessionID: "playback-stuck",
+		cancel: sync.OnceFunc(func() { close(remuxCanceled) }), done: done,
+	}
+	requestCtx, cancelRequest := context.WithCancel(t.Context())
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), time.Second)
+	defer cancelWait()
+	req := httptest.NewRequest(http.MethodDelete, "/transcode/transport-stuck", nil).WithContext(requestCtx)
+	routeContext := chi.NewRouteContext()
+	routeContext.URLParams.Add("session_id", "transport-stuck")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeContext))
+	rr := httptest.NewRecorder()
+	stopDone := make(chan struct{})
+	go func() {
+		server.handleStop(rr, req)
+		close(stopDone)
+	}()
+
+	select {
+	case <-remuxCanceled:
+	case <-waitCtx.Done():
+		t.Fatal("stop did not cancel the progressive remux")
+	}
+	cancelRequest()
+	select {
+	case <-stopDone:
+	case <-waitCtx.Done():
+		t.Fatal("stop did not return after its shutdown wait was canceled")
+	}
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, body = %s; want retryable shutdown failure", rr.Code, rr.Body.String())
+	}
+	server.mu.Lock()
+	delete(server.progressiveRemuxes, "transport-stuck")
+	server.mu.Unlock()
+	close(done)
 }
 
 func TestHandleStopReturnsUnavailableWhenProgressiveAuthorityDeleteFails(t *testing.T) {
@@ -2226,6 +2323,8 @@ func TestHandleProgressiveRemuxRefusesStoppedTransportAfterRestart(t *testing.T)
 
 func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 	server := newTestServer(t)
+	tracker := &recordingSessionTracker{}
+	server.tracker = tracker
 	server.nodeRowID = func() (int, bool) { return 11, true }
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
@@ -2303,6 +2402,14 @@ func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 	server.mu.RUnlock()
 	if active {
 		t.Fatal("completed remux handler remained registered")
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if len(tracker.tracked) != 1 || tracker.tracked[0].SessionID != claims.SessionID {
+		t.Fatalf("tracked sessions = %#v, want viewer session %q", tracker.tracked, claims.SessionID)
+	}
+	if len(tracker.removed) != 1 || tracker.removed[0] != claims.SessionID {
+		t.Fatalf("removed sessions = %v, want viewer session %q", tracker.removed, claims.SessionID)
 	}
 }
 

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -2236,7 +2237,7 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: transportID}}
 	server.SetRecipeStore(store)
 
-	if err := server.teardownForForceReload(t.Context()); err != nil {
+	if err := server.teardownForForceReload(t.Context(), ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2263,16 +2264,17 @@ func TestForceReloadTeardownCancelsProgressiveRemux(t *testing.T) {
 func TestForceReloadTeardownRevokesDormantProgressiveAuthorities(t *testing.T) {
 	server := newTestServer(t)
 	server.tracker = newBlockingSessionTracker()
-	server.registeredNodeURL = func() (string, bool) { return "https://registered-node.example", true }
+	server.registeredNodeURL = func() (string, bool) { return "https://new-registered-node.example", true }
 	store := &stubRecipeStore{ok: true, card: &playback.RecipeCard{TranscodeTransportID: "dormant-transport"}}
 	server.SetRecipeStore(store)
 
-	if err := server.teardownForForceReload(t.Context()); err != nil {
+	if err := server.teardownForForceReload(t.Context(), "https://old-registered-node.example"); err != nil {
 		t.Fatal(err)
 	}
 
-	if len(store.revokedNodes) != 1 || store.revokedNodes[0] != "https://registered-node.example" {
-		t.Fatalf("node authority revocations = %v, want registered route URL", store.revokedNodes)
+	wantRevoked := []string{"https://old-registered-node.example", "https://new-registered-node.example"}
+	if !slices.Equal(store.revokedNodes, wantRevoked) {
+		t.Fatalf("node authority revocations = %v, want %v", store.revokedNodes, wantRevoked)
 	}
 	if len(store.deletes) != 0 {
 		t.Fatalf("dormant authority was unexpectedly enumerated: deletes = %v", store.deletes)

--- a/internal/transcodenode/server_test.go
+++ b/internal/transcodenode/server_test.go
@@ -2208,8 +2208,8 @@ func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 	}()
 	select {
 	case <-storeHit:
-	case <-waitCtx.Done():
-		t.Fatal("remux did not reach durable authority validation")
+		t.Fatal("remux validated durable authority outside the force-reload gate")
+	case <-time.After(50 * time.Millisecond):
 	}
 	select {
 	case <-done:
@@ -2218,6 +2218,11 @@ func TestHandleProgressiveRemuxWaitsForForceReloadGate(t *testing.T) {
 	}
 	server.reloadMu.Unlock()
 	locked = false
+	select {
+	case <-storeHit:
+	case <-waitCtx.Done():
+		t.Fatal("remux did not validate durable authority after the force-reload gate opened")
+	}
 	select {
 	case <-done:
 	case <-waitCtx.Done():

--- a/internal/transcodenode/streamtelemetry_test.go
+++ b/internal/transcodenode/streamtelemetry_test.go
@@ -106,6 +106,41 @@ func TestMountedTranscodeNodeSegmentTelemetry(t *testing.T) {
 	}
 }
 
+func TestMountedTranscodeNodeProgressiveRemuxTelemetry(t *testing.T) {
+	srv, registry, server := telemetryNodeServer(t)
+	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
+	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ffmpegPath := filepath.Join(t.TempDir(), "ffmpeg.sh")
+	if err := os.WriteFile(ffmpegPath, []byte("#!/bin/sh\nprintf node-remux-bytes\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srv.watcher.Config().Playback.FFmpegPath = ffmpegPath
+	claims := streamtoken.Claims{
+		SessionID: "viewer-session", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
+		TranscodeNode: "http://node", TranscodeTransportID: "transport-session",
+		RoutingWorkload: "remux", RoutingExecution: "transcode", RoutingEgress: "proxy",
+	}
+	token, err := streamtoken.Sign(claims, testSecret, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, body := nodeMediaRequest(t, server, "/remux/transport-session", token)
+	if status != http.StatusOK || string(body) != "node-remux-bytes" {
+		t.Fatalf("remux = %d %q", status, body)
+	}
+	snapshot := registry.Sweep()
+	if len(snapshot.Sessions) != 1 || snapshot.Sessions[0].SessionID != "viewer-session" {
+		t.Fatalf("sessions = %+v", snapshot.Sessions)
+	}
+	routes := snapshot.Sessions[0].Routes
+	if len(routes) != 1 || routes[0].Role != streamtelemetry.RoleInternalRelay || routes[0].BytesAccepted != int64(len(body)) {
+		t.Fatalf("routes = %+v", routes)
+	}
+}
+
 func TestMountedTranscodeNodeArtifactTelemetry(t *testing.T) {
 	t.Run("successful relay", func(t *testing.T) {
 		srv, registry, server := telemetryNodeServer(t)

--- a/internal/transcodenode/streamtelemetry_test.go
+++ b/internal/transcodenode/streamtelemetry_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/noderouting"
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/streamtelemetry"
 	"github.com/Silo-Server/silo-server/internal/streamtoken"
@@ -120,8 +121,12 @@ func TestMountedTranscodeNodeProgressiveRemuxTelemetry(t *testing.T) {
 	claims := streamtoken.Claims{
 		SessionID: "viewer-session", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
 		TranscodeNode: "http://node", TranscodeTransportID: "transport-session",
-		RoutingWorkload: "remux", RoutingExecution: "transcode", RoutingEgress: "proxy",
+		RoutingWorkload:  string(noderouting.WorkloadRemux),
+		RoutingExecution: string(noderouting.ExecutionTranscode),
+		RoutingEgress:    string(noderouting.EgressProxy),
 	}
+	card := playback.RecipeCardFromClaims(&claims)
+	srv.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})
 	token, err := streamtoken.Sign(claims, testSecret, time.Hour)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/transcodenode/streamtelemetry_test.go
+++ b/internal/transcodenode/streamtelemetry_test.go
@@ -109,6 +109,7 @@ func TestMountedTranscodeNodeSegmentTelemetry(t *testing.T) {
 
 func TestMountedTranscodeNodeProgressiveRemuxTelemetry(t *testing.T) {
 	srv, registry, server := telemetryNodeServer(t)
+	srv.nodeRowID = func() (int, bool) { return 11, true }
 	mediaPath := filepath.Join(t.TempDir(), "movie.mkv")
 	if err := os.WriteFile(mediaPath, []byte("source"), 0o600); err != nil {
 		t.Fatal(err)
@@ -121,9 +122,10 @@ func TestMountedTranscodeNodeProgressiveRemuxTelemetry(t *testing.T) {
 	claims := streamtoken.Claims{
 		SessionID: "viewer-session", MediaPath: mediaPath, PlayMethod: string(playback.PlayRemux),
 		TranscodeNode: "http://node", TranscodeTransportID: "transport-session",
-		RoutingWorkload:  string(noderouting.WorkloadRemux),
-		RoutingExecution: string(noderouting.ExecutionTranscode),
-		RoutingEgress:    string(noderouting.EgressProxy),
+		RoutingWorkload:        string(noderouting.WorkloadRemux),
+		RoutingExecution:       string(noderouting.ExecutionTranscode),
+		RoutingExecutionNodeID: 11,
+		RoutingEgress:          string(noderouting.EgressProxy),
 	}
 	card := playback.RecipeCardFromClaims(&claims)
 	srv.SetRecipeStore(&stubRecipeStore{card: &card, ok: true})

--- a/internal/transcodenode/testdata/media_routes.txt
+++ b/internal/transcodenode/testdata/media_routes.txt
@@ -10,6 +10,8 @@ HEAD /downloads/artifacts/{artifact_id}	media	transfer	internal_relay	false	true
 POST /downloads/prepare	non-media
 GET /hw-capabilities	non-media
 GET /metrics	non-media
+GET /remux/{session_id}	media	playback	internal_relay	false	true
+HEAD /remux/{session_id}	media	playback	internal_relay	false	true
 GET /status	non-media
 POST /transcode/start	non-media
 DELETE /transcode/{session_id}	non-media
@@ -28,6 +30,8 @@ HEAD /downloads/artifacts/{artifact_id}	media	transfer	internal_relay	false	true
 POST /downloads/prepare	non-media
 GET /hw-capabilities	non-media
 GET /metrics	non-media
+GET /remux/{session_id}	media	playback	internal_relay	false	true
+HEAD /remux/{session_id}	media	playback	internal_relay	false	true
 GET /status	non-media
 POST /transcode/start	non-media
 DELETE /transcode/{session_id}	non-media

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -2559,6 +2559,16 @@ export interface AdminSession {
   effective_play_method?: string;
   /** Server-side identification of Jellyfin-ecosystem clients (the JF pill). */
   is_jellyfin_client?: boolean;
+  /** Resolved playback workload and route. Node IDs/names are omitted when
+   * that phase runs on the integrated API process (or direct play has no
+   * executor). */
+  routing_workload?: string;
+  routing_execution?: string;
+  routing_execution_node_id?: number;
+  routing_execution_node_name?: string;
+  routing_egress?: string;
+  routing_egress_node_id?: number;
+  routing_egress_node_name?: string;
 }
 
 export interface OperationalLogEntry {

--- a/web/src/components/PlaybackRouteBadges.tsx
+++ b/web/src/components/PlaybackRouteBadges.tsx
@@ -1,0 +1,29 @@
+import type { AdminSession } from "@/api/types";
+import { getSessionRouteNodes, type ActivityRouteNode } from "@/pages/adminActivityPresentation";
+
+const BADGE_COLORS: Record<ActivityRouteNode["kind"], string> = {
+  transcode: "border-warning/25 bg-warning/10 text-warning",
+  proxy: "border-info/25 bg-info/10 text-info",
+  server: "border-primary/10 bg-primary/5 text-primary",
+  legacy: "border-primary/10 bg-primary/5 text-primary",
+};
+
+/** Compact, role-labeled badges for each participant in a playback route. */
+export function PlaybackRouteBadges({ session }: { session: AdminSession }) {
+  return getSessionRouteNodes(session).map((node) => (
+    <span
+      key={node.key}
+      title={`${node.label}: ${node.name}`}
+      aria-label={`${node.label}: ${node.name}`}
+      className={`inline-flex max-w-full items-center gap-1 rounded border px-1.5 py-0.5 text-[9px] font-semibold ${BADGE_COLORS[node.kind]}`}
+    >
+      {node.kind === "transcode" || node.kind === "proxy" ? (
+        <>
+          <span className="opacity-70">{node.label}</span>
+          <span aria-hidden="true">·</span>
+        </>
+      ) : null}
+      <span className="truncate">{node.name}</span>
+    </span>
+  ));
+}

--- a/web/src/components/admin/dashboard/widgets/NowPlayingWidget.tsx
+++ b/web/src/components/admin/dashboard/widgets/NowPlayingWidget.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 import { Pause, Play } from "lucide-react";
 import { JellyfinSessionPill } from "@/components/JellyfinSessionPill";
+import { PlaybackRouteBadges } from "@/components/PlaybackRouteBadges";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useAdminSessions } from "@/hooks/queries/admin/stats";
 import {
@@ -185,11 +186,7 @@ function StreamCard({ session }: { session: AdminSession }) {
               <span className="truncate">{clientLabel}</span>
             </span>
           ) : null}
-          {session.reporting_node && (
-            <span className="border-primary/10 bg-primary/5 text-primary inline-flex rounded border px-1.5 py-0.5 text-[9px] font-semibold">
-              {session.node_display_name || session.reporting_node}
-            </span>
-          )}
+          <PlaybackRouteBadges session={session} />
           {(session.profile_name || session.profile_id) && (
             <SessionProfilePill label={session.profile_name || session.profile_id} />
           )}

--- a/web/src/pages/AdminActivity.tsx
+++ b/web/src/pages/AdminActivity.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { AdminSessionActions } from "@/components/AdminSessionActions";
 import { JellyfinSessionPill } from "@/components/JellyfinSessionPill";
+import { PlaybackRouteBadges } from "@/components/PlaybackRouteBadges";
 import { useRealtimeEvents } from "@/components/realtimeEventsContext";
 import { useOperationalLogs } from "@/hooks/queries/admin/logs";
 import { usePageActivity } from "@/hooks/usePageActivity";
@@ -31,10 +32,12 @@ import {
   formatTranscodeModeSummary,
   getSessionClientLabel,
   getSessionClientLabelFull,
+  getSessionRouteNodes,
   formatVideoDetail,
   formatVideoSummary,
   normalizeContainerDecision,
   normalizeStreamDecision,
+  type ActivityRouteNode,
   type ToneMapSummary,
 } from "@/pages/adminActivityPresentation";
 import {
@@ -64,6 +67,12 @@ type SortField = "username" | "media" | "method" | "node" | "started";
 type SortDir = "asc" | "desc";
 
 const REFRESH_SPINNER_MIN_VISIBLE_MS = 1_000;
+
+function routeSortValue(session: AdminSession): string {
+  return getSessionRouteNodes(session)
+    .map((node) => `${node.label} ${node.name}`)
+    .join(" ");
+}
 
 export default function AdminActivity() {
   const { data: sessions = [], isLoading, refetch: refresh } = useAdminSessions();
@@ -134,11 +143,18 @@ export default function AdminActivity() {
     return counts;
   }, [sessions]);
 
-  const nodes = useMemo(() => {
-    const counts: Record<string, number> = {};
-    for (const s of sessions)
-      counts[s.reporting_node || "unknown"] = (counts[s.reporting_node || "unknown"] || 0) + 1;
-    return counts;
+  const routeNodes = useMemo(() => {
+    const counts = new Map<string, ActivityRouteNode & { count: number }>();
+    for (const session of sessions) {
+      for (const node of getSessionRouteNodes(session)) {
+        const current = counts.get(node.key);
+        counts.set(node.key, {
+          ...node,
+          count: (current?.count ?? 0) + 1,
+        });
+      }
+    }
+    return [...counts.values()];
   }, [sessions]);
 
   // Filter + sort
@@ -157,11 +173,18 @@ export default function AdminActivity() {
           // compact label deliberately omits the build.
           getSessionClientLabelFull(s).toLowerCase().includes(q) ||
           s.client_user_agent?.toLowerCase().includes(q) ||
-          s.client_ip?.toLowerCase().includes(q),
+          s.client_ip?.toLowerCase().includes(q) ||
+          getSessionRouteNodes(s).some((node) =>
+            `${node.label} ${node.name}`.toLowerCase().includes(q),
+          ),
       );
     }
     if (methodFilter) result = result.filter((s) => classifyActivityMethod(s) === methodFilter);
-    if (nodeFilter) result = result.filter((s) => s.reporting_node === nodeFilter);
+    if (nodeFilter) {
+      result = result.filter((s) =>
+        getSessionRouteNodes(s).some((node) => node.key === nodeFilter),
+      );
+    }
     if (typeFilter) result = result.filter((s) => s.media_type === typeFilter);
 
     return [...result].sort((a, b) => {
@@ -177,7 +200,7 @@ export default function AdminActivity() {
           cmp = compareActivityMethods(classifyActivityMethod(a), classifyActivityMethod(b));
           break;
         case "node":
-          cmp = (a.reporting_node || "").localeCompare(b.reporting_node || "");
+          cmp = routeSortValue(a).localeCompare(routeSortValue(b));
           break;
         case "started":
           cmp = new Date(a.started_at).getTime() - new Date(b.started_at).getTime();
@@ -231,7 +254,7 @@ export default function AdminActivity() {
           <p className="page-subtitle text-sm sm:text-base">
             {sessions.length === 0
               ? "No active streams"
-              : `${sessions.length} active stream${sessions.length !== 1 ? "s" : ""} across ${Object.keys(nodes).length} node${Object.keys(nodes).length !== 1 ? "s" : ""}`}
+              : `${sessions.length} active stream${sessions.length !== 1 ? "s" : ""} across ${routeNodes.length} node${routeNodes.length !== 1 ? "s" : ""}`}
           </p>
         </div>
         <div className="flex items-center gap-1.5">
@@ -373,28 +396,31 @@ export default function AdminActivity() {
           </div>
 
           {/* Node breakdown */}
-          {Object.keys(nodes).length > 1 && (
+          {routeNodes.length > 1 && (
             <div className="border-border border-t pt-3">
               <div className="text-muted-foreground mb-2 text-[10px] font-semibold tracking-wider uppercase">
-                By Node
+                By Routing Node
               </div>
               <div className="flex flex-wrap gap-1.5">
-                {Object.entries(nodes)
-                  .sort(([, a], [, b]) => b - a)
-                  .map(([node, count]) => (
+                {[...routeNodes]
+                  .sort((a, b) => b.count - a.count)
+                  .map((node) => (
                     <button
-                      key={node}
-                      onClick={() => setNodeFilter(nodeFilter === node ? null : node)}
+                      key={node.key}
+                      onClick={() => setNodeFilter(nodeFilter === node.key ? null : node.key)}
                       className={`bg-surface border-border hover:border-primary/20 rounded-md border px-2.5 py-1 text-[11px] font-medium transition-all ${
-                        nodeFilter === node
+                        nodeFilter === node.key
                           ? "border-primary/40 bg-primary/10 text-primary"
                           : nodeFilter
                             ? "opacity-30"
                             : ""
                       }`}
                     >
-                      {node}
-                      <span className="text-muted-foreground ml-1.5 tabular-nums">{count}</span>
+                      <span className="text-muted-foreground mr-1">{node.label}</span>
+                      {node.name}
+                      <span className="text-muted-foreground ml-1.5 tabular-nums">
+                        {node.count}
+                      </span>
                     </button>
                   ))}
               </div>
@@ -408,7 +434,7 @@ export default function AdminActivity() {
         <div className="relative min-w-[200px] flex-1">
           <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-3.5 w-3.5 -translate-y-1/2" />
           <Input
-            placeholder="Filter by user or media..."
+            placeholder="Filter by user, media, client, or node..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="h-8 pl-9 text-[13px]"
@@ -476,7 +502,7 @@ export default function AdminActivity() {
               Playback
             </SortHeader>
             <SortHeader field="node" current={sortField} dir={sortDir} onClick={toggleSort}>
-              Node
+              Route
             </SortHeader>
             <SortHeader
               field="started"
@@ -704,8 +730,8 @@ function StreamRow({
 
         {/* Node */}
         <div className="min-w-0">
-          <div className="text-muted-foreground truncate text-[12px]">
-            {session.node_display_name || session.reporting_node || "—"}
+          <div className="flex min-w-0 flex-wrap gap-1">
+            <PlaybackRouteBadges session={session} />
           </div>
         </div>
 
@@ -855,6 +881,9 @@ function StreamRow({
               {session.is_paused ? "Paused" : "Playing"}
             </span>
             <span className="font-mono tabular-nums">{playbackPosition}</span>
+          </div>
+          <div className="mt-1.5 flex min-w-0 flex-wrap gap-1">
+            <PlaybackRouteBadges session={session} />
           </div>
           <div className="mt-2 rounded-md border border-white/6 bg-white/[0.03] px-2 py-1.5">
             <div className="flex min-w-0 flex-wrap items-center gap-1.5">

--- a/web/src/pages/admin-settings/PlaybackSettings.test.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.test.tsx
@@ -171,16 +171,16 @@ describe("PlaybackSettings layout", () => {
 });
 
 describe("PlaybackSettings node routing", () => {
-  const standardRouting = {
+  const defaultRouting = {
     "playback.routing.direct_play_egress": "prefer_proxy",
-    "playback.routing.remux_execution": "prefer_worker",
+    "playback.routing.remux_execution": "prefer_transcode",
     "playback.routing.remux_egress": "prefer_proxy",
-    "playback.routing.video_transcode_execution": "prefer_worker",
+    "playback.routing.video_transcode_execution": "prefer_transcode",
     "playback.routing.video_transcode_egress": "prefer_proxy",
   };
 
   it("stages every primitive setting when a preset is selected", async () => {
-    const form = makeForm({ "playback.hw_accel": "none", ...standardRouting });
+    const form = makeForm({ "playback.hw_accel": "none", ...defaultRouting });
     useSettingsFormMock.mockReturnValue(form);
 
     render(<PlaybackSettings />);
@@ -196,6 +196,38 @@ describe("PlaybackSettings node routing", () => {
     expect(form.save).not.toHaveBeenCalled();
   });
 
+  it("labels the built-in routing policy as Silo Defaults", () => {
+    useSettingsFormMock.mockReturnValue(
+      makeForm({ "playback.hw_accel": "none", ...defaultRouting }),
+    );
+
+    render(<PlaybackSettings />);
+
+    expect(screen.getByRole("button", { name: "Silo Defaults" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Standard cluster" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Custom")).not.toBeInTheDocument();
+  });
+
+  it("offers a transcode-node preference and explains what a worker is", async () => {
+    useSettingsFormMock.mockReturnValue(
+      makeForm({
+        "playback.hw_accel": "none",
+        ...defaultRouting,
+      }),
+    );
+
+    render(<PlaybackSettings />);
+
+    const remuxExecution = screen.getByRole("combobox", { name: "Remux execution" });
+    expect(remuxExecution).toHaveTextContent("Prefer transcode node");
+    await userEvent.click(remuxExecution);
+    expect(await screen.findByRole("option", { name: "Prefer any worker" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Prefer transcode node" })).toBeVisible();
+    expect(screen.getByText(/A worker can be a proxy/)).toBeVisible();
+    expect(screen.getByText(/Transcode node → any worker → API/)).toBeVisible();
+    expect(screen.getByText(/Video transcode workers are transcode nodes/)).toBeVisible();
+  });
+
   it("warns when hard routes lack nodes or universal client-origin support", () => {
     useAdminNodesMock.mockReturnValue({
       data: [transcodeNode({ healthy: false })],
@@ -204,7 +236,7 @@ describe("PlaybackSettings node routing", () => {
     useSettingsFormMock.mockReturnValue(
       makeForm({
         "playback.hw_accel": "none",
-        ...standardRouting,
+        ...defaultRouting,
         "playback.routing.direct_play_egress": "proxy_only",
         "playback.routing.remux_execution": "worker_only",
       }),

--- a/web/src/pages/admin-settings/PlaybackSettings.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.tsx
@@ -48,8 +48,9 @@ const TRANSCODING_ADVANCED_KEYS = [
 ];
 
 const executionOptions = [
-  { value: "prefer_worker", label: "Prefer worker" },
-  { value: "worker_only", label: "Worker only" },
+  { value: "prefer_worker", label: "Prefer any worker" },
+  { value: "prefer_transcode", label: "Prefer transcode node" },
+  { value: "worker_only", label: "Any worker only" },
   { value: "prefer_api", label: "Prefer API server" },
   { value: "api_only", label: "API server only" },
 ];
@@ -61,16 +62,21 @@ const egressOptions = [
   { value: "api_only", label: "API server only" },
 ];
 
-function executionPreview(value: string) {
+type ExecutionWorkload = "remux" | "video_transcode";
+
+function executionPreview(value: string, workload: ExecutionWorkload) {
+  const worker = workload === "remux" ? "Any worker" : "Transcode node";
   switch (value) {
+    case "prefer_transcode":
+      return workload === "remux" ? "Transcode node → any worker → API" : "Transcode node → API";
     case "worker_only":
-      return "Worker only";
+      return `${worker} only`;
     case "prefer_api":
-      return "API → worker";
+      return `API → ${worker.toLowerCase()}`;
     case "api_only":
       return "API only";
     default:
-      return "Worker → API";
+      return `${worker} → API`;
   }
 }
 
@@ -88,8 +94,8 @@ function egressPreview(value: string) {
 }
 
 /** The whole path for a workload that needs an executor, e.g. "Worker → API · Proxy → API". */
-function routePreview(execution: string, egress: string) {
-  return `${executionPreview(execution)} · ${egressPreview(egress)}`;
+function routePreview(execution: string, egress: string, workload: ExecutionWorkload) {
+  return `${executionPreview(execution, workload)} · ${egressPreview(egress)}`;
 }
 
 // A routing policy either picks who runs the work (execution) or who serves the
@@ -131,13 +137,15 @@ const ROUTING_FIELDS: readonly RoutingField[] = [
     key: "playback.routing.remux_execution",
     label: "Remux execution",
     kind: "execution",
-    description: "Includes container changes, audio adaptation, and copied-video HLS.",
+    description:
+      "A worker can be a proxy or transcode node. Prefer transcode node runs HLS or progressive remux there when supported; progressive output is relayed through the selected proxy.",
   },
   { key: "playback.routing.remux_egress", label: "Remux egress", kind: "egress" },
   {
     key: "playback.routing.video_transcode_execution",
     label: "Video transcode execution",
     kind: "execution",
+    description: "Video transcode workers are transcode nodes; proxy nodes only provide egress.",
   },
   {
     key: "playback.routing.video_transcode_egress",
@@ -148,12 +156,12 @@ const ROUTING_FIELDS: readonly RoutingField[] = [
 
 const ROUTING_PRESETS = {
   standard: {
-    label: "Standard cluster",
+    label: "Silo Defaults",
     values: {
       "playback.routing.direct_play_egress": "prefer_proxy",
-      "playback.routing.remux_execution": "prefer_worker",
+      "playback.routing.remux_execution": "prefer_transcode",
       "playback.routing.remux_egress": "prefer_proxy",
-      "playback.routing.video_transcode_execution": "prefer_worker",
+      "playback.routing.video_transcode_execution": "prefer_transcode",
       "playback.routing.video_transcode_egress": "prefer_proxy",
     },
   },
@@ -570,6 +578,7 @@ export default function PlaybackSettings() {
                 route={routePreview(
                   routingValues["playback.routing.remux_execution"],
                   routingValues["playback.routing.remux_egress"],
+                  "remux",
                 )}
               />
               <PreferredPathRow
@@ -577,6 +586,7 @@ export default function PlaybackSettings() {
                 route={routePreview(
                   routingValues["playback.routing.video_transcode_execution"],
                   routingValues["playback.routing.video_transcode_egress"],
+                  "video_transcode",
                 )}
               />
             </div>

--- a/web/src/pages/adminActivityPresentation.test.ts
+++ b/web/src/pages/adminActivityPresentation.test.ts
@@ -18,6 +18,7 @@ import {
   formatVideoSummary,
   getSessionClientLabel,
   getSessionClientLabelFull,
+  getSessionRouteNodes,
   normalizeContainerDecision,
   normalizeStreamDecision,
 } from "./adminActivityPresentation";
@@ -34,6 +35,7 @@ function makeSession(overrides: Partial<AdminSession> = {}): AdminSession {
     media_type: overrides.media_type ?? "movie",
     play_method: overrides.play_method ?? "transcode",
     reporting_node: overrides.reporting_node ?? "local",
+    node_display_name: overrides.node_display_name,
     file_duration: overrides.file_duration ?? 3600,
     started_at: overrides.started_at ?? new Date().toISOString(),
     updated_at: overrides.updated_at ?? new Date().toISOString(),
@@ -48,6 +50,13 @@ function makeSession(overrides: Partial<AdminSession> = {}): AdminSession {
     client_user_agent: overrides.client_user_agent,
     effective_play_method: overrides.effective_play_method,
     is_jellyfin_client: overrides.is_jellyfin_client,
+    routing_workload: overrides.routing_workload,
+    routing_execution: overrides.routing_execution,
+    routing_execution_node_id: overrides.routing_execution_node_id,
+    routing_execution_node_name: overrides.routing_execution_node_name,
+    routing_egress: overrides.routing_egress,
+    routing_egress_node_id: overrides.routing_egress_node_id,
+    routing_egress_node_name: overrides.routing_egress_node_name,
     audio_track_index: overrides.audio_track_index ?? 0,
     transcode_audio: overrides.transcode_audio ?? true,
     stream_bitrate_kbps: overrides.stream_bitrate_kbps ?? 8000,
@@ -350,6 +359,123 @@ describe("adminActivityPresentation", () => {
     // even when the client name looks like a Jellyfin client.
     expect(isJellyfinSession(makeSession({ client_name: "Jellyfin Web" }))).toBe(false);
     expect(isJellyfinSession(makeSession())).toBe(false);
+  });
+
+  it("shows both transcode and proxy nodes in playback route order", () => {
+    expect(
+      getSessionRouteNodes(
+        makeSession({
+          reporting_node: "transcode-legacy",
+          routing_workload: "video_transcode",
+          routing_execution: "transcode",
+          routing_execution_node_id: 21,
+          routing_execution_node_name: "silo-transcode-01",
+          routing_egress: "proxy",
+          routing_egress_node_id: 34,
+          routing_egress_node_name: "silo-proxy-02",
+        }),
+      ),
+    ).toEqual([
+      {
+        key: "transcode:21",
+        kind: "transcode",
+        label: "Transcode",
+        name: "silo-transcode-01",
+      },
+      { key: "proxy:34", kind: "proxy", label: "Proxy", name: "silo-proxy-02" },
+    ]);
+  });
+
+  it("shows a proxy once when it both executes and serves a remux", () => {
+    expect(
+      getSessionRouteNodes(
+        makeSession({
+          routing_workload: "remux",
+          routing_execution: "proxy",
+          routing_execution_node_id: 34,
+          routing_execution_node_name: "silo-proxy-02",
+          routing_egress: "proxy",
+          routing_egress_node_id: 34,
+          routing_egress_node_name: "silo-proxy-02",
+        }),
+      ),
+    ).toEqual([{ key: "proxy:34", kind: "proxy", label: "Proxy", name: "silo-proxy-02" }]);
+  });
+
+  it("keeps the reporting server identity for API-local routes", () => {
+    expect(
+      getSessionRouteNodes(
+        makeSession({
+          reporting_node: "api-a",
+          routing_workload: "direct_play",
+          routing_execution: "none",
+          routing_egress: "api",
+        }),
+      ),
+    ).toEqual([{ key: "server:api-a", kind: "server", label: "Server", name: "api-a" }]);
+  });
+
+  it("keeps local and legacy activity rows readable", () => {
+    expect(
+      getSessionRouteNodes(
+        makeSession({
+          reporting_node: "local",
+          routing_workload: "direct_play",
+          routing_execution: "none",
+          routing_egress: "api",
+        }),
+      ),
+    ).toEqual([{ key: "server:local", kind: "server", label: "Server", name: "Local server" }]);
+
+    expect(
+      getSessionRouteNodes(
+        makeSession({ reporting_node: "worker-legacy", node_display_name: "Basement worker" }),
+      ),
+    ).toEqual([
+      {
+        key: "legacy:Basement worker",
+        kind: "legacy",
+        label: "Node",
+        name: "Basement worker",
+      },
+    ]);
+  });
+
+  it("uses the resolved display name for a reconstructed remote transcode", () => {
+    expect(
+      getSessionRouteNodes(
+        makeSession({
+          node_display_name: "silo-transcode-recovered",
+          routing_workload: "video_transcode",
+          routing_execution: "transcode",
+          routing_egress: "api",
+        }),
+      ),
+    ).toEqual([
+      {
+        key: "transcode:silo-transcode-recovered",
+        kind: "transcode",
+        label: "Transcode",
+        name: "silo-transcode-recovered",
+      },
+    ]);
+  });
+
+  it("falls back to routing node IDs when a registered node name is unavailable", () => {
+    expect(
+      getSessionRouteNodes(
+        makeSession({
+          routing_workload: "video_transcode",
+          routing_execution: "transcode",
+          routing_execution_node_id: 21,
+          routing_egress: "proxy",
+          routing_egress_node_id: 34,
+        }),
+      ),
+    ).toEqual([
+      { key: "transcode:21", kind: "transcode", label: "Transcode", name: "Node #21" },
+      { key: "proxy:34", kind: "proxy", label: "Proxy", name: "Node #34" },
+    ]);
   });
 
   it("labels HLS copy-original sessions as container HLS with copied video", () => {

--- a/web/src/pages/adminActivityPresentation.test.ts
+++ b/web/src/pages/adminActivityPresentation.test.ts
@@ -402,6 +402,25 @@ describe("adminActivityPresentation", () => {
     ).toEqual([{ key: "proxy:34", kind: "proxy", label: "Proxy", name: "silo-proxy-02" }]);
   });
 
+  it("preserves distinct proxy execution and egress nodes", () => {
+    expect(
+      getSessionRouteNodes(
+        makeSession({
+          routing_workload: "remux",
+          routing_execution: "proxy",
+          routing_execution_node_id: 34,
+          routing_execution_node_name: "silo-proxy-executor",
+          routing_egress: "proxy",
+          routing_egress_node_id: 35,
+          routing_egress_node_name: "silo-proxy-egress",
+        }),
+      ),
+    ).toEqual([
+      { key: "proxy:34", kind: "proxy", label: "Proxy", name: "silo-proxy-executor" },
+      { key: "proxy:35", kind: "proxy", label: "Proxy", name: "silo-proxy-egress" },
+    ]);
+  });
+
   it("keeps the reporting server identity for API-local routes", () => {
     expect(
       getSessionRouteNodes(

--- a/web/src/pages/adminActivityPresentation.ts
+++ b/web/src/pages/adminActivityPresentation.ts
@@ -287,6 +287,71 @@ export function getSessionClientLabelFull(session: AdminSession): string {
   return session.client_label_full?.trim() || getSessionClientLabel(session);
 }
 
+export interface ActivityRouteNode {
+  key: string;
+  kind: "transcode" | "proxy" | "server" | "legacy";
+  label: "Transcode" | "Proxy" | "Server" | "Node";
+  name: string;
+}
+
+function namedRouteNode(
+  kind: "transcode" | "proxy",
+  name: string | undefined,
+  id: number | undefined,
+): ActivityRouteNode {
+  const label = kind === "transcode" ? "Transcode" : "Proxy";
+  const trimmedName = name?.trim();
+  return {
+    key: `${kind}:${id ?? trimmedName ?? "unknown"}`,
+    kind,
+    label,
+    name: trimmedName || (id !== undefined ? `Node #${id}` : `Unknown ${kind} node`),
+  };
+}
+
+function reportingServerRouteNode(session: AdminSession): ActivityRouteNode {
+  const reportedName = session.reporting_node?.trim();
+  if (!reportedName || reportedName.toLowerCase() === "local") {
+    return { key: "server:local", kind: "server", label: "Server", name: "Local server" };
+  }
+  return { key: `server:${reportedName}`, kind: "server", label: "Server", name: reportedName };
+}
+
+/**
+ * Return registered playback nodes in work-to-viewer order. Routes without a
+ * registered node retain the reporting API server's identity, while rows from
+ * older servers fall back to their legacy node fields.
+ */
+export function getSessionRouteNodes(session: AdminSession): ActivityRouteNode[] {
+  const execution = session.routing_execution?.trim();
+  const egress = session.routing_egress?.trim();
+  const hasResolvedRoute = Boolean(session.routing_workload?.trim() || execution || egress);
+
+  if (!hasResolvedRoute) {
+    const reportedName = session.node_display_name?.trim() || session.reporting_node?.trim();
+    const name =
+      !reportedName || reportedName.toLowerCase() === "local" ? "Local server" : reportedName;
+    return [{ key: `legacy:${name}`, kind: "legacy", label: "Node", name }];
+  }
+
+  const nodes: ActivityRouteNode[] = [];
+  const executionNodeName =
+    session.routing_execution_node_name?.trim() || session.node_display_name;
+  if (execution === "transcode") {
+    nodes.push(namedRouteNode("transcode", executionNodeName, session.routing_execution_node_id));
+  } else if (execution === "proxy" && egress !== "proxy") {
+    nodes.push(namedRouteNode("proxy", executionNodeName, session.routing_execution_node_id));
+  }
+
+  if (egress === "proxy") {
+    nodes.push(
+      namedRouteNode("proxy", session.routing_egress_node_name, session.routing_egress_node_id),
+    );
+  }
+
+  return nodes.length > 0 ? nodes : [reportingServerRouteNode(session)];
+}
+
 export function formatSourceContainerSummary(session: AdminSession): string {
   return formatContainer(session.source_container) || "Unknown source";
 }

--- a/web/src/pages/adminActivityPresentation.ts
+++ b/web/src/pages/adminActivityPresentation.ts
@@ -339,14 +339,19 @@ export function getSessionRouteNodes(session: AdminSession): ActivityRouteNode[]
     session.routing_execution_node_name?.trim() || session.node_display_name;
   if (execution === "transcode") {
     nodes.push(namedRouteNode("transcode", executionNodeName, session.routing_execution_node_id));
-  } else if (execution === "proxy" && egress !== "proxy") {
+  } else if (execution === "proxy") {
     nodes.push(namedRouteNode("proxy", executionNodeName, session.routing_execution_node_id));
   }
 
   if (egress === "proxy") {
-    nodes.push(
-      namedRouteNode("proxy", session.routing_egress_node_name, session.routing_egress_node_id),
+    const egressNode = namedRouteNode(
+      "proxy",
+      session.routing_egress_node_name,
+      session.routing_egress_node_id,
     );
+    if (!nodes.some((node) => node.key === egressNode.key)) {
+      nodes.push(egressNode);
+    }
   }
 
   return nodes.length > 0 ? nodes : [reportingServerRouteNode(session)];


### PR DESCRIPTION
## What changed

- Show execution and egress nodes separately on the activity page and dashboard, including route-aware filtering and sorting.
- Add `Prefer transcode node` and use transcode execution with proxy egress in the renamed `Silo Defaults` preset.
- Let native protocol V3 progressive remuxes run FFmpeg on a transcode node while a proxy remains the client-facing origin.
- Gate the two-node route with executor and relay capability markers so mixed-version clusters do not select incompatible nodes.

## Why

Progressive remuxes that adapt audio were still running FFmpeg on the proxy. The activity page also showed only one route node, which made execution and egress look like the same job. This change lets a dedicated transcode node execute the remux, relays its output through the selected proxy, and reports both roles.

## Compatibility and rollout

- The new two-node route applies only to native protocol V3 progressive remux. Jellyfin-compatible playback keeps its existing route behavior.
- API, proxy, and transcode-node binaries should be deployed together. Nodes without the new capability markers are excluded during a rolling upgrade.
- Existing playback sessions are not rerouted. A new start or replan is required.
- Existing explicit routing settings are preserved. The new values apply to unset defaults or when `Silo Defaults` is selected.

## Validation

Local gates on final head `9eb1ecde4`:

```text
make test-go
make embed-stub
go build ./...
gofmt -l .  # no output
go vet ./...
golangci-lint run --new-from-merge-base=origin/main ./...  # 0 issues
go test -race ./internal/transcodenode -run 'Test(HandleProgressiveRemux|ProgressiveRemuxRunsOnThisNode|ForceReloadTeardown)'
SILO_TEST_REDIS_URL=redis://100.86.116.20:6379/0 go test -race ./internal/noderecipe -run TestNodeAuthorityGenerationRevokesDormantRecipes -count=1
pnpm --dir web run lint
pnpm --dir web run format:check
pnpm --dir web run build
make test-web  # 356 files, 3057 tests
make verify-settings-bindings-all
make verify-playback-fixtures
make verify-local-paths
git diff --check
```

Shared-dev validation on the same head:

- Central API and the ns12/ns17 transcode and proxy roles all reported healthy.
- A H.264 + E-AC-3 5.1 source planned as progressive MP4 with video copy, AAC stereo conversion, transcode execution, and proxy egress.
- A dormant route had all three Redis authority records (recipe, generation, digest), and `HEAD` returned 200 without starting FFmpeg.
- Force-reloading stable execution node ID 3 made both `HEAD` and `GET` return 410, left active jobs at zero, and explicit stop removed all three authority records.
- A fresh post-reload `GET` returned 200 and streamed 158,109,019 bytes in 10 seconds; the transcode node reported exactly one active job and the proxy heartbeat reported 21,207 kbps egress.
- An overlapping `GET` for the same transport returned 409.
- User stop returned 204, replay returned 410, all three Redis authority records were removed, and the execution node returned to zero active jobs.
- Browser verification confirmed separate Transcode/Proxy activity badges, route filters, the `Prefer transcode node` setting, and the route preview.

Final review-hardening revalidation on exact head `9eb1ecde4`:

- The full documented local gate passed again, including 3,057 web tests; focused progressive-stop/force-reload tests passed 30 repeated runs and 15 race-detector runs.
- The deployed `internal/transcodenode/server.go` SHA-256 matched the PR worktree exactly, and the central API plus all four ns12/ns17 worker roles passed the runtime doctor/health checks.
- A live progressive remux produced two active jobs, 4,404 kbps proxy egress, three durable authority keys, and two remux tracker records keyed by the viewer playback session. User stop returned 204 in 159 ms with all worker jobs already at zero; replay returned 404.
- With another remux active, central force-reload of executor node 3 returned 200/`ok` in 152 ms with executor jobs already at zero. Viewer-keyed remux tracker records were removed, replay returned 410, central stop returned 204, every worker stayed at zero jobs, and no authority keys remained.
- Exact-head Go, Web, docs-hygiene, and CodeRabbit checks passed, and all review threads were resolved.

Related issue: #619

## AI Disclosure

- Tool(s): T3 Code (Codex)
- Model(s): gpt-5.6-sol
- Involvement: AI-assisted
- Adversarial review: Multiple independent correctness, concurrency, contract, and simplicity passes reviewed the feature and each hardening revision. Their findings were fixed with regression coverage, including relay-capability gating, durable stopped-URL authority, canonical telemetry, fallback on stale capabilities/store failures, split-horizon node identity, rolling old-writer compatibility, digest-bound Redis sidecars, URL-repoint revocation, serialized force-reload authority validation, unresolved-row tracker fallback, stable-node-ID authority that survives process replacement, joined progressive-remux shutdown before stop/reload acknowledgement, and viewer-session-keyed node tracking. The final over-engineering pass found nothing else to cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback routing can now prefer transcode nodes for remuxing and video transcoding.
  * Progressive remux playback supports eligible transcode-node and proxy routes while preserving requested transport.
  * Admin activity displays execution and egress nodes with clearer route badges.
  * Playback settings distinguish remux and video-transcode workloads and provide updated route previews.
* **Bug Fixes**
  * Improved route fallback, reservation cleanup, session teardown, and authority handling when routing resources are unavailable.
* **Documentation**
  * Expanded playback routing guidance, supported worker types, and execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
