### PR TITLE
test(jellycompat): restore CI baseline

### DIFF
--- a/internal/jellycompat/handlers_items_test.go
+++ b/internal/jellycompat/handlers_items_test.go
@@ -810,7 +810,6 @@ func TestHandleEpisodes_UnknownSeasonIDReturnsNotFound(t *testing.T) {
 	}
 }
 
-
 // TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404 — same contract for
 // undecodable IDs. Decode failure must NOT 404 for the same reason.
 func TestHandleUpcoming_InvalidSeriesId_ReturnsEmptyNot404(t *testing.T) {

--- a/internal/jellycompat/parent_browse_test.go
+++ b/internal/jellycompat/parent_browse_test.go
@@ -2,7 +2,6 @@ package jellycompat
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -22,7 +22,7 @@ func (f *fakeSeasonByIDRepo) GetByID(_ context.Context, id string) (*models.Seas
 	if s, ok := f.seasons[id]; ok {
 		return s, nil
 	}
-	return nil, errors.New("season not found")
+	return nil, catalog.ErrSeasonNotFound
 }
 
 // fakeSeasonEpisodeRepo implements episodeRepoForBatchLoader, serving episodes by


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

The repository-wide Go CI gate was red for two baseline issues in the same jellycompat test area: one extra blank line failed `gofmt`, and the shared season-repository fake returned a generic error instead of the production not-found sentinel.

## Approach

Apply `gofmt`'s one-line correction and make the fake repository return `catalog.ErrSeasonNotFound`, matching the real repository contract.

## Validation

- `gofmt -d internal/jellycompat/handlers_items_test.go internal/jellycompat/parent_browse_test.go` — no output.
- `go test ./internal/jellycompat -run '^TestHandleEpisodes_UnknownSeasonIDReturnsNotFound$' -count=1 -v` — passed.
- Modern Go Guidelines checked for the test file; sentinel-aware error handling is consistent with the applicable guidance.

## Risks

Test-only and whitespace-only. Production behavior is unchanged.

## AI Disclosure

- Harness: Codex desktop
- Tool(s): Codex
- Model(s): GPT-5; the exact backend identifier was not exposed by the harness
- Involvement: AI-assisted
- Adversarial review: Ponytail review of the two-line baseline fix — Lean already. Ship.
