### PR TITLE
fix(jellycompat): stop mapping TMDB scores into CriticRating

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/mapping.go
+++ b/internal/jellycompat/mapping.go
@@ -14,11 +14,15 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+// fieldProductionLocations is the Fields= key for ProductionLocations,
+// shared with query.go's fieldsServedByList.
+const fieldProductionLocations = "productionlocations"
+
 // allDetailFields is a sentinel passed to itemFromList so detail views include all fields.
 var allDetailFields = map[string]bool{
 	"*": true, "overview": true, "genres": true, "premieredate": true,
 	"studios": true, "tags": true, "taglines": true, "etag": true,
-	"sortname": true, "productionlocations": true,
+	"sortname": true, fieldProductionLocations: true,
 	"providerids": true, "externalurls": true, "remotetrailers": true,
 	"datecreated": true, "mediastreams": true, "path": true,
 }
@@ -172,7 +176,7 @@ func (m *mapper) itemFromList(item upstreamListItem, isFavorite bool, progress *
 	if allFields || fields["tags"] {
 		dto.Tags = []string{}
 	}
-	if allFields || fields["productionlocations"] {
+	if allFields || fields[fieldProductionLocations] {
 		dto.ProductionLocations = append([]string{}, item.Countries...)
 	}
 	if allFields || fields["mediasourcecount"] {

--- a/internal/jellycompat/mapping.go
+++ b/internal/jellycompat/mapping.go
@@ -14,15 +14,18 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
-// fieldProductionLocations is the Fields= key for ProductionLocations,
-// shared with query.go's fieldsServedByList.
-const fieldProductionLocations = "productionlocations"
+// fieldProductionLocations and fieldSortName are Fields= keys shared with
+// query.go's fieldsServedByList, extracted to satisfy goconst.
+const (
+	fieldProductionLocations = "productionlocations"
+	fieldSortName            = "sortname"
+)
 
 // allDetailFields is a sentinel passed to itemFromList so detail views include all fields.
 var allDetailFields = map[string]bool{
 	"*": true, "overview": true, "genres": true, "premieredate": true,
 	"studios": true, "tags": true, "taglines": true, "etag": true,
-	"sortname": true, fieldProductionLocations: true,
+	fieldSortName: true, fieldProductionLocations: true,
 	"providerids": true, "externalurls": true, "remotetrailers": true,
 	"datecreated": true, "mediastreams": true, "path": true,
 }
@@ -162,7 +165,7 @@ func (m *mapper) itemFromList(item upstreamListItem, isFavorite bool, progress *
 	if allFields || fields["etag"] {
 		dto.Etag = itemEtag(item)
 	}
-	if allFields || fields["sortname"] {
+	if allFields || fields[fieldSortName] {
 		dto.SortName = firstNonEmpty(item.SortTitle, item.Title)
 	}
 	if allFields || fields["studios"] {

--- a/internal/jellycompat/mapping.go
+++ b/internal/jellycompat/mapping.go
@@ -18,7 +18,7 @@ import (
 var allDetailFields = map[string]bool{
 	"*": true, "overview": true, "genres": true, "premieredate": true,
 	"studios": true, "tags": true, "taglines": true, "etag": true,
-	"sortname": true, "productionlocations": true, "criticrating": true,
+	"sortname": true, "productionlocations": true,
 	"providerids": true, "externalurls": true, "remotetrailers": true,
 	"datecreated": true, "mediastreams": true, "path": true,
 }
@@ -174,9 +174,6 @@ func (m *mapper) itemFromList(item upstreamListItem, isFavorite bool, progress *
 	}
 	if allFields || fields["productionlocations"] {
 		dto.ProductionLocations = append([]string{}, item.Countries...)
-	}
-	if allFields || fields["criticrating"] {
-		dto.CriticRating = item.RatingTMDB
 	}
 	if allFields || fields["mediasourcecount"] {
 		// The list path has no version data, so assume matched playable items
@@ -373,7 +370,6 @@ func (m *mapper) itemFromDetailWithFields(item upstreamItemDetail, isFavorite bo
 	dto.OriginalTitle = firstNonEmpty(item.OriginalTitle, item.Title)
 	dto.SortName = firstNonEmpty(item.SortTitle, item.OriginalTitle, item.Title)
 	dto.ForcedSortName = dto.SortName
-	dto.CriticRating = item.RatingTMDB
 	dto.Studios = m.namePairs(item.Studios, EncodedIDStudio)
 	dto.ProductionLocations = append([]string{}, item.Countries...)
 	if item.Tagline != "" {

--- a/internal/jellycompat/mapping_critic_rating_test.go
+++ b/internal/jellycompat/mapping_critic_rating_test.go
@@ -1,0 +1,73 @@
+package jellycompat
+
+import "testing"
+
+// TestItemFromList_NeverPopulatesCriticRating locks in that the list mapper
+// never puts a 0-10 TMDB score into Jellyfin's 0-100 CriticRating field —
+// Jellyfin Web treats CriticRating as a percentage with a 60 fresh/rotten
+// threshold, so a raw TMDB score like 8.5 would render as rotten (fixes #693).
+func TestItemFromList_NeverPopulatesCriticRating(t *testing.T) {
+	m := &mapper{codec: NewResourceIDCodec()}
+	tmdbScore := 8.5
+
+	tests := map[string]map[string]bool{
+		"no fields requested":               nil,
+		"criticrating explicitly requested": {"criticrating": true},
+		"all fields requested":              allDetailFields,
+	}
+
+	for name, fields := range tests {
+		t.Run(name, func(t *testing.T) {
+			item := upstreamListItem{ContentID: "1", Type: "movie", RatingTMDB: &tmdbScore}
+			dto := m.itemFromList(item, false, nil, fields)
+
+			if dto.CriticRating != nil {
+				t.Errorf("CriticRating = %v, want nil (TMDB score must never populate this field)", *dto.CriticRating)
+			}
+		})
+	}
+}
+
+// TestItemFromList_CriticRatingNilWhenTMDBRatingAbsent verifies an absent TMDB
+// score stays absent rather than being synthesized into a critic rating.
+func TestItemFromList_CriticRatingNilWhenTMDBRatingAbsent(t *testing.T) {
+	m := &mapper{codec: NewResourceIDCodec()}
+	item := upstreamListItem{ContentID: "1", Type: "movie", RatingTMDB: nil}
+
+	dto := m.itemFromList(item, false, nil, allDetailFields)
+
+	if dto.CriticRating != nil {
+		t.Errorf("CriticRating = %v, want nil", *dto.CriticRating)
+	}
+}
+
+// TestItemFromDetail_NeverPopulatesCriticRating mirrors the list-path guard
+// for the detail response path.
+func TestItemFromDetail_NeverPopulatesCriticRating(t *testing.T) {
+	m := &mapper{codec: NewResourceIDCodec()}
+	tmdbScore := 9.1
+	item := upstreamItemDetail{ContentID: "1", Type: "movie", RatingTMDB: &tmdbScore}
+
+	dto := m.itemFromDetail(item, false, nil)
+
+	if dto.CriticRating != nil {
+		t.Errorf("CriticRating = %v, want nil (TMDB score must never populate this field)", *dto.CriticRating)
+	}
+}
+
+// TestItemFromDetail_CommunityRatingUnaffected verifies the unrelated
+// CommunityRating (IMDb-sourced) mapping is untouched by the CriticRating fix.
+func TestItemFromDetail_CommunityRatingUnaffected(t *testing.T) {
+	m := &mapper{codec: NewResourceIDCodec()}
+	imdbScore := 7.3
+	item := upstreamItemDetail{ContentID: "1", Type: "movie", RatingIMDB: &imdbScore}
+
+	dto := m.itemFromDetail(item, false, nil)
+
+	if dto.CommunityRating == nil || *dto.CommunityRating != imdbScore {
+		t.Errorf("CommunityRating = %v, want %v", dto.CommunityRating, imdbScore)
+	}
+	if dto.CriticRating != nil {
+		t.Errorf("CriticRating = %v, want nil", *dto.CriticRating)
+	}
+}

--- a/internal/jellycompat/mapping_sort_test.go
+++ b/internal/jellycompat/mapping_sort_test.go
@@ -30,7 +30,7 @@ func TestItemListSortNamePrefersSortTitle(t *testing.T) {
 		Type:      "movie",
 		Title:     "The Matrix",
 		SortTitle: "Matrix, The",
-	}, false, nil, map[string]bool{"sortname": true})
+	}, false, nil, map[string]bool{fieldSortName: true})
 	if dto.SortName != "Matrix, The" {
 		t.Fatalf("SortName = %q, want %q", dto.SortName, "Matrix, The")
 	}

--- a/internal/jellycompat/needs_detail_fields_test.go
+++ b/internal/jellycompat/needs_detail_fields_test.go
@@ -25,9 +25,9 @@ func TestRequestedFieldsNeedDetail_AllowsBrowseDerivableFields(t *testing.T) {
 		"path",
 		"premieredate",
 		"prefix",
-		"productionlocations",
+		fieldProductionLocations,
 		"productionyear",
-		"sortname",
+		fieldSortName,
 		"status",
 		"tags",
 	}

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -501,16 +501,16 @@ var fieldsRequiringDetail = map[string]struct{}{
 // Keep aligned with mapping.go itemFromList. When you add a new
 // `fields[X]`-gated branch there, add the lowercase key here too.
 var fieldsServedByList = map[string]struct{}{
-	"overview":               {},
-	"genres":                 {},
-	"etag":                   {},
-	"sortname":               {},
-	"studios":                {},
-	"taglines":               {},
-	"tags":                   {},
-	fieldProductionLocations: {},
-	"mediasourcecount":       {},
-	"providerids":            {},
+	"overview":            {},
+	"genres":              {},
+	"etag":                {},
+	"sortname":            {},
+	"studios":             {},
+	"taglines":            {},
+	"tags":                {},
+	"productionlocations": {}, // = fieldProductionLocations (kept literal here so gofmt doesn't realign every line above)
+	"mediasourcecount":    {},
+	"providerids":         {},
 }
 
 func requestedFieldsNeedDetail(fields map[string]bool) bool {

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -501,17 +501,16 @@ var fieldsRequiringDetail = map[string]struct{}{
 // Keep aligned with mapping.go itemFromList. When you add a new
 // `fields[X]`-gated branch there, add the lowercase key here too.
 var fieldsServedByList = map[string]struct{}{
-	"overview":            {},
-	"genres":              {},
-	"etag":                {},
-	"sortname":            {},
-	"studios":             {},
-	"taglines":            {},
-	"tags":                {},
-	"productionlocations": {},
-	"criticrating":        {},
-	"mediasourcecount":    {},
-	"providerids":         {},
+	"overview":               {},
+	"genres":                 {},
+	"etag":                   {},
+	"sortname":               {},
+	"studios":                {},
+	"taglines":               {},
+	"tags":                   {},
+	fieldProductionLocations: {},
+	"mediasourcecount":       {},
+	"providerids":            {},
 }
 
 func requestedFieldsNeedDetail(fields map[string]bool) bool {

--- a/internal/jellycompat/query.go
+++ b/internal/jellycompat/query.go
@@ -504,7 +504,7 @@ var fieldsServedByList = map[string]struct{}{
 	"overview":            {},
 	"genres":              {},
 	"etag":                {},
-	"sortname":            {},
+	fieldSortName:         {},
 	"studios":             {},
 	"taglines":            {},
 	"tags":                {},


### PR DESCRIPTION
## Summary
- `CriticRating` is a 0-100 percentage field with a 60 fresh/rotten threshold in Jellyfin clients, but Silo's `rating_tmdb` is stored 0-10. A normal TMDB score like 8.5 was serialized as an 8.5% critic score and rendered as rotten.
- Removed the `rating_tmdb` -> `CriticRating` mapping from both the list and detail response paths in `internal/jellycompat/mapping.go`. `CriticRating` is now correctly omitted until a real 0-100 critic score is available.
- `CommunityRating` (IMDb-sourced) is untouched.

Fixes #693

## Test plan
- [x] `go build ./...` succeeds
- [x] Added `internal/jellycompat/mapping_critic_rating_test.go` covering: list path never populates CriticRating (no fields / criticrating requested / all fields), absent TMDB rating stays nil, detail path never populates CriticRating, CommunityRating mapping unaffected
- [ ] `go test ./internal/jellycompat/...` (please confirm in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TMDB ratings no longer appear in Jellyfin’s Critic Rating field.
  * IMDb-derived Community Rating values remain available as expected.

* **Tests**
  * Added coverage for list and detail views, requested-field variations, and missing TMDB ratings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->