### PR TITLE
fix(mdblist): prevent API key leakage in transport errors (fixes #692)

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -22,7 +22,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by

--- a/internal/mdblist/discovery.go
+++ b/internal/mdblist/discovery.go
@@ -113,11 +113,11 @@ func (c *Client) fetchLists(ctx context.Context, path string, q url.Values) ([]L
 	u := c.baseURL + path + "?" + q.Encode()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating mdblist request: %w", err)
+		return nil, fmt.Errorf("creating mdblist request: %w", sanitizeAPIKeyError(err, c.currentAPIKey()))
 	}
 	res, err := c.http.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("calling mdblist: %w", err)
+		return nil, fmt.Errorf("calling mdblist: %w", sanitizeAPIKeyError(err, c.currentAPIKey()))
 	}
 	defer res.Body.Close()
 	if res.StatusCode == http.StatusUnauthorized || res.StatusCode == http.StatusForbidden {
@@ -150,4 +150,30 @@ func canonicalListURL(user, slug string) string {
 		return ""
 	}
 	return fmt.Sprintf("https://mdblist.com/lists/%s/%s", user, slug)
+}
+
+func sanitizeAPIKeyError(err error, apiKey string) error {
+	if err == nil {
+		return nil
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		sanitized := *urlErr
+		if parsed, parseErr := url.Parse(sanitized.URL); parseErr == nil {
+			q := parsed.Query()
+			if q.Has("apikey") {
+				q.Set("apikey", "[REDACTED]")
+				parsed.RawQuery = q.Encode()
+				sanitized.URL = parsed.String()
+			}
+		}
+		if apiKey != "" && strings.Contains(sanitized.URL, apiKey) {
+			sanitized.URL = strings.ReplaceAll(sanitized.URL, apiKey, "[REDACTED]")
+		}
+		return &sanitized
+	}
+	if apiKey != "" && strings.Contains(err.Error(), apiKey) {
+		return errors.New(strings.ReplaceAll(err.Error(), apiKey, "[REDACTED]"))
+	}
+	return err
 }

--- a/internal/mdblist/discovery_test.go
+++ b/internal/mdblist/discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSearchAttachesAPIKeyAndQuery(t *testing.T) {
@@ -86,5 +87,27 @@ func TestSearchSurfacesUpstreamErrors(t *testing.T) {
 	c.baseURL = srv.URL
 	if _, err := c.Search(context.Background(), "x"); err == nil {
 		t.Fatal("expected unauthorized error, got nil")
+	}
+}
+
+func TestTransportErrorOmitsAPIKey(t *testing.T) {
+	secretKey := "super-secret-mdblist-key-12345"
+	c := NewClient(secretKey, &http.Client{})
+	c.baseURL = "http://127.0.0.1:0"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := c.Search(ctx, "test")
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+
+	errStr := err.Error()
+	if strings.Contains(errStr, secretKey) {
+		t.Fatalf("transport error leaked API key! error string: %s", errStr)
+	}
+	if !strings.Contains(errStr, "REDACTED") {
+		t.Fatalf("expected REDACTED in sanitized transport error string: %s", errStr)
 	}
 }

--- a/internal/watchsync/providers/mdblist/provider.go
+++ b/internal/watchsync/providers/mdblist/provider.go
@@ -595,7 +595,7 @@ func (p *Provider) doOnce(ctx context.Context, method, path, target string, payl
 	}
 	req, err := http.NewRequestWithContext(ctx, method, target, body)
 	if err != nil {
-		return -1, fmt.Errorf("create mdblist request: %w", err)
+		return -1, fmt.Errorf("create mdblist request: %w", sanitizeAPIKeyError(err, target))
 	}
 	if payload != nil {
 		req.Header.Set("Content-Type", "application/json")
@@ -604,7 +604,7 @@ func (p *Provider) doOnce(ctx context.Context, method, path, target string, payl
 
 	resp, err := p.client.Do(req)
 	if err != nil {
-		return -1, fmt.Errorf("send mdblist request: %w", err)
+		return -1, fmt.Errorf("send mdblist request: %w", sanitizeAPIKeyError(err, target))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusTooManyRequests {
@@ -1299,4 +1299,29 @@ func stringFromJSON(value any) string {
 		return s
 	}
 	return ""
+}
+
+func sanitizeAPIKeyError(err error, target string) error {
+	if err == nil {
+		return nil
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		sanitized := *urlErr
+		if parsed, parseErr := url.Parse(sanitized.URL); parseErr == nil {
+			q := parsed.Query()
+			if q.Has("apikey") {
+				q.Set("apikey", "[REDACTED]")
+				parsed.RawQuery = q.Encode()
+				sanitized.URL = parsed.String()
+			}
+		}
+		return &sanitized
+	}
+	if parsedTarget, parseErr := url.Parse(target); parseErr == nil {
+		if key := parsedTarget.Query().Get("apikey"); key != "" && strings.Contains(err.Error(), key) {
+			return errors.New(strings.ReplaceAll(err.Error(), key, "[REDACTED]"))
+		}
+	}
+	return err
 }

--- a/internal/watchsync/providers/mdblist/provider_test.go
+++ b/internal/watchsync/providers/mdblist/provider_test.go
@@ -806,9 +806,28 @@ func TestDoFloorsRetryAfterWhenRetriesExhausted(t *testing.T) {
 	if attempts != maxRetryAttempts+1 {
 		t.Fatalf("got %d attempts, want %d", attempts, maxRetryAttempts+1)
 	}
-	// The short Retry-After hints proved untrustworthy, so the deferral must
-	// be floored rather than parroting the last 1s hint.
 	if rle.RetryAfter != defaultRetryAfter {
 		t.Fatalf("got retry-after %s, want floored %s", rle.RetryAfter, defaultRetryAfter)
+	}
+}
+
+func TestProviderTransportErrorOmitsAPIKey(t *testing.T) {
+	secretKey := "mdblist-secret-provider-key-999"
+	p := NewProvider(http.DefaultClient, "http://127.0.0.1:0")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := p.fetchUser(ctx, secretKey)
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+
+	errStr := err.Error()
+	if strings.Contains(errStr, secretKey) {
+		t.Fatalf("provider transport error leaked API key! error string: %s", errStr)
+	}
+	if !strings.Contains(errStr, "REDACTED") {
+		t.Fatalf("expected REDACTED in sanitized provider transport error: %s", errStr)
 	}
 }


### PR DESCRIPTION
Fixes #692.

### Summary
Sanitize MDBList transport errors so secret API keys (\pikey=...\) are never exposed in error text, API responses, logs, or telemetry outputs.

When HTTP transport calls fail (e.g. connection refused, DNS error, timeout), Go's \*url.Error\ formats the full request URL containing \?apikey=SECRET\ into \err.Error()\.

### Changes
1. **\internal/mdblist/discovery.go\**: Added \sanitizeAPIKeyError(err error, apiKey string)\ helper which sanitizes \urlErr.URL\ query parameters (\pikey=[REDACTED]\) and redacts any literal API key instances in the error message before returning from \Search\, \Top\, or \Check\.
2. **\internal/watchsync/providers/mdblist/provider.go\**: Wrapped \p.client.Do\ transport error returns in \doOnce\ with \sanitizeAPIKeyError\.
3. **\internal/mdblist/discovery_test.go\ & \internal/watchsync/providers/mdblist/provider_test.go\**: Added unit tests (\TestTransportErrorOmitsAPIKey\ and \TestProviderTransportErrorOmitsAPIKey\) verifying that network/dial transport errors omit sentinel API key strings and contain redacted query parameter placeholders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API keys are now redacted from error messages and URLs when requests fail.
  * Upcoming shows with an invalid series identifier now return an empty result instead of a 404 error.
  * Rate-limit errors now provide a consistent retry delay after all retry attempts are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->