### PR TITLE
fix(jellycompat): expose opted-in personal collections as BoxSets

### DIFF
--- a/internal/catalog/browse_backdrop_test.go
+++ b/internal/catalog/browse_backdrop_test.go
@@ -1,8 +1,11 @@
 package catalog
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
 )
 
 // TestBuildBrowsePlan_RequireBackdrop asserts the ImageTypes=Backdrop filter
@@ -27,5 +30,68 @@ func TestBuildBrowsePlan_RequireBackdrop(t *testing.T) {
 	}
 	if strings.Contains(plan.whereClause, predicate) {
 		t.Fatalf("RequireBackdrop unset: predicate should be absent.\ngot: %s", plan.whereClause)
+	}
+}
+
+func TestCatalogCollectionFiltersReachBrowse(t *testing.T) {
+	req := CatalogRequest{
+		Source:          CatalogSourceUserCollection,
+		CollectionID:    "collection-1",
+		PersonID:        42,
+		RequireBackdrop: true,
+	}
+	if !catalogRequestHasOverlay(req) {
+		t.Fatal("person/backdrop collection filters were not recognized as an overlay")
+	}
+
+	base := catalogBaseCollectionRequest(req)
+	filters, earlyEmpty, err := catalogBrowseFilters(base, AccessFilter{})
+	if err != nil || earlyEmpty {
+		t.Fatalf("catalogBrowseFilters err=%v earlyEmpty=%v", err, earlyEmpty)
+	}
+	if filters.PersonID != 42 || !filters.RequireBackdrop {
+		t.Fatalf("browse filters = %+v, want person 42 with backdrop", filters)
+	}
+}
+
+func TestResolveExactOrderedMediaItems_BackdropBeforePagination(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		require bool
+		offset  int
+		wantID  string
+		total   int
+		more    bool
+	}{
+		{"unfiltered", false, 0, "missing", 4, true},
+		{"first filtered page", true, 0, "first", 2, true},
+		{"second filtered page", true, 1, "second", 2, false},
+		{"past filtered end", true, 2, "", 2, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			items := []*models.MediaItem{
+				{ContentID: "missing", Type: "episode"},
+				{ContentID: "first", Type: "episode", BackdropPath: "first.jpg"},
+				{ContentID: "blank", Type: "episode", BackdropPath: "   "},
+				{ContentID: "second", Type: "episode", BackdropPath: "second.jpg"},
+			}
+			result, err := (&CatalogResolver{}).resolveExactOrderedMediaItems(context.Background(), items, CatalogRequest{
+				Source: CatalogSourceUserCollection, UseSourceOrder: true,
+				RequireBackdrop: tc.require, Limit: 1, Offset: tc.offset,
+			}, AccessFilter{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Total != tc.total || result.HasMore != tc.more || !result.TotalExact {
+				t.Fatalf("incorrect filtered pagination: %+v", result)
+			}
+			if tc.wantID == "" {
+				if len(result.Items) != 0 {
+					t.Fatalf("expected empty page, got %+v", result.Items)
+				}
+			} else if len(result.Items) != 1 || result.Items[0].ContentID != tc.wantID {
+				t.Fatalf("expected %s, got %+v", tc.wantID, result.Items)
+			}
+		})
 	}
 }

--- a/internal/catalog/catalog_request.go
+++ b/internal/catalog/catalog_request.go
@@ -18,19 +18,21 @@ const (
 
 // CatalogRequest is the normalized request shape shared by catalog parsing and resolution.
 type CatalogRequest struct {
-	Source         CatalogSource
-	Scope          string
-	SectionID      string
-	LibraryID      int
-	CollectionID   string
-	PersonID       int64
-	NamePrefix     string
-	SearchQuery    string
-	Query          QueryDefinition
-	Limit          int
-	Offset         int
-	UseSourceOrder bool
-	SkipTotal      bool
+	Source          CatalogSource
+	Scope           string
+	SectionID       string
+	LibraryID       int
+	CollectionID    string
+	PersonID        int64
+	RequireBackdrop bool
+	Randomize       bool
+	NamePrefix      string
+	SearchQuery     string
+	Query           QueryDefinition
+	Limit           int
+	Offset          int
+	UseSourceOrder  bool
+	SkipTotal       bool
 	// SnapshotAt freezes the result set to items created at or before this
 	// timestamp, preventing offset-based pagination drift when new items are
 	// added during a scan.  Nil means the server will generate a snapshot.

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"slices"
 	"strconv"
 	"strings"
@@ -681,6 +682,9 @@ func (r *CatalogResolver) resolveCollectionWithEffectiveSort(
 	// default come into play. A frozen sort from an earlier page of this request
 	// wins over both — see CatalogRequest.ResolvedSort.
 	switch {
+	case req.Randomize:
+		req.Query.Sort = QuerySort{}
+		req.UseSourceOrder = true
 	case req.ResolvedSort != nil:
 		req.Query.Sort = *req.ResolvedSort
 		req.UseSourceOrder = req.Query.Sort.Field == ""
@@ -720,6 +724,16 @@ func (r *CatalogResolver) resolveUserCollectionItems(
 			items, err = FilterCollectionItemsByDisplayQuery(ctx, r.itemRepo.pool, items, collection.DisplayQueryDefinition, access)
 			if err != nil {
 				return nil, err
+			}
+			if req.PersonID > 0 {
+				items, err = r.fetchAccessibleItemsByID(ctx, contentIDsFromMediaItems(items), catalogBaseCollectionRequest(req), access)
+				if err != nil {
+					return nil, err
+				}
+			}
+			// Keep unscoped overlays on the source's relation (notably episodes).
+			if req.Query.MediaScope == "" {
+				req.Query.MediaScope = def.MediaScope
 			}
 			return r.resolveExactOrderedMediaItems(ctx, items, req, access)
 		}
@@ -841,11 +855,20 @@ func (r *CatalogResolver) resolveExactOrderedMediaItems(ctx context.Context, ite
 	req = normalizeExactCollectionOverlayRequest(req, items)
 	items = filterCatalogSearchItems(items, req.SearchQuery)
 	items = filterCatalogNamePrefix(items, req.NamePrefix)
+	if req.RequireBackdrop {
+		// Match browse's BTRIM predicate using hydrated images, including episode inheritance.
+		items = slices.DeleteFunc(items, func(item *models.MediaItem) bool {
+			return item == nil || strings.Trim(item.BackdropPath, " ") == ""
+		})
+	}
 	if req.UseSourceOrder {
 		var err error
 		items, err = r.filterExactSourceItemsByQuery(ctx, items, req.Query, access)
 		if err != nil {
 			return nil, err
+		}
+		if req.Randomize {
+			rand.Shuffle(len(items), func(i, j int) { items[i], items[j] = items[j], items[i] })
 		}
 		total := len(items)
 		paged := paginateCatalogItems(items, req.Offset, req.Limit)
@@ -1491,6 +1514,9 @@ func validateCatalogCollectionRequest(req CatalogRequest, allowPersonalizedSorts
 func catalogRequestHasOverlay(req CatalogRequest) bool {
 	return strings.TrimSpace(req.SearchQuery) != "" ||
 		strings.TrimSpace(req.NamePrefix) != "" ||
+		req.PersonID > 0 ||
+		req.RequireBackdrop ||
+		req.Randomize ||
 		catalogQueryHasFilter(req.Query) ||
 		strings.TrimSpace(req.Query.Sort.Field) != ""
 }
@@ -2073,12 +2099,14 @@ func (r *CatalogResolver) loadCollectionSourceBaseItems(ctx context.Context, req
 
 func catalogBaseCollectionRequest(req CatalogRequest) CatalogRequest {
 	return CatalogRequest{
-		Source:         req.Source,
-		CollectionID:   req.CollectionID,
-		Limit:          req.Limit,
-		Offset:         req.Offset,
-		SkipTotal:      req.SkipTotal,
-		UseSourceOrder: true,
+		Source:          req.Source,
+		CollectionID:    req.CollectionID,
+		PersonID:        req.PersonID,
+		RequireBackdrop: req.RequireBackdrop,
+		Limit:           req.Limit,
+		Offset:          req.Offset,
+		SkipTotal:       req.SkipTotal,
+		UseSourceOrder:  true,
 	}
 }
 
@@ -2272,6 +2300,8 @@ func catalogBrowseFilters(req CatalogRequest, access AccessFilter) (BrowseFilter
 		NamePrefix:         req.NamePrefix,
 		DisabledLibraryIDs: slices.Clone(access.DisabledLibraryIDs),
 		MaxContentRating:   access.MaxContentRating,
+		PersonID:           req.PersonID,
+		RequireBackdrop:    req.RequireBackdrop,
 	}
 	applyCatalogBrowseOverlayRules(&filters, req.Query)
 

--- a/internal/catalog/collection_sort_precedence_test.go
+++ b/internal/catalog/collection_sort_precedence_test.go
@@ -192,6 +192,37 @@ func TestEffectiveCollectionSortAllowsPersonalizedOnUserCollections(t *testing.T
 	}
 }
 
+func TestCollectionRandomizeSkipsSavedSort(t *testing.T) {
+	store := &sortPrefStore{pref: &userstore.CollectionSortPreference{SortField: "title", SortOrder: "asc"}}
+	resolver := &CatalogResolver{storeProvider: &sortPrefProvider{store: store}}
+	var resolved CatalogRequest
+
+	result, err := resolver.resolveCollectionWithEffectiveSort(
+		context.Background(),
+		CatalogRequest{Source: CatalogSourceUserCollection, UseSourceOrder: true, Randomize: true},
+		AccessFilter{UserID: 7, ProfileID: "profile-1"},
+		userstore.CollectionKindUser,
+		"collection-1",
+		[]byte(`{"field":"release_date","order":"desc"}`),
+		func(req CatalogRequest) (*CatalogResult, error) {
+			resolved = req
+			return &CatalogResult{}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("resolve random collection sort: %v", err)
+	}
+	if !resolved.Randomize || !resolved.UseSourceOrder || resolved.Query.Sort != (QuerySort{}) {
+		t.Fatalf("resolved request = %+v, want random source path", resolved)
+	}
+	if store.calls != 0 {
+		t.Fatalf("random request performed %d saved-sort lookups, want 0", store.calls)
+	}
+	if result.EffectiveSort != (QuerySort{}) {
+		t.Fatalf("effective sort = %+v, want no metadata sort", result.EffectiveSort)
+	}
+}
+
 func TestPersonalSourceSortPreferencePrecedence(t *testing.T) {
 	access := AccessFilter{UserID: 7, ProfileID: "profile-1"}
 	for _, source := range []CatalogSource{CatalogSourceWatchlist, CatalogSourceFavorites} {

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -93,7 +93,7 @@ type Cacher struct {
 
 // New creates a new Cacher backed by the given ObjectPutter.
 func New(s3 ObjectPutter) *Cacher {
-	return &Cacher{s3: s3, httpClient: newSecureHTTPClient(), enforcePublicURLs: true}
+	return &Cacher{s3: s3, httpClient: NewPublicHTTPClient(), enforcePublicURLs: true}
 }
 
 // SetArtworkRevisionTracker wires durable revision lifecycle tracking. The
@@ -509,7 +509,7 @@ func (c *Cacher) downloadImage(ctx context.Context, rawURL string) ([]byte, erro
 
 	client := c.httpClient
 	if client == nil {
-		client = newSecureHTTPClient()
+		client = NewPublicHTTPClient()
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -533,13 +533,18 @@ func (c *Cacher) downloadImage(ctx context.Context, rawURL string) ([]byte, erro
 	return data, nil
 }
 
-func newSecureHTTPClient() *http.Client {
+// NewPublicHTTPClient fetches untrusted image URLs without accessing private
+// networks or environment proxies. DNS is checked at dial time, including redirects.
+func NewPublicHTTPClient() *http.Client {
 	transport := &http.Transport{
 		Proxy:               nil,
 		DialContext:         secureImageDialContext,
+		MaxIdleConns:        100,
+		IdleConnTimeout:     90 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 	return &http.Client{
+		Timeout:   downloadTimeout,
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
@@ -603,6 +608,13 @@ func resolvePublicAddr(ctx context.Context, host string) (netip.Addr, error) {
 func isPublicAddr(addr netip.Addr) bool {
 	if addr.Is4In6() {
 		addr = addr.Unmap()
+	}
+	// IsPrivate excludes shared address space and IPv4 translation prefixes;
+	// those can still reach private hosts (including tailnets and NAT64).
+	if netip.MustParsePrefix("100.64.0.0/10").Contains(addr) ||
+		netip.MustParsePrefix("64:ff9b::/96").Contains(addr) ||
+		netip.MustParsePrefix("64:ff9b:1::/48").Contains(addr) {
+		return false
 	}
 	return addr.IsGlobalUnicast() &&
 		!addr.IsPrivate() &&

--- a/internal/imagecache/imagecache.go
+++ b/internal/imagecache/imagecache.go
@@ -609,9 +609,10 @@ func isPublicAddr(addr netip.Addr) bool {
 	if addr.Is4In6() {
 		addr = addr.Unmap()
 	}
-	// IsPrivate excludes shared address space and IPv4 translation prefixes;
-	// those can still reach private hosts (including tailnets and NAT64).
+	// IsPrivate excludes shared/benchmarking space and IPv4 translation
+	// prefixes; those can still reach private hosts (including tailnets and NAT64).
 	if netip.MustParsePrefix("100.64.0.0/10").Contains(addr) ||
+		netip.MustParsePrefix("198.18.0.0/15").Contains(addr) ||
 		netip.MustParsePrefix("64:ff9b::/96").Contains(addr) ||
 		netip.MustParsePrefix("64:ff9b:1::/48").Contains(addr) {
 		return false

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -34,14 +34,20 @@ func TestPublicImageDestinations(t *testing.T) {
 		"10.0.0.1", "172.16.0.1", "192.168.1.1", "169.254.169.254", "fe80::1", "fd00::1",
 		"100.64.0.0", "100.127.255.255", "::ffff:100.100.100.100",
 		"64:ff9b::7f00:1", "64:ff9b:1::7f00:1",
+		"198.18.0.0", "198.18.0.1", "198.19.255.255",
+		"::ffff:198.18.0.0", "::ffff:198.18.0.1", "::ffff:198.19.255.255",
 	} {
 		t.Run(host, func(t *testing.T) {
 			if addr, err := resolvePublicAddr(t.Context(), host); err == nil {
-				t.Fatalf("accepted non-public destination %s", addr)
+				t.Errorf("accepted non-public destination %s", addr)
+			}
+			u := &url.URL{Scheme: "http", Host: net.JoinHostPort(host, "80"), Path: "/poster.jpg"}
+			if err := validatePublicImageURL(u); net.ParseIP(host) != nil && err == nil {
+				t.Error("accepted non-public image URL")
 			}
 		})
 	}
-	for _, host := range []string{"1.1.1.1", "2606:4700:4700::1111", "100.63.255.255", "100.128.0.0"} {
+	for _, host := range []string{"1.1.1.1", "2606:4700:4700::1111", "100.63.255.255", "100.128.0.0", "198.17.255.255", "198.20.0.0", "::ffff:198.17.255.255", "::ffff:198.20.0.0"} {
 		if _, err := resolvePublicAddr(t.Context(), host); err != nil {
 			t.Fatalf("rejected public address %s: %v", host, err)
 		}

--- a/internal/imagecache/imagecache_test.go
+++ b/internal/imagecache/imagecache_test.go
@@ -8,8 +8,10 @@ import (
 	"image/color"
 	"image/jpeg"
 	"image/png"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -25,6 +27,76 @@ const (
 	testTMDBProviderID    = "tmdb"
 	testMoviesContentType = "movies"
 )
+
+func TestPublicImageDestinations(t *testing.T) {
+	for _, host := range []string{
+		"127.0.0.1", "::1", "::ffff:127.0.0.1", "localhost",
+		"10.0.0.1", "172.16.0.1", "192.168.1.1", "169.254.169.254", "fe80::1", "fd00::1",
+		"100.64.0.0", "100.127.255.255", "::ffff:100.100.100.100",
+		"64:ff9b::7f00:1", "64:ff9b:1::7f00:1",
+	} {
+		t.Run(host, func(t *testing.T) {
+			if addr, err := resolvePublicAddr(t.Context(), host); err == nil {
+				t.Fatalf("accepted non-public destination %s", addr)
+			}
+		})
+	}
+	for _, host := range []string{"1.1.1.1", "2606:4700:4700::1111", "100.63.255.255", "100.128.0.0"} {
+		if _, err := resolvePublicAddr(t.Context(), host); err != nil {
+			t.Fatalf("rejected public address %s: %v", host, err)
+		}
+	}
+}
+
+func TestPublicImageClientRedirects(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if target := r.URL.Query().Get("target"); target != "" {
+			http.Redirect(w, r, target, http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	client := NewPublicHTTPClient()
+	t.Cleanup(client.CloseIdleConnections)
+	if client.Timeout <= 0 {
+		t.Fatal("public image requests must have a timeout")
+	}
+	transport := client.Transport.(*http.Transport)
+	dial := transport.DialContext
+	// Only the initial public-origin fixture is local. Redirect destinations
+	// still pass through the real DNS/address guard without external requests.
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if address == "poster.example.test:80" {
+			return (&net.Dialer{}).DialContext(ctx, network, server.Listener.Addr().String())
+		}
+		return dial(ctx, network, address)
+	}
+	for _, tc := range []struct {
+		name, target string
+		wantError    bool
+	}{
+		{"public image", "", false},
+		{"public redirect", "http://poster.example.test/image.jpg", false},
+		{"loopback redirect", server.URL, true},
+		{"hostname redirect", strings.Replace(server.URL, "127.0.0.1", "localhost", 1), true},
+		{"mapped IPv6 redirect", "http://[::ffff:127.0.0.1]/image.jpg", true},
+		{"non-HTTP redirect", "file:///image.jpg", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := client.Get("http://poster.example.test/?target=" + url.QueryEscape(tc.target))
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			if (err != nil) != tc.wantError {
+				t.Fatalf("request error = %v, want error = %t", err, tc.wantError)
+			}
+			if err == nil && resp.StatusCode != http.StatusOK {
+				t.Fatalf("public image status = %d, want 200", resp.StatusCode)
+			}
+		})
+	}
+}
 
 // makeTestJPEG generates a minimal solid-color JPEG for use in tests.
 func makeTestJPEG(t *testing.T) []byte {

--- a/internal/jellycompat/handlers_collections.go
+++ b/internal/jellycompat/handlers_collections.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/usercollections"
 )
 
 // collectionSource is the subset of *catalog.LibraryCollectionRepository the
@@ -23,6 +25,47 @@ type collectionSource interface {
 	GetByID(ctx context.Context, id string) (*models.LibraryCollection, error)
 	ListItems(ctx context.Context, collectionID string) ([]*models.LibraryCollectionItem, error)
 	AnyVisibleInLibraries(ctx context.Context, libraryIDs []int) (bool, error)
+}
+
+// userCollectionSource is the subset of *usercollections.Store the compat layer
+// relies on to expose the session owner's own personal collections — the ones
+// they opted into their server Collections — as Jellyfin BoxSets. Every method
+// takes the owning user and viewing profile: these rows are private, and the
+// store's ACL is the privacy boundary for normal browse reads; ImageCandidates
+// is used only behind a signed image capability check.
+type userCollectionSource interface {
+	List(ctx context.Context, userID int, profileID string, visibleLibraryIDs []int) ([]usercollections.ServerVisibleCollection, error)
+	Get(ctx context.Context, userID int, profileID, id string, visibleLibraryIDs []int) (*usercollections.ServerVisibleCollection, error)
+	AnyVisible(ctx context.Context, userID int, profileID string, visibleLibraryIDs []int) (bool, error)
+	ImageCandidates(ctx context.Context, id string) ([]usercollections.ServerVisibleCollection, error)
+}
+
+// compatCollection is one collection on the BoxSet surface. Personal
+// collections are adapted to the library collection shape so artwork, DTO
+// mapping, search, sorting and paging stay on a single code path; only where
+// their members come from differs.
+type compatCollection struct {
+	*models.LibraryCollection
+	// personal marks a collection owned by the session user rather than the
+	// server, so its members come from user_personal_collection_items.
+	personal bool
+}
+
+// libraryCollectionFromUser adapts a personal collection to the library
+// collection shape. Personal collections carry no library binding — they
+// resolve against everything their owner can see — so LibraryID/LibraryIDs stay
+// empty and collectionVisible is not consulted for them; the store's ownership
+// and profile ACL already decided visibility, hence "visible".
+func libraryCollectionFromUser(c usercollections.ServerVisibleCollection) *models.LibraryCollection {
+	return &models.LibraryCollection{
+		ID:              c.ID,
+		Title:           c.Name,
+		Description:     c.Description,
+		CollectionType:  c.CollectionType,
+		Visibility:      catalog.LibraryCollectionVisibilityVisible,
+		PosterURL:       c.PosterPath,
+		PosterThumbhash: c.PosterThumbhash,
+	}
 }
 
 // collectionsViewID is the canonical Jellyfin "Collections" (boxsets)
@@ -94,21 +137,32 @@ func (h *ItemsHandler) collectionsView() baseItemDTO {
 }
 
 // collectionsViewVisible reports whether the Collections view should appear in
-// the session's library list. It is shown only when at least one collection is
-// visible to the session, via an index-only EXISTS probe scoped to the
-// libraries the session can already see. A probe error fails closed (no tab)
-// rather than failing the whole /UserViews response.
-func (h *ItemsHandler) collectionsViewVisible(ctx context.Context, libraries []upstreamUserLibrary) bool {
-	if h.collections == nil {
-		return false
-	}
+// the session's library list. It is shown when at least one collection is
+// visible to the session — a library collection scoped to a library the session
+// can already see, or one of the session owner's own opted-in personal
+// collections — via index-only EXISTS probes. A probe error fails closed (no
+// tab) rather than failing the whole /UserViews response.
+func (h *ItemsHandler) collectionsViewVisible(ctx context.Context, session *Session, libraries []upstreamUserLibrary) bool {
 	ids := make([]int, 0, len(libraries))
 	for _, lib := range libraries {
 		ids = append(ids, lib.ID)
 	}
-	visible, err := h.collections.AnyVisibleInLibraries(ctx, ids)
+	if h.collections != nil {
+		visible, err := h.collections.AnyVisibleInLibraries(ctx, ids)
+		if err != nil {
+			slog.DebugContext(ctx, "jellycompat collections view existence check failed", "component", "jellycompat", "error", err)
+		} else if visible {
+			return true
+		}
+	}
+	if h.userCollections == nil {
+		return false
+	}
+	// Without this a user whose only collections are personal would never see
+	// the Collections tab, and so could never reach them.
+	visible, err := h.userCollections.AnyVisible(ctx, session.StreamAppUserID, session.ProfileID, ids)
 	if err != nil {
-		slog.DebugContext(ctx, "jellycompat collections view existence check failed", "component", "jellycompat", "error", err)
+		slog.DebugContext(ctx, "jellycompat user collections view existence check failed", "component", "jellycompat", "error", err)
 		return false
 	}
 	return visible
@@ -120,6 +174,10 @@ func (h *ItemsHandler) collectionsViewVisible(ctx context.Context, libraries []u
 type smartCollectionQueryExecutor interface {
 	Preview(ctx context.Context, def catalog.QueryDefinition, access catalog.AccessFilter, limit int) ([]*models.MediaItem, int, error)
 	PreviewPage(ctx context.Context, def catalog.QueryDefinition, access catalog.AccessFilter, limit, offset int, includeTotal bool) ([]*models.MediaItem, int, bool, error)
+}
+
+type personalCollectionCatalogResolver interface {
+	Resolve(ctx context.Context, req catalog.CatalogRequest, access catalog.AccessFilter) (*catalog.CatalogResult, error)
 }
 
 // visibleLibraryIDSet returns the set of library IDs the session may see on
@@ -141,6 +199,15 @@ func (h *ItemsHandler) visibleLibraryIDs(ctx context.Context, session *Session) 
 	return visibleLibraryIDSet(ctx, h.content, session)
 }
 
+func libraryIDSlice(ids map[int]struct{}) []int {
+	out := make([]int, 0, len(ids))
+	for id := range ids {
+		out = append(out, id)
+	}
+	sort.Ints(out)
+	return out
+}
+
 // collectionVisible reports whether any of the collection's libraries is
 // visible to the session. Collections scoped only to hidden or ABS-surface
 // libraries stay off the compat surface.
@@ -157,11 +224,44 @@ func collectionVisible(c *models.LibraryCollection, visible map[int]struct{}) bo
 	return false
 }
 
-// loadVisibleCollection fetches a collection and applies the compat
-// visibility rules. Returns (nil, nil) when the collection does not exist or
-// the session may not see it; infrastructure errors propagate so transient
-// failures don't masquerade as 404s.
-func (h *ItemsHandler) loadVisibleCollection(ctx context.Context, session *Session, collectionID string) (*models.LibraryCollection, error) {
+// loadVisibleCollection resolves a source-tagged BoxSet route ID to the
+// collection behind it, applying the compat visibility rules. Returns
+// (nil, nil) when the collection does not exist or the session may not see it —
+// the two are deliberately indistinguishable, which is what keeps another
+// user's personal collection private. Infrastructure errors propagate so
+// transient failures don't masquerade as 404s.
+func (h *ItemsHandler) loadVisibleCollection(ctx context.Context, session *Session, collectionID string, personalRoute bool) (*compatCollection, error) {
+	if !personalRoute {
+		collection, err := h.loadVisibleLibraryCollection(ctx, session, collectionID)
+		if err != nil || collection == nil {
+			return nil, err
+		}
+		return &compatCollection{LibraryCollection: collection}, nil
+	}
+	if h.userCollections == nil {
+		return nil, nil
+	}
+	visible, err := h.visibleLibraryIDs(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	personal, err := h.userCollections.Get(ctx, session.StreamAppUserID, session.ProfileID, collectionID, libraryIDSlice(visible))
+	if err != nil {
+		return nil, err
+	}
+	if personal == nil {
+		return nil, nil
+	}
+	return &compatCollection{
+		LibraryCollection: libraryCollectionFromUser(*personal),
+		personal:          true,
+	}, nil
+}
+
+// loadVisibleLibraryCollection fetches a library collection and applies the
+// compat visibility rules, returning (nil, nil) when it does not exist or the
+// session may not see it.
+func (h *ItemsHandler) loadVisibleLibraryCollection(ctx context.Context, session *Session, collectionID string) (*models.LibraryCollection, error) {
 	if h.collections == nil {
 		return nil, nil
 	}
@@ -185,15 +285,17 @@ func (h *ItemsHandler) loadVisibleCollection(ctx context.Context, session *Sessi
 	return collection, nil
 }
 
-// boxSetFromCollection maps a library collection to a Jellyfin BoxSet DTO.
-// Image tags are signed from the stable artwork key (like library views) so
-// they survive restarts and presign rotation; the in-memory image cache is
-// seeded as the warm path.
-func (h *ItemsHandler) boxSetFromCollection(ctx context.Context, c *models.LibraryCollection) baseItemDTO {
-	routeID := h.codec.EncodeStringID(EncodedIDCollection, c.ID)
+func (h *ItemsHandler) boxSetFromCompatCollection(ctx context.Context, c *compatCollection) baseItemDTO {
+	kind := EncodedIDCollection
+	if c.personal {
+		kind = EncodedIDUserCollection
+	}
+	routeID := h.codec.EncodeStringID(kind, c.ID)
 	imgTags := map[string]string{}
 	if posterURL := h.presignCollectionPoster(ctx, c.PosterURL); posterURL != "" {
-		if h.images != nil {
+		// Personal artwork resolves durably; never expose its untrusted URLs
+		// through the global legacy-tag cache, which bypasses that resolver.
+		if h.images != nil && !c.personal {
 			h.images.RememberSized(routeID, "Primary", posterURL, compatCardImageSize)
 		}
 		imgTags["Primary"] = h.mapper.imageTagSigner.Tag(
@@ -228,7 +330,7 @@ func (h *ItemsHandler) boxSetFromCollection(ctx context.Context, c *models.Libra
 		},
 	}
 	if backdropURL := h.presignCollectionPoster(ctx, c.BackdropURL); backdropURL != "" {
-		if h.images != nil {
+		if h.images != nil && !c.personal {
 			h.images.RememberSized(routeID, "Backdrop", backdropURL, compatCardImageSize)
 		}
 		dto.BackdropImageTags = []string{h.mapper.imageTagSigner.Tag(
@@ -268,20 +370,31 @@ func (h *ItemsHandler) presignCollectionPoster(ctx context.Context, path string)
 
 // boxSetsByIDs maps the given collection IDs to BoxSet DTOs, skipping any the
 // session may not see. Used by /Items?Ids= re-hydration.
-func (h *ItemsHandler) boxSetsByIDs(ctx context.Context, session *Session, collectionIDs []string) ([]baseItemDTO, error) {
-	if len(collectionIDs) == 0 || h.collections == nil {
+func (h *ItemsHandler) boxSetsByIDs(ctx context.Context, session *Session, collectionIDs, personalCollectionIDs []string) ([]baseItemDTO, error) {
+	if len(collectionIDs) == 0 && len(personalCollectionIDs) == 0 {
 		return nil, nil
 	}
-	items := make([]baseItemDTO, 0, len(collectionIDs))
+	type collectionRef struct {
+		id       string
+		personal bool
+	}
+	refs := make([]collectionRef, 0, len(collectionIDs)+len(personalCollectionIDs))
 	for _, id := range collectionIDs {
-		collection, err := h.loadVisibleCollection(ctx, session, id)
+		refs = append(refs, collectionRef{id: id})
+	}
+	for _, id := range personalCollectionIDs {
+		refs = append(refs, collectionRef{id: id, personal: true})
+	}
+	items := make([]baseItemDTO, 0, len(refs))
+	for _, ref := range refs {
+		collection, err := h.loadVisibleCollection(ctx, session, ref.id, ref.personal)
 		if err != nil {
 			return nil, err
 		}
 		if collection == nil {
 			continue
 		}
-		items = append(items, h.boxSetFromCollection(ctx, collection))
+		items = append(items, h.boxSetFromCompatCollection(ctx, collection))
 	}
 	return items, nil
 }
@@ -291,7 +404,7 @@ func (h *ItemsHandler) boxSetsByIDs(ctx context.Context, session *Session, colle
 // Filtering, sorting, and paging happen on the lightweight collection rows;
 // DTOs (with artwork presigning) are built only for the returned page.
 func (h *ItemsHandler) handleBoxSetsList(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
-	if h.collections == nil {
+	if h.collections == nil && h.userCollections == nil {
 		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
 		return
 	}
@@ -319,27 +432,49 @@ func (h *ItemsHandler) handleBoxSetsList(w http.ResponseWriter, r *http.Request,
 		libFilter = &query.parentLibraryID
 	}
 
-	collections, err := h.collections.ListAll(r.Context(), libFilter, catalog.ListLibraryCollectionsOptions{})
-	if err != nil {
-		writeCompatUpstreamError(w, err)
-		return
+	var collections []*models.LibraryCollection
+	if h.collections != nil {
+		var err error
+		collections, err = h.collections.ListAll(r.Context(), libFilter, catalog.ListLibraryCollectionsOptions{})
+		if err != nil {
+			writeCompatUpstreamError(w, err)
+			return
+		}
 	}
 
 	searchTerm := strings.ToLower(strings.TrimSpace(query.searchTerm))
 	namePrefix := strings.ToLower(query.namePrefix)
-	matched := make([]*models.LibraryCollection, 0, len(collections))
+	matched := make([]*compatCollection, 0, len(collections))
 	for _, c := range collections {
 		if !collectionVisible(c, visible) {
 			continue
 		}
-		title := strings.ToLower(c.Title)
-		if searchTerm != "" && !strings.Contains(title, searchTerm) {
+		if !collectionTitleMatches(c.Title, searchTerm, namePrefix) {
 			continue
 		}
-		if namePrefix != "" && !strings.HasPrefix(title, namePrefix) {
-			continue
+		matched = append(matched, &compatCollection{LibraryCollection: c})
+	}
+
+	// The session owner's own opted-in personal collections list alongside the
+	// server's. They carry no library binding, so collectionVisible does not
+	// apply — the store scoped them to this user, this profile and (when the
+	// request names one) this library.
+	if h.userCollections != nil {
+		visibleIDs := libraryIDSlice(visible)
+		if libFilter != nil {
+			visibleIDs = []int{*libFilter}
 		}
-		matched = append(matched, c)
+		personal, err := h.userCollections.List(r.Context(), session.StreamAppUserID, session.ProfileID, visibleIDs)
+		if err != nil {
+			writeCompatUpstreamError(w, err)
+			return
+		}
+		for _, c := range personal {
+			if !collectionTitleMatches(c.Name, searchTerm, namePrefix) {
+				continue
+			}
+			matched = append(matched, &compatCollection{LibraryCollection: libraryCollectionFromUser(c), personal: true})
+		}
 	}
 
 	if query.sort == "sort_title" {
@@ -363,13 +498,23 @@ func (h *ItemsHandler) handleBoxSetsList(w http.ResponseWriter, r *http.Request,
 	page := slicePage(matched, query.startIndex, pageLimit)
 	items := make([]baseItemDTO, 0, len(page))
 	for _, c := range page {
-		items = append(items, h.boxSetFromCollection(r.Context(), c))
+		items = append(items, h.boxSetFromCompatCollection(r.Context(), c))
 	}
 	writeJSON(w, http.StatusOK, queryResultDTO{
 		Items:            items,
 		TotalRecordCount: len(matched),
 		StartIndex:       query.startIndex,
 	})
+}
+
+// collectionTitleMatches applies the BoxSet listing's search-term and
+// name-prefix filters. Both filters are expected pre-lowercased.
+func collectionTitleMatches(title, searchTerm, namePrefix string) bool {
+	title = strings.ToLower(title)
+	if searchTerm != "" && !strings.Contains(title, searchTerm) {
+		return false
+	}
+	return namePrefix == "" || strings.HasPrefix(title, namePrefix)
 }
 
 // slicePage returns the [startIndex, startIndex+limit) window of items;
@@ -389,8 +534,8 @@ func slicePage[T any](items []T, startIndex, limit int) []T {
 }
 
 // handleBoxSetItem serves GET /Items/{id} when the ID decodes as a collection.
-func (h *ItemsHandler) handleBoxSetItem(w http.ResponseWriter, r *http.Request, session *Session, collectionID string) {
-	collection, err := h.loadVisibleCollection(r.Context(), session, collectionID)
+func (h *ItemsHandler) handleBoxSetItem(w http.ResponseWriter, r *http.Request, session *Session, collectionID string, personalRoute bool) {
+	collection, err := h.loadVisibleCollection(r.Context(), session, collectionID, personalRoute)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
@@ -399,7 +544,7 @@ func (h *ItemsHandler) handleBoxSetItem(w http.ResponseWriter, r *http.Request, 
 		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
 		return
 	}
-	writeJSON(w, http.StatusOK, h.boxSetFromCollection(r.Context(), collection))
+	writeJSON(w, http.StatusOK, h.boxSetFromCompatCollection(r.Context(), collection))
 }
 
 // handleBoxSetChildren serves GET /Items?ParentId={boxsetId} by hydrating the
@@ -407,13 +552,30 @@ func (h *ItemsHandler) handleBoxSetItem(w http.ResponseWriter, r *http.Request, 
 // position order is preserved; an explicit SortBy delegates ordering and
 // paging to the catalog browse path.
 func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery) {
-	collection, err := h.loadVisibleCollection(r.Context(), session, query.parentCollectionID)
+	personalRoute := query.parentPersonalCollectionID != ""
+	collectionID := query.parentCollectionID
+	if personalRoute {
+		collectionID = query.parentPersonalCollectionID
+	}
+	collection, err := h.loadVisibleCollection(r.Context(), session, collectionID, personalRoute)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return
 	}
 	if collection == nil {
 		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+		return
+	}
+	// Personal collections resolve entirely through the catalog resolver, which
+	// already owns their membership, display filter, sorting and paging. Without
+	// it they have no members to serve, the same way a nil collections source
+	// yields no library collections.
+	if collection.personal {
+		if h.collectionResolver == nil {
+			writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+			return
+		}
+		h.handlePersonalBoxSetChildren(w, r, session, query, collection)
 		return
 	}
 
@@ -428,7 +590,7 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 	if catalog.IsLiveQueryType(collection.CollectionType) && !query.sortExplicit {
 		routeID := h.codec.EncodeStringID(EncodedIDCollection, collection.ID)
 		pageIDs, total, ok, pageErr := h.smartCollectionContentIDPage(
-			r.Context(), session, collection, query.startIndex, query.limit)
+			r.Context(), session, collection.LibraryCollection, query.startIndex, query.limit)
 		if pageErr != nil {
 			writeCompatUpstreamError(w, pageErr)
 			return
@@ -464,10 +626,11 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 	// time and store no rows in library_collection_items, so ListItems returns
 	// nothing for them — that previously left smart-collection BoxSets showing a
 	// non-zero ChildCount but no browsable children. Resolve them via the query
-	// executor; stored collections keep the materialized ListItems path.
+	// executor; stored collections keep the materialized ListItems path, from
+	// user_personal_collection_items when the collection is the session owner's.
 	var contentIDs []string
 	if catalog.IsLiveQueryType(collection.CollectionType) {
-		contentIDs, err = h.smartCollectionContentIDs(r.Context(), session, collection)
+		contentIDs, err = h.smartCollectionContentIDs(r.Context(), session, collection.LibraryCollection)
 		if err != nil {
 			writeCompatUpstreamError(w, err)
 			return
@@ -520,6 +683,95 @@ func (h *ItemsHandler) handleBoxSetChildren(w http.ResponseWriter, r *http.Reque
 	}
 	page := slicePage(ordered, query.startIndex, query.limit)
 	h.writeCollectionItemsPage(w, r, session, query, routeID, page, len(ordered))
+}
+
+//nolint:goconst // Keep Jellyfin sort and filter vocabulary beside its protocol translation.
+func (h *ItemsHandler) handlePersonalBoxSetChildren(w http.ResponseWriter, r *http.Request, session *Session, query itemsQuery, collection *compatCollection) {
+	if (query.hasItemTypeFilter && len(query.itemTypes) == 0) ||
+		(query.mediaTypesExplicit && !query.mediaTypesSet["video"]) {
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+		return
+	}
+	def := catalog.QueryDefinition{}
+	randomize := false
+	if query.sortExplicit {
+		sortField := query.sort
+		switch sortField {
+		case "sort_title":
+			sortField = "title"
+		case "created_at":
+			sortField = "added_at"
+		case "random":
+			randomize = true
+		}
+		if !randomize {
+			resolved, ok := catalog.NormalizeCollectionSort(sortField, query.order, true)
+			if !ok {
+				writeError(w, http.StatusBadRequest, "BadRequest", "Unsupported collection sort")
+				return
+			}
+			def.Sort = resolved
+		}
+	}
+	itemTypes := query.itemTypes
+	if !query.hasItemTypeFilter {
+		itemTypes = compatVideoTypeList
+	}
+	// Use exact type rules: the catalog's episode scope can expand collections
+	// or fall back to their top-level members instead of filtering them.
+	typeRules := make([]catalog.QueryRule, 0, len(itemTypes))
+	for _, itemType := range itemTypes {
+		if slices.Contains(compatVideoTypeList, itemType) {
+			typeRules = append(typeRules, catalog.QueryRule{Field: "type", Op: "is", Value: itemType})
+		}
+	}
+	if len(typeRules) == 0 {
+		writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+		return
+	}
+	def.Groups = append(def.Groups, catalog.QueryGroup{Match: "any", Rules: typeRules})
+	var rules []catalog.QueryRule
+	if query.genreName != "" {
+		rules = append(rules, catalog.QueryRule{Field: "genre", Op: "contains", Value: query.genreName})
+	}
+	if query.isPlayed != nil {
+		rules = append(rules, catalog.QueryRule{Field: "watched", Op: "is", Value: *query.isPlayed})
+	}
+	if query.isFavorite {
+		rules = append(rules, catalog.QueryRule{Field: "favorited", Op: "is", Value: true})
+	}
+	if query.isResumable {
+		rules = append(rules, catalog.QueryRule{Field: "in_progress", Op: "is", Value: true})
+	}
+	if len(rules) > 0 {
+		def.Groups = append(def.Groups, catalog.QueryGroup{Match: "all", Rules: rules})
+	}
+	access := h.resolveAccessFilter(r.Context(), session)
+	access.MaxContentRating = clampMaxContentRating(access.MaxContentRating, query.maxOfficialRating)
+	result, err := h.collectionResolver.Resolve(r.Context(), catalog.CatalogRequest{
+		Source:          catalog.CatalogSourceUserCollection,
+		CollectionID:    collection.ID,
+		PersonID:        query.personID,
+		NamePrefix:      query.namePrefix,
+		SearchQuery:     query.searchTerm,
+		Query:           def,
+		Limit:           query.limit,
+		Offset:          query.startIndex,
+		UseSourceOrder:  !query.sortExplicit || randomize,
+		RequireBackdrop: query.requireBackdrop,
+		Randomize:       randomize,
+	}, access)
+	if err != nil {
+		if errors.Is(err, catalog.ErrCatalogSourceNotFound) {
+			writeJSON(w, http.StatusOK, emptyQueryResult(query.startIndex))
+			return
+		}
+		writeCompatUpstreamError(w, err)
+		return
+	}
+	listItems := h.compatListItemsFromModels(r.Context(), access, result.Items)
+	routeID := h.codec.EncodeStringID(EncodedIDUserCollection, collection.ID)
+	h.writeCollectionItemsPage(w, r, session, query, routeID, listItems, result.Total)
 }
 
 // writeCollectionItemsPage hydrates user state for one page of collection

--- a/internal/jellycompat/handlers_collections.go
+++ b/internal/jellycompat/handlers_collections.go
@@ -35,9 +35,9 @@ type collectionSource interface {
 // is used only behind a signed image capability check.
 type userCollectionSource interface {
 	List(ctx context.Context, userID int, profileID string, visibleLibraryIDs []int) ([]usercollections.ServerVisibleCollection, error)
-	Get(ctx context.Context, userID int, profileID, id string, visibleLibraryIDs []int) (*usercollections.ServerVisibleCollection, error)
+	Get(ctx context.Context, userID int, profileID, key string, visibleLibraryIDs []int) (*usercollections.ServerVisibleCollection, error)
 	AnyVisible(ctx context.Context, userID int, profileID string, visibleLibraryIDs []int) (bool, error)
-	ImageCandidates(ctx context.Context, id string) ([]usercollections.ServerVisibleCollection, error)
+	ImageCandidates(ctx context.Context, key string) ([]usercollections.ServerVisibleCollection, error)
 }
 
 // compatCollection is one collection on the BoxSet surface. Personal

--- a/internal/jellycompat/handlers_collections_test.go
+++ b/internal/jellycompat/handlers_collections_test.go
@@ -146,10 +146,14 @@ func collectionsTestSession() *Session {
 	return &Session{StreamAppUserID: 1, ProfileID: "profile-1"}
 }
 
-func performItemsRequest(t *testing.T, h *ItemsHandler, target string) queryResultDTO {
+func performItemsRequest(t *testing.T, h *ItemsHandler, target string, sessions ...*Session) queryResultDTO {
 	t.Helper()
+	session := collectionsTestSession()
+	if len(sessions) > 0 {
+		session = sessions[0]
+	}
 	req := httptest.NewRequest("GET", target, nil)
-	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, collectionsTestSession()))
+	req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, session))
 	rec := httptest.NewRecorder()
 	h.HandleItems(rec, req)
 	if rec.Code != 200 {

--- a/internal/jellycompat/handlers_images.go
+++ b/internal/jellycompat/handlers_images.go
@@ -12,9 +12,13 @@ import (
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/artworkkey"
+	"github.com/Silo-Server/silo-server/internal/branding"
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/imagecache"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
+
+var personalCollectionImageClient = imagecache.NewPublicHTTPClient()
 
 // ImagesHandler serves Jellyfin-compatible image routes.
 type ImagesHandler struct {
@@ -36,6 +40,9 @@ type ImagesHandler struct {
 	// collections is optional; when set, BoxSet (library collection) artwork
 	// resolves durably instead of depending on the in-memory image cache.
 	collections collectionSource
+	// userCollections is optional; when set, personal-collection BoxSets resolve
+	// their artwork too, for their owner only.
+	userCollections userCollectionSource
 	// frontendFS is optional; when set, app-relative artwork references (bundled
 	// collection-template posters like "/images/collection-templates/x.jpg") are
 	// served straight from the embedded frontend assets. Without it those paths
@@ -117,7 +124,11 @@ func (h *ImagesHandler) HandleItemImage(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if collectionID, err := h.codec.DecodeStringID(EncodedIDCollection, routeID); err == nil {
-		h.serveCollectionImage(w, r, routeID, imageType, tag, collectionID)
+		h.serveCollectionImage(w, r, h.codec.EncodeStringID(EncodedIDCollection, collectionID), imageType, tag, collectionID, false)
+		return
+	}
+	if collectionID, err := h.codec.DecodeStringID(EncodedIDUserCollection, routeID); err == nil {
+		h.serveCollectionImage(w, r, h.codec.EncodeStringID(EncodedIDUserCollection, collectionID), imageType, tag, collectionID, true)
 		return
 	}
 
@@ -361,21 +372,13 @@ func collectionImageTagSeed(routeID, imageType string, c *models.LibraryCollecti
 // via an authenticated session whose libraries include the collection. Stored
 // artwork is presigned/served as before; collections without a usable poster
 // fall back to a generated gradient poster captioned with the title.
-func (h *ImagesHandler) serveCollectionImage(w http.ResponseWriter, r *http.Request, routeID, imageType, tag, collectionID string) {
-	if h.collections == nil {
-		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
-		return
-	}
-	collection, err := h.collections.GetByID(r.Context(), collectionID)
+func (h *ImagesHandler) serveCollectionImage(w http.ResponseWriter, r *http.Request, routeID, imageType, tag, collectionID string, personalRoute bool) {
+	collection, personal, err := h.loadImageCollection(r, routeID, imageType, tag, collectionID, personalRoute)
 	if err != nil {
-		if errors.Is(err, catalog.ErrLibraryCollectionNotFound) {
-			writeError(w, http.StatusNotFound, "NotFound", "Item not found")
-			return
-		}
 		writeCompatUpstreamError(w, err)
 		return
 	}
-	if collection == nil || !strings.EqualFold(collection.Visibility, "visible") {
+	if collection == nil {
 		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
 		return
 	}
@@ -386,7 +389,10 @@ func (h *ImagesHandler) serveCollectionImage(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	authorized := tag != "" && h.imageTags != nil && h.imageTags.Equal(seed, "", tag)
+	// Personal collections resolve only through their owner session or a valid
+	// signed capability; library collections still need their library visibility
+	// checked when no signed tag authorizes the fetch.
+	authorized := personal || (tag != "" && h.imageTags != nil && h.imageTags.Equal(seed, "", tag))
 	if !authorized {
 		ok, err := h.collectionVisibleToRequest(r, collection)
 		if err != nil {
@@ -399,7 +405,15 @@ func (h *ImagesHandler) serveCollectionImage(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	if key := collectionArtworkKey(collection, imageType); key != "" {
+	if key := strings.TrimSpace(collectionArtworkKey(collection, imageType)); key != "" {
+		if _, err := parseRemoteImageURL(key); personal && err == nil {
+			// Personal poster URLs are user-controlled. Only object-store keys
+			// presigned below may use the trusted (possibly private) image client.
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Content-Security-Policy", branding.AssetContentSecurityPolicy)
+			h.proxyImageURL(w, r, key, personalCollectionImageClient)
+			return
+		}
 		if imageURL := h.presignCollectionArtwork(r.Context(), key); imageURL != "" {
 			h.serveImageURL(w, r, imageURL)
 			return
@@ -413,16 +427,73 @@ func (h *ImagesHandler) serveCollectionImage(w http.ResponseWriter, r *http.Requ
 	h.serveGeneratedPoster(w, collection.Title)
 }
 
-// collectionVisibleToRequest reports whether the request's session may see the
-// collection. A missing session resolves to not-visible (anonymous image GETs
-// without a valid tag get a clean 404).
-func (h *ImagesHandler) collectionVisibleToRequest(r *http.Request, collection *models.LibraryCollection) (bool, error) {
+// loadImageCollection resolves a BoxSet route ID for artwork: a library
+// collection, or — when the request's session owns it — one of that user's
+// personal collections. personal reports which of the two it found, since only
+// library collections need a further visibility check. Returns (nil, false, nil)
+// when neither is visible to the request.
+func (h *ImagesHandler) loadImageCollection(r *http.Request, routeID, imageType, tag, collectionID string, personalRoute bool) (*models.LibraryCollection, bool, error) {
+	if !personalRoute && h.collections != nil {
+		collection, err := h.collections.GetByID(r.Context(), collectionID)
+		if err != nil && !errors.Is(err, catalog.ErrLibraryCollectionNotFound) {
+			return nil, false, err
+		}
+		if collection != nil && strings.EqualFold(collection.Visibility, "visible") {
+			return collection, false, nil
+		}
+	}
+
+	if !personalRoute || h.userCollections == nil {
+		return nil, false, nil
+	}
+	session := h.requestSession(r)
+	if session != nil {
+		visible, err := visibleLibraryIDSet(r.Context(), h.content, session)
+		if err != nil {
+			return nil, false, err
+		}
+		personal, err := h.userCollections.Get(r.Context(), session.StreamAppUserID, session.ProfileID, collectionID, libraryIDSlice(visible))
+		if err != nil {
+			return nil, false, err
+		}
+		if personal != nil {
+			return libraryCollectionFromUser(*personal), true, nil
+		}
+	}
+	if tag == "" || h.imageTags == nil {
+		return nil, false, nil
+	}
+	candidates, err := h.userCollections.ImageCandidates(r.Context(), collectionID)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, candidate := range candidates {
+		collection := libraryCollectionFromUser(candidate)
+		seed, served := collectionImageTagSeed(routeID, imageType, collection)
+		if served && h.imageTags.Equal(seed, "", tag) {
+			return collection, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// requestSession resolves the request's session, falling back to the bearer
+// token so anonymous-looking image GETs still resolve their caller.
+func (h *ImagesHandler) requestSession(r *http.Request) *Session {
 	session := SessionFromContext(r.Context())
 	if session == nil && h.sessions != nil {
 		if token, ok := ExtractToken(r); ok {
 			session, _ = h.sessions.Get(token)
 		}
 	}
+	return session
+}
+
+// collectionVisibleToRequest reports whether the request's session may see the
+// collection. A missing session resolves to not-visible (anonymous image GETs
+// without a valid tag get a clean 404).
+func (h *ImagesHandler) collectionVisibleToRequest(r *http.Request, collection *models.LibraryCollection) (bool, error) {
+	session := h.requestSession(r)
 	if session == nil {
 		return false, nil
 	}
@@ -635,7 +706,7 @@ func (h *ImagesHandler) serveImageURL(w http.ResponseWriter, r *http.Request, im
 		return
 	}
 	if shouldProxyCompatImageRequest(r) {
-		h.proxyImageURL(w, r, imageURL)
+		h.proxyImageURL(w, r, imageURL, h.httpClient)
 		return
 	}
 	h.redirectImageURL(w, r, imageURL)
@@ -682,7 +753,7 @@ func (h *ImagesHandler) redirectImageURL(w http.ResponseWriter, r *http.Request,
 	http.Redirect(w, r, imageURL, http.StatusFound)
 }
 
-func (h *ImagesHandler) proxyImageURL(w http.ResponseWriter, r *http.Request, imageURL string) {
+func (h *ImagesHandler) proxyImageURL(w http.ResponseWriter, r *http.Request, imageURL string, client *http.Client) {
 	target, err := parseRemoteImageURL(imageURL)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "UpstreamError", "Failed to load image")
@@ -696,7 +767,6 @@ func (h *ImagesHandler) proxyImageURL(w http.ResponseWriter, r *http.Request, im
 	}
 	copyConditionalImageRequestHeaders(req.Header, r.Header)
 
-	client := h.httpClient
 	if client == nil {
 		client = http.DefaultClient
 	}

--- a/internal/jellycompat/handlers_images.go
+++ b/internal/jellycompat/handlers_images.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/Silo-Server/silo-server/internal/artworkkey"
 	"github.com/Silo-Server/silo-server/internal/branding"
 	"github.com/Silo-Server/silo-server/internal/catalog"
@@ -128,7 +130,10 @@ func (h *ImagesHandler) HandleItemImage(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	if collectionID, err := h.codec.DecodeStringID(EncodedIDUserCollection, routeID); err == nil {
-		h.serveCollectionImage(w, r, h.codec.EncodeStringID(EncodedIDUserCollection, collectionID), imageType, tag, collectionID, true)
+		// DecodeStringID validated the UUID and returned a lookup key, not the
+		// native ID. Canonicalize the original route for the signed image tag.
+		canonicalID, _ := uuid.Parse(routeID)
+		h.serveCollectionImage(w, r, canonicalID.String(), imageType, tag, collectionID, true)
 		return
 	}
 

--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -49,6 +49,12 @@ type ItemsHandler struct {
 	// collections is optional; when set, library collections are exposed as
 	// Jellyfin BoxSets. posterPresigner/presignTTL resolve their artwork keys.
 	collections collectionSource
+	// userCollections is optional; when set, the session owner's own personal
+	// collections that opted into server collections are exposed as BoxSets too.
+	userCollections userCollectionSource
+	// collectionResolver keeps personal BoxSet membership, display filtering and
+	// saved/default sorting identical to the native catalog surface.
+	collectionResolver personalCollectionCatalogResolver
 	// queryExecutor is optional; when set, smart (live-query) collections
 	// resolve their BoxSet children at read time instead of from stored items.
 	queryExecutor   smartCollectionQueryExecutor
@@ -129,7 +135,7 @@ func (h *ItemsHandler) userViews(ctx context.Context, session *Session) ([]baseI
 	}
 
 	items := make([]baseItemDTO, 0, len(libraries)+1)
-	if h.collectionsViewVisible(ctx, libraries) {
+	if h.collectionsViewVisible(ctx, session, libraries) {
 		items = append(items, h.collectionsView())
 	}
 	for _, library := range libraries {
@@ -174,9 +180,9 @@ func (h *ItemsHandler) HandleItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch {
-	case len(query.specificIDs) > 0 || len(query.specificCollectionIDs) > 0 || idsRequestCollectionsView(r):
+	case len(query.specificIDs) > 0 || len(query.specificCollectionIDs) > 0 || len(query.specificPersonalCollectionIDs) > 0 || idsRequestCollectionsView(r):
 		h.handleSpecificItems(w, r, session, query)
-	case query.parentCollectionID != "":
+	case query.parentCollectionID != "" || query.parentPersonalCollectionID != "":
 		h.handleBoxSetChildren(w, r, session, query)
 	case query.hasItemTypeFilter && len(query.itemTypes) == 0:
 		// Every requested type is one catalog browse cannot serve. BoxSet has
@@ -322,10 +328,9 @@ func (h *ItemsHandler) HandleItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if collectionID, err := h.codec.DecodeStringID(EncodedIDCollection, rawID); err == nil {
-		h.handleBoxSetItem(w, r, session, collectionID)
+		h.handleBoxSetItem(w, r, session, collectionID, false)
 		return
 	}
-
 	if mediaSourceID, err := h.codec.DecodeIntID(EncodedIDMediaSource, rawID); err == nil {
 		contentID, ok := h.codec.LookupMediaSourceOwner(mediaSourceID)
 		if !ok {
@@ -342,6 +347,10 @@ func (h *ItemsHandler) HandleItem(w http.ResponseWriter, r *http.Request) {
 
 	contentID, err := decodeContentID(h.codec, rawID)
 	if err != nil {
+		if collectionID, collectionErr := h.codec.DecodeStringID(EncodedIDUserCollection, rawID); collectionErr == nil {
+			h.handleBoxSetItem(w, r, session, collectionID, true)
+			return
+		}
 		writeError(w, http.StatusNotFound, "NotFound", "Item not found")
 		return
 	}
@@ -2449,7 +2458,7 @@ func (h *ItemsHandler) handleSpecificItems(w http.ResponseWriter, r *http.Reques
 
 	// Ids= may also reference collections (BoxSet route IDs handed out by the
 	// collections listing); append their DTOs so clients can re-hydrate them.
-	boxSets, err := h.boxSetsByIDs(r.Context(), session, query.specificCollectionIDs)
+	boxSets, err := h.boxSetsByIDs(r.Context(), session, query.specificCollectionIDs, query.specificPersonalCollectionIDs)
 	if err != nil {
 		writeCompatUpstreamError(w, err)
 		return

--- a/internal/jellycompat/idcodec.go
+++ b/internal/jellycompat/idcodec.go
@@ -15,28 +15,30 @@ import (
 type EncodedIDType byte
 
 const (
-	EncodedIDLibrary     EncodedIDType = 1
-	EncodedIDItem        EncodedIDType = 2
-	EncodedIDMediaSource EncodedIDType = 3
-	EncodedIDSeason      EncodedIDType = 4
-	EncodedIDPlaySession EncodedIDType = 5
-	EncodedIDGenre       EncodedIDType = 6
-	EncodedIDStudio      EncodedIDType = 7
-	EncodedIDPerson      EncodedIDType = 8
-	EncodedIDImageProxy  EncodedIDType = 9
-	EncodedIDCollection  EncodedIDType = 10
+	EncodedIDLibrary        EncodedIDType = 1
+	EncodedIDItem           EncodedIDType = 2
+	EncodedIDMediaSource    EncodedIDType = 3
+	EncodedIDSeason         EncodedIDType = 4
+	EncodedIDPlaySession    EncodedIDType = 5
+	EncodedIDGenre          EncodedIDType = 6
+	EncodedIDStudio         EncodedIDType = 7
+	EncodedIDPerson         EncodedIDType = 8
+	EncodedIDImageProxy     EncodedIDType = 9
+	EncodedIDCollection     EncodedIDType = 10
+	EncodedIDUserCollection EncodedIDType = 11
 )
 
 var (
 	pseudoUserNamespace = uuid.MustParse("3dfcc388-bf95-5572-bc16-7f1a375992dd")
 	stringIDNamespaces  = map[EncodedIDType]uuid.UUID{
-		EncodedIDItem:        uuid.MustParse("0b6716ca-1f61-5987-b17b-f592f04fd6b3"),
-		EncodedIDSeason:      uuid.MustParse("29831b2b-dad5-5a85-b506-4d1fb2da01ed"),
-		EncodedIDPlaySession: uuid.MustParse("75a69ca8-f95f-5e9d-ac0a-d34a37b93eb4"),
-		EncodedIDGenre:       uuid.MustParse("c0cbb8ea-8331-52c0-b160-15e7cf899fb0"),
-		EncodedIDStudio:      uuid.MustParse("23712982-b769-592d-9360-b4d3f39654db"),
-		EncodedIDPerson:      uuid.MustParse("a4e7c1d6-3b8f-5a2e-9c01-7d6f4e8b2a13"),
-		EncodedIDCollection:  uuid.MustParse("7f3c2a91-5b64-5c1d-8e07-9a2f4d6b1c35"),
+		EncodedIDItem:           uuid.MustParse("0b6716ca-1f61-5987-b17b-f592f04fd6b3"),
+		EncodedIDSeason:         uuid.MustParse("29831b2b-dad5-5a85-b506-4d1fb2da01ed"),
+		EncodedIDPlaySession:    uuid.MustParse("75a69ca8-f95f-5e9d-ac0a-d34a37b93eb4"),
+		EncodedIDGenre:          uuid.MustParse("c0cbb8ea-8331-52c0-b160-15e7cf899fb0"),
+		EncodedIDStudio:         uuid.MustParse("23712982-b769-592d-9360-b4d3f39654db"),
+		EncodedIDPerson:         uuid.MustParse("a4e7c1d6-3b8f-5a2e-9c01-7d6f4e8b2a13"),
+		EncodedIDCollection:     uuid.MustParse("7f3c2a91-5b64-5c1d-8e07-9a2f4d6b1c35"),
+		EncodedIDUserCollection: uuid.MustParse("92825e52-6e8a-5a5f-93a1-07f48e10e80b"),
 	}
 )
 
@@ -89,6 +91,11 @@ func EncodeNumericID(kind EncodedIDType, value uint64) uuid.UUID {
 // genres and studios, and the rare content_id too large to pack — falls back to
 // a hashed UUID recorded in the reverse map.
 func (c *ResourceIDCodec) EncodeStringID(kind EncodedIDType, value string) string {
+	if kind == EncodedIDUserCollection {
+		if packed, ok := packUserCollectionUUID(value); ok {
+			return packed.String()
+		}
+	}
 	if numeric, err := strconv.ParseUint(value, 10, 64); err == nil {
 		return EncodeNumericID(kind, numeric).String()
 	}
@@ -133,6 +140,11 @@ func (c *ResourceIDCodec) EncodeIntID(kind EncodedIDType, value int64) string {
 // to parse is rejected), then the stateless numeric encoding, then the reverse
 // map for hashed ids.
 func (c *ResourceIDCodec) DecodeStringID(kind EncodedIDType, raw string) (string, error) {
+	if kind == EncodedIDUserCollection {
+		if id, ok := unpackUserCollectionUUID(raw); ok {
+			return id, nil
+		}
+	}
 	if isContentIDKind(kind) {
 		if id, ok := unpackContentIDUUID(kind, raw); ok {
 			return id, nil
@@ -150,6 +162,31 @@ func (c *ResourceIDCodec) DecodeStringID(kind EncodedIDType, raw string) (string
 		return "", fmt.Errorf("unknown compat id %q", raw)
 	}
 	return registered.value, nil
+}
+
+// Personal UUIDv4 IDs use a high first-nibble marker, outside the numeric and
+// packed content ID kinds. Save that nibble in the fixed version bits and clear
+// the variant bits to distinguish hashed UUIDs. No reverse map is needed.
+func packUserCollectionUUID(value string) (uuid.UUID, bool) {
+	id, err := uuid.Parse(value)
+	if err != nil || id.Version() != 4 || id.Variant() != uuid.RFC4122 {
+		return uuid.UUID{}, false
+	}
+	id[6] = id[0]&0xf0 | id[6]&0x0f
+	id[0] = byte(EncodedIDUserCollection)<<4 | id[0]&0x0f
+	id[8] &= 0x3f
+	return id, true
+}
+
+func unpackUserCollectionUUID(raw string) (string, bool) {
+	id, err := uuid.Parse(raw)
+	if err != nil || id[0]>>4 != byte(EncodedIDUserCollection) || id[8]>>6 != 0 {
+		return "", false
+	}
+	id[0] = id[6]&0xf0 | id[0]&0x0f
+	id[6] = 0x40 | id[6]&0x0f
+	id[8] = 0x80 | id[8]&0x3f
+	return id.String(), true
 }
 
 // isContentIDKind reports whether a compat id kind carries a Silo content_id (as
@@ -241,6 +278,11 @@ func DecodeID(raw string) (DecodedID, error) {
 	parsed, err := uuid.Parse(raw)
 	if err != nil {
 		return DecodedID{}, fmt.Errorf("parse uuid: %w", err)
+	}
+	for _, b := range parsed[1:8] {
+		if b != 0 {
+			return DecodedID{}, fmt.Errorf("uuid is not a numeric compat id")
+		}
 	}
 
 	return DecodedID{

--- a/internal/jellycompat/idcodec.go
+++ b/internal/jellycompat/idcodec.go
@@ -1,7 +1,9 @@
 package jellycompat
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"sync"
@@ -31,14 +33,13 @@ const (
 var (
 	pseudoUserNamespace = uuid.MustParse("3dfcc388-bf95-5572-bc16-7f1a375992dd")
 	stringIDNamespaces  = map[EncodedIDType]uuid.UUID{
-		EncodedIDItem:           uuid.MustParse("0b6716ca-1f61-5987-b17b-f592f04fd6b3"),
-		EncodedIDSeason:         uuid.MustParse("29831b2b-dad5-5a85-b506-4d1fb2da01ed"),
-		EncodedIDPlaySession:    uuid.MustParse("75a69ca8-f95f-5e9d-ac0a-d34a37b93eb4"),
-		EncodedIDGenre:          uuid.MustParse("c0cbb8ea-8331-52c0-b160-15e7cf899fb0"),
-		EncodedIDStudio:         uuid.MustParse("23712982-b769-592d-9360-b4d3f39654db"),
-		EncodedIDPerson:         uuid.MustParse("a4e7c1d6-3b8f-5a2e-9c01-7d6f4e8b2a13"),
-		EncodedIDCollection:     uuid.MustParse("7f3c2a91-5b64-5c1d-8e07-9a2f4d6b1c35"),
-		EncodedIDUserCollection: uuid.MustParse("92825e52-6e8a-5a5f-93a1-07f48e10e80b"),
+		EncodedIDItem:        uuid.MustParse("0b6716ca-1f61-5987-b17b-f592f04fd6b3"),
+		EncodedIDSeason:      uuid.MustParse("29831b2b-dad5-5a85-b506-4d1fb2da01ed"),
+		EncodedIDPlaySession: uuid.MustParse("75a69ca8-f95f-5e9d-ac0a-d34a37b93eb4"),
+		EncodedIDGenre:       uuid.MustParse("c0cbb8ea-8331-52c0-b160-15e7cf899fb0"),
+		EncodedIDStudio:      uuid.MustParse("23712982-b769-592d-9360-b4d3f39654db"),
+		EncodedIDPerson:      uuid.MustParse("a4e7c1d6-3b8f-5a2e-9c01-7d6f4e8b2a13"),
+		EncodedIDCollection:  uuid.MustParse("7f3c2a91-5b64-5c1d-8e07-9a2f4d6b1c35"),
 	}
 )
 
@@ -92,9 +93,16 @@ func EncodeNumericID(kind EncodedIDType, value uint64) uuid.UUID {
 // a hashed UUID recorded in the reverse map.
 func (c *ResourceIDCodec) EncodeStringID(kind EncodedIDType, value string) string {
 	if kind == EncodedIDUserCollection {
-		if packed, ok := packUserCollectionUUID(value); ok {
-			return packed.String()
-		}
+		// A typed 112-bit lookup key, like local content IDs. The store resolves
+		// it through an index, including ULIDs/legacy IDs, without a reverse map.
+		// Keep this hash in sync with jellycompat_user_collection_key in SQL.
+		sum := sha256.Sum256([]byte(value))
+		var id uuid.UUID
+		// The marker occupies the variant byte, outside RFC 4122 hashes.
+		id[0], id[8] = byte(kind), 1
+		copy(id[1:8], sum[:7])
+		copy(id[9:], sum[7:14])
+		return id.String()
 	}
 	if numeric, err := strconv.ParseUint(value, 10, 64); err == nil {
 		return EncodeNumericID(kind, numeric).String()
@@ -133,7 +141,8 @@ func (c *ResourceIDCodec) EncodeIntID(kind EncodedIDType, value int64) string {
 	return EncodeNumericID(kind, uint64(value)).String()
 }
 
-// DecodeStringID decodes a compat UUID back to the original native string ID.
+// DecodeStringID decodes a compat UUID to its native ID, or an indexed lookup
+// key for personal collections (whose native IDs may be arbitrary strings).
 //
 // A reversibly packed content_id is decoded first (and re-packed to confirm the
 // UUID genuinely came from the packer, so an opaque id whose bytes merely happen
@@ -141,9 +150,10 @@ func (c *ResourceIDCodec) EncodeIntID(kind EncodedIDType, value int64) string {
 // map for hashed ids.
 func (c *ResourceIDCodec) DecodeStringID(kind EncodedIDType, raw string) (string, error) {
 	if kind == EncodedIDUserCollection {
-		if id, ok := unpackUserCollectionUUID(raw); ok {
-			return id, nil
+		if id, err := uuid.Parse(raw); err == nil && id[0] == byte(kind) && id[8] == 1 {
+			return hex.EncodeToString(id[1:8]) + hex.EncodeToString(id[9:]), nil
 		}
+		return "", fmt.Errorf("unknown personal collection id %q", raw)
 	}
 	if isContentIDKind(kind) {
 		if id, ok := unpackContentIDUUID(kind, raw); ok {
@@ -162,31 +172,6 @@ func (c *ResourceIDCodec) DecodeStringID(kind EncodedIDType, raw string) (string
 		return "", fmt.Errorf("unknown compat id %q", raw)
 	}
 	return registered.value, nil
-}
-
-// Personal UUIDv4 IDs use a high first-nibble marker, outside the numeric and
-// packed content ID kinds. Save that nibble in the fixed version bits and clear
-// the variant bits to distinguish hashed UUIDs. No reverse map is needed.
-func packUserCollectionUUID(value string) (uuid.UUID, bool) {
-	id, err := uuid.Parse(value)
-	if err != nil || id.Version() != 4 || id.Variant() != uuid.RFC4122 {
-		return uuid.UUID{}, false
-	}
-	id[6] = id[0]&0xf0 | id[6]&0x0f
-	id[0] = byte(EncodedIDUserCollection)<<4 | id[0]&0x0f
-	id[8] &= 0x3f
-	return id, true
-}
-
-func unpackUserCollectionUUID(raw string) (string, bool) {
-	id, err := uuid.Parse(raw)
-	if err != nil || id[0]>>4 != byte(EncodedIDUserCollection) || id[8]>>6 != 0 {
-		return "", false
-	}
-	id[0] = id[6]&0xf0 | id[0]&0x0f
-	id[6] = 0x40 | id[6]&0x0f
-	id[8] = 0x80 | id[8]&0x3f
-	return id.String(), true
 }
 
 // isContentIDKind reports whether a compat id kind carries a Silo content_id (as

--- a/internal/jellycompat/idcodec_test.go
+++ b/internal/jellycompat/idcodec_test.go
@@ -1,6 +1,8 @@
 package jellycompat
 
 import (
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/contentid"
@@ -46,6 +48,50 @@ func TestLegacyNumericContentIDRoundTrips(t *testing.T) {
 	got, err := NewResourceIDCodec().DecodeStringID(EncodedIDItem, u)
 	if err != nil || got != legacy {
 		t.Fatalf("legacy numeric round trip = (%q, %v), want (%q, nil)", got, err, legacy)
+	}
+}
+
+func TestUserCollectionIDDecodesWithoutSharedState(t *testing.T) {
+	for _, id := range []string{
+		"731d3da2-4f4b-4a71-8f2f-38e1d34775b0",
+		"02c40000-0000-4000-8000-000000000000",
+		"04c40000-0000-4000-8000-000000000000",
+		"00000000-0000-4000-8000-000000000000",
+		"ffffffff-ffff-4fff-bfff-ffffffffffff",
+	} {
+		t.Run(id, func(t *testing.T) {
+			encoded := NewResourceIDCodec().EncodeStringID(EncodedIDUserCollection, id)
+			if encoded == id {
+				t.Fatal("personal route ID must carry a source marker")
+			}
+			if adminID := NewResourceIDCodec().EncodeStringID(EncodedIDCollection, id); adminID == encoded {
+				t.Fatal("personal and admin collections must have distinct route IDs")
+			}
+			for _, route := range []string{encoded, strings.ReplaceAll(encoded, "-", "")} {
+				codec := NewResourceIDCodec()
+				got, err := codec.DecodeStringID(EncodedIDUserCollection, route)
+				if err != nil || got != id {
+					t.Fatalf("user collection round trip = (%q, %v), want (%q, nil)", got, err, id)
+				}
+				for kind := EncodedIDLibrary; kind < EncodedIDUserCollection; kind++ {
+					if _, err := codec.DecodeStringID(kind, route); err == nil {
+						t.Errorf("personal collection route decoded as kind %d", kind)
+					}
+				}
+				query := parseItemsQuery(httptest.NewRequest("GET", "/Items?ParentId="+route+"&Ids="+route, nil), codec)
+				if query.parentPersonalCollectionID != id || len(query.specificPersonalCollectionIDs) != 1 || query.specificPersonalCollectionIDs[0] != id {
+					t.Errorf("personal route was misclassified: %+v", query)
+				}
+			}
+		})
+	}
+	for _, id := range []string{"movie-tmdb-228064", "local-00000000b0000000000000000000"} {
+		for _, kind := range []EncodedIDType{EncodedIDItem, EncodedIDSeason} {
+			contentRoute := NewResourceIDCodec().EncodeStringID(kind, id)
+			if _, ok := unpackUserCollectionUUID(contentRoute); ok {
+				t.Errorf("content route %q decoded as a personal collection", contentRoute)
+			}
+		}
 	}
 }
 

--- a/internal/jellycompat/idcodec_test.go
+++ b/internal/jellycompat/idcodec_test.go
@@ -1,6 +1,8 @@
 package jellycompat
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -58,20 +60,28 @@ func TestUserCollectionIDDecodesWithoutSharedState(t *testing.T) {
 		"04c40000-0000-4000-8000-000000000000",
 		"00000000-0000-4000-8000-000000000000",
 		"ffffffff-ffff-4fff-bfff-ffffffffffff",
+		"01K3M9K0R7D6Y9T7F1P6W2H8ZX",
+		"731d3da2-4f4b-5a71-8f2f-38e1d34775b0",
+		"00000000000000000000000000",
+		"7ZZZZZZZZZZZZZZZZZZZZZZZZZ",
+		"123",
+		"legacy-collection",
 	} {
 		t.Run(id, func(t *testing.T) {
 			encoded := NewResourceIDCodec().EncodeStringID(EncodedIDUserCollection, id)
+			sum := sha256.Sum256([]byte(id))
+			key := hex.EncodeToString(sum[:14])
 			if encoded == id {
 				t.Fatal("personal route ID must carry a source marker")
 			}
 			if adminID := NewResourceIDCodec().EncodeStringID(EncodedIDCollection, id); adminID == encoded {
 				t.Fatal("personal and admin collections must have distinct route IDs")
 			}
-			for _, route := range []string{encoded, strings.ReplaceAll(encoded, "-", "")} {
+			for _, route := range []string{encoded, strings.ReplaceAll(encoded, "-", ""), strings.ToUpper(encoded)} {
 				codec := NewResourceIDCodec()
 				got, err := codec.DecodeStringID(EncodedIDUserCollection, route)
-				if err != nil || got != id {
-					t.Fatalf("user collection round trip = (%q, %v), want (%q, nil)", got, err, id)
+				if err != nil || got != key {
+					t.Fatalf("user collection lookup key = (%q, %v), want (%q, nil)", got, err, key)
 				}
 				for kind := EncodedIDLibrary; kind < EncodedIDUserCollection; kind++ {
 					if _, err := codec.DecodeStringID(kind, route); err == nil {
@@ -79,7 +89,7 @@ func TestUserCollectionIDDecodesWithoutSharedState(t *testing.T) {
 					}
 				}
 				query := parseItemsQuery(httptest.NewRequest("GET", "/Items?ParentId="+route+"&Ids="+route, nil), codec)
-				if query.parentPersonalCollectionID != id || len(query.specificPersonalCollectionIDs) != 1 || query.specificPersonalCollectionIDs[0] != id {
+				if query.parentPersonalCollectionID != key || len(query.specificPersonalCollectionIDs) != 1 || query.specificPersonalCollectionIDs[0] != key {
 					t.Errorf("personal route was misclassified: %+v", query)
 				}
 			}
@@ -88,9 +98,22 @@ func TestUserCollectionIDDecodesWithoutSharedState(t *testing.T) {
 	for _, id := range []string{"movie-tmdb-228064", "local-00000000b0000000000000000000"} {
 		for _, kind := range []EncodedIDType{EncodedIDItem, EncodedIDSeason} {
 			contentRoute := NewResourceIDCodec().EncodeStringID(kind, id)
-			if _, ok := unpackUserCollectionUUID(contentRoute); ok {
+			if _, err := NewResourceIDCodec().DecodeStringID(EncodedIDUserCollection, contentRoute); err == nil {
 				t.Errorf("content route %q decoded as a personal collection", contentRoute)
 			}
+		}
+	}
+}
+
+func TestUserCollectionIDRejectsHashedUUIDs(t *testing.T) {
+	// Other opaque kinds use RFC 4122 UUIDv5 hashes. Even if their leading
+	// bytes match the personal kind, they must never enter the personal path.
+	for _, raw := range []string{
+		"0b010000-0000-5000-8000-000000000000",
+		"0b010000-0000-5000-bfff-ffffffffffff",
+	} {
+		if _, err := NewResourceIDCodec().DecodeStringID(EncodedIDUserCollection, raw); err == nil {
+			t.Errorf("accepted another kind's hashed UUID %s", raw)
 		}
 	}
 }

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -12,41 +12,43 @@ import (
 )
 
 type itemsQuery struct {
-	limit                  int
-	startIndex             int
-	enableTotalRecordCount bool
-	searchTerm             string
-	namePrefix             string
-	maxOfficialRating      string
-	parentLibraryID        int
-	parentItemID           string
-	parentSeasonID         string
-	parentCollectionID     string
-	specificIDs            []string
-	specificCollectionIDs  []string
-	itemTypes              []string
-	genreName              string
-	isFavorite             bool
-	isResumable            bool
-	hasItemTypeFilter      bool // true when IncludeItemTypes or ExcludeItemTypes was present in the request
-	wantsBoxSets           bool // true when IncludeItemTypes contains BoxSet
-	wantsViews             bool // true when IncludeItemTypes contains CollectionFolder
-	sortExplicit           bool // true when SortBy was present in the request
-	needsDetailFields      bool // true when requested Fields include detail-level data (e.g. MediaSources)
-	itemType               string
-	sort                   string
-	order                  string
-	personID               int64
-	isPlayed               *bool // nil = not specified
-	imageTypeLimit         *int  // nil = not specified
-	requireBackdrop        bool  // true when ImageTypes includes Backdrop (filter, not just a hint)
-	mediaTypes             []string
-	mediaTypesSet          map[string]bool
-	mediaTypesExplicit     bool
-	requestedFields        map[string]bool // parsed from Fields param
-	fieldsExplicit         bool            // true when Fields was in the request
-	startItemID            string          // raw encoded ID from StartItemId param
-	adjacentTo             string          // raw encoded ID from AdjacentTo param
+	limit                         int
+	startIndex                    int
+	enableTotalRecordCount        bool
+	searchTerm                    string
+	namePrefix                    string
+	maxOfficialRating             string
+	parentLibraryID               int
+	parentItemID                  string
+	parentSeasonID                string
+	parentCollectionID            string
+	parentPersonalCollectionID    string
+	specificIDs                   []string
+	specificCollectionIDs         []string
+	specificPersonalCollectionIDs []string
+	itemTypes                     []string
+	genreName                     string
+	isFavorite                    bool
+	isResumable                   bool
+	hasItemTypeFilter             bool // true when IncludeItemTypes or ExcludeItemTypes was present in the request
+	wantsBoxSets                  bool // true when IncludeItemTypes contains BoxSet
+	wantsViews                    bool // true when IncludeItemTypes contains CollectionFolder
+	sortExplicit                  bool // true when SortBy was present in the request
+	needsDetailFields             bool // true when requested Fields include detail-level data (e.g. MediaSources)
+	itemType                      string
+	sort                          string
+	order                         string
+	personID                      int64
+	isPlayed                      *bool // nil = not specified
+	imageTypeLimit                *int  // nil = not specified
+	requireBackdrop               bool  // true when ImageTypes includes Backdrop (filter, not just a hint)
+	mediaTypes                    []string
+	mediaTypesSet                 map[string]bool
+	mediaTypesExplicit            bool
+	requestedFields               map[string]bool // parsed from Fields param
+	fieldsExplicit                bool            // true when Fields was in the request
+	startItemID                   string          // raw encoded ID from StartItemId param
+	adjacentTo                    string          // raw encoded ID from AdjacentTo param
 }
 
 func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
@@ -74,6 +76,8 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 			result.parentSeasonID = seasonID
 		} else if contentID, itemErr := decodeItemID(codec, parentID); itemErr == nil && contentID != "" {
 			result.parentItemID = contentID
+		} else if collectionID, collErr := codec.DecodeStringID(EncodedIDUserCollection, parentID); collErr == nil && collectionID != "" {
+			result.parentPersonalCollectionID = collectionID
 		}
 	}
 
@@ -85,6 +89,8 @@ func parseItemsQuery(r *http.Request, codec *ResourceIDCodec) itemsQuery {
 				result.specificIDs = append(result.specificIDs, decoded)
 			} else if collectionID, collErr := codec.DecodeStringID(EncodedIDCollection, raw); collErr == nil && collectionID != "" {
 				result.specificCollectionIDs = append(result.specificCollectionIDs, collectionID)
+			} else if collectionID, collErr := codec.DecodeStringID(EncodedIDUserCollection, raw); collErr == nil && collectionID != "" {
+				result.specificPersonalCollectionIDs = append(result.specificPersonalCollectionIDs, collectionID)
 			}
 		}
 	}

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/recommendations"
 	"github.com/Silo-Server/silo-server/internal/sections"
 	"github.com/Silo-Server/silo-server/internal/subtitles"
+	"github.com/Silo-Server/silo-server/internal/usercollections"
 )
 
 // NewRouter builds the Jellyfin-compatibility router.
@@ -79,6 +80,15 @@ func NewRouter(deps Dependencies) chi.Router {
 	itemsHandler.recommender = deps.Recommender
 	if deps.DB != nil {
 		itemsHandler.collections = catalog.NewLibraryCollectionRepository(deps.DB)
+		// Personal collections the owner opted into their server collections are
+		// exposed alongside the library ones, scoped to that owner's session.
+		itemsHandler.userCollections = usercollections.NewStore(deps.DB)
+		if deps.BrowseRepo != nil && deps.ItemRepo != nil && deps.UserStoreProvider != nil {
+			itemsHandler.collectionResolver = catalog.NewCatalogResolver(deps.BrowseRepo, deps.ItemRepo).
+				WithUserStoreProvider(deps.UserStoreProvider).
+				WithEpisodeRepository(deps.EpisodeRepo).
+				WithSearchProvider(deps.CatalogSearchProvider)
+		}
 		// Smart (live-query) collections derive membership at read time, so the
 		// BoxSet children path needs a query executor to resolve them.
 		itemsHandler.queryExecutor = &catalog.QueryExecutor{Pool: deps.DB}
@@ -145,6 +155,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	}
 	imagesHandler := NewImagesHandler(deps.ContentService, deps.IDCodec, deps.SessionStore, deps.ImageCache, deps.PersonRepo, deps.DetailSvc, deps.ItemRepo, deps.FolderRepo, deps.SeasonRepo, deps.EpisodeRepo, deps.AccessFilterFn, deps.PosterPresigner, deps.PresignTTL, deps.JWTSecret, deps.HTTPClient)
 	imagesHandler.collections = itemsHandler.collections
+	imagesHandler.userCollections = itemsHandler.userCollections
 	imagesHandler.frontendFS = deps.FrontendFS
 	displayPrefsHandler := NewDisplayPreferencesHandler(deps.UserStoreProvider)
 	recsHandler := NewRecommendationsHandler(deps.Recommender, deps.ItemRepo, deps.DetailSvc, deps.ContentService, deps.UserDataService, deps.IDCodec, deps.Config, deps.AccessFilterFn)

--- a/internal/jellycompat/user_collections_boxset_test.go
+++ b/internal/jellycompat/user_collections_boxset_test.go
@@ -2,11 +2,13 @@ package jellycompat
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -15,7 +17,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 
+	"github.com/Silo-Server/silo-server/internal/audiobooks"
+	"github.com/Silo-Server/silo-server/internal/audiobooks/abs"
 	"github.com/Silo-Server/silo-server/internal/branding"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -78,7 +83,8 @@ func (f *fakeUserCollectionSource) List(_ context.Context, userID int, profileID
 func (f *fakeUserCollectionSource) Get(_ context.Context, userID int, profileID, id string, libraryIDs []int) (*usercollections.ServerVisibleCollection, error) {
 	f.gotUserID, f.gotProfileID = userID, profileID
 	for _, row := range f.rows {
-		if row.ID == id && f.visible(userID, profileID, row) &&
+		sum := sha256.Sum256([]byte(row.ID))
+		if fmt.Sprintf("%x", sum[:14]) == id && f.visible(userID, profileID, row) &&
 			(len(row.libraryIDs) == 0 || slices.ContainsFunc(row.libraryIDs, func(id int) bool { return slices.Contains(libraryIDs, id) })) {
 			found := row.ServerVisibleCollection
 			return &found, nil
@@ -101,7 +107,8 @@ func (f *fakeUserCollectionSource) AnyVisible(_ context.Context, userID int, pro
 func (f *fakeUserCollectionSource) ImageCandidates(_ context.Context, id string) ([]usercollections.ServerVisibleCollection, error) {
 	var out []usercollections.ServerVisibleCollection
 	for _, row := range f.rows {
-		if row.ID == id {
+		sum := sha256.Sum256([]byte(row.ID))
+		if fmt.Sprintf("%x", sum[:14]) == id {
 			out = append(out, row.ServerVisibleCollection)
 		}
 	}
@@ -237,7 +244,7 @@ func TestHandleItem_PersonalCollectionResolvesForOwnerOnly(t *testing.T) {
 
 func requestBoxSetItem(t *testing.T, h *ItemsHandler, collectionID string) *httptest.ResponseRecorder {
 	t.Helper()
-	routeID := h.codec.EncodeStringID(EncodedIDUserCollection, collectionID)
+	routeID := NewResourceIDCodec().EncodeStringID(EncodedIDUserCollection, collectionID)
 	req := httptest.NewRequest("GET", "/Items/"+routeID, nil)
 	ctx := context.WithValue(req.Context(), compatSessionKey, collectionsTestSession())
 	rctx := chi.NewRouteContext()
@@ -291,20 +298,125 @@ func TestHandleItems_PersonalBoxSetChildrenUseCatalogResolver(t *testing.T) {
 }
 
 func TestHandleItems_PersonalBoxSetRouteSurvivesFreshCodec(t *testing.T) {
-	const collectionID = "731d3da2-4f4b-4a71-8f2f-38e1d34775b0"
-	list := ownedUserCollection(collectionID, "Restart Safe")
-	h := newUserCollectionsTestHandler(&fakeCollectionSource{},
-		&fakeUserCollectionSource{rows: []fakeUserCollection{list}},
-		[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
-	h.collectionResolver = &fakePersonalCollectionResolver{result: &catalog.CatalogResult{
-		Items: []*models.MediaItem{{ContentID: "m-1", Type: "movie", Title: "Still Here"}},
-		Total: 1,
-	}}
+	for _, collectionID := range []string{
+		"731d3da2-4f4b-4a71-8f2f-38e1d34775b0",
+		"01K3M9K0R7D6Y9T7F1P6W2H8ZX", // ABS creates ULIDs, including after migration 156.
+		"731d3da2-4f4b-5a71-8f2f-38e1d34775b0",
+		"legacy-collection",
+	} {
+		t.Run(collectionID, func(t *testing.T) {
+			list := ownedUserCollection(collectionID, "Restart Safe")
+			h := newUserCollectionsTestHandler(&fakeCollectionSource{},
+				&fakeUserCollectionSource{rows: []fakeUserCollection{list}},
+				[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+			h.collectionResolver = &fakePersonalCollectionResolver{result: &catalog.CatalogResult{
+				Items: []*models.MediaItem{{ContentID: "m-1", Type: "movie", Title: "Still Here"}},
+				Total: 1,
+			}}
 
-	parentID := NewResourceIDCodec().EncodeStringID(EncodedIDUserCollection, collectionID)
-	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
-	if len(result.Items) != 1 || result.Items[0].Name != "Still Here" {
-		t.Fatalf("fresh codec failed to resolve cached personal route: %+v", result.Items)
+			parentID := NewResourceIDCodec().EncodeStringID(EncodedIDUserCollection, collectionID)
+			result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+			if len(result.Items) != 1 || result.Items[0].Name != "Still Here" {
+				t.Fatalf("fresh codec failed to resolve cached personal route: %+v", result.Items)
+			}
+		})
+	}
+}
+
+func TestPersonalBoxSetABSCollectionSurvivesFreshCodec(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	var userID int
+	if err := pool.QueryRow(ctx, `INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`, "boxset-test-"+uuid.NewString()).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID) })
+	store, err := pgstore.NewPostgresProvider(pool).ForUser(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := &Session{StreamAppUserID: userID, ProfileID: uuid.NewString()}
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: session.ProfileID, Name: "Test profile"}); err != nil {
+		t.Fatal(err)
+	}
+	// Use the current ABS write path, not just a hand-inserted legacy row.
+	id := ulid.Make().String()
+	if err := (&audiobooks.ABSCollectionStore{Pool: pool}).CreateCollection(ctx, abs.Collection{
+		ID: id, UserID: strconv.Itoa(userID), ProfileID: session.ProfileID, Name: "Test collection",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	optIn := true
+	profiles := []string{session.ProfileID}
+	if err := store.UpdateCollection(ctx, userstore.UpdateCollectionInput{
+		ID: id, RequestProfileID: session.ProfileID, IncludeInServerCollections: &optIn, AllowedProfileIDs: &profiles,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	source := usercollections.NewStore(pool)
+	h := newCollectionsTestHandler(&fakeCollectionSource{}, nil, nil)
+	h.userCollections = source
+	h.mapper.imageTagSigner = newImageTagSigner("image-secret")
+	listing := performItemsRequest(t, h, "/Items?IncludeItemTypes=BoxSet", session)
+	if len(listing.Items) != 1 || listing.Items[0].Name != "Test collection" {
+		t.Fatalf("ABS collection not listed: %+v", listing)
+	}
+	routeID, tag := listing.Items[0].ID, listing.Items[0].ImageTags["Primary"]
+	if tag == "" {
+		t.Fatal("listed collection has no signed artwork tag")
+	}
+	resolver := &fakePersonalCollectionResolver{result: &catalog.CatalogResult{
+		Items: []*models.MediaItem{{ContentID: "movie-tmdb-123", Type: "movie", Title: "Test movie"}}, Total: 1,
+	}}
+	h.collectionResolver = resolver
+	for _, raw := range []string{routeID, strings.ReplaceAll(routeID, "-", ""), strings.ToUpper(routeID)} {
+		t.Run(raw, func(t *testing.T) {
+			for _, path := range []string{"/Items?Ids=" + raw, "/Items?ParentId=" + raw} {
+				h.codec = NewResourceIDCodec()
+				result := performItemsRequest(t, h, path, session)
+				if len(result.Items) != 1 {
+					t.Fatalf("cold %s: %+v", path, result)
+				}
+				if strings.Contains(path, "?Ids=") && (result.Items[0].ID != routeID || result.Items[0].Type != "BoxSet") {
+					t.Fatalf("cold Ids resolved the wrong item: %+v", result.Items[0])
+				}
+				if strings.Contains(path, "?ParentId=") && (result.Items[0].Name != "Test movie" || result.Items[0].ParentID != routeID) {
+					t.Fatalf("cold ParentId resolved the wrong children: %+v", result.Items[0])
+				}
+			}
+			if resolver.gotReq.CollectionID != id {
+				t.Fatalf("resolver received %q, want original ULID %q", resolver.gotReq.CollectionID, id)
+			}
+			for _, viewer := range []*Session{session, {StreamAppUserID: userID, ProfileID: "unshared"}, {StreamAppUserID: userID + 10000, ProfileID: session.ProfileID}} {
+				h.codec = NewResourceIDCodec()
+				req := httptest.NewRequest(http.MethodGet, "/Items/"+raw, nil)
+				rctx := chi.NewRouteContext()
+				rctx.URLParams.Add("id", raw)
+				req = req.WithContext(context.WithValue(context.WithValue(req.Context(), compatSessionKey, viewer), chi.RouteCtxKey, rctx))
+				rec := httptest.NewRecorder()
+				h.HandleItem(rec, req)
+				want := http.StatusNotFound
+				if viewer == session {
+					want = http.StatusOK
+				}
+				if rec.Code != want {
+					t.Fatalf("cold detail: status=%d, want=%d, body=%s", rec.Code, want, rec.Body.String())
+				}
+			}
+			for _, imageTag := range []string{tag, "0123456789abcdef", ""} {
+				images := &ImagesHandler{codec: NewResourceIDCodec(), userCollections: source, imageTags: h.mapper.imageTagSigner}
+				req := httptest.NewRequest(http.MethodGet, "/Items/"+raw+"/Images/Primary?tag="+imageTag, nil)
+				rec := httptest.NewRecorder()
+				images.HandleItemImage(rec, withImageRouteParams(req, raw, "Primary"))
+				want := http.StatusNotFound
+				if imageTag == tag {
+					want = http.StatusOK
+				}
+				if rec.Code != want {
+					t.Fatalf("cold signed image: status=%d, want=%d, body=%s", rec.Code, want, rec.Body.String())
+				}
+			}
+		})
 	}
 }
 

--- a/internal/jellycompat/user_collections_boxset_test.go
+++ b/internal/jellycompat/user_collections_boxset_test.go
@@ -1,0 +1,620 @@
+package jellycompat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/Silo-Server/silo-server/internal/branding"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/usercollections"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
+)
+
+// fakeUserCollection is one row in fakeUserCollectionSource, carrying the
+// ownership and sharing facts the real store enforces in SQL.
+type fakeUserCollection struct {
+	usercollections.ServerVisibleCollection
+	userID     int
+	profileIDs []string
+	libraryIDs []int // empty means library-agnostic
+}
+
+// fakeUserCollectionSource is an in-memory userCollectionSource mirroring the
+// store's privacy rules. It records the identity it was asked about, so tests
+// can pin that handlers pass the session's own user and profile through rather
+// than widening the query.
+type fakeUserCollectionSource struct {
+	rows []fakeUserCollection
+
+	gotUserID     int
+	gotProfileID  string
+	gotLibraryIDs []int
+}
+
+type fakePersonalCollectionResolver struct {
+	result    *catalog.CatalogResult
+	gotReq    catalog.CatalogRequest
+	gotAccess catalog.AccessFilter
+}
+
+func (f *fakePersonalCollectionResolver) Resolve(_ context.Context, req catalog.CatalogRequest, access catalog.AccessFilter) (*catalog.CatalogResult, error) {
+	f.gotReq, f.gotAccess = req, access
+	return f.result, nil
+}
+
+func (f *fakeUserCollectionSource) visible(userID int, profileID string, row fakeUserCollection) bool {
+	return row.userID == userID && slices.Contains(row.profileIDs, profileID)
+}
+
+func (f *fakeUserCollectionSource) List(_ context.Context, userID int, profileID string, libraryIDs []int) ([]usercollections.ServerVisibleCollection, error) {
+	f.gotUserID, f.gotProfileID, f.gotLibraryIDs = userID, profileID, append([]int(nil), libraryIDs...)
+	var out []usercollections.ServerVisibleCollection
+	for _, row := range f.rows {
+		if !f.visible(userID, profileID, row) {
+			continue
+		}
+		if len(row.libraryIDs) > 0 && !slices.ContainsFunc(row.libraryIDs, func(id int) bool { return slices.Contains(libraryIDs, id) }) {
+			continue
+		}
+		out = append(out, row.ServerVisibleCollection)
+	}
+	return out, nil
+}
+
+func (f *fakeUserCollectionSource) Get(_ context.Context, userID int, profileID, id string, libraryIDs []int) (*usercollections.ServerVisibleCollection, error) {
+	f.gotUserID, f.gotProfileID = userID, profileID
+	for _, row := range f.rows {
+		if row.ID == id && f.visible(userID, profileID, row) &&
+			(len(row.libraryIDs) == 0 || slices.ContainsFunc(row.libraryIDs, func(id int) bool { return slices.Contains(libraryIDs, id) })) {
+			found := row.ServerVisibleCollection
+			return &found, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeUserCollectionSource) AnyVisible(_ context.Context, userID int, profileID string, libraryIDs []int) (bool, error) {
+	f.gotUserID, f.gotProfileID = userID, profileID
+	for _, row := range f.rows {
+		if f.visible(userID, profileID, row) &&
+			(len(row.libraryIDs) == 0 || slices.ContainsFunc(row.libraryIDs, func(id int) bool { return slices.Contains(libraryIDs, id) })) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeUserCollectionSource) ImageCandidates(_ context.Context, id string) ([]usercollections.ServerVisibleCollection, error) {
+	var out []usercollections.ServerVisibleCollection
+	for _, row := range f.rows {
+		if row.ID == id {
+			out = append(out, row.ServerVisibleCollection)
+		}
+	}
+	return out, nil
+}
+
+// ownedUserCollection builds an opted-in personal collection owned by the
+// identity collectionsTestSession() carries (user 1, profile-1).
+func ownedUserCollection(id, name string) fakeUserCollection {
+	return fakeUserCollection{
+		ServerVisibleCollection: usercollections.ServerVisibleCollection{
+			ID:               id,
+			Name:             name,
+			CreatorProfileID: "profile-1",
+			CollectionType:   "mdblist",
+		},
+		userID:     1,
+		profileIDs: []string{"profile-1"},
+	}
+}
+
+func newUserCollectionsTestHandler(admin *fakeCollectionSource, personal *fakeUserCollectionSource, libraries []upstreamUserLibrary, itemRepo itemRepoForBatchLoader) *ItemsHandler {
+	h := newCollectionsTestHandler(admin, libraries, itemRepo)
+	h.userCollections = personal
+	return h
+}
+
+func boxSetNames(items []baseItemDTO) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, item.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func TestHandleItems_BoxSetListingIncludesOwnPersonalCollections(t *testing.T) {
+	admin := &fakeCollectionSource{
+		collections: []*models.LibraryCollection{
+			{ID: "101", LibraryID: 1, Title: "Studio Picks", Visibility: "visible", ItemCount: 3},
+		},
+	}
+	watchlist := ownedUserCollection("u-1", "My Watchlist")
+	watchlist.ItemCount = 7
+	personal := &fakeUserCollectionSource{rows: []fakeUserCollection{watchlist}}
+	h := newUserCollectionsTestHandler(admin, personal, []upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	result := performItemsRequest(t, h, "/Items?ParentId="+collectionsViewID)
+	if got := boxSetNames(result.Items); !slices.Equal(got, []string{"My Watchlist", "Studio Picks"}) {
+		t.Fatalf("expected library and personal collections listed together, got %v", got)
+	}
+	if personal.gotUserID != 1 || personal.gotProfileID != "profile-1" {
+		t.Fatalf("expected the listing scoped to the session identity, got user %d profile %q",
+			personal.gotUserID, personal.gotProfileID)
+	}
+	if !slices.Equal(personal.gotLibraryIDs, []int{1}) {
+		t.Fatalf("expected the visible library set [1], got %v", personal.gotLibraryIDs)
+	}
+	for _, item := range result.Items {
+		switch item.Name {
+		case "My Watchlist":
+			if item.Type != "BoxSet" || !item.IsFolder || item.ChildCount != 0 {
+				t.Fatalf("unexpected personal BoxSet DTO: %+v", item)
+			}
+		case "Studio Picks":
+			if item.ChildCount != 3 {
+				t.Fatalf("library collection lost its stored count: %+v", item)
+			}
+		}
+	}
+}
+
+// TestHandleItems_BoxSetListingHidesOtherProfilesPersonalCollections is the
+// privacy pin: personal collections are private, so neither another user's rows
+// nor rows their owner shared with a different profile may reach this session.
+func TestHandleItems_BoxSetListingHidesOtherProfilesPersonalCollections(t *testing.T) {
+	otherUser := ownedUserCollection("u-2", "Someone Else's List")
+	otherUser.userID = 2
+	otherProfile := ownedUserCollection("u-3", "Not My Profile")
+	otherProfile.profileIDs = []string{"profile-2"}
+	personal := &fakeUserCollectionSource{rows: []fakeUserCollection{otherUser, otherProfile}}
+	h := newUserCollectionsTestHandler(&fakeCollectionSource{}, personal,
+		[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	result := performItemsRequest(t, h, "/Items?ParentId="+collectionsViewID)
+	if len(result.Items) != 0 {
+		t.Fatalf("expected no collections, got %v", boxSetNames(result.Items))
+	}
+}
+
+func TestHandleItems_BoxSetListingHidesCollectionsOutsideVisibleLibraries(t *testing.T) {
+	hiddenLibrary := ownedUserCollection("u-hidden", "Hidden Library List")
+	hiddenLibrary.libraryIDs = []int{2}
+	personal := &fakeUserCollectionSource{rows: []fakeUserCollection{hiddenLibrary}}
+	h := newUserCollectionsTestHandler(&fakeCollectionSource{}, personal,
+		[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	result := performItemsRequest(t, h, "/Items?ParentId="+collectionsViewID)
+	if len(result.Items) != 0 {
+		t.Fatalf("expected hidden-library collection to stay off Jellyfin, got %v", boxSetNames(result.Items))
+	}
+}
+
+func TestHandleItem_PersonalCollectionResolvesForOwnerOnly(t *testing.T) {
+	hidden := ownedUserCollection("u-3", "Not My Profile")
+	hidden.profileIDs = []string{"profile-2"}
+	personal := &fakeUserCollectionSource{rows: []fakeUserCollection{
+		ownedUserCollection("u-1", "My Watchlist"),
+		hidden,
+	}}
+	h := newUserCollectionsTestHandler(&fakeCollectionSource{}, personal, nil, nil)
+
+	t.Run("owned", func(t *testing.T) {
+		rec := requestBoxSetItem(t, h, "u-1")
+		if rec.Code != 200 {
+			t.Fatalf("expected 200 for an owned collection, got %d: %s", rec.Code, rec.Body.String())
+		}
+		var item baseItemDTO
+		if err := json.Unmarshal(rec.Body.Bytes(), &item); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		if item.Type != "BoxSet" || item.Name != "My Watchlist" {
+			t.Fatalf("unexpected BoxSet: %+v", item)
+		}
+	})
+
+	t.Run("not shared with this profile", func(t *testing.T) {
+		if rec := requestBoxSetItem(t, h, "u-3"); rec.Code != 404 {
+			t.Fatalf("expected 404 for a collection this profile cannot see, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func requestBoxSetItem(t *testing.T, h *ItemsHandler, collectionID string) *httptest.ResponseRecorder {
+	t.Helper()
+	routeID := h.codec.EncodeStringID(EncodedIDUserCollection, collectionID)
+	req := httptest.NewRequest("GET", "/Items/"+routeID, nil)
+	ctx := context.WithValue(req.Context(), compatSessionKey, collectionsTestSession())
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", routeID)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, rctx))
+	rec := httptest.NewRecorder()
+	h.HandleItem(rec, req)
+	return rec
+}
+
+func TestHandleItems_PersonalBoxSetChildrenUseCatalogResolver(t *testing.T) {
+	const collectionID = "731d3da2-4f4b-4a71-8f2f-38e1d34775b0"
+	list := ownedUserCollection(collectionID, "Release Order")
+	resolver := &fakePersonalCollectionResolver{result: &catalog.CatalogResult{
+		Items: []*models.MediaItem{
+			{ContentID: "m-new", Type: "movie", Title: "New Release"},
+			{ContentID: "m-old", Type: "movie", Title: "Old Release"},
+		},
+		Total: 2,
+	}}
+	h := newUserCollectionsTestHandler(&fakeCollectionSource{},
+		&fakeUserCollectionSource{rows: []fakeUserCollection{list}},
+		[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+	h.collectionResolver = resolver
+
+	parentID := NewResourceIDCodec().EncodeStringID(EncodedIDUserCollection, collectionID)
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+	if got := boxSetNames(result.Items); len(got) != 2 {
+		t.Fatalf("expected resolver items, got %v", got)
+	}
+	if result.Items[0].Name != "New Release" || result.Items[1].Name != "Old Release" {
+		t.Fatalf("expected resolver order, got %q, %q", result.Items[0].Name, result.Items[1].Name)
+	}
+	if resolver.gotReq.Source != catalog.CatalogSourceUserCollection || resolver.gotReq.CollectionID != collectionID || !resolver.gotReq.UseSourceOrder {
+		t.Fatalf("unexpected resolver request: %+v", resolver.gotReq)
+	}
+
+	performItemsRequest(t, h, "/Items?ParentId="+parentID+"&SortBy=DateCreated&SortOrder=Descending")
+	if resolver.gotReq.UseSourceOrder || resolver.gotReq.Query.Sort != (catalog.QuerySort{Field: "added_at", Order: "desc"}) {
+		t.Fatalf("explicit Jellyfin sort was not mapped to the catalog sort: %+v", resolver.gotReq)
+	}
+
+	personID := h.codec.EncodeIntID(EncodedIDPerson, 42)
+	performItemsRequest(t, h, "/Items?ParentId="+parentID+"&SortBy=Random&PersonIds="+personID+"&ImageTypes=Backdrop")
+	if !resolver.gotReq.Randomize || !resolver.gotReq.UseSourceOrder || resolver.gotReq.Query.Sort != (catalog.QuerySort{}) {
+		t.Fatalf("random sort was not preserved: %+v", resolver.gotReq)
+	}
+	if resolver.gotReq.PersonID != 42 || !resolver.gotReq.RequireBackdrop {
+		t.Fatalf("existing Jellyfin filters were not forwarded: %+v", resolver.gotReq)
+	}
+}
+
+func TestHandleItems_PersonalBoxSetRouteSurvivesFreshCodec(t *testing.T) {
+	const collectionID = "731d3da2-4f4b-4a71-8f2f-38e1d34775b0"
+	list := ownedUserCollection(collectionID, "Restart Safe")
+	h := newUserCollectionsTestHandler(&fakeCollectionSource{},
+		&fakeUserCollectionSource{rows: []fakeUserCollection{list}},
+		[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+	h.collectionResolver = &fakePersonalCollectionResolver{result: &catalog.CatalogResult{
+		Items: []*models.MediaItem{{ContentID: "m-1", Type: "movie", Title: "Still Here"}},
+		Total: 1,
+	}}
+
+	parentID := NewResourceIDCodec().EncodeStringID(EncodedIDUserCollection, collectionID)
+	result := performItemsRequest(t, h, "/Items?ParentId="+parentID)
+	if len(result.Items) != 1 || result.Items[0].Name != "Still Here" {
+		t.Fatalf("fresh codec failed to resolve cached personal route: %+v", result.Items)
+	}
+}
+
+// TestUserViews_ShowsCollectionsViewForPersonalCollectionsOnly guards the case
+// that made the bug total: without the personal probe, a user whose only
+// collections are personal never gets the Collections tab, so nothing below it
+// is reachable either.
+func TestUserViews_ShowsCollectionsViewForPersonalCollectionsOnly(t *testing.T) {
+	personal := &fakeUserCollectionSource{rows: []fakeUserCollection{ownedUserCollection("u-1", "My Watchlist")}}
+	h := newUserCollectionsTestHandler(&fakeCollectionSource{}, personal,
+		[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	result := performItemsRequest(t, h, "/Items")
+	if len(result.Items) != 2 || result.Items[0].ID != collectionsViewID {
+		t.Fatalf("expected the Collections view ahead of the library, got %+v", result.Items)
+	}
+}
+
+// TestServeCollectionImage_PersonalCollectionOwnerOnly pins that personal
+// artwork follows the collection's privacy: the owner or a signed capability
+// resolves it, while a stranger or anonymous request without that tag does not.
+func TestServeCollectionImage_PersonalCollectionOwnerOnly(t *testing.T) {
+	const collectionID = "731d3da2-4f4b-4a71-8f2f-38e1d34775b0"
+	codec := NewResourceIDCodec()
+	routeID := codec.EncodeStringID(EncodedIDUserCollection, collectionID)
+	h := &ImagesHandler{
+		content:         &librariesContentService{libraries: []upstreamUserLibrary{{ID: 1, Type: "movies"}}},
+		codec:           codec,
+		images:          NewImageCache(time.Hour, time.Now),
+		imageTags:       newImageTagSigner("image-secret"),
+		collections:     &fakeCollectionSource{},
+		userCollections: &fakeUserCollectionSource{rows: []fakeUserCollection{ownedUserCollection(collectionID, "My Watchlist")}},
+	}
+
+	serve := func(requestID string, session *Session, tag string) *httptest.ResponseRecorder {
+		path := "/Items/" + requestID + "/Images/Primary"
+		if tag != "" {
+			path += "?tag=" + tag
+		}
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if session != nil {
+			req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, session))
+		}
+		req = withImageRouteParams(req, requestID, "Primary")
+		rec := httptest.NewRecorder()
+		h.HandleItemImage(rec, req)
+		return rec
+	}
+
+	if rec := serve(routeID, collectionsTestSession(), ""); rec.Code != http.StatusOK {
+		t.Fatalf("owner: status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := serve(routeID, &Session{StreamAppUserID: 2, ProfileID: "profile-2"}, ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("other user: status = %d, want 404", rec.Code)
+	}
+	if rec := serve(routeID, nil, ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("anonymous: status = %d, want 404", rec.Code)
+	}
+	candidate := libraryCollectionFromUser(ownedUserCollection(collectionID, "My Watchlist").ServerVisibleCollection)
+	seed, _ := collectionImageTagSeed(routeID, "Primary", candidate)
+	// Anonymous candidates skip the profile ACL, so every UUID representation
+	// must still reject a forged capability.
+	for _, requestID := range []string{routeID, strings.ReplaceAll(routeID, "-", ""), strings.ToUpper(routeID)} {
+		if rec := serve(requestID, nil, h.imageTags.Tag(seed, "")); rec.Code != http.StatusOK {
+			t.Errorf("signed capability for %s: status = %d, want 200; body=%s", requestID, rec.Code, rec.Body.String())
+		}
+		if rec := serve(requestID, nil, "0123456789abcdef"); rec.Code != http.StatusNotFound {
+			t.Errorf("forged tag for %s: status = %d, want 404", requestID, rec.Code)
+		}
+	}
+	if rec := serve(routeID, &Session{StreamAppUserID: 2, ProfileID: "profile-2"}, "0123456789abcdef"); rec.Code != http.StatusNotFound {
+		t.Fatalf("stranger with a forged tag: status = %d, want 404", rec.Code)
+	}
+}
+
+func TestPersonalCollectionPosterNetworkBoundary(t *testing.T) {
+	var hits atomic.Int32
+	const body = "poster-fixture"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	for _, tc := range []struct {
+		name, poster string
+		wantStatus   int
+		wantFetch    bool
+	}{
+		{"loopback URL", server.URL, http.StatusBadGateway, false},
+		{"loopback hostname", strings.Replace(server.URL, "127.0.0.1", "localhost", 1), http.StatusBadGateway, false},
+		{"stored poster", "collections/test/poster.jpg", http.StatusOK, true},
+		{"bundled poster", "/images/test.jpg", http.StatusOK, false},
+	} {
+		for _, signed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/signed=%t", tc.name, signed), func(t *testing.T) {
+				codec := NewResourceIDCodec()
+				row := ownedUserCollection(uuid.NewString(), "My Watchlist")
+				row.PosterPath = tc.poster
+				routeID := codec.EncodeStringID(EncodedIDUserCollection, row.ID)
+				h := &ImagesHandler{
+					codec: codec, images: NewImageCache(time.Hour, time.Now),
+					content:         &librariesContentService{},
+					imageTags:       newImageTagSigner("image-secret"),
+					userCollections: &fakeUserCollectionSource{rows: []fakeUserCollection{row}},
+					posterSigner:    fakeLibraryPosterPresigner{url: server.URL},
+					frontendFS:      fstest.MapFS{"images/test.jpg": {Data: []byte(body)}},
+				}
+				path := "/Items/" + routeID + "/Images/Primary"
+				if signed {
+					seed, _ := collectionImageTagSeed(routeID, "Primary", libraryCollectionFromUser(row.ServerVisibleCollection))
+					path += "?tag=" + compatImageProxyTag(h.imageTags.Tag(seed, ""))
+				}
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				if !signed {
+					req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, collectionsTestSession()))
+					req.Header.Set("User-Agent", "Infuse")
+				}
+				rec := httptest.NewRecorder()
+				before := hits.Load()
+				h.HandleItemImage(rec, withImageRouteParams(req, routeID, "Primary"))
+				if tc.wantStatus == http.StatusBadGateway &&
+					(rec.Header().Get("Content-Security-Policy") != branding.AssetContentSecurityPolicy || rec.Header().Get("X-Content-Type-Options") != "nosniff") {
+					t.Error("untrusted poster response lacks sandbox/nosniff headers")
+				}
+				if rec.Code != tc.wantStatus {
+					t.Errorf("status = %d, want %d; body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+				}
+				if fetched := hits.Load() != before; fetched != tc.wantFetch {
+					t.Errorf("server-side fetch = %t, want %t", fetched, tc.wantFetch)
+				}
+				if gotBody := rec.Body.String() == body; gotBody != (tc.wantStatus == http.StatusOK) {
+					t.Errorf("returned fixture bytes = %t", gotBody)
+				}
+			})
+		}
+	}
+}
+
+func TestPersonalCollectionPosterCannotUseLegacyTagFallback(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("internal-marker"))
+	}))
+	t.Cleanup(server.Close)
+	row := ownedUserCollection(uuid.NewString(), "My Watchlist")
+	row.PosterPath = server.URL
+	items := newUserCollectionsTestHandler(&fakeCollectionSource{},
+		&fakeUserCollectionSource{rows: []fakeUserCollection{row}},
+		[]upstreamUserLibrary{{ID: 1, Type: "movies"}}, nil)
+	listing := performItemsRequest(t, items, "/Items?ParentId="+collectionsViewID)
+	if len(listing.Items) != 1 || listing.Items[0].ImageTags["Primary"] == "" {
+		t.Fatalf("missing personal BoxSet poster: %+v", listing)
+	}
+	h := &ImagesHandler{codec: items.codec, images: items.images}
+	// A different item ID must not bypass personal-image authorization or the
+	// public-network guard via the global, URL-derived legacy cache tag.
+	routeID := uuid.NewString()
+	req := httptest.NewRequest(http.MethodGet, "/Items/"+routeID+"/Images/Primary?tag="+tagValue(server.URL), nil)
+	req.Header.Set("User-Agent", "Infuse")
+	rec := httptest.NewRecorder()
+	h.HandleItemImage(rec, withImageRouteParams(req, routeID, "Primary"))
+	if rec.Code != http.StatusNotFound || hits.Load() != 0 {
+		t.Fatalf("legacy cache bypass: status=%d backend requests=%d body=%s", rec.Code, hits.Load(), rec.Body.String())
+	}
+}
+
+func TestHandleItems_PersonalBoxSetMediaTypeFilters(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	var userID int
+	if err := pool.QueryRow(ctx, `INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`, "boxset-test-"+uuid.NewString()).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID) })
+	var libraryID int
+	if err := pool.QueryRow(ctx, `INSERT INTO media_folders (type, name, enabled) VALUES ('series', 'Test Library', true) RETURNING id`).Scan(&libraryID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, libraryID) })
+	provider := pgstore.NewPostgresProvider(pool)
+	store, err := provider.ForUser(ctx, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := &Session{StreamAppUserID: userID, ProfileID: "profile-1"}
+	if err := store.CreateProfile(ctx, userstore.Profile{ID: session.ProfileID, Name: "Test profile"}); err != nil {
+		t.Fatal(err)
+	}
+	collection, err := store.CreateCollection(ctx, userstore.CreateCollectionInput{
+		CreatorProfileID: session.ProfileID, Name: "Mixed collection", IncludeInServerCollections: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	episodeID := uuid.NewString()
+	for position, item := range []struct{ kind, title string }{
+		{"audiobook", "Audio Book"}, {"movie", "First Movie"}, {"podcast", "Podcast"},
+		{"series", "Series"}, {"movie", "Second Movie"},
+	} {
+		id := uuid.NewString()
+		if _, err := pool.Exec(ctx, `INSERT INTO media_items (content_id, type, title, created_at) VALUES ($1, $2, $3, NOW() - INTERVAL '1 day')`, id, item.kind, item.title); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = $1`, id) })
+		if _, err := pool.Exec(ctx, `INSERT INTO user_personal_collection_items (user_id, collection_id, media_item_id, position) VALUES ($1, $2, $3, $4)`, userID, collection.ID, id, position); err != nil {
+			t.Fatal(err)
+		}
+		if item.kind == "series" {
+			if _, err := pool.Exec(ctx, `INSERT INTO episodes (content_id, series_id, season_number, episode_number, title, created_at) VALUES ($1, $2, 1, 1, 'Episode', NOW() - INTERVAL '1 day')`, episodeID, id); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := pool.Exec(ctx, `INSERT INTO episode_libraries (episode_id, media_folder_id, first_seen_at) VALUES ($1, $2, NOW() - INTERVAL '1 day')`, episodeID, libraryID); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	h := newCollectionsTestHandler(&fakeCollectionSource{}, []upstreamUserLibrary{{ID: libraryID, Type: "series"}}, nil)
+	h.userCollections = usercollections.NewStore(pool)
+	h.collectionResolver = catalog.NewCatalogResolver(catalog.NewBrowseRepository(pool), catalog.NewItemRepository(pool)).WithUserStoreProvider(provider)
+	h.accessFilter = func(_ context.Context, userID int, profileID string) catalog.AccessFilter {
+		return catalog.AccessFilter{UserID: userID, ProfileID: profileID}
+	}
+	parentID := h.codec.EncodeStringID(EncodedIDUserCollection, collection.ID)
+	for _, tc := range []struct {
+		query string
+		want  []string
+		total int
+	}{
+		{"", []string{"First Movie", "Second Movie", "Series"}, 3},
+		{"&MediaTypes=Video", []string{"First Movie", "Second Movie", "Series"}, 3},
+		{"&SortBy=SortName", []string{"First Movie", "Second Movie", "Series"}, 3},
+		{"&Limit=1&StartIndex=1", []string{"Series"}, 3},
+		{"&IncludeItemTypes=Movie", []string{"First Movie", "Second Movie"}, 2},
+		{"&IncludeItemTypes=Movie,Series", []string{"First Movie", "Second Movie", "Series"}, 3},
+		{"&IncludeItemTypes=Episode", nil, 0},
+		{"&IncludeItemTypes=Season", nil, 0},
+		{"&ExcludeItemTypes=Movie,Series", nil, 0},
+		{"&MediaTypes=Audio", nil, 0},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			result := performItemsRequest(t, h, "/Items?ParentId="+parentID+tc.query, session)
+			if got := boxSetNames(result.Items); !slices.Equal(got, tc.want) || result.TotalRecordCount != tc.total {
+				t.Fatalf("got %v (total %d), want %v (total %d)", got, result.TotalRecordCount, tc.want, tc.total)
+			}
+		})
+	}
+	smart, err := store.CreateCollection(ctx, userstore.CreateCollectionInput{
+		CreatorProfileID: session.ProfileID, Name: "Episodes", CollectionType: "smart",
+		IncludeInServerCollections: true, QueryDefinition: `{"media_scope":"episode"}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.accessFilter = func(_ context.Context, userID int, profileID string) catalog.AccessFilter {
+		return catalog.AccessFilter{UserID: userID, ProfileID: profileID, AllowedContentIDs: []string{episodeID}}
+	}
+	base, err := h.collectionResolver.Resolve(ctx, catalog.CatalogRequest{
+		Source: catalog.CatalogSourceUserCollection, CollectionID: smart.ID, UseSourceOrder: true,
+	}, h.resolveAccessFilter(ctx, session))
+	if err != nil || len(base.Items) != 1 {
+		t.Fatalf("episode fixture must resolve before any overlay: result=%+v err=%v", base, err)
+	}
+	parentID = h.codec.EncodeStringID(EncodedIDUserCollection, smart.ID)
+	for _, query := range []string{"", "&IncludeItemTypes=Episode", "&SortBy=SortName"} {
+		t.Run("smart episodes"+query, func(t *testing.T) {
+			result := performItemsRequest(t, h, "/Items?ParentId="+parentID+query, session)
+			if len(result.Items) != 1 || result.Items[0].Type != "Episode" || result.TotalRecordCount != 1 {
+				t.Fatalf("smart episode collection lost its members: %+v", result)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name     string
+		backdrop string
+		want     int
+	}{
+		{"inherited backdrop", "test/backdrop.jpg", 1},
+		{"missing backdrop", "", 0},
+		{"blank backdrop", "   ", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := pool.Exec(ctx, `UPDATE media_items SET backdrop_path = $1 WHERE content_id = (SELECT series_id FROM episodes WHERE content_id = $2)`, tc.backdrop, episodeID); err != nil {
+				t.Fatal(err)
+			}
+			for _, query := range []string{"", "&SortBy=SortName"} {
+				path := "/Items?ParentId=" + parentID + query
+				unfiltered := performItemsRequest(t, h, path, session)
+				if len(unfiltered.Items) != 1 || unfiltered.Items[0].Type != "Episode" {
+					t.Fatal("episode must remain visible without the image filter")
+				}
+				filtered := performItemsRequest(t, h, path+"&ImageTypes=Backdrop&Limit=1", session)
+				if len(filtered.Items) != tc.want || filtered.TotalRecordCount != tc.want {
+					t.Errorf("%s: got %d items (total %d), want %d", query, len(filtered.Items), filtered.TotalRecordCount, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestUserViews_HidesCollectionsViewWhenPersonalCollectionsBelongToOthers(t *testing.T) {
+	otherUser := ownedUserCollection("u-2", "Someone Else's List")
+	otherUser.userID = 2
+	personal := &fakeUserCollectionSource{rows: []fakeUserCollection{otherUser}}
+	h := newUserCollectionsTestHandler(&fakeCollectionSource{}, personal,
+		[]upstreamUserLibrary{{ID: 1, Name: "Movies", Type: "movies"}}, nil)
+
+	result := performItemsRequest(t, h, "/Items")
+	if len(result.Items) != 1 || result.Items[0].ID == collectionsViewID {
+		t.Fatalf("expected only the library view, got %+v", result.Items)
+	}
+}

--- a/internal/usercollections/listing.go
+++ b/internal/usercollections/listing.go
@@ -2,9 +2,11 @@ package usercollections
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -30,6 +32,43 @@ type ServerVisibleCollection struct {
 // the response.
 const serverVisibleListLimit = 500
 
+// serverVisibleWhere is the ownership + opt-in + profile-ACL predicate that
+// gates every server-visible read. Personal collections are private, so this
+// privacy boundary is defined once and shared by all readers: $1 is the owning
+// user and $2 the viewing profile.
+const serverVisibleWhere = `upc.user_id = $1
+	AND upc.include_in_server_collections = TRUE
+	AND EXISTS (
+		SELECT 1 FROM user_personal_collection_profiles vp
+		WHERE vp.user_id = upc.user_id
+		  AND vp.collection_id = upc.id
+		  AND vp.profile_id = $2
+	)`
+
+// scopeConfigExpr picks the JSON object that carries a collection's library
+// scope: a smart collection scopes through its query, an imported one through
+// its source_config, and older rows fall back to the query definition.
+const scopeConfigExpr = `CASE
+		WHEN upc.collection_type = 'smart' THEN upc.query_definition
+		WHEN upc.source_config ? 'library_ids' THEN upc.source_config
+		ELSE upc.query_definition
+	END`
+
+// scopeMatchesLibraries is the library-overlap predicate over a scope_config
+// column. A row with no library_ids, or an empty list, is library-agnostic and
+// matches every set.
+func scopeMatchesLibraries(scopeColumn, libraryIDsParam string) string {
+	return `(
+		NOT (` + scopeColumn + ` ? 'library_ids')
+		OR jsonb_array_length(COALESCE(` + scopeColumn + `->'library_ids', '[]'::jsonb)) = 0
+		OR EXISTS (
+			SELECT 1
+			FROM unnest(` + libraryIDsParam + `::int[]) library_id
+			WHERE ` + scopeColumn + `->'library_ids' @> to_jsonb(library_id)
+		)
+	)`
+}
+
 // ListServerVisibleByLibrary returns the current user's personal collections
 // that have opted into their library Collections tab and whose library scope
 // matches the requested library. Imported exact collections read library_ids
@@ -37,37 +76,29 @@ const serverVisibleListLimit = 500
 // collection with no library_ids is treated as library-agnostic and therefore
 // visible in every library tab. Other users' collections are never returned.
 func ListServerVisibleByLibrary(ctx context.Context, pool *pgxpool.Pool, userID int, profileID string, libraryID int) ([]ServerVisibleCollection, error) {
+	return listServerVisible(ctx, pool, userID, profileID, []int{libraryID}, false)
+}
+
+// listServerVisible backs native single-library and Jellyfin visible-library
+// reads. Scoped collections must overlap visibleLibraryIDs; unscoped rows stay
+// visible. videoOnly excludes unified audiobook/podcast playlists.
+func listServerVisible(ctx context.Context, pool *pgxpool.Pool, userID int, profileID string, visibleLibraryIDs []int, videoOnly bool) ([]ServerVisibleCollection, error) {
 	rows, err := pool.Query(ctx,
 		`WITH visible_collections AS (
 			SELECT upc.id, upc.creator_profile_id, upc.name, upc.description, upc.collection_type,
 			       upc.item_count, upc.poster_url, upc.poster_thumbhash, upc.created_at, upc.updated_at,
-			       CASE
-			         WHEN upc.collection_type = 'smart' THEN upc.query_definition
-			         WHEN upc.source_config ? 'library_ids' THEN upc.source_config
-			         ELSE upc.query_definition
-			       END AS scope_config
+			       `+scopeConfigExpr+` AS scope_config
 			FROM user_personal_collections upc
-			WHERE upc.user_id = $1
-			  AND upc.include_in_server_collections = TRUE
-			  AND EXISTS (
-			    SELECT 1 FROM user_personal_collection_profiles vp
-			    WHERE vp.user_id = upc.user_id
-			      AND vp.collection_id = upc.id
-			      AND vp.profile_id = $2
-			  )
+			WHERE `+serverVisibleWhere+`
 		)
 		 SELECT id, creator_profile_id, name, description, collection_type, item_count,
 		        poster_url, poster_thumbhash, created_at, updated_at
 		 FROM visible_collections
-		 WHERE TRUE
-		   AND (
-		     NOT (scope_config ? 'library_ids')
-		     OR jsonb_array_length(COALESCE(scope_config->'library_ids', '[]'::jsonb)) = 0
-		     OR scope_config->'library_ids' @> to_jsonb($3::int)
-		   )
+		 WHERE `+scopeMatchesLibraries("scope_config", "$3")+`
+		   AND (NOT $4::boolean OR collection_type <> 'playlist')
 		 ORDER BY name ASC
-		 LIMIT $4`,
-		userID, profileID, libraryID, serverVisibleListLimit,
+		 LIMIT $5`,
+		userID, profileID, visibleLibraryIDs, videoOnly, serverVisibleListLimit,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing server-visible user collections: %w", err)
@@ -83,6 +114,124 @@ func ListServerVisibleByLibrary(ctx context.Context, pool *pgxpool.Pool, userID 
 			&c.ItemCount, &c.PosterPath, &c.PosterThumbhash, &createdAt, &updatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scanning server-visible user collection: %w", err)
+		}
+		c.CreatedAt = createdAt.UTC().Format(time.RFC3339)
+		c.UpdatedAt = updatedAt.UTC().Format(time.RFC3339)
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// Store reads a user's server-visible personal collections, mirroring
+// catalog.LibraryCollectionRepository for the admin side. Callers pass the
+// owning user and the viewing profile on every read; nothing here can reach
+// another user's rows.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// List returns video collections visible to profileID and overlapping the
+// Jellyfin-visible library set. See ListServerVisibleByLibrary.
+func (s *Store) List(ctx context.Context, userID int, profileID string, visibleLibraryIDs []int) ([]ServerVisibleCollection, error) {
+	return listServerVisible(ctx, s.pool, userID, profileID, visibleLibraryIDs, true)
+}
+
+// Get returns one server-visible video collection by ID, intersected with the
+// viewer's Jellyfin-visible libraries. Returns (nil, nil) for missing,
+// unauthorized, hidden-scope or non-opted-in rows so callers cannot distinguish
+// those cases.
+func (s *Store) Get(ctx context.Context, userID int, profileID, id string, visibleLibraryIDs []int) (*ServerVisibleCollection, error) {
+	var (
+		c                    ServerVisibleCollection
+		createdAt, updatedAt time.Time
+	)
+	err := s.pool.QueryRow(ctx,
+		`WITH visible_collection AS (
+			SELECT upc.id, upc.creator_profile_id, upc.name, upc.description, upc.collection_type,
+			       upc.item_count, upc.poster_url, upc.poster_thumbhash, upc.created_at, upc.updated_at,
+			       `+scopeConfigExpr+` AS scope_config
+			FROM user_personal_collections upc
+			WHERE `+serverVisibleWhere+`
+			  AND upc.id = $3
+			  AND upc.collection_type <> 'playlist'
+		)
+		 SELECT id, creator_profile_id, name, description, collection_type, item_count,
+		        poster_url, poster_thumbhash, created_at, updated_at
+		 FROM visible_collection
+		 WHERE `+scopeMatchesLibraries("scope_config", "$4"),
+		userID, profileID, id, visibleLibraryIDs,
+	).Scan(
+		&c.ID, &c.CreatorProfileID, &c.Name, &c.Description, &c.CollectionType,
+		&c.ItemCount, &c.PosterPath, &c.PosterThumbhash, &createdAt, &updatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading server-visible user collection: %w", err)
+	}
+	c.CreatedAt = createdAt.UTC().Format(time.RFC3339)
+	c.UpdatedAt = updatedAt.UTC().Format(time.RFC3339)
+	return &c, nil
+}
+
+// AnyVisible reports whether the profile has at least one server-visible
+// collection. An EXISTS probe rather than a list, because it gates
+// a surface (the Collections view) that is rebuilt on every client refresh.
+func (s *Store) AnyVisible(ctx context.Context, userID int, profileID string, visibleLibraryIDs []int) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS (
+			WITH visible_collections AS (
+				SELECT `+scopeConfigExpr+` AS scope_config
+				FROM user_personal_collections upc
+				WHERE `+serverVisibleWhere+`
+				  AND upc.collection_type <> 'playlist'
+			)
+			 SELECT 1 FROM visible_collections
+			 WHERE `+scopeMatchesLibraries("scope_config", "$3")+`
+		)`,
+		userID, profileID, visibleLibraryIDs,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("probing server-visible user collections: %w", err)
+	}
+	return exists, nil
+}
+
+// ImageCandidates returns opted-in personal collection metadata by native ID.
+//
+// This is the one read that deliberately skips serverVisibleWhere: it has no
+// owning user or viewing profile to scope by. Jellyfin clients load artwork
+// from plain <img> elements, which carry no token, so a poster can only be
+// authorized by the signed tag minted when its owner listed the collection.
+// Rows can share an ID across users (the primary key is user_id + id), hence a
+// list: the caller picks the row whose artwork reproduces that signature.
+//
+// Callers MUST verify the signature before serving bytes, and MUST NOT use this
+// for a browse read — it can return another user's collection.
+// TestServeCollectionImage_PersonalCollectionOwnerOnly pins both halves.
+func (s *Store) ImageCandidates(ctx context.Context, id string) ([]ServerVisibleCollection, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, creator_profile_id, name, description, collection_type, item_count,
+		        poster_url, poster_thumbhash, created_at, updated_at
+		 FROM user_personal_collections
+		 WHERE id = $1 AND include_in_server_collections = TRUE AND collection_type <> 'playlist'`, id)
+	if err != nil {
+		return nil, fmt.Errorf("loading signed-image collection candidates: %w", err)
+	}
+	defer rows.Close()
+	var out []ServerVisibleCollection
+	for rows.Next() {
+		var c ServerVisibleCollection
+		var createdAt, updatedAt time.Time
+		if err := rows.Scan(&c.ID, &c.CreatorProfileID, &c.Name, &c.Description, &c.CollectionType,
+			&c.ItemCount, &c.PosterPath, &c.PosterThumbhash, &createdAt, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scanning signed-image collection candidate: %w", err)
 		}
 		c.CreatedAt = createdAt.UTC().Format(time.RFC3339)
 		c.UpdatedAt = updatedAt.UTC().Format(time.RFC3339)

--- a/internal/usercollections/listing.go
+++ b/internal/usercollections/listing.go
@@ -140,11 +140,11 @@ func (s *Store) List(ctx context.Context, userID int, profileID string, visibleL
 	return listServerVisible(ctx, s.pool, userID, profileID, visibleLibraryIDs, true)
 }
 
-// Get returns one server-visible video collection by ID, intersected with the
-// viewer's Jellyfin-visible libraries. Returns (nil, nil) for missing,
+// Get returns one server-visible video collection by its Jellyfin lookup key,
+// intersected with the viewer's Jellyfin-visible libraries. Returns (nil, nil) for missing,
 // unauthorized, hidden-scope or non-opted-in rows so callers cannot distinguish
 // those cases.
-func (s *Store) Get(ctx context.Context, userID int, profileID, id string, visibleLibraryIDs []int) (*ServerVisibleCollection, error) {
+func (s *Store) Get(ctx context.Context, userID int, profileID, key string, visibleLibraryIDs []int) (*ServerVisibleCollection, error) {
 	var (
 		c                    ServerVisibleCollection
 		createdAt, updatedAt time.Time
@@ -156,14 +156,14 @@ func (s *Store) Get(ctx context.Context, userID int, profileID, id string, visib
 			       `+scopeConfigExpr+` AS scope_config
 			FROM user_personal_collections upc
 			WHERE `+serverVisibleWhere+`
-			  AND upc.id = $3
+			  AND jellycompat_user_collection_key(upc.id) = $3
 			  AND upc.collection_type <> 'playlist'
 		)
 		 SELECT id, creator_profile_id, name, description, collection_type, item_count,
 		        poster_url, poster_thumbhash, created_at, updated_at
 		 FROM visible_collection
 		 WHERE `+scopeMatchesLibraries("scope_config", "$4"),
-		userID, profileID, id, visibleLibraryIDs,
+		userID, profileID, key, visibleLibraryIDs,
 	).Scan(
 		&c.ID, &c.CreatorProfileID, &c.Name, &c.Description, &c.CollectionType,
 		&c.ItemCount, &c.PosterPath, &c.PosterThumbhash, &createdAt, &updatedAt,
@@ -203,7 +203,7 @@ func (s *Store) AnyVisible(ctx context.Context, userID int, profileID string, vi
 	return exists, nil
 }
 
-// ImageCandidates returns opted-in personal collection metadata by native ID.
+// ImageCandidates returns opted-in personal collection metadata by Jellyfin lookup key.
 //
 // This is the one read that deliberately skips serverVisibleWhere: it has no
 // owning user or viewing profile to scope by. Jellyfin clients load artwork
@@ -215,12 +215,13 @@ func (s *Store) AnyVisible(ctx context.Context, userID int, profileID string, vi
 // Callers MUST verify the signature before serving bytes, and MUST NOT use this
 // for a browse read — it can return another user's collection.
 // TestServeCollectionImage_PersonalCollectionOwnerOnly pins both halves.
-func (s *Store) ImageCandidates(ctx context.Context, id string) ([]ServerVisibleCollection, error) {
+func (s *Store) ImageCandidates(ctx context.Context, key string) ([]ServerVisibleCollection, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT id, creator_profile_id, name, description, collection_type, item_count,
 		        poster_url, poster_thumbhash, created_at, updated_at
 		 FROM user_personal_collections
-		 WHERE id = $1 AND include_in_server_collections = TRUE AND collection_type <> 'playlist'`, id)
+		 WHERE jellycompat_user_collection_key(id) = $1
+		   AND include_in_server_collections = TRUE AND collection_type <> 'playlist'`, key)
 	if err != nil {
 		return nil, fmt.Errorf("loading signed-image collection candidates: %w", err)
 	}

--- a/internal/usercollections/store_postgres_test.go
+++ b/internal/usercollections/store_postgres_test.go
@@ -1,0 +1,264 @@
+package usercollections
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newStoreTestPool connects to the database named by SILO_TEST_DATABASE_URL,
+// skipping when it is unset or has not applied the personal-collection
+// migrations. Mirrors the jellycompat compat-pool harness.
+func newStoreTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	var tableName *string
+	if err := pool.QueryRow(ctx, `SELECT to_regclass('public.user_personal_collections')::text`).Scan(&tableName); err != nil {
+		t.Fatalf("check user_personal_collections table: %v", err)
+	}
+	if tableName == nil || *tableName == "" {
+		t.Skip("test database has not applied the personal collection migrations")
+	}
+	return pool
+}
+
+const (
+	storeTestOwnerProfile = "store-test-profile-owner"
+	storeTestOtherProfile = "store-test-profile-other"
+	storeTestIDPrefix     = "store-test-"
+)
+
+// storeTestFixture owns a unique user; deleting it cascades to its collections.
+type storeTestFixture struct {
+	pool   *pgxpool.Pool
+	userID int
+}
+
+func newStoreTestFixture(t *testing.T) *storeTestFixture {
+	t.Helper()
+	pool := newStoreTestPool(t)
+	ctx := context.Background()
+
+	var userID int
+	if err := pool.QueryRow(ctx, `INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`, storeTestIDPrefix+uuid.NewString()).Scan(&userID); err != nil {
+		t.Fatalf("create test user: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID); err != nil {
+			t.Errorf("delete test user: %v", err)
+		}
+	})
+	return &storeTestFixture{pool: pool, userID: userID}
+}
+
+type storeTestCollection struct {
+	id           string
+	name         string
+	optIn        bool
+	sharedWith   []string
+	collType     string
+	queryDef     string
+	displayQuery string
+	sourceConfig string
+}
+
+func (f *storeTestFixture) insert(t *testing.T, c storeTestCollection) {
+	t.Helper()
+	ctx := context.Background()
+	if c.collType == "" {
+		c.collType = "manual"
+	}
+	if c.sourceConfig == "" {
+		c.sourceConfig = "{}"
+	}
+	if c.queryDef == "" {
+		c.queryDef = "{}" // NOT NULL; display_query_definition stays NULL when unset
+	}
+	if _, err := f.pool.Exec(ctx,
+		`INSERT INTO user_personal_collections
+		   (id, user_id, profile_id, creator_profile_id, name, description, collection_type,
+		    include_in_server_collections, source_config, query_definition, display_query_definition)
+		 VALUES ($1, $2, $3, $3, $4, '', $5, $6, $7::jsonb,
+		         $8::jsonb, NULLIF($9, '')::jsonb)`,
+		c.id, f.userID, storeTestOwnerProfile, c.name, c.collType, c.optIn,
+		c.sourceConfig, c.queryDef, c.displayQuery,
+	); err != nil {
+		t.Fatalf("insert collection %s: %v", c.id, err)
+	}
+	for _, profileID := range c.sharedWith {
+		if _, err := f.pool.Exec(ctx,
+			`INSERT INTO user_personal_collection_profiles (user_id, collection_id, profile_id)
+			 VALUES ($1, $2, $3)`,
+			f.userID, c.id, profileID,
+		); err != nil {
+			t.Fatalf("share collection %s with %s: %v", c.id, profileID, err)
+		}
+	}
+}
+
+// TestStoreGetEnforcesOwnershipOptInAndProfile exercises the privacy predicate
+// against a real database: only an opted-in collection shared with the asking
+// profile, and owned by the asking user, resolves.
+func TestStoreGetEnforcesOwnershipOptInAndProfile(t *testing.T) {
+	t.Parallel()
+	f := newStoreTestFixture(t)
+	store := NewStore(f.pool)
+	ctx := context.Background()
+
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "visible", name: "Visible", optIn: true,
+		sharedWith:   []string{storeTestOwnerProfile},
+		collType:     "mdblist",
+		queryDef:     `{"match":"all"}`,
+		displayQuery: `{"match":"all","groups":[{"match":"all","rules":[{"field":"watched","op":"equals","value":false}]}]}`,
+	})
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "not-opted-in", name: "Not Opted In", optIn: false,
+		sharedWith: []string{storeTestOwnerProfile},
+	})
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "other-profile", name: "Other Profile", optIn: true,
+		sharedWith: []string{storeTestOtherProfile},
+	})
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "hidden-library", name: "Hidden Library", optIn: true,
+		sharedWith: []string{storeTestOwnerProfile}, sourceConfig: `{"library_ids":[9]}`,
+	})
+
+	got, err := store.Get(ctx, f.userID, storeTestOwnerProfile, storeTestIDPrefix+"visible", []int{7})
+	if err != nil {
+		t.Fatalf("get visible collection: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected the opted-in, shared collection to resolve")
+	}
+	if got.Name != "Visible" || got.CollectionType != "mdblist" {
+		t.Fatalf("unexpected collection: %+v", *got)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		userID    int
+		profileID string
+		id        string
+	}{
+		{"not opted in", f.userID, storeTestOwnerProfile, storeTestIDPrefix + "not-opted-in"},
+		{"shared with another profile", f.userID, storeTestOwnerProfile, storeTestIDPrefix + "other-profile"},
+		{"owned by another user", f.userID + 10_000, storeTestOwnerProfile, storeTestIDPrefix + "visible"},
+		{"scoped outside visible libraries", f.userID, storeTestOwnerProfile, storeTestIDPrefix + "hidden-library"},
+		{"unknown id", f.userID, storeTestOwnerProfile, storeTestIDPrefix + "missing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := store.Get(ctx, tc.userID, tc.profileID, tc.id, []int{7})
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if got != nil {
+				t.Fatalf("expected no collection, got %+v", *got)
+			}
+		})
+	}
+}
+
+func TestStoreAnyVisible(t *testing.T) {
+	t.Parallel()
+	f := newStoreTestFixture(t)
+	store := NewStore(f.pool)
+	ctx := context.Background()
+
+	if visible, err := store.AnyVisible(ctx, f.userID, storeTestOtherProfile, []int{7}); err != nil || visible {
+		t.Fatalf("expected no collections for an unshared profile, got visible=%v err=%v", visible, err)
+	}
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "hidden-probe", name: "Hidden Probe", optIn: true,
+		sharedWith: []string{storeTestOtherProfile}, sourceConfig: `{"library_ids":[9]}`,
+	})
+	if visible, err := store.AnyVisible(ctx, f.userID, storeTestOtherProfile, []int{7}); err != nil || visible {
+		t.Fatalf("expected hidden-library collection not to enable the view, got visible=%v err=%v", visible, err)
+	}
+
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "probe", name: "Probe", optIn: true,
+		sharedWith: []string{storeTestOtherProfile},
+	})
+
+	if visible, err := store.AnyVisible(ctx, f.userID, storeTestOtherProfile, []int{7}); err != nil || !visible {
+		t.Fatalf("expected the shared collection to be probed, got visible=%v err=%v", visible, err)
+	}
+	if visible, err := store.AnyVisible(ctx, f.userID+10_000, storeTestOtherProfile, []int{7}); err != nil || visible {
+		t.Fatalf("expected another user's probe to be empty, got visible=%v err=%v", visible, err)
+	}
+}
+
+// TestStoreListLibraryScope pins the library predicate: scoped rows must
+// overlap the visible library set, and library-agnostic rows show under any of
+// them.
+func TestStoreListLibraryScope(t *testing.T) {
+	t.Parallel()
+	f := newStoreTestFixture(t)
+	store := NewStore(f.pool)
+	ctx := context.Background()
+
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "lib-7", name: "Scoped To 7", optIn: true,
+		sharedWith: []string{storeTestOwnerProfile}, sourceConfig: `{"library_ids":[7]}`,
+	})
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "agnostic", name: "Agnostic", optIn: true,
+		sharedWith: []string{storeTestOwnerProfile},
+	})
+	f.insert(t, storeTestCollection{
+		id: storeTestIDPrefix + "not-opted-in-list", name: "Not Opted In", optIn: false,
+		sharedWith: []string{storeTestOwnerProfile},
+	})
+	for _, kind := range []string{"mdblist", "smart"} {
+		f.insert(t, storeTestCollection{
+			id: storeTestIDPrefix + kind + "-invalid-scope", name: "Out Of Range", optIn: true,
+			sharedWith: []string{storeTestOwnerProfile}, collType: kind,
+			sourceConfig: `{"library_ids":[2147483648,"7"]}`,
+			queryDef:     `{"library_ids":[2147483648,"7"]}`,
+		})
+	}
+
+	names := func(t *testing.T, libraryIDs []int) []string {
+		t.Helper()
+		rows, err := store.List(ctx, f.userID, storeTestOwnerProfile, libraryIDs)
+		if err != nil {
+			t.Fatalf("list libraries %v: %v", libraryIDs, err)
+		}
+		out := make([]string, 0, len(rows))
+		for _, row := range rows {
+			out = append(out, row.Name)
+		}
+		return out
+	}
+	if got := names(t, []int{7, 8}); len(got) != 2 {
+		t.Fatalf("the visible library set should return both collections, got %v", got)
+	}
+	if got := names(t, []int{7}); len(got) != 2 {
+		t.Fatalf("library 7 should list its own plus the agnostic one, got %v", got)
+	}
+	if got := names(t, []int{8}); len(got) != 1 || got[0] != "Agnostic" {
+		t.Fatalf("library 8 should list only the agnostic collection, got %v", got)
+	}
+	// A negative ID is reachable from the request path (Atoi accepts it) and must
+	// stay a plain non-matching library, never a wildcard.
+	if got := names(t, []int{-1}); len(got) != 1 || got[0] != "Agnostic" {
+		t.Fatalf("a negative library must not widen the query, got %v", got)
+	}
+	if got, err := ListServerVisibleByLibrary(ctx, f.pool, f.userID, storeTestOwnerProfile, 7); err != nil || len(got) != 2 {
+		t.Fatalf("native library listing must ignore invalid scopes: got=%v err=%v", got, err)
+	}
+}

--- a/internal/usercollections/store_postgres_test.go
+++ b/internal/usercollections/store_postgres_test.go
@@ -2,6 +2,8 @@ package usercollections
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"testing"
 
@@ -137,7 +139,8 @@ func TestStoreGetEnforcesOwnershipOptInAndProfile(t *testing.T) {
 		sharedWith: []string{storeTestOwnerProfile}, sourceConfig: `{"library_ids":[9]}`,
 	})
 
-	got, err := store.Get(ctx, f.userID, storeTestOwnerProfile, storeTestIDPrefix+"visible", []int{7})
+	sum := sha256.Sum256([]byte(storeTestIDPrefix + "visible"))
+	got, err := store.Get(ctx, f.userID, storeTestOwnerProfile, hex.EncodeToString(sum[:14]), []int{7})
 	if err != nil {
 		t.Fatalf("get visible collection: %v", err)
 	}
@@ -161,7 +164,8 @@ func TestStoreGetEnforcesOwnershipOptInAndProfile(t *testing.T) {
 		{"unknown id", f.userID, storeTestOwnerProfile, storeTestIDPrefix + "missing"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := store.Get(ctx, tc.userID, tc.profileID, tc.id, []int{7})
+			sum := sha256.Sum256([]byte(tc.id))
+			got, err := store.Get(ctx, tc.userID, tc.profileID, hex.EncodeToString(sum[:14]), []int{7})
 			if err != nil {
 				t.Fatalf("get: %v", err)
 			}
@@ -199,6 +203,36 @@ func TestStoreAnyVisible(t *testing.T) {
 	}
 	if visible, err := store.AnyVisible(ctx, f.userID+10_000, storeTestOtherProfile, []int{7}); err != nil || visible {
 		t.Fatalf("expected another user's probe to be empty, got visible=%v err=%v", visible, err)
+	}
+}
+
+func TestStoreCompatKeys(t *testing.T) {
+	t.Parallel()
+	f := newStoreTestFixture(t)
+	store := NewStore(f.pool)
+	for _, id := range []string{
+		"01K3M9K0R7D6Y9T7F1P6W2H8ZX", uuid.NewString(), "legacy-collection", "123", `test-å-\-集合`,
+	} {
+		t.Run(id, func(t *testing.T) {
+			f.insert(t, storeTestCollection{id: id, name: "Test collection", optIn: true, sharedWith: []string{storeTestOwnerProfile}})
+			sum := sha256.Sum256([]byte(id))
+			key := hex.EncodeToString(sum[:14])
+			got, err := store.Get(t.Context(), f.userID, storeTestOwnerProfile, key, nil)
+			if err != nil || got == nil || got.ID != id {
+				t.Fatalf("lookup key must resolve the unchanged native ID: got=%+v err=%v", got, err)
+			}
+			candidates, err := store.ImageCandidates(t.Context(), key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, c := range candidates {
+				found = found || c.ID == id
+			}
+			if !found {
+				t.Fatal("signed-image candidates did not resolve the native ID")
+			}
+		})
 	}
 }
 

--- a/migrations/sql/20260829190916_index_user_collection_image_candidates.sql
+++ b/migrations/sql/20260829190916_index_user_collection_image_candidates.sql
@@ -1,8 +1,13 @@
+-- +goose NO TRANSACTION
+
 -- +goose Up
-CREATE INDEX idx_user_personal_collections_image_candidates
+-- Concurrent builds can leave an invalid index after interruption; rebuild on retry.
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_personal_collections_image_candidates;
+
+CREATE INDEX CONCURRENTLY idx_user_personal_collections_image_candidates
     ON user_personal_collections (id)
     WHERE include_in_server_collections = TRUE
       AND collection_type <> 'playlist';
 
 -- +goose Down
-DROP INDEX IF EXISTS idx_user_personal_collections_image_candidates;
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_personal_collections_image_candidates;

--- a/migrations/sql/20260829190916_index_user_collection_image_candidates.sql
+++ b/migrations/sql/20260829190916_index_user_collection_image_candidates.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+CREATE INDEX idx_user_personal_collections_image_candidates
+    ON user_personal_collections (id)
+    WHERE include_in_server_collections = TRUE
+      AND collection_type <> 'playlist';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_user_personal_collections_image_candidates;

--- a/migrations/sql/20260831080145_index_user_collection_compat_keys.sql
+++ b/migrations/sql/20260831080145_index_user_collection_compat_keys.sql
@@ -1,8 +1,10 @@
+-- +goose NO TRANSACTION
+
 -- +goose Up
 -- Explicit UTF-8 makes the lookup key independent of client encoding. Keep
 -- the 112-bit SHA-256 prefix in sync with ResourceIDCodec's personal ID kind.
 -- +goose StatementBegin
-CREATE FUNCTION jellycompat_user_collection_key(collection_id text)
+CREATE OR REPLACE FUNCTION jellycompat_user_collection_key(collection_id text)
 RETURNS text
 LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
 AS $$
@@ -10,18 +12,23 @@ AS $$
 $$;
 -- +goose StatementEnd
 
-CREATE INDEX idx_user_personal_collections_compat_key
+-- Concurrent builds can leave an invalid index after interruption; rebuild on retry.
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_personal_collections_compat_key;
+
+CREATE INDEX CONCURRENTLY idx_user_personal_collections_compat_key
     ON user_personal_collections (jellycompat_user_collection_key(id))
     WHERE include_in_server_collections = TRUE
       AND collection_type <> 'playlist';
 
-DROP INDEX idx_user_personal_collections_image_candidates;
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_personal_collections_image_candidates;
 
 -- +goose Down
-CREATE INDEX idx_user_personal_collections_image_candidates
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_personal_collections_image_candidates;
+
+CREATE INDEX CONCURRENTLY idx_user_personal_collections_image_candidates
     ON user_personal_collections (id)
     WHERE include_in_server_collections = TRUE
       AND collection_type <> 'playlist';
 
-DROP INDEX idx_user_personal_collections_compat_key;
-DROP FUNCTION jellycompat_user_collection_key(text);
+DROP INDEX CONCURRENTLY IF EXISTS idx_user_personal_collections_compat_key;
+DROP FUNCTION IF EXISTS jellycompat_user_collection_key(text);

--- a/migrations/sql/20260831080145_index_user_collection_compat_keys.sql
+++ b/migrations/sql/20260831080145_index_user_collection_compat_keys.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- Explicit UTF-8 makes the lookup key independent of client encoding. Keep
+-- the 112-bit SHA-256 prefix in sync with ResourceIDCodec's personal ID kind.
+-- +goose StatementBegin
+CREATE FUNCTION jellycompat_user_collection_key(collection_id text)
+RETURNS text
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+    SELECT substr(encode(sha256(convert_to(collection_id, 'UTF8')), 'hex'), 1, 28)
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX idx_user_personal_collections_compat_key
+    ON user_personal_collections (jellycompat_user_collection_key(id))
+    WHERE include_in_server_collections = TRUE
+      AND collection_type <> 'playlist';
+
+DROP INDEX idx_user_personal_collections_image_candidates;
+
+-- +goose Down
+CREATE INDEX idx_user_personal_collections_image_candidates
+    ON user_personal_collections (id)
+    WHERE include_in_server_collections = TRUE
+      AND collection_type <> 'playlist';
+
+DROP INDEX idx_user_personal_collections_compat_key;
+DROP FUNCTION jellycompat_user_collection_key(text);

--- a/migrations/user_collection_indexes_test.go
+++ b/migrations/user_collection_indexes_test.go
@@ -1,0 +1,75 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserCollectionIndexesAreConcurrentAndRetrySafe(t *testing.T) {
+	const imageIndex = "idx_user_personal_collections_image_candidates"
+	const keyIndex = "idx_user_personal_collections_compat_key"
+	for _, tc := range []struct {
+		file string
+		up   string
+		down string
+	}{
+		{"20260829190916_index_user_collection_image_candidates.sql", imageIndex, ""},
+		{"20260831080145_index_user_collection_compat_keys.sql", keyIndex, imageIndex},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			data, err := FS.ReadFile("sql/" + tc.file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			migration := string(data)
+			if !strings.Contains(migration, "-- +goose NO TRANSACTION") {
+				t.Error("concurrent index operations must run outside a transaction")
+			}
+			for _, line := range strings.Split(migration, "\n") {
+				line = strings.TrimSpace(line)
+				for _, operation := range []string{"CREATE INDEX ", "DROP INDEX "} {
+					if strings.HasPrefix(line, operation) && !strings.HasPrefix(line, operation+"CONCURRENTLY ") {
+						t.Errorf("blocking index operation: %s", line)
+					}
+				}
+			}
+			up, down, ok := strings.Cut(migration, "-- +goose Down")
+			if !ok {
+				t.Fatal("missing Down migration")
+			}
+			for _, direction := range []struct {
+				sql    string
+				build  string
+				remove string
+			}{
+				{normalizeSQL(up), tc.up, tc.down},
+				{normalizeSQL(down), tc.down, tc.up},
+			} {
+				createAt := -1
+				if direction.build != "" {
+					// A failed concurrent build leaves an invalid index: IF NOT EXISTS
+					// alone would skip it instead of rebuilding it on the next attempt.
+					cleanupAt := strings.Index(direction.sql, "DROP INDEX CONCURRENTLY IF EXISTS "+direction.build+";")
+					createAt = strings.Index(direction.sql, "CREATE INDEX CONCURRENTLY "+direction.build+" ON ")
+					if cleanupAt < 0 || createAt < 0 || cleanupAt > createAt {
+						t.Errorf("%s must have concurrent retry cleanup before its build", direction.build)
+					}
+				}
+				if direction.remove != "" {
+					dropAt := strings.Index(direction.sql, "DROP INDEX CONCURRENTLY IF EXISTS "+direction.remove+";")
+					if dropAt < 0 || dropAt < createAt {
+						t.Errorf("%s must be dropped concurrently after the replacement is built", direction.remove)
+					}
+				}
+			}
+			if tc.up == keyIndex {
+				if !strings.Contains(up, "CREATE OR REPLACE FUNCTION jellycompat_user_collection_key(") {
+					t.Error("function creation must tolerate retry after a partial Up")
+				}
+				if !strings.Contains(down, "DROP FUNCTION IF EXISTS jellycompat_user_collection_key(text);") {
+					t.Error("function removal must tolerate retry after a partial Down")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION

## Problem

Related issue: #861. Closes #861.

Personal collections with **Include in server collections** enabled appear in
Silo but are missing from the Jellyfin-compatible API. If a user has only
personal collections, the Collections view is missing too.

## Approach

- Include opted-in personal collections alongside server BoxSets, restricted to
  the owning account, allowed profiles and visible library scope.
- Reuse the native catalog resolver for collection membership, watched/display
  filters, saved/default sorting and pagination. Reuse the existing BoxSet DTO
  and artwork handling; filter to video items on the Jellyfin surface.
- Add restart-safe personal collection IDs and an index for signed poster lookup.
- Reuse the guarded image client for user-controlled poster URLs and keep those
  URLs out of the legacy global image cache. Trusted object-store keys and
  bundled artwork retain their existing paths. Reuse the existing asset CSP
  with `nosniff` for untrusted external poster responses.

Personal BoxSet metadata omits stored member counts; child responses report the
accessible, filtered total. This does not export custom home sections, add list
providers or change synchronization schedules. The native v1 contract is
unchanged, so no Apple/Android contract changes are required.

## Validation

Tested on macOS with Go 1.27.0 and Node 22.23.2, based on upstream `ab4f9a80`.
The before/after HTTP and PostgreSQL reproduction is recorded in #861: the
same test fails on clean upstream and passes with this change.

Focused tests used a disposable, migrated PostgreSQL 18 database selected by
`SILO_TEST_DATABASE_URL`; no database tests in this selection were skipped.

```sh
go test -race -v -p=1 -count=1 ./internal/catalog ./internal/jellycompat ./internal/usercollections ./internal/imagecache -run 'Collection|BoxSet|Backdrop|^TestStore|^TestPublicImage'
```

Output excerpt:

```text
ok  	github.com/Silo-Server/silo-server/internal/catalog	1.857s
ok  	github.com/Silo-Server/silo-server/internal/jellycompat	3.218s
ok  	github.com/Silo-Server/silo-server/internal/usercollections	1.616s
ok  	github.com/Silo-Server/silo-server/internal/imagecache	1.774s
```

Also passed: `make embed-stub`, `go build ./...`, `go vet ./...`,
`pnpm install --frozen-lockfile`, `pnpm run lint` (174 warnings, no errors),
`pnpm run format:check`, `pnpm run build`, `make verify-settings-bindings-all`,
`make verify-playback-fixtures` and `make verify-local-paths`.

```text
$ golangci-lint run --new-from-merge-base=origin/main ./...
0 issues.
```

`make test-web` passed with the repository's existing exclusions. Output excerpt:

```text
 Test Files  356 passed (356)
      Tests  3048 passed (3048)
```

The full gate is not green:

- `make lint`: 298 findings; clean upstream also reports 298. Changed-line lint
  passes for the complete patch.
- `gofmt -l .`: reports the unchanged `internal/jellycompat/handlers_items_test.go`,
  identical to clean upstream. All Go files in this PR are formatted.
- `make test-go` without a database: fails in `jellycompat`, `playback` and
  `transcodenode`. Those packages also fail on clean upstream; the failing test
  set varies between runs (50 here, 41 on upstream). The unknown-season
  500-versus-404 failure reproduces on both. No unrelated test fixes or skips
  were added.

Manual verification used local HTTP/database fixtures.

## Risks

- Signed poster URLs are shareable bearer capabilities. They do not authorize
  collection metadata or member access, which still requires account/profile checks.

## AI Disclosure

- Tool(s): Codex.
- Model(s): `gpt-5.6-sol`.
- Involvement: AI-assisted.
- Adversarial review: Reviewed the complete diff, callers, access checks, ID
  namespaces, image authorization, filtering and pagination. Earlier reviews
  corrected ID collisions, library-scope overflow, media-type filtering,
  episode/backdrop handling, personal-poster SSRF and a legacy-cache bypass.
  Also fixed database fixtures that skipped without an existing account.
  Regression tests failed before correction and passed afterward. The latest
  review reran the repository gate and compared failing packages with clean
  upstream, with the limitations reported above.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Personal collections now appear as Jellyfin BoxSets alongside library collections.
  - Collection listings support ownership, visibility, searching, sorting, filtering, and paging.
  - Added randomized ordering and person- or backdrop-based filtering.
  - Personal collection artwork is supported with secure access controls.
  - Personal collection IDs remain compatible across UUID, ULID, legacy, numeric, and Unicode formats.

- **Bug Fixes**
  - Backdrop filtering now occurs before pagination for accurate results and totals.
  - Improved protection against redirects to private, local, or restricted image destinations.
  - Personal collection visibility and artwork access are correctly restricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->