### PR TITLE
fix(web): add webkit video fullscreen fallback for iPhone Safari

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +23,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -914,10 +914,7 @@ describe("VideoPlayer translation handoff", () => {
     const webkitEnterFullscreen = vi.fn();
     const webkitExitFullscreen = vi.fn();
 
-    const { container } = render(
-      <VideoPlayer plan={directPlan} planRevision={1} sessionId="session-1" />,
-      { wrapper },
-    );
+    const { container } = renderPlayer();
 
     const video = container.querySelector("video") as HTMLVideoElement & {
       webkitSupportsFullscreen?: boolean;
@@ -945,10 +942,7 @@ describe("VideoPlayer translation handoff", () => {
   });
 
   it("tracks WebKit fullscreen events on the video element", async () => {
-    const { container } = render(
-      <VideoPlayer plan={directPlan} planRevision={1} sessionId="session-1" />,
-      { wrapper },
-    );
+    const { container } = renderPlayer();
 
     const video = container.querySelector("video") as HTMLVideoElement & {
       webkitDisplayingFullscreen?: boolean;

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -930,7 +930,9 @@ describe("VideoPlayer translation handoff", () => {
     video.webkitExitFullscreen = webkitExitFullscreen;
 
     // Simulate container requestFullscreen rejecting (as WebKit on iPhone does)
-    const playerContainer = container.querySelector('[data-testid="player-container"]') as HTMLElement;
+    const playerContainer = container.querySelector(
+      '[data-testid="player-container"]',
+    ) as HTMLElement;
     if (playerContainer) {
       playerContainer.requestFullscreen = vi.fn().mockRejectedValue(new Error("Not supported"));
     }

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -24,6 +24,8 @@ const controls = vi.hoisted(() => ({
     subtitleTracks: PlayerSubtitleInfo[];
     visible: boolean;
     onSurfaceTap?: (event: React.MouseEvent<HTMLElement>) => void;
+    isFullscreen?: boolean;
+    onFullscreenToggle?: () => void;
   },
 }));
 const playerSeek = vi.hoisted(() => vi.fn());
@@ -100,6 +102,8 @@ vi.mock("./PlayerControls", () => ({
       subtitleTracks: PlayerSubtitleInfo[];
       visible: boolean;
       onSurfaceTap?: (event: React.MouseEvent<HTMLElement>) => void;
+      isFullscreen?: boolean;
+      onFullscreenToggle?: () => void;
     }) => {
       controls.current = props;
       return null;
@@ -904,5 +908,62 @@ describe("VideoPlayer translation handoff", () => {
     await waitFor(() => expect(onSubtitleChanged).toHaveBeenCalledWith(4, undefined));
     expect(controls.current?.activeSubtitleIndex).toBe(4);
     expect(controls.current?.subtitleTracks).toEqual([downloadedTrack]);
+  });
+
+  it("falls back to webkitEnterFullscreen when requestFullscreen fails on iPhone Safari", async () => {
+    const webkitEnterFullscreen = vi.fn();
+    const webkitExitFullscreen = vi.fn();
+
+    const { container } = render(
+      <VideoPlayer plan={directPlan} planRevision={1} sessionId="session-1" />,
+      { wrapper },
+    );
+
+    const video = container.querySelector("video") as HTMLVideoElement & {
+      webkitSupportsFullscreen?: boolean;
+      webkitDisplayingFullscreen?: boolean;
+      webkitEnterFullscreen?: () => void;
+      webkitExitFullscreen?: () => void;
+    };
+    video.webkitSupportsFullscreen = true;
+    video.webkitEnterFullscreen = webkitEnterFullscreen;
+    video.webkitExitFullscreen = webkitExitFullscreen;
+
+    // Simulate container requestFullscreen rejecting (as WebKit on iPhone does)
+    const playerContainer = container.querySelector('[data-testid="player-container"]') as HTMLElement;
+    if (playerContainer) {
+      playerContainer.requestFullscreen = vi.fn().mockRejectedValue(new Error("Not supported"));
+    }
+
+    act(() => {
+      controls.current?.onFullscreenToggle?.();
+    });
+
+    await waitFor(() => expect(webkitEnterFullscreen).toHaveBeenCalledOnce());
+  });
+
+  it("tracks WebKit fullscreen events on the video element", async () => {
+    const { container } = render(
+      <VideoPlayer plan={directPlan} planRevision={1} sessionId="session-1" />,
+      { wrapper },
+    );
+
+    const video = container.querySelector("video") as HTMLVideoElement & {
+      webkitDisplayingFullscreen?: boolean;
+    };
+
+    video.webkitDisplayingFullscreen = true;
+    act(() => {
+      video.dispatchEvent(new Event("webkitbeginfullscreen"));
+    });
+
+    expect(controls.current?.isFullscreen).toBe(true);
+
+    video.webkitDisplayingFullscreen = false;
+    act(() => {
+      video.dispatchEvent(new Event("webkitendfullscreen"));
+    });
+
+    expect(controls.current?.isFullscreen).toBe(false);
   });
 });

--- a/web/src/player/components/VideoPlayer.test.tsx
+++ b/web/src/player/components/VideoPlayer.test.tsx
@@ -910,36 +910,47 @@ describe("VideoPlayer translation handoff", () => {
     expect(controls.current?.subtitleTracks).toEqual([downloadedTrack]);
   });
 
-  it("falls back to webkitEnterFullscreen when requestFullscreen fails on iPhone Safari", async () => {
-    const webkitEnterFullscreen = vi.fn();
-    const webkitExitFullscreen = vi.fn();
+  it.each(["missing", "rejecting"])(
+    "falls back to webkitEnterFullscreen when requestFullscreen is %s",
+    async (mode) => {
+      const webkitEnterFullscreen = vi.fn();
+      const webkitExitFullscreen = vi.fn();
 
-    const { container } = renderPlayer();
+      const { container } = renderPlayer();
 
-    const video = container.querySelector("video") as HTMLVideoElement & {
-      webkitSupportsFullscreen?: boolean;
-      webkitDisplayingFullscreen?: boolean;
-      webkitEnterFullscreen?: () => void;
-      webkitExitFullscreen?: () => void;
-    };
-    video.webkitSupportsFullscreen = true;
-    video.webkitEnterFullscreen = webkitEnterFullscreen;
-    video.webkitExitFullscreen = webkitExitFullscreen;
+      const video = container.querySelector("video") as HTMLVideoElement & {
+        webkitSupportsFullscreen?: boolean;
+        webkitDisplayingFullscreen?: boolean;
+        webkitEnterFullscreen?: () => void;
+        webkitExitFullscreen?: () => void;
+      };
+      video.webkitSupportsFullscreen = true;
+      video.webkitEnterFullscreen = webkitEnterFullscreen;
+      video.webkitExitFullscreen = webkitExitFullscreen;
 
-    // Simulate container requestFullscreen rejecting (as WebKit on iPhone does)
-    const playerContainer = container.querySelector(
-      '[data-testid="player-container"]',
-    ) as HTMLElement;
-    if (playerContainer) {
-      playerContainer.requestFullscreen = vi.fn().mockRejectedValue(new Error("Not supported"));
-    }
+      // Simulate container requestFullscreen rejecting (as WebKit on iPhone does)
+      const playerContainer = container.querySelector(".player-container") as HTMLElement;
+      expect(playerContainer).not.toBeNull();
+      const requestFullscreen = vi.fn().mockRejectedValue(new Error("Not supported"));
+      Object.defineProperty(playerContainer, "requestFullscreen", {
+        value: mode === "rejecting" ? requestFullscreen : undefined,
+        configurable: true,
+      });
 
-    act(() => {
-      controls.current?.onFullscreenToggle?.();
-    });
+      act(() => {
+        controls.current?.onFullscreenToggle?.();
+      });
 
-    await waitFor(() => expect(webkitEnterFullscreen).toHaveBeenCalledOnce());
-  });
+      await waitFor(() => expect(webkitEnterFullscreen).toHaveBeenCalledOnce());
+      expect(requestFullscreen).toHaveBeenCalledTimes(mode === "rejecting" ? 1 : 0);
+
+      video.webkitDisplayingFullscreen = true;
+      act(() => {
+        controls.current?.onFullscreenToggle?.();
+      });
+      expect(webkitExitFullscreen).toHaveBeenCalledOnce();
+    },
+  );
 
   it("tracks WebKit fullscreen events on the video element", async () => {
     const { container } = renderPlayer();

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -2030,9 +2030,25 @@ export function VideoPlayer({
 
   // -- Fullscreen tracking --
   useEffect(() => {
-    const onChange = () => setIsFullscreen(!!document.fullscreenElement);
+    const video = videoRef.current as (HTMLVideoElement & {
+      webkitDisplayingFullscreen?: boolean;
+    }) | null;
+
+    const onChange = () => {
+      const isDocFullscreen = !!document.fullscreenElement;
+      const isVideoFullscreen = !!video?.webkitDisplayingFullscreen;
+      setIsFullscreen(isDocFullscreen || isVideoFullscreen);
+    };
+
     document.addEventListener("fullscreenchange", onChange);
-    return () => document.removeEventListener("fullscreenchange", onChange);
+    video?.addEventListener("webkitbeginfullscreen", onChange);
+    video?.addEventListener("webkitendfullscreen", onChange);
+
+    return () => {
+      document.removeEventListener("fullscreenchange", onChange);
+      video?.removeEventListener("webkitbeginfullscreen", onChange);
+      video?.removeEventListener("webkitendfullscreen", onChange);
+    };
   }, []);
 
   // -- Subtitle appearance --
@@ -2437,10 +2453,31 @@ export function VideoPlayer({
   }, []);
 
   const handleFullscreenToggle = useCallback(() => {
+    const video = videoRef.current as (HTMLVideoElement & {
+      webkitSupportsFullscreen?: boolean;
+      webkitDisplayingFullscreen?: boolean;
+      webkitEnterFullscreen?: () => void;
+      webkitExitFullscreen?: () => void;
+    }) | null;
+
     if (document.fullscreenElement) {
       document.exitFullscreen().catch(() => {});
-    } else {
-      containerRef.current?.requestFullscreen().catch(() => {});
+    } else if (video?.webkitDisplayingFullscreen) {
+      video.webkitExitFullscreen?.();
+    } else if (containerRef.current?.requestFullscreen) {
+      containerRef.current.requestFullscreen().catch(() => {
+        if (
+          video?.webkitSupportsFullscreen !== false &&
+          typeof video?.webkitEnterFullscreen === "function"
+        ) {
+          video.webkitEnterFullscreen();
+        }
+      });
+    } else if (
+      video?.webkitSupportsFullscreen !== false &&
+      typeof video?.webkitEnterFullscreen === "function"
+    ) {
+      video.webkitEnterFullscreen();
     }
   }, []);
 

--- a/web/src/player/components/VideoPlayer.tsx
+++ b/web/src/player/components/VideoPlayer.tsx
@@ -2030,9 +2030,11 @@ export function VideoPlayer({
 
   // -- Fullscreen tracking --
   useEffect(() => {
-    const video = videoRef.current as (HTMLVideoElement & {
-      webkitDisplayingFullscreen?: boolean;
-    }) | null;
+    const video = videoRef.current as
+      | (HTMLVideoElement & {
+          webkitDisplayingFullscreen?: boolean;
+        })
+      | null;
 
     const onChange = () => {
       const isDocFullscreen = !!document.fullscreenElement;
@@ -2453,12 +2455,14 @@ export function VideoPlayer({
   }, []);
 
   const handleFullscreenToggle = useCallback(() => {
-    const video = videoRef.current as (HTMLVideoElement & {
-      webkitSupportsFullscreen?: boolean;
-      webkitDisplayingFullscreen?: boolean;
-      webkitEnterFullscreen?: () => void;
-      webkitExitFullscreen?: () => void;
-    }) | null;
+    const video = videoRef.current as
+      | (HTMLVideoElement & {
+          webkitSupportsFullscreen?: boolean;
+          webkitDisplayingFullscreen?: boolean;
+          webkitEnterFullscreen?: () => void;
+          webkitExitFullscreen?: () => void;
+        })
+      | null;
 
     if (document.fullscreenElement) {
       document.exitFullscreen().catch(() => {});

--- a/web/src/player/hooks/useKeyboardShortcuts.ts
+++ b/web/src/player/hooks/useKeyboardShortcuts.ts
@@ -41,10 +41,32 @@ export function useKeyboardShortcuts(
         case "f":
         case "F":
           e.preventDefault();
-          if (document.fullscreenElement) {
-            document.exitFullscreen().catch(() => {});
-          } else {
-            containerRef.current?.requestFullscreen().catch(() => {});
+          {
+            const webkitVideo = video as HTMLVideoElement & {
+              webkitSupportsFullscreen?: boolean;
+              webkitDisplayingFullscreen?: boolean;
+              webkitEnterFullscreen?: () => void;
+              webkitExitFullscreen?: () => void;
+            };
+            if (document.fullscreenElement) {
+              document.exitFullscreen().catch(() => {});
+            } else if (webkitVideo.webkitDisplayingFullscreen) {
+              webkitVideo.webkitExitFullscreen?.();
+            } else if (containerRef.current?.requestFullscreen) {
+              containerRef.current.requestFullscreen().catch(() => {
+                if (
+                  webkitVideo.webkitSupportsFullscreen !== false &&
+                  typeof webkitVideo.webkitEnterFullscreen === "function"
+                ) {
+                  webkitVideo.webkitEnterFullscreen();
+                }
+              });
+            } else if (
+              webkitVideo.webkitSupportsFullscreen !== false &&
+              typeof webkitVideo.webkitEnterFullscreen === "function"
+            ) {
+              webkitVideo.webkitEnterFullscreen();
+            }
           }
           break;
 


### PR DESCRIPTION
## Summary
- Fixes #680.
- On iPhone WebKit / Safari, `Element.requestFullscreen()` on arbitrary `<div>` containers is unsupported or rejects, and standard fullscreen events are not dispatched for the document. Fullscreen video playback on iPhone WebKit must go through HTMLVideoElement's native WebKit fullscreen APIs (`webkitSupportsFullscreen`, `webkitEnterFullscreen()`, `webkitExitFullscreen()`, `webkitbeginfullscreen`, `webkitendfullscreen`).
- Previously, tapping the fullscreen button in the web player or pressing the fullscreen shortcut called `containerRef.current.requestFullscreen()` directly, which silently failed on iPhone.
- This change:
  - Updates `handleFullscreenToggle` and `useKeyboardShortcuts` to catch failed/unsupported container fullscreen requests and fall back to `video.webkitEnterFullscreen()`.
  - Supports exiting native WebKit fullscreen via `video.webkitExitFullscreen()`.
  - Updates fullscreen state tracking to listen for `webkitbeginfullscreen` and `webkitendfullscreen` on the video element in addition to `fullscreenchange` on `document`.
  - Adds unit tests verifying the WebKit video fullscreen fallback and event tracking.

## Test Plan
- [x] Added unit tests in `VideoPlayer.test.tsx` verifying fallback to `webkitEnterFullscreen` when container `requestFullscreen` fails, and verification of WebKit fullscreen events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Safari and iPhone-compatible fullscreen support for video playback.
  * Fullscreen controls and keyboard shortcuts now fall back to the video’s native fullscreen mode when standard fullscreen is unavailable or fails.
  * Fullscreen state updates correctly when entering or exiting native video fullscreen.
  * Exiting fullscreen now works consistently through both the on-screen controls and keyboard shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->