### PR TITLE
chore(db): drop dead plex_sync, user_playback_sessions, and content_id_migration_map tables [schema-hygiene 1/4]

### DIFF
--- a/docs/architecture/deterministic-content-id.md
+++ b/docs/architecture/deterministic-content-id.md
@@ -208,7 +208,9 @@ are remapped via add-then-swap, not in-place PK mutation. It dynamically
 enumerates the reference graph (the three PKs, every FK child from
 `pg_constraint`, and soft-reference columns by name — **65 columns** on the real
 schema), drops/recreates FKs and triggers, and retains a `content_id_migration_map`
-audit table for rollback.
+audit table for rollback. Migration `20260901152535_drop_dead_tables` drops that
+map ahead of the 1.0 schema lock, so on any database past it the remap is no
+longer reversible in place — restore from a backup instead.
 
 **Collisions are never merged.** If two items derive to the same key, or a key is
 already taken, those rows keep their Sonyflake id and are flagged `collision` in

--- a/docs/architecture/secret-encryption.md
+++ b/docs/architecture/secret-encryption.md
@@ -142,6 +142,8 @@ Deliberately **not** encrypted (tracked as follow-ups):
   lookup. They need a deterministic **blind-index hash** column instead:
   `api_keys.api_key`, `webhook_sync_connections.webhook_secret`,
   `jellycompat_sessions.token`, and `watch_together_rooms.join_token`.
-Excluded (not a gap): `plex_sync_connections.*` is a dead table (zero Go
-references); `oauth_completion.token_ciphertext` is already AES-GCM;
-`users.password_hash` and the `*_hash` columns are already hashed.
+Excluded (not a gap): `oauth_completion.token_ciphertext` is already AES-GCM;
+`users.password_hash` and the `*_hash` columns are already hashed. The
+`plex_sync_*` tables, whose `plex_server_token` was never encrypted, were dropped
+as dead tables; `webhook_sync_connections.access_token` superseded them and is
+encrypted.

--- a/internal/catalog/orphan_cleanup.go
+++ b/internal/catalog/orphan_cleanup.go
@@ -51,14 +51,6 @@ const orphanedMediaItemSafetyConditions = `NOT EXISTS (
 	WHERE pha.media_item_id = mi.content_id
   )
   AND NOT EXISTS (
-	SELECT 1 FROM public.plex_sync_item_bindings psib
-	WHERE psib.media_item_id = mi.content_id
-  )
-  AND NOT EXISTS (
-	SELECT 1 FROM public.plex_sync_item_state psis
-	WHERE psis.media_item_id = mi.content_id
-  )
-  AND NOT EXISTS (
 	SELECT 1 FROM public.podcast_feeds pf
 	WHERE pf.media_item_id = mi.content_id
   )

--- a/internal/catalog/orphan_cleanup_test.go
+++ b/internal/catalog/orphan_cleanup_test.go
@@ -35,6 +35,8 @@ func TestOrphanedProvisionalPredicatePreservesDurableMediaItemReferences(t *test
 		"abs_playlist_items",
 		"abs_playlists",
 		"watch_provider_favorite_items",
+		"plex_sync_item_bindings",
+		"plex_sync_item_state",
 	} {
 		if strings.Contains(predicate, droppedTable) {
 			t.Fatalf("cleanup predicate must not reference dropped legacy table %q", droppedTable)

--- a/internal/metadata/provider_id_integrity.go
+++ b/internal/metadata/provider_id_integrity.go
@@ -788,30 +788,6 @@ var mediaItemMergeSteps = []mediaItemMergeStep{
 			  AND dest.user_id = src.user_id
 			  AND dest.profile_id = src.profile_id`},
 	{"move series playback preferences", `UPDATE user_series_playback_preferences SET series_id = $2 WHERE series_id = $1`},
-	{"merge plex sync item bindings timestamps", `
-			UPDATE plex_sync_item_bindings dest
-			SET last_seen_at = GREATEST(dest.last_seen_at, src.last_seen_at),
-			    updated_at = NOW()
-			FROM plex_sync_item_bindings src
-			WHERE src.media_item_id = $1
-			  AND dest.connection_id = src.connection_id
-			  AND (dest.media_item_id = $2 OR dest.plex_rating_key = src.plex_rating_key)
-			  AND dest.media_item_id <> src.media_item_id`},
-	{"delete duplicate plex sync item bindings", `
-			DELETE FROM plex_sync_item_bindings src
-			USING plex_sync_item_bindings dest
-			WHERE src.media_item_id = $1
-			  AND dest.connection_id = src.connection_id
-			  AND (dest.media_item_id = $2 OR dest.plex_rating_key = src.plex_rating_key)
-			  AND dest.media_item_id <> src.media_item_id`},
-	{"move remaining plex sync item bindings", `UPDATE plex_sync_item_bindings SET media_item_id = $2, updated_at = NOW() WHERE media_item_id = $1`},
-	{"delete duplicate plex sync item state", `
-			DELETE FROM plex_sync_item_state src
-			USING plex_sync_item_state dest
-			WHERE src.media_item_id = $1
-			  AND dest.media_item_id = $2
-			  AND dest.mapping_id = src.mapping_id`},
-	{"move plex sync item state", `UPDATE plex_sync_item_state SET media_item_id = $2, updated_at = NOW() WHERE media_item_id = $1`},
 	{"move webhook sync item state", `UPDATE webhook_sync_item_state SET media_item_id = $2, updated_at = NOW() WHERE media_item_id = $1`},
 	{"move watch together rooms selected", `UPDATE watch_together_rooms SET selected_content_id = $2 WHERE selected_content_id = $1`},
 	{"move watch together suggestions", `UPDATE watch_together_suggestions SET content_id = $2 WHERE content_id = $1`},

--- a/migrations/sql/20260901152535_drop_dead_tables.sql
+++ b/migrations/sql/20260901152535_drop_dead_tables.sql
@@ -1,0 +1,151 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Drop tables that no code reads or writes, ahead of the 1.0 schema lock.
+--
+-- 1. plex_sync_* (migration 059) was superseded by webhook_sync_* in migration
+--    060, which copied every connection, actor mapping, and item state row into
+--    the new tables. Nothing has written to the plex_sync_* tables since. The
+--    only remaining Go references were vestigial guards in the orphaned-item
+--    cleanup predicate and the content-id merge steps; both are removed in the
+--    same change.
+-- 2. user_playback_sessions came from the 001 baseline and never had a reader or
+--    writer in this repository. Live playback sessions are playback_sessions /
+--    playback_sessions_sync.
+-- 3. content_id_migration_map is the audit/rollback artifact left behind by
+--    migration 20260612130000. Keeping it also keeps that migration's Down able
+--    to reverse the content-id remap, so this drop is the point of no return for
+--    that rollback; see the Down section below.
+--
+-- Drop order follows the foreign keys: item_state -> actor_mappings and
+-- item_bindings -> connections, so children go first.
+DROP TABLE IF EXISTS public.plex_sync_item_state;
+DROP TABLE IF EXISTS public.plex_sync_item_bindings;
+DROP TABLE IF EXISTS public.plex_sync_actor_mappings;
+DROP TABLE IF EXISTS public.plex_sync_connections;
+
+DROP TABLE IF EXISTS public.user_playback_sessions;
+
+DROP TABLE IF EXISTS public.content_id_migration_map;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Reverse by recreating the six tables empty, following the convention set by
+-- migration 156: schemas are inlined from their original migrations with the
+-- original constraint and index names, so an up-down-up cycle is idempotent.
+--
+-- Lossy in reverse, deliberately: these tables held no live data, and this
+-- migration does not archive their rows anywhere, so the Down cannot restore
+-- content. In particular, rolling further back past migration 20260612130000
+-- afterwards finds an empty content_id_migration_map: its Down reverts the
+-- content-id collation but no longer remaps deterministic ids back to their
+-- Sonyflake originals. Restore from a backup instead of relying on that path.
+
+-- BEGIN inlined from migrations/sql/059_plex_sync.sql
+CREATE TABLE IF NOT EXISTS public.plex_sync_connections (
+    id uuid PRIMARY KEY,
+    user_id integer NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    plex_server_id text NOT NULL,
+    plex_server_name text NOT NULL DEFAULT '',
+    plex_base_url text NOT NULL,
+    plex_server_token text NOT NULL,
+    webhook_secret text NOT NULL,
+    bindings_ready boolean NOT NULL DEFAULT false,
+    last_webhook_received_at timestamptz,
+    last_webhook_error_at timestamptz,
+    last_webhook_error_message text,
+    last_writeback_at timestamptz,
+    last_writeback_error_at timestamptz,
+    last_writeback_error_message text,
+    last_binding_refresh_at timestamptz,
+    last_binding_refresh_error_at timestamptz,
+    last_binding_refresh_error_message text,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT plex_sync_connections_user_server_unique UNIQUE (user_id, plex_server_id),
+    CONSTRAINT plex_sync_connections_webhook_secret_unique UNIQUE (webhook_secret)
+);
+
+CREATE TABLE IF NOT EXISTS public.plex_sync_actor_mappings (
+    id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    connection_id uuid NOT NULL REFERENCES public.plex_sync_connections(id) ON DELETE CASCADE,
+    plex_account_id bigint NOT NULL,
+    plex_account_title text NOT NULL DEFAULT '',
+    silo_profile_id text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT plex_sync_actor_mappings_connection_account_unique UNIQUE (connection_id, plex_account_id),
+    CONSTRAINT plex_sync_actor_mappings_connection_profile_unique UNIQUE (connection_id, silo_profile_id)
+);
+
+-- media_item_id is text COLLATE "C" here, not plain text: migration
+-- 20260612130000 recollated every content-id column it swept by name, and these
+-- two tables were in that sweep.
+CREATE TABLE IF NOT EXISTS public.plex_sync_item_bindings (
+    connection_id uuid NOT NULL REFERENCES public.plex_sync_connections(id) ON DELETE CASCADE,
+    media_item_id text COLLATE pg_catalog."C" NOT NULL,
+    plex_rating_key text NOT NULL,
+    plex_key text NOT NULL DEFAULT '',
+    plex_type text NOT NULL,
+    plex_guid text NOT NULL DEFAULT '',
+    last_seen_at timestamptz NOT NULL DEFAULT now(),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT plex_sync_item_bindings_pkey PRIMARY KEY (connection_id, media_item_id),
+    CONSTRAINT plex_sync_item_bindings_connection_rating_key_unique UNIQUE (connection_id, plex_rating_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.plex_sync_item_state (
+    mapping_id integer NOT NULL REFERENCES public.plex_sync_actor_mappings(id) ON DELETE CASCADE,
+    media_item_id text COLLATE pg_catalog."C" NOT NULL,
+    last_plex_state_at timestamptz,
+    last_silo_state_at timestamptz,
+    last_synced_direction text NOT NULL DEFAULT '',
+    last_plex_position_ms bigint NOT NULL DEFAULT 0,
+    last_silo_position_ms bigint NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT plex_sync_item_state_pkey PRIMARY KEY (mapping_id, media_item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_plex_sync_actor_mappings_connection
+    ON public.plex_sync_actor_mappings (connection_id);
+
+CREATE INDEX IF NOT EXISTS idx_plex_sync_actor_mappings_profile
+    ON public.plex_sync_actor_mappings (silo_profile_id);
+
+CREATE INDEX IF NOT EXISTS idx_plex_sync_item_bindings_connection_last_seen
+    ON public.plex_sync_item_bindings (connection_id, last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_plex_sync_item_state_mapping_updated
+    ON public.plex_sync_item_state (mapping_id, updated_at DESC);
+-- END inlined
+
+-- BEGIN inlined from migrations/sql/001_schema.sql
+CREATE TABLE IF NOT EXISTS public.user_playback_sessions (
+    session_id text NOT NULL,
+    user_id integer NOT NULL,
+    profile_id text NOT NULL,
+    media_file_id integer NOT NULL,
+    play_method text NOT NULL,
+    position_seconds double precision DEFAULT 0 NOT NULL,
+    is_paused boolean DEFAULT false NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT user_playback_sessions_pkey PRIMARY KEY (user_id, session_id),
+    CONSTRAINT user_playback_sessions_user_id_fkey FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE
+);
+-- END inlined
+
+-- BEGIN inlined from migrations/sql/20260612130000_deterministic_content_id.sql
+CREATE TABLE IF NOT EXISTS public.content_id_migration_map (
+    old_id text PRIMARY KEY,
+    new_id text NOT NULL,
+    entity text NOT NULL,
+    status text NOT NULL DEFAULT 'mapped'
+);
+
+CREATE INDEX IF NOT EXISTS content_id_migration_map_new_id_idx
+    ON public.content_id_migration_map (new_id);
+-- END inlined
+-- +goose StatementEnd


### PR DESCRIPTION
## Problem

Related issue: #135

The 1.0 schema workstream locks the database schema alongside the API v2 contract, and the squashed 1.0 baseline should not inherit dead tables. The effective schema still carries six: the four `plex_sync_*` tables (superseded by `webhook_sync_*`; migration 060 already copied their data), `user_playback_sessions` (001-era, referenced by no code), and `content_id_migration_map` (artifact of the completed deterministic-content-ID migration).

Base branch: `main`. This is the first schema-hygiene PR; later schema PRs (integrity FKs/indexes, type/identity standardization, bigint widenings) stack on it.

## Approach

One Goose migration (`migrations/sql/20260901152535_drop_dead_tables.sql`, created with `make migrate-create`) drops the six tables, children before parents. The last vestigial code references go in the same change: two `NOT EXISTS` guards in the catalog orphan-cleanup predicate and five plex_sync merge steps in metadata provider-ID integrity (the `webhook_sync_item_state` step remains). The regression test now asserts the predicate must *not* reference the dropped tables while keeping all 13 durable guards.

The Down recreates all six tables empty with their original DDL — including the `COLLATE "C"` that migration `20260612130000` applied to `media_item_id` columns — following the migration 156 precedent. The migration comment and `docs/architecture/deterministic-content-id.md` record that the content-ID reverse remap becomes a no-op on databases past this point.

Deadness evidence: repo-wide sweeps (Go including string-built SQL, SQL, web, tests) hit only historical migrations; `git log -S` shows the plexsync writer package was deleted in the same commit that added migration 060's data copy. The `legacyPlexSync*` identifiers in `webhook_sync.go` are JSON DTO names over the live `webhook_sync_*` tables.

## Validation

- Full chain from an empty scratch database: applied cleanly; `migrate-status` 357 applied / 0 pending; all six tables absent (`to_regclass` NULL).
- `make migrate-down-to VERSION=20260830022104`: six tables recreated; `pg_dump --schema-only` byte-identical to the pre-drop baseline (columns, defaults, collation, constraint/index/FK names). Re-up clean (up→down→up idempotent).
- Independent review reproduction: plex_sync rows seeded at migration 59, chain run to HEAD — data present in `webhook_sync_connections` / `webhook_sync_profile_mappings` / `webhook_sync_item_state` before the drop applies.
- `make migrate-validate`: pass. `make embed-stub`, `go build ./...`, `gofmt -l` (empty), `go vet ./...`: pass.
- `golangci-lint run --new-from-merge-base="origin/main" ./...`: 0 issues.
- `make test-go`: all packages ok. Web: `pnpm run lint`, `format:check`, `build`, `make test-web`: pass.
- `make verify-settings-bindings-all`, `make verify-playback-fixtures`, `make verify-local-paths`: pass.

## Risks

- Mixed-version window: an API node still on the previous release errors with `42P01` in the orphan-cleanup task and provider-ID merge steps once an upgraded node applies this migration. Failures are atomic and transient (a single DELETE / one transaction) — no data loss. Upgrade all API nodes promptly.
- The Down recreates the tables empty (dropped data is not restorable), and the deterministic-content-ID reverse remap (`20260612130000` Down) becomes a no-op past this migration. Both are documented in the migration and the architecture doc.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code
- Tool(s): Claude Code (orchestrator session driving implementation and review subagents)
- Model(s): claude-opus-5 (implementation), claude-fable-5 (orchestration and all review agents)
- Involvement: Fully AI-generated; maintainer review pending (opened by the orchestrating agent under the maintainer's program instruction)
- Adversarial review: four independent blind review agents (destructive-safety/data-loss at maximum effort, migration discipline, code correctness, test adequacy). The data-loss reviewer independently seeded plex_sync data at migration 59, verified its presence in `webhook_sync_*` at HEAD, and reproduced up→down→up on its own scratch database. Zero blocking/major findings; two minor findings (mixed-version window, commit hygiene) resolved via the Risks note and by committing all files together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified database migration behavior, including when certain legacy data can no longer be restored in place.
  - Documented encrypted credential coverage and identified the current replacement for legacy synchronization data.

- **Maintenance**
  - Removed unused legacy synchronization and playback tables during migration.
  - Improved cleanup of orphaned media items associated with retired synchronization features.
  - Simplified media-item canonicalization by removing obsolete remapping steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->