### PR TITLE
fix(scanner): prune stale troubleshooting roots on full library scan

### DIFF
--- a/internal/scanner/dead_root_test.go
+++ b/internal/scanner/dead_root_test.go
@@ -190,6 +190,76 @@ func TestDeleteMissingByFolderProtectedRoots(t *testing.T) {
 	}
 }
 
+func TestScannedRootRepository_DeleteMissingByFolder(t *testing.T) {
+	pool := newDeadRootTestPool(t)
+	ctx := context.Background()
+	folderID1 := seedDeadRootTestFolder(t, pool, "movies", "Scanned Root Repo Test 1")
+	folderID2 := seedDeadRootTestFolder(t, pool, "movies", "Scanned Root Repo Test 2")
+
+	repo := NewScannedRootRepository(pool)
+
+	root1 := models.ScannedMediaRoot{
+		MediaFolderID: folderID1,
+		RootPath:      "/media/movies1/Movie A",
+		Title:         "Movie A",
+		State:         "matched",
+		Year:          2020,
+	}
+	root2 := models.ScannedMediaRoot{
+		MediaFolderID: folderID1,
+		RootPath:      "/media/movies2/Movie B", // path that will be removed
+		Title:         "Movie B",
+		State:         "ambiguous",
+		Year:          2021,
+	}
+	rootOtherFolder := models.ScannedMediaRoot{
+		MediaFolderID: folderID2,
+		RootPath:      "/media/movies2/Movie B",
+		Title:         "Movie B",
+		State:         "ambiguous",
+		Year:          2021,
+	}
+
+	if err := repo.UpsertMany(ctx, []models.ScannedMediaRoot{root1, root2, rootOtherFolder}); err != nil {
+		t.Fatalf("UpsertMany: %v", err)
+	}
+
+	// Scoped delete under /media/movies1 does not touch /media/movies2
+	if err := repo.DeleteMissingInScope(ctx, folderID1, "/media/movies1", []string{root1.RootPath}); err != nil {
+		t.Fatalf("DeleteMissingInScope: %v", err)
+	}
+	got, err := repo.Get(ctx, folderID1, root2.RootPath)
+	if err != nil {
+		t.Fatalf("Get root2: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("root2 was deleted by DeleteMissingInScope for unrelated scope")
+	}
+
+	// Full scan delete (only saw root1) removes root2 from folderID1, but leaves folderID2 intact
+	if err := repo.DeleteMissingByFolder(ctx, folderID1, []string{root1.RootPath}); err != nil {
+		t.Fatalf("DeleteMissingByFolder: %v", err)
+	}
+
+	got, err = repo.Get(ctx, folderID1, root2.RootPath)
+	if err != nil {
+		t.Fatalf("Get root2: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("root2 remained after DeleteMissingByFolder")
+	}
+
+	got1, err := repo.Get(ctx, folderID1, root1.RootPath)
+	if err != nil || got1 == nil {
+		t.Fatalf("root1 was removed unexpectedly: %v", err)
+	}
+
+	gotOther, err := repo.Get(ctx, folderID2, rootOtherFolder.RootPath)
+	if err != nil || gotOther == nil {
+		t.Fatalf("other folder root was removed unexpectedly: %v", err)
+	}
+}
+
 // TestScanFolderDeadRootProtection walks the real scan pipeline end to end
 // with two on-disk roots and verifies the full dead-root story:
 //

--- a/internal/scanner/root_snapshot_repo.go
+++ b/internal/scanner/root_snapshot_repo.go
@@ -246,3 +246,20 @@ func (r *ScannedRootRepository) DeleteMissingInScope(ctx context.Context, folder
 	}
 	return nil
 }
+
+// DeleteMissingByFolder removes scanned roots for a folder that were not seen
+// anywhere in the library during an authoritative full scan.
+func (r *ScannedRootRepository) DeleteMissingByFolder(ctx context.Context, folderID int, seenRoots []string) error {
+	if seenRoots == nil {
+		seenRoots = []string{}
+	}
+	_, err := r.pool.Exec(ctx, `
+		DELETE FROM scanned_media_roots
+		WHERE media_folder_id = $1
+		  AND NOT (root_path = ANY($2))
+	`, folderID, seenRoots)
+	if err != nil {
+		return fmt.Errorf("deleting missing scanned roots by folder: %w", err)
+	}
+	return nil
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -789,6 +789,7 @@ func (s *Scanner) scanPaths(
 		reconcileRoots,
 		rootInference.Snapshots,
 		pruneUnseen,
+		allowEmptyRootGuard,
 	); err != nil {
 		return nil, fmt.Errorf("reconciling scanned roots: %w", err)
 	}
@@ -1387,6 +1388,16 @@ func (s *Scanner) scanFolderByRoots(
 	}
 	result.FilesDeleted += deletedOutsideRoots
 
+	if len(protectedScanRoots) == 0 && s.rootSnapshotRepo != nil {
+		allSeenRoots := make([]string, 0, len(result.RootObservations))
+		for _, obs := range result.RootObservations {
+			allSeenRoots = append(allSeenRoots, obs.RootPath)
+		}
+		if err := s.rootSnapshotRepo.DeleteMissingByFolder(ctx, folder.ID, allSeenRoots); err != nil {
+			return nil, fmt.Errorf("deleting missing scanned roots for folder %d: %w", folder.ID, err)
+		}
+	}
+
 	if s.seriesQueueSyncer != nil {
 		reportProgress(ctx, ProgressUpdate{
 			Phase:        "queue_sync",
@@ -1817,6 +1828,7 @@ func (s *Scanner) applyScopedScan(
 		scope.reconcileRoots,
 		scope.rootInference.Snapshots,
 		pruneUnseen,
+		false,
 	); err != nil {
 		return fmt.Errorf("reconciling scanned roots for scope %q: %w", scope.reconcileRoots[0], err)
 	}
@@ -2540,6 +2552,7 @@ func (s *Scanner) ScanFile(ctx context.Context, filePath string, folder *models.
 		nil,
 		rootInference.Snapshots,
 		true,
+		false,
 	); err != nil {
 		return fmt.Errorf("reconciling scanned root for file: %w", err)
 	}
@@ -3499,7 +3512,9 @@ func filterGroupLocationsByScope(locations []models.MediaGroupLocation, scopePat
 }
 
 // reconcileScannedRoots upserts the root snapshots this scan observed and,
-// when pruneUnseen is set, deletes the snapshots in scope that it did not.
+// when pruneUnseen is set, deletes the snapshots that it did not.
+// When isFullScan is true, unobserved snapshots across the entire folder are pruned.
+// Otherwise, only snapshots under the scoped roots are pruned.
 // Callers must pass pruneUnseen=false when the walk could not read part of the
 // tree: the observed set is then a lower bound, and pruning against it drops
 // snapshots for media that is still there.
@@ -3509,9 +3524,26 @@ func (s *Scanner) reconcileScannedRoots(
 	scopeRoots []string,
 	roots []models.ScannedMediaRoot,
 	pruneUnseen bool,
+	isFullScan bool,
 ) error {
 	if s == nil || s.rootSnapshotRepo == nil {
 		return nil
+	}
+
+	if err := s.rootSnapshotRepo.UpsertMany(ctx, roots); err != nil {
+		return err
+	}
+
+	if !pruneUnseen {
+		return nil
+	}
+
+	if isFullScan {
+		seenAllRoots := make([]string, 0, len(roots))
+		for _, root := range roots {
+			seenAllRoots = append(seenAllRoots, root.RootPath)
+		}
+		return s.rootSnapshotRepo.DeleteMissingByFolder(ctx, folderID, seenAllRoots)
 	}
 
 	seenByScope := make(map[string][]string, len(scopeRoots))
@@ -3526,13 +3558,7 @@ func (s *Scanner) reconcileScannedRoots(
 			}
 		}
 	}
-	if err := s.rootSnapshotRepo.UpsertMany(ctx, roots); err != nil {
-		return err
-	}
 
-	if !pruneUnseen {
-		return nil
-	}
 	for scope, seenRoots := range seenByScope {
 		if err := s.rootSnapshotRepo.DeleteMissingInScope(ctx, folderID, scope, seenRoots); err != nil {
 			return err


### PR DESCRIPTION
## Summary
- Fixes #754.
- When a library path is removed or replaced, full-library scans previously only reconciled `scanned_media_roots` within the currently configured scope roots (`scopeRoots`). Any records belonging to the removed paths remained in `scanned_media_roots` indefinitely and continued appearing in the library troubleshooting diagnostics.
- This change:
  - Adds `DeleteMissingByFolder(ctx, folderID, seenRoots)` to `ScannedRootRepository` to delete roots for a folder that were not seen anywhere in the library.
  - Updates `reconcileScannedRoots` in `internal/scanner/scanner.go` to prune by folder on full scans when all roots are healthy, while preserving scoped scan isolation (`DeleteMissingInScope`) for subtree and single-file scans.
  - Adds TV scan completion folder-wide cleanup for scanned media roots.
  - Adds `TestScannedRootRepository_DeleteMissingByFolder` in `internal/scanner/dead_root_test.go` verifying that full-library cleanup removes unobserved roots while scoped cleanup retains entries outside the scope.

## Test Plan
- [x] Added `TestScannedRootRepository_DeleteMissingByFolder` covering folder-wide vs scoped root pruning.
- [x] Verified `gofmt` and Go formatting.
