### PR TITLE
fix(catalog): default history source to source order and accept personalized sorts

### DIFF
--- a/internal/catalog/catalog_personal_sort_test.go
+++ b/internal/catalog/catalog_personal_sort_test.go
@@ -1,0 +1,34 @@
+package catalog
+
+import (
+	"testing"
+)
+
+func TestValidateCatalogPersonalRequest_PersonalizedSorts(t *testing.T) {
+	personalizedSorts := []string{"date_viewed", "progress", "plays"}
+	sources := []CatalogSource{CatalogSourceHistory, CatalogSourceFavorites, CatalogSourceWatchlist}
+
+	for _, source := range sources {
+		for _, sortField := range personalizedSorts {
+			req := CatalogRequest{
+				Source: source,
+				Query: QueryDefinition{
+					Sort: QuerySort{
+						Field: sortField,
+						Order: "desc",
+					},
+				},
+			}
+
+			// When allowPersonalizedSorts is true (e.g. active profile present)
+			if err := validateCatalogPersonalRequest(req, true); err != nil {
+				t.Errorf("validateCatalogPersonalRequest(source=%s, sort=%s, allow=true) unexpectedly failed: %v", source, sortField, err)
+			}
+
+			// When allowPersonalizedSorts is false
+			if err := validateCatalogPersonalRequest(req, false); err == nil {
+				t.Errorf("validateCatalogPersonalRequest(source=%s, sort=%s, allow=false) should fail for personalized sort %s", source, sortField, sortField)
+			}
+		}
+	}
+}

--- a/internal/catalog/catalog_resolver.go
+++ b/internal/catalog/catalog_resolver.go
@@ -237,7 +237,7 @@ func (r *CatalogResolver) Resolve(ctx context.Context, req CatalogRequest, acces
 		}
 		return r.resolveUserCollectionSource(ctx, req, access)
 	case CatalogSourceFavorites, CatalogSourceWatchlist, CatalogSourceHistory:
-		if err := validateCatalogPersonalRequest(req); err != nil {
+		if err := validateCatalogPersonalRequest(req, strings.TrimSpace(access.ProfileID) != ""); err != nil {
 			return nil, err
 		}
 		return r.resolvePersonalSource(ctx, req, access)
@@ -1037,7 +1037,7 @@ func (r *CatalogResolver) ListFiltersWithOptions(ctx context.Context, req Catalo
 			return nil, err
 		}
 	case CatalogSourceFavorites, CatalogSourceWatchlist, CatalogSourceHistory:
-		if err := validateCatalogPersonalRequest(req); err != nil {
+		if err := validateCatalogPersonalRequest(req, strings.TrimSpace(access.ProfileID) != ""); err != nil {
 			return nil, err
 		}
 		if access.UserID <= 0 || strings.TrimSpace(access.ProfileID) == "" {
@@ -1141,7 +1141,7 @@ func (r *CatalogResolver) SearchFacet(ctx context.Context, req CatalogRequest, a
 			return nil, err
 		}
 	case CatalogSourceFavorites, CatalogSourceWatchlist, CatalogSourceHistory:
-		if err := validateCatalogPersonalRequest(req); err != nil {
+		if err := validateCatalogPersonalRequest(req, strings.TrimSpace(access.ProfileID) != ""); err != nil {
 			return nil, err
 		}
 		if access.UserID <= 0 || strings.TrimSpace(access.ProfileID) == "" {
@@ -1434,13 +1434,13 @@ func validateCatalogQueryRequest(req CatalogRequest, allowPersonalizedSorts bool
 	)
 }
 
-func validateCatalogPersonalRequest(req CatalogRequest) error {
+func validateCatalogPersonalRequest(req CatalogRequest, allowPersonalizedSorts bool) error {
 	switch req.Source {
 	case CatalogSourceFavorites, CatalogSourceWatchlist, CatalogSourceHistory:
 	default:
 		return fmt.Errorf("%w: source %q is not supported", ErrInvalidCatalogRequest, req.Source)
 	}
-	return validateCatalogOverlayQuery(req.SearchQuery, req.Query, catalogPersonalRuleFields, catalogPersonalSortFields(), false)
+	return validateCatalogOverlayQuery(req.SearchQuery, req.Query, catalogPersonalRuleFields, QuerySortFieldSet(allowPersonalizedSorts), false)
 }
 
 func validateCatalogPersonRequest(req CatalogRequest) error {
@@ -1620,10 +1620,6 @@ var catalogPersonalRuleFields = map[string]bool{
 }
 
 func catalogQuerySortFields() map[string]bool {
-	return QuerySortFieldSet(false)
-}
-
-func catalogPersonalSortFields() map[string]bool {
 	return QuerySortFieldSet(false)
 }
 

--- a/web/src/components/catalog/CatalogFiltersPanel.tsx
+++ b/web/src/components/catalog/CatalogFiltersPanel.tsx
@@ -110,7 +110,13 @@ export default function CatalogFiltersPanel({
         resultCountLabel={resultCountLabel}
         resultCountLoading={resultCountLoading}
         sourceOrderLabel={
-          isCollectionSource ? "Collection Order" : supportsSourceOrder ? "List Order" : undefined
+          isCollectionSource
+            ? "Collection Order"
+            : state.source === "history"
+              ? "Watch History"
+              : supportsSourceOrder
+                ? "List Order"
+                : undefined
         }
         allowEpisodeMediaScope={!isCollectionSource}
       />

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -107,7 +107,10 @@ function CatalogResults({
   const isCollectionSource =
     state.source === "library_collection" || state.source === "user_collection";
   const hasSavedSortPreference =
-    isCollectionSource || state.source === "watchlist" || state.source === "favorites";
+    isCollectionSource ||
+    state.source === "watchlist" ||
+    state.source === "favorites" ||
+    state.source === "history";
   const allowPersonalizedOverlayControls = catalogSourceAllowsOverlay(state.source);
   const removeHistory = useRemoveHistory();
   const [selectionMode, setSelectionMode] = useState(false);

--- a/web/src/pages/catalogSearchParams.test.ts
+++ b/web/src/pages/catalogSearchParams.test.ts
@@ -101,7 +101,10 @@ describe("parseCatalogSearchParams", () => {
         .uses_source_order,
     ).toBe(false);
     expect(parseCatalogSearchParams(params("source=favorites")).uses_source_order).toBe(true);
-    expect(parseCatalogSearchParams(params("source=history")).uses_source_order).toBe(false);
+    expect(parseCatalogSearchParams(params("source=history")).uses_source_order).toBe(true);
+    expect(parseCatalogSearchParams(params("source=history&sort=title")).uses_source_order).toBe(
+      false,
+    );
   });
 
   it("normalizes legacy sort aliases in catalog URLs", () => {

--- a/web/src/pages/catalogSearchParams.ts
+++ b/web/src/pages/catalogSearchParams.ts
@@ -74,7 +74,12 @@ function isCollectionSource(source: CatalogSource): boolean {
 // field. The watchlist's stored order can mirror a watch provider's list
 // order (e.g. MDBList) via sort_index; favorites use their entry order.
 export function catalogSourceSupportsSourceOrder(source: CatalogSource): boolean {
-  return isCollectionSource(source) || source === "watchlist" || source === "favorites";
+  return (
+    isCollectionSource(source) ||
+    source === "watchlist" ||
+    source === "favorites" ||
+    source === "history"
+  );
 }
 
 export function catalogSourceAllowsOverlay(source: CatalogSource): boolean {


### PR DESCRIPTION
## Problem

Related issue: #874

Opening the History page in the web UI fails with HTTP 400 (`invalid catalog request: sort.field "date_viewed" is not supported`) or returns 0 results because:
1. `history` was omitted from `catalogSourceSupportsSourceOrder` in `web/src/pages/catalogSearchParams.ts`, causing `/catalog?source=history` to default `uses_source_order` to `false` and choose an explicit sort field (`date_viewed`).
2. The catalog API's `validateCatalogPersonalRequest` in `internal/catalog/catalog_resolver.go` validated against `catalogPersonalSortFields()` (which hardcoded `QuerySortFieldSet(false)`), rejecting personalized sort fields (`date_viewed`, `progress`, `plays`) even though personal sources have an active profile scope and the query builder already supports those sort plans.

## Approach

1. Added `history` to `catalogSourceSupportsSourceOrder` in `web/src/pages/catalogSearchParams.ts` so navigating to History defaults to source order (the profile's chronological watch history) without injecting an explicit sort.
2. Configured `"Watch History"` as the `sourceOrderLabel` in `CatalogFiltersPanel.tsx` and included `history` in `hasSavedSortPreference` in `Catalog.tsx`.
3. Updated `validateCatalogPersonalRequest` in `internal/catalog/catalog_resolver.go` to accept `allowPersonalizedSorts bool` (passing `QuerySortFieldSet(allowPersonalizedSorts)` to `validateCatalogOverlayQuery`), aligning personal source validation with query and collection sources.
4. Added focused unit tests in `internal/catalog/catalog_personal_sort_test.go` and updated `web/src/pages/catalogSearchParams.test.ts`.

## Validation

### Go Tests
```
$ go test -v -run "TestValidateCatalogPersonalRequest_PersonalizedSorts" ./internal/catalog
=== RUN   TestValidateCatalogPersonalRequest_PersonalizedSorts
--- PASS: TestValidateCatalogPersonalRequest_PersonalizedSorts (0.00s)
PASS
ok  	github.com/Silo-Server/silo-server/internal/catalog	1.316s

$ go test -v -run "Test.*Catalog.*" ./internal/catalog
PASS
ok  	github.com/Silo-Server/silo-server/internal/catalog	1.330s
```

## Risks

None identified.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watch History catalogs now support source-order sorting, matching other personal catalog sources.
  * Watch History is clearly labeled in the catalog filters.
  * History views now retain and recognize saved sort preferences.

* **Bug Fixes**
  * Improved handling of personalized sorting options, including date viewed, progress, and plays.
  * Corrected default and explicit sorting behavior for Watch History searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->