### PR TITLE
fix(jellycompat): stop mapping 0-10 TMDB scores into CriticRating (fixes #693)

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/mapping.go
+++ b/internal/jellycompat/mapping.go
@@ -175,9 +175,6 @@ func (m *mapper) itemFromList(item upstreamListItem, isFavorite bool, progress *
 	if allFields || fields["productionlocations"] {
 		dto.ProductionLocations = append([]string{}, item.Countries...)
 	}
-	if allFields || fields["criticrating"] {
-		dto.CriticRating = item.RatingTMDB
-	}
 	if allFields || fields["mediasourcecount"] {
 		// The list path has no version data, so assume matched playable items
 		// have exactly one source. Unmatched/file-missing items leave this
@@ -373,7 +370,6 @@ func (m *mapper) itemFromDetailWithFields(item upstreamItemDetail, isFavorite bo
 	dto.OriginalTitle = firstNonEmpty(item.OriginalTitle, item.Title)
 	dto.SortName = firstNonEmpty(item.SortTitle, item.OriginalTitle, item.Title)
 	dto.ForcedSortName = dto.SortName
-	dto.CriticRating = item.RatingTMDB
 	dto.Studios = m.namePairs(item.Studios, EncodedIDStudio)
 	dto.ProductionLocations = append([]string{}, item.Countries...)
 	if item.Tagline != "" {

--- a/internal/jellycompat/mapping_critic_rating_test.go
+++ b/internal/jellycompat/mapping_critic_rating_test.go
@@ -1,0 +1,85 @@
+package jellycompat
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func floatPtr(v float64) *float64 {
+	return &v
+}
+
+func TestMapping_CriticRatingNotPopulatedFromTMDB(t *testing.T) {
+	codec := NewResourceIDCodec()
+	m := newMapper(codec, nil)
+
+	tmdbRating := floatPtr(8.5)
+	imdbRating := floatPtr(7.8)
+
+	listItem := upstreamListItem{
+		ContentID:  "movie-1",
+		Type:       "movie",
+		Title:      "Test Movie",
+		RatingTMDB: tmdbRating,
+		RatingIMDB: imdbRating,
+	}
+
+	t.Run("itemFromList without fields", func(t *testing.T) {
+		dto := m.itemFromList(listItem, false, nil, map[string]bool{})
+		if dto.CriticRating != nil {
+			t.Fatalf("expected CriticRating to be nil, got %v", *dto.CriticRating)
+		}
+		if dto.CommunityRating == nil || *dto.CommunityRating != 7.8 {
+			t.Fatalf("expected CommunityRating to be 7.8, got %v", dto.CommunityRating)
+		}
+	})
+
+	t.Run("itemFromList with requested criticrating field", func(t *testing.T) {
+		dto := m.itemFromList(listItem, false, nil, map[string]bool{"criticrating": true})
+		if dto.CriticRating != nil {
+			t.Fatalf("expected CriticRating to be nil even when criticrating field requested, got %v", *dto.CriticRating)
+		}
+	})
+
+	t.Run("itemFromList with allDetailFields sentinel", func(t *testing.T) {
+		dto := m.itemFromList(listItem, false, nil, allDetailFields)
+		if dto.CriticRating != nil {
+			t.Fatalf("expected CriticRating to be nil with allDetailFields, got %v", *dto.CriticRating)
+		}
+	})
+
+	detailItem := upstreamItemDetail{
+		ContentID:  "movie-1",
+		Type:       "movie",
+		Title:      "Test Movie",
+		RatingTMDB: tmdbRating,
+		RatingIMDB: imdbRating,
+	}
+
+	t.Run("itemFromDetail", func(t *testing.T) {
+		dto := m.itemFromDetail(detailItem, false, nil)
+		if dto.CriticRating != nil {
+			t.Fatalf("expected CriticRating to be nil on detail mapping, got %v", *dto.CriticRating)
+		}
+		if dto.CommunityRating == nil || *dto.CommunityRating != 7.8 {
+			t.Fatalf("expected CommunityRating to be 7.8 on detail mapping, got %v", dto.CommunityRating)
+		}
+	})
+
+	t.Run("JSON serialization omits CriticRating when nil", func(t *testing.T) {
+		dto := m.itemFromDetail(detailItem, false, nil)
+		data, err := json.Marshal(dto)
+		if err != nil {
+			t.Fatalf("unexpected marshal error: %v", err)
+		}
+
+		var raw map[string]any
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+
+		if val, exists := raw["CriticRating"]; exists {
+			t.Fatalf("expected CriticRating key to be omitted from JSON when nil, but found %v", val)
+		}
+	})
+}

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +22,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by


### PR DESCRIPTION
Fixes #693.

### Summary
Stop assigning 0–10 TMDB scores (\item.RatingTMDB\) to Jellyfin's \CriticRating\ on list and detail item mappings in \internal/jellycompat/mapping.go\.

Jellyfin clients (Web, Swiftfin, Findroid) interpret \CriticRating\ as a 0–100 percentage score (e.g. Rotten Tomatoes score) and threshold 60% for fresh vs. rotten. Exposing 0–10 TMDB scores in \CriticRating\ resulted in normal TMDB scores (such as 8.5) rendering as an 8.5% rotten critic score.

### Changes
1. **\internal/jellycompat/mapping.go\**: Removed \dto.CriticRating = item.RatingTMDB\ from both \itemFromList\ and \itemFromDetailWithFields\. \CriticRating\ now remains \
il\ (omitted from JSON) when no 0-100 critic score is present.
2. **\internal/jellycompat/mapping_critic_rating_test.go\**: Added unit test coverage verifying that list and detail mappings leave \CriticRating\ as \
il\ (even when \Fields=criticrating\ is requested), \CommunityRating\ continues to reflect IMDb ratings, and JSON serialization omits the \CriticRating\ key when \
il\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Critic ratings are no longer incorrectly populated from TMDB ratings.
  * Critic rating fields now remain empty when requested, preventing misleading rating information.
  * Community ratings continue to display the IMDb rating correctly.
  * Empty critic ratings are omitted from serialized responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->