### PR TITLE
chore(db): add missing user FKs, FK leading indexes, and users role/enabled NOT NULL [schema-hygiene 2/4]

### DIFF
--- a/internal/playback/planstore/postgres_test.go
+++ b/internal/playback/planstore/postgres_test.go
@@ -92,7 +92,7 @@ func newPlanstoreFixture(t *testing.T) *planstoreFixture {
 		t.Fatalf("insert fixture media folder: %v", err)
 	}
 	if err := pool.QueryRow(ctx, `
-		INSERT INTO users (username) VALUES ($1) RETURNING id`, unique).Scan(&f.userID); err != nil {
+		INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`, unique).Scan(&f.userID); err != nil {
 		t.Fatalf("insert fixture user: %v", err)
 	}
 	if err := pool.QueryRow(ctx, `

--- a/migrations/schema_integrity_test.go
+++ b/migrations/schema_integrity_test.go
@@ -1,0 +1,360 @@
+package migrations
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The three migrations in this release are load-bearing in ways a reader cannot
+// see from the file name: the ON DELETE action chosen per table decides whether
+// deleting an account destroys or merely detaches a row, each ADD CONSTRAINT is
+// only appliable because a sweep for orphans runs first, and the two backfill
+// values decide what a pre-existing NULL becomes forever. These tests pin all of
+// that as exact text, so changing an action, dropping a sweep, or reordering the
+// pair fails here instead of on someone's database.
+
+const (
+	fkLeadingIndexesMigration = "sql/20260901161657_fk_leading_indexes.sql"
+	userFKIntegrityMigration  = "sql/20260901161700_user_fk_integrity.sql"
+	usersNotNullMigration     = "sql/20260901161702_users_role_enabled_not_null.sql"
+)
+
+var sqlLineComment = regexp.MustCompile(`(?m)--.*$`)
+
+// readMigrationSections returns the Up and Down halves of a migration with line
+// comments removed and whitespace collapsed, so assertions can quote statements
+// as single-line SQL and compare positions without prose interfering.
+func readMigrationSections(t *testing.T, name string) (up, down string) {
+	t.Helper()
+	raw, err := FS.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read migration %s: %v", name, err)
+	}
+	// Strip goose annotations first; they are themselves SQL comments.
+	body := string(raw)
+	parts := strings.SplitN(body, "-- +goose Down", 2)
+	if len(parts) != 2 {
+		t.Fatalf("migration %s missing goose Down section", name)
+	}
+	normalize := func(s string) string {
+		return strings.Join(strings.Fields(sqlLineComment.ReplaceAllString(s, "")), " ")
+	}
+	return normalize(parts[0]), normalize(parts[1])
+}
+
+// sweepKind is how a table's pre-existing orphans are dealt with before its
+// foreign key can be validated.
+type sweepKind int
+
+const (
+	// sweepDeleteNotNull deletes every row whose non-nullable user column points
+	// at an account that no longer exists.
+	sweepDeleteNotNull sweepKind = iota
+	// sweepDeleteNullable deletes orphans but skips rows where the column is
+	// NULL, because the column is nullable and NULL is a legal value.
+	sweepDeleteNullable
+	// sweepUpdateSetNull keeps the row and nulls the dangling attribution.
+	sweepUpdateSetNull
+)
+
+type userFKContract struct {
+	table      string
+	column     string
+	constraint string
+	onDelete   string
+	sweep      sweepKind
+}
+
+// The complete contract of 20260901161700_user_fk_integrity: seventeen
+// constraints, the ON DELETE action each one carries, and the sweep that has to
+// precede it.
+var userFKContracts = []userFKContract{
+	{"push_devices", "user_id", "push_devices_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"web_push_subscriptions", "user_id", "web_push_subscriptions_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"notification_webhooks", "user_id", "notification_webhooks_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"notification_email_prefs", "user_id", "notification_email_prefs_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"notification_discord_prefs", "user_id", "notification_discord_prefs_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"notification_discord_link_state", "user_id", "notification_discord_link_state_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"notification_deliveries", "user_id", "notification_deliveries_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"profile_series_interest", "user_id", "profile_series_interest_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"user_audio_preferences", "user_id", "user_audio_preferences_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"recommendation_cache", "user_id", "recommendation_cache_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"playback_sessions_sync", "user_id", "playback_sessions_sync_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"jellycompat_sessions", "streamapp_user_id", "jellycompat_sessions_streamapp_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	{"admin_jobs", "created_by_user_id", "admin_jobs_created_by_user_id_fkey", "CASCADE", sweepDeleteNotNull},
+	// Nullable but CASCADE on purpose: the column is what makes the session an
+	// impersonation, so nulling it would quietly convert a live impersonation
+	// into an ordinary session for the impersonated user.
+	{"auth_sessions", "impersonator_user_id", "auth_sessions_impersonator_user_id_fkey", "CASCADE", sweepDeleteNullable},
+	{"activity_log", "impersonator_user_id", "activity_log_impersonator_user_id_fkey", "SET NULL", sweepUpdateSetNull},
+	{"subtitle_ai_jobs", "requested_by", "subtitle_ai_jobs_requested_by_fkey", "SET NULL", sweepUpdateSetNull},
+	{"metadata_translation_jobs", "requested_by", "metadata_translation_jobs_requested_by_fkey", "SET NULL", sweepUpdateSetNull},
+}
+
+func (c userFKContract) addConstraintSQL() string {
+	return fmt.Sprintf(
+		"ALTER TABLE public.%s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES public.users(id) ON DELETE %s;",
+		c.table, c.constraint, c.column, c.onDelete,
+	)
+}
+
+func (c userFKContract) dropConstraintSQL() string {
+	return fmt.Sprintf("ALTER TABLE public.%s DROP CONSTRAINT IF EXISTS %s;", c.table, c.constraint)
+}
+
+func (c userFKContract) sweepSQL() string {
+	missingParent := fmt.Sprintf("NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.%s)", c.column)
+	switch c.sweep {
+	case sweepDeleteNotNull:
+		return fmt.Sprintf("DELETE FROM public.%s t WHERE %s;", c.table, missingParent)
+	case sweepDeleteNullable:
+		return fmt.Sprintf("DELETE FROM public.%s t WHERE t.%s IS NOT NULL AND %s;", c.table, c.column, missingParent)
+	case sweepUpdateSetNull:
+		return fmt.Sprintf("UPDATE public.%s t SET %s = NULL WHERE t.%s IS NOT NULL AND %s;",
+			c.table, c.column, c.column, missingParent)
+	default:
+		return ""
+	}
+}
+
+func TestUserFKIntegrityMigrationContract(t *testing.T) {
+	up, down := readMigrationSections(t, userFKIntegrityMigration)
+
+	if got, want := strings.Count(up, "ADD CONSTRAINT"), len(userFKContracts); got != want {
+		t.Fatalf("up adds %d constraints, contract lists %d: update this test alongside the migration", got, want)
+	}
+	if got, want := strings.Count(down, "DROP CONSTRAINT"), len(userFKContracts); got != want {
+		t.Fatalf("down drops %d constraints, contract lists %d", got, want)
+	}
+
+	for _, c := range userFKContracts {
+		add := c.addConstraintSQL()
+		addAt := strings.Index(up, add)
+		if addAt < 0 {
+			t.Errorf("%s: up missing exact constraint %q", c.table, add)
+			continue
+		}
+
+		// The sweep is what makes ADD CONSTRAINT appliable on an upgraded
+		// database that already holds orphans, and its shape encodes whether
+		// those rows are destroyed or merely detached. Both the text and the
+		// ordering are part of the contract.
+		sweep := c.sweepSQL()
+		sweepAt := strings.Index(up, sweep)
+		if sweepAt < 0 {
+			t.Errorf("%s: up missing exact orphan sweep %q", c.table, sweep)
+			continue
+		}
+		if sweepAt > addAt {
+			t.Errorf("%s: orphan sweep runs after ADD CONSTRAINT; the constraint cannot validate", c.table)
+		}
+
+		if drop := c.dropConstraintSQL(); !strings.Contains(down, drop) {
+			t.Errorf("%s: down missing %q", c.table, drop)
+		}
+	}
+
+	// A SET NULL action on a column the sweep deletes from (or vice versa) would
+	// be internally inconsistent, so pin the pairing itself.
+	for _, c := range userFKContracts {
+		if c.onDelete == "SET NULL" && c.sweep != sweepUpdateSetNull {
+			t.Errorf("%s: SET NULL constraint must pair with an UPDATE ... SET NULL sweep", c.table)
+		}
+		if c.sweep == sweepUpdateSetNull && c.onDelete != "SET NULL" {
+			t.Errorf("%s: UPDATE ... SET NULL sweep must pair with a SET NULL constraint", c.table)
+		}
+	}
+
+	// The migration runs in one transaction on purpose; NO TRANSACTION would
+	// leave a half-applied set of constraints behind after a failure.
+	raw, err := FS.ReadFile(userFKIntegrityMigration)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	if strings.Contains(string(raw), "+goose NO TRANSACTION") {
+		t.Fatal("user FK integrity migration must stay transactional")
+	}
+}
+
+func TestUsersRoleEnabledNotNullMigrationContract(t *testing.T) {
+	up, down := readMigrationSections(t, usersNotNullMigration)
+
+	// The backfill values are the durable decision here: they are what every
+	// pre-existing NULL becomes, irreversibly. 'user' is the fail-closed role.
+	for _, step := range []struct{ backfill, setNotNull string }{
+		{
+			backfill:   "UPDATE public.users SET role = 'user' WHERE role IS NULL;",
+			setNotNull: "ALTER TABLE public.users ALTER COLUMN role SET NOT NULL;",
+		},
+		{
+			backfill:   "UPDATE public.users SET enabled = true WHERE enabled IS NULL;",
+			setNotNull: "ALTER TABLE public.users ALTER COLUMN enabled SET NOT NULL;",
+		},
+	} {
+		backfillAt := strings.Index(up, step.backfill)
+		if backfillAt < 0 {
+			t.Errorf("up missing exact backfill %q", step.backfill)
+			continue
+		}
+		notNullAt := strings.Index(up, step.setNotNull)
+		if notNullAt < 0 {
+			t.Errorf("up missing %q", step.setNotNull)
+			continue
+		}
+		if backfillAt > notNullAt {
+			t.Errorf("backfill %q runs after SET NOT NULL; the ALTER would fail on any NULL row", step.backfill)
+		}
+	}
+
+	for _, want := range []string{
+		"ALTER TABLE public.users ALTER COLUMN enabled DROP NOT NULL;",
+		"ALTER TABLE public.users ALTER COLUMN role DROP NOT NULL;",
+	} {
+		if !strings.Contains(down, want) {
+			t.Errorf("down missing %q", want)
+		}
+	}
+
+	// role deliberately gains no DEFAULT: an insert that forgets the column must
+	// fail rather than silently create an ordinary account.
+	if strings.Contains(up, "ALTER COLUMN role SET DEFAULT") {
+		t.Error("up must not give users.role a DEFAULT")
+	}
+}
+
+// fkLeadingIndexes is the complete set this release creates. Two of them --
+// idx_page_sections_library_id and
+// idx_watch_provider_scrobble_sessions_connection_id -- exist because the only
+// index leading on those FK columns is partial, and a partial index does not
+// cover the rows a cascade visits. Removing either reintroduces a sequential
+// scan per parent delete, so the list is pinned.
+var fkLeadingIndexes = []string{
+	"idx_abs_playback_sessions_content_id",
+	"idx_abs_playback_sessions_media_file_id",
+	"idx_abs_rss_feeds_library_item_id",
+	"idx_admin_jobs_created_by_user_id",
+	"idx_auth_sessions_user_id",
+	"idx_autoscan_connections_request_integration_id",
+	"idx_autoscan_sources_connection_id",
+	"idx_autoscan_webhook_deliveries_source_id",
+	"idx_device_login_requests_approved_by_user_id",
+	"idx_device_login_requests_auth_session_id",
+	"idx_downloaded_subtitles_downloaded_by",
+	"idx_downloads_media_file_id",
+	"idx_intro_season_analysis_state_media_folder_id",
+	"idx_invitations_accepted_user_id",
+	"idx_invitations_access_group_id",
+	"idx_invitations_invited_by",
+	"idx_invite_codes_created_by",
+	"idx_jellycompat_sessions_streamapp_user_id",
+	"idx_library_collection_items_media_item_id",
+	"idx_library_collection_libraries_group_id",
+	"idx_library_provider_chains_plugin_installation_id",
+	"idx_literary_work_match_decisions_created_by",
+	"idx_literary_works_primary_cover_content_id",
+	"idx_marker_edit_audit_api_key_id",
+	"idx_marker_edit_audit_impersonator_user_id",
+	"idx_media_group_overrides_created_by_user_id",
+	"idx_media_group_overrides_updated_by_user_id",
+	"idx_media_identity_overrides_created_by_user_id",
+	"idx_media_identity_overrides_updated_by_user_id",
+	"idx_media_request_events_actor_user_id",
+	"idx_media_request_targets_integration_id",
+	"idx_media_root_overrides_created_by_user_id",
+	"idx_media_root_overrides_updated_by_user_id",
+	"idx_metadata_translation_jobs_requested_by",
+	"idx_notification_deliveries_release_event_id",
+	"idx_notification_discord_link_state_user_id",
+	"idx_notification_webhooks_user_id",
+	"idx_page_sections_library_id",
+	"idx_playback_route_events_user_id",
+	"idx_playback_sessions_sync_user_id",
+	"idx_playback_v3_attempts_effective_media_file_id",
+	"idx_playback_v3_attempts_requested_media_file_id",
+	"idx_playback_v3_attempts_user_id",
+	"idx_plugin_auth_identities_user_id",
+	"idx_plugin_installations_repository_id",
+	"idx_policy_document_versions_created_by_user_id",
+	"idx_policy_documents_active_version_id",
+	"idx_profile_series_interest_user_id",
+	"idx_push_devices_user_id",
+	"idx_subtitle_ai_jobs_requested_by",
+	"idx_user_profile_allowed_libraries_library_id",
+	"idx_watch_provider_auth_sessions_user_id",
+	"idx_watch_provider_connections_user_id",
+	"idx_watch_provider_scrobble_sessions_connection_id",
+	"idx_watch_together_rooms_host_user_id",
+	"idx_watch_together_suggestions_suggester_user_id",
+	"idx_web_push_subscriptions_user_id",
+}
+
+func TestFKLeadingIndexesMigrationContract(t *testing.T) {
+	raw, err := FS.ReadFile(fkLeadingIndexesMigration)
+	if err != nil {
+		t.Fatalf("read migration: %v", err)
+	}
+	migration := string(raw)
+
+	// CONCURRENTLY cannot run inside a transaction, and the recovery block that
+	// drops invalid leftovers is only reachable because of it.
+	if !strings.HasPrefix(migration, "-- +goose NO TRANSACTION") {
+		t.Fatal("index migration must declare NO TRANSACTION")
+	}
+
+	parts := strings.SplitN(migration, "-- +goose Down", 2)
+	if len(parts) != 2 {
+		t.Fatal("migration missing goose Down section")
+	}
+	up, down := parts[0], parts[1]
+
+	// The recovery list is the array of names the DO block drops if an earlier
+	// CONCURRENTLY build left them invalid; an index missing from it can never
+	// be rebuilt, because CREATE INDEX IF NOT EXISTS skips the invalid leftover.
+	_, recovery, ok := strings.Cut(up, "ARRAY[")
+	if !ok {
+		t.Fatal("up missing the invalid-leftover recovery array")
+	}
+	recovery, _, ok = strings.Cut(recovery, "])")
+	if !ok {
+		t.Fatal("invalid-leftover recovery array is unterminated")
+	}
+
+	for _, name := range fkLeadingIndexes {
+		if !strings.Contains(recovery, "'"+name+"'") {
+			t.Errorf("%s missing from the invalid-leftover recovery list", name)
+		}
+		if !strings.Contains(up, "CREATE INDEX CONCURRENTLY IF NOT EXISTS "+name+"\n") {
+			t.Errorf("%s is not created concurrently", name)
+		}
+		if !strings.Contains(down, "DROP INDEX CONCURRENTLY IF EXISTS public."+name+";") {
+			t.Errorf("%s is not dropped by the down migration", name)
+		}
+	}
+
+	// Counts, so an index added to the migration without being added here (or
+	// removed from one of the three lists) fails rather than passing silently.
+	for _, count := range []struct {
+		what string
+		got  int
+	}{
+		{"recovery-list entries", strings.Count(recovery, "'idx_")},
+		{"CREATE INDEX statements", strings.Count(up, "CREATE INDEX CONCURRENTLY IF NOT EXISTS ")},
+		{"DROP INDEX statements", strings.Count(down, "DROP INDEX CONCURRENTLY IF EXISTS public.")},
+	} {
+		if count.got != len(fkLeadingIndexes) {
+			t.Errorf("%s: got %d, want %d", count.what, count.got, len(fkLeadingIndexes))
+		}
+	}
+
+	// Every index here exists to serve a foreign key check, which only uses an
+	// index whose predicate provably holds for the rows it is proving absent. A
+	// WHERE clause on any of them would silently defeat the migration.
+	for _, chunk := range strings.Split(up, "CREATE INDEX CONCURRENTLY IF NOT EXISTS ")[1:] {
+		statement, _, _ := strings.Cut(chunk, ";")
+		if strings.Contains(strings.ToUpper(statement), "WHERE") {
+			t.Errorf("FK leading index must not be partial: %q", strings.Join(strings.Fields(statement), " "))
+		}
+	}
+}

--- a/migrations/sql/20260901161657_fk_leading_indexes.sql
+++ b/migrations/sql/20260901161657_fk_leading_indexes.sql
@@ -1,0 +1,348 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- Give every foreign-key column a leading index.
+--
+-- Postgres indexes the referenced side of a foreign key (the parent's primary
+-- or unique key) automatically and the referencing side not at all. Every
+-- DELETE or key UPDATE on the parent therefore has to prove no child row
+-- references the vanishing key, and without an index whose FIRST key column is
+-- the referencing column that proof is a sequential scan of the whole child
+-- table -- per deleted row, holding a row lock the entire time. Deleting one
+-- user currently scans auth_sessions, playback_v3_attempts and
+-- playback_route_events end to end; deleting one media file scans downloads and
+-- abs_playback_sessions; removing a media item scans library_collection_items.
+--
+-- The audit that produced this list, run against a scratch database with the
+-- full chain applied:
+--
+--   SELECT DISTINCT c.relname, a.attname
+--   FROM pg_constraint con
+--   JOIN pg_class c ON c.oid = con.conrelid
+--   JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+--   JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = con.conkey[1]
+--   WHERE con.contype = 'f' AND NOT c.relispartition
+--     AND NOT EXISTS (
+--       SELECT 1 FROM pg_index i
+--       WHERE i.indrelid = con.conrelid AND i.indkey[0] = con.conkey[1]
+--     );
+--
+-- conkey[1] and indkey[0] are the point: a column that only appears second in a
+-- composite index (or is covered only by a partial index whose predicate does
+-- not span the rows the cascade touches) does not satisfy the reference check,
+-- while a column that leads any existing primary key, unique constraint, or
+-- plain index already does and is deliberately absent below.
+--
+-- 45 columns come from the constraints that already existed; the remaining 10
+-- are columns that 20260901161700_user_fk_integrity constrains in this same
+-- release and that had no leading index either. The other seven columns it
+-- constrains already lead an index: five a primary key or plain index, and two
+-- -- auth_sessions.impersonator_user_id and activity_log.impersonator_user_id --
+-- a partial index whose predicate is exactly "IS NOT NULL", which is precisely
+-- the row set an ON DELETE action visits. None of those is duplicated here.
+--
+-- Every index is built CONCURRENTLY and this migration runs outside a
+-- transaction: a plain CREATE INDEX takes a SHARE lock that blocks all writes
+-- to the table for the length of the build, and this builds 55 of them. The
+-- cost is that a CONCURRENTLY build which fails leaves an invalid index behind,
+-- so the block below drops any invalid leftovers from an earlier attempt before
+-- rebuilding -- the same recovery the existing concurrent-index migrations do,
+-- expressed as one loop because of the number of indexes involved.
+-- +goose StatementBegin
+DO $$
+DECLARE
+    leftover text;
+BEGIN
+    FOR leftover IN
+        SELECT c.relname
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE n.nspname = 'public'
+          AND NOT i.indisvalid
+          AND c.relname = ANY (ARRAY[
+              'idx_abs_playback_sessions_content_id',
+              'idx_abs_playback_sessions_media_file_id',
+              'idx_abs_rss_feeds_library_item_id',
+              'idx_admin_jobs_created_by_user_id',
+              'idx_auth_sessions_user_id',
+              'idx_autoscan_connections_request_integration_id',
+              'idx_autoscan_sources_connection_id',
+              'idx_autoscan_webhook_deliveries_source_id',
+              'idx_device_login_requests_approved_by_user_id',
+              'idx_device_login_requests_auth_session_id',
+              'idx_downloaded_subtitles_downloaded_by',
+              'idx_downloads_media_file_id',
+              'idx_intro_season_analysis_state_media_folder_id',
+              'idx_invitations_accepted_user_id',
+              'idx_invitations_access_group_id',
+              'idx_invitations_invited_by',
+              'idx_invite_codes_created_by',
+              'idx_jellycompat_sessions_streamapp_user_id',
+              'idx_library_collection_items_media_item_id',
+              'idx_library_collection_libraries_group_id',
+              'idx_library_provider_chains_plugin_installation_id',
+              'idx_literary_work_match_decisions_created_by',
+              'idx_literary_works_primary_cover_content_id',
+              'idx_marker_edit_audit_api_key_id',
+              'idx_marker_edit_audit_impersonator_user_id',
+              'idx_media_group_overrides_created_by_user_id',
+              'idx_media_group_overrides_updated_by_user_id',
+              'idx_media_identity_overrides_created_by_user_id',
+              'idx_media_identity_overrides_updated_by_user_id',
+              'idx_media_request_events_actor_user_id',
+              'idx_media_request_targets_integration_id',
+              'idx_media_root_overrides_created_by_user_id',
+              'idx_media_root_overrides_updated_by_user_id',
+              'idx_metadata_translation_jobs_requested_by',
+              'idx_notification_deliveries_release_event_id',
+              'idx_notification_discord_link_state_user_id',
+              'idx_notification_webhooks_user_id',
+              'idx_playback_route_events_user_id',
+              'idx_playback_sessions_sync_user_id',
+              'idx_playback_v3_attempts_effective_media_file_id',
+              'idx_playback_v3_attempts_requested_media_file_id',
+              'idx_playback_v3_attempts_user_id',
+              'idx_plugin_auth_identities_user_id',
+              'idx_plugin_installations_repository_id',
+              'idx_policy_document_versions_created_by_user_id',
+              'idx_policy_documents_active_version_id',
+              'idx_profile_series_interest_user_id',
+              'idx_push_devices_user_id',
+              'idx_subtitle_ai_jobs_requested_by',
+              'idx_user_profile_allowed_libraries_library_id',
+              'idx_watch_provider_auth_sessions_user_id',
+              'idx_watch_provider_connections_user_id',
+              'idx_watch_together_rooms_host_user_id',
+              'idx_watch_together_suggestions_suggester_user_id',
+              'idx_web_push_subscriptions_user_id'
+          ])
+    LOOP
+        EXECUTE format('DROP INDEX public.%I', leftover);
+    END LOOP;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_abs_playback_sessions_content_id
+    ON public.abs_playback_sessions (content_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_abs_playback_sessions_media_file_id
+    ON public.abs_playback_sessions (media_file_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_abs_rss_feeds_library_item_id
+    ON public.abs_rss_feeds (library_item_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_admin_jobs_created_by_user_id
+    ON public.admin_jobs (created_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_auth_sessions_user_id
+    ON public.auth_sessions (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_autoscan_connections_request_integration_id
+    ON public.autoscan_connections (request_integration_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_autoscan_sources_connection_id
+    ON public.autoscan_sources (connection_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_autoscan_webhook_deliveries_source_id
+    ON public.autoscan_webhook_deliveries (source_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_device_login_requests_approved_by_user_id
+    ON public.device_login_requests (approved_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_device_login_requests_auth_session_id
+    ON public.device_login_requests (auth_session_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_downloaded_subtitles_downloaded_by
+    ON public.downloaded_subtitles (downloaded_by);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_downloads_media_file_id
+    ON public.downloads (media_file_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_intro_season_analysis_state_media_folder_id
+    ON public.intro_season_analysis_state (media_folder_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invitations_accepted_user_id
+    ON public.invitations (accepted_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invitations_access_group_id
+    ON public.invitations (access_group_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invitations_invited_by
+    ON public.invitations (invited_by);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_invite_codes_created_by
+    ON public.invite_codes (created_by);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_jellycompat_sessions_streamapp_user_id
+    ON public.jellycompat_sessions (streamapp_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_library_collection_items_media_item_id
+    ON public.library_collection_items (media_item_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_library_collection_libraries_group_id
+    ON public.library_collection_libraries (group_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_library_provider_chains_plugin_installation_id
+    ON public.library_provider_chains (plugin_installation_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_literary_work_match_decisions_created_by
+    ON public.literary_work_match_decisions (created_by);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_literary_works_primary_cover_content_id
+    ON public.literary_works (primary_cover_content_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_marker_edit_audit_api_key_id
+    ON public.marker_edit_audit (api_key_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_marker_edit_audit_impersonator_user_id
+    ON public.marker_edit_audit (impersonator_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_group_overrides_created_by_user_id
+    ON public.media_group_overrides (created_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_group_overrides_updated_by_user_id
+    ON public.media_group_overrides (updated_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_identity_overrides_created_by_user_id
+    ON public.media_identity_overrides (created_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_identity_overrides_updated_by_user_id
+    ON public.media_identity_overrides (updated_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_request_events_actor_user_id
+    ON public.media_request_events (actor_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_request_targets_integration_id
+    ON public.media_request_targets (integration_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_root_overrides_created_by_user_id
+    ON public.media_root_overrides (created_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_media_root_overrides_updated_by_user_id
+    ON public.media_root_overrides (updated_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metadata_translation_jobs_requested_by
+    ON public.metadata_translation_jobs (requested_by);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_deliveries_release_event_id
+    ON public.notification_deliveries (release_event_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_discord_link_state_user_id
+    ON public.notification_discord_link_state (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_webhooks_user_id
+    ON public.notification_webhooks (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_playback_route_events_user_id
+    ON public.playback_route_events (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_playback_sessions_sync_user_id
+    ON public.playback_sessions_sync (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_playback_v3_attempts_effective_media_file_id
+    ON public.playback_v3_attempts (effective_media_file_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_playback_v3_attempts_requested_media_file_id
+    ON public.playback_v3_attempts (requested_media_file_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_playback_v3_attempts_user_id
+    ON public.playback_v3_attempts (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plugin_auth_identities_user_id
+    ON public.plugin_auth_identities (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plugin_installations_repository_id
+    ON public.plugin_installations (repository_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_policy_document_versions_created_by_user_id
+    ON public.policy_document_versions (created_by_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_policy_documents_active_version_id
+    ON public.policy_documents (active_version_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_profile_series_interest_user_id
+    ON public.profile_series_interest (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_push_devices_user_id
+    ON public.push_devices (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_subtitle_ai_jobs_requested_by
+    ON public.subtitle_ai_jobs (requested_by);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_profile_allowed_libraries_library_id
+    ON public.user_profile_allowed_libraries (library_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_provider_auth_sessions_user_id
+    ON public.watch_provider_auth_sessions (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_provider_connections_user_id
+    ON public.watch_provider_connections (user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_together_rooms_host_user_id
+    ON public.watch_together_rooms (host_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_together_suggestions_suggester_user_id
+    ON public.watch_together_suggestions (suggester_user_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_web_push_subscriptions_user_id
+    ON public.web_push_subscriptions (user_id);
+
+-- +goose Down
+-- Drop the 55 indexes again. Nothing else in the schema depends on them: the
+-- foreign keys they serve remain valid, they just go back to scanning.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_web_push_subscriptions_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_together_suggestions_suggester_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_together_rooms_host_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_provider_connections_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_provider_auth_sessions_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_user_profile_allowed_libraries_library_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_subtitle_ai_jobs_requested_by;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_push_devices_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_profile_series_interest_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_policy_documents_active_version_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_policy_document_versions_created_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_plugin_installations_repository_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_plugin_auth_identities_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_v3_attempts_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_v3_attempts_requested_media_file_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_v3_attempts_effective_media_file_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_sessions_sync_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_route_events_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_notification_webhooks_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_notification_discord_link_state_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_notification_deliveries_release_event_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_metadata_translation_jobs_requested_by;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_root_overrides_updated_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_root_overrides_created_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_request_targets_integration_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_request_events_actor_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_identity_overrides_updated_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_identity_overrides_created_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_group_overrides_updated_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_media_group_overrides_created_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_marker_edit_audit_impersonator_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_marker_edit_audit_api_key_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_literary_works_primary_cover_content_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_literary_work_match_decisions_created_by;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_library_provider_chains_plugin_installation_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_library_collection_libraries_group_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_library_collection_items_media_item_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_jellycompat_sessions_streamapp_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_invite_codes_created_by;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_invitations_invited_by;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_invitations_access_group_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_invitations_accepted_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_intro_season_analysis_state_media_folder_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_downloads_media_file_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_downloaded_subtitles_downloaded_by;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_device_login_requests_auth_session_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_device_login_requests_approved_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_autoscan_webhook_deliveries_source_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_autoscan_sources_connection_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_autoscan_connections_request_integration_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_auth_sessions_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_admin_jobs_created_by_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_abs_rss_feeds_library_item_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_abs_playback_sessions_media_file_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_abs_playback_sessions_content_id;

--- a/migrations/sql/20260901161657_fk_leading_indexes.sql
+++ b/migrations/sql/20260901161657_fk_leading_indexes.sql
@@ -24,25 +24,67 @@
 --     AND NOT EXISTS (
 --       SELECT 1 FROM pg_index i
 --       WHERE i.indrelid = con.conrelid AND i.indkey[0] = con.conkey[1]
+--         AND i.indpred IS NULL
 --     );
 --
--- conkey[1] and indkey[0] are the point: a column that only appears second in a
--- composite index (or is covered only by a partial index whose predicate does
--- not span the rows the cascade touches) does not satisfy the reference check,
--- while a column that leads any existing primary key, unique constraint, or
--- plain index already does and is deliberately absent below.
+-- conkey[1], indkey[0] and indpred are the three points. A column that only
+-- appears second in a composite index does not satisfy the reference check.
+-- Neither does a column that leads only a PARTIAL index: the planner may use
+-- such an index for the check only when the predicate provably holds for the
+-- rows being proved absent, so the audit refuses to count partial indexes at
+-- all (indpred IS NULL) and any exception is argued per case below rather than
+-- assumed. A column that leads a total primary key, unique constraint, or plain
+-- index already satisfies the check and is deliberately absent from the list.
 --
--- 45 columns come from the constraints that already existed; the remaining 10
+-- 47 columns come from the constraints that already existed; the remaining 10
 -- are columns that 20260901161700_user_fk_integrity constrains in this same
 -- release and that had no leading index either. The other seven columns it
--- constrains already lead an index: five a primary key or plain index, and two
--- -- auth_sessions.impersonator_user_id and activity_log.impersonator_user_id --
--- a partial index whose predicate is exactly "IS NOT NULL", which is precisely
--- the row set an ON DELETE action visits. None of those is duplicated here.
+-- constrains already lead an index -- five a primary key or plain index, two a
+-- partial one covered by the review below -- and are not duplicated here.
+--
+-- Two of the 47 lead a partial index and would have escaped a laxer audit that
+-- counted any leading index as coverage. They are here because their predicate
+-- turns on a column OTHER than the referencing one, so it excludes rows the
+-- cascade must still visit:
+--
+--   * watch_provider_scrobble_sessions.connection_id -- its primary key is
+--     (playback_session_id, connection_id), so connection_id is second there,
+--     and idx_watch_provider_scrobble_sessions_open leads on connection_id but
+--     is restricted to WHERE stop_sent_at IS NULL. The CASCADE from
+--     watch_provider_connections has to visit ENDED sessions too, and those are
+--     exactly the rows that index excludes. Nothing deletes them on a schedule,
+--     so they accumulate for the life of the deployment and every provider
+--     disconnect seq-scans the pile.
+--   * page_sections.library_id -- idx_page_sections_library leads on library_id
+--     but is restricted to WHERE enabled = true AND library_id IS NOT NULL, so
+--     the CASCADE from media_folders cannot use it for disabled sections. The
+--     table holds a few rows per library, so the plain index below costs almost
+--     nothing; it is here to keep the rule uniform rather than to fix a hot
+--     path.
+--
+-- Re-running the audit above after this migration still returns nine distinct
+-- table/column pairs (plus one row per activity_log partition, which inherits
+-- the parent's constraint and partial index and is covered by the same
+-- argument; the partition count grows weekly), and all nine are the documented
+-- exception rather than a miss. Every one of them
+-- leads a partial index whose predicate is exactly "<that same column> IS NOT
+-- NULL", which every cascade-relevant row satisfies by definition: a child row
+-- matching a parent key cannot have a NULL in the referencing column. The index
+-- therefore covers the whole row set the action visits.
+--
+--   activity_log.impersonator_user_id, auth_sessions.impersonator_user_id
+--     (constrained by 20260901161700 in this release)
+--   episode_libraries.first_seen_scan_run_id, history_import_runs.mapping_id,
+--   marker_edit_audit.user_id, media_files.episode_id, media_files.extra_id,
+--   media_files.first_seen_scan_run_id,
+--   push_delivery_attempts.notification_delivery_id
+--
+-- Any future addition to that list needs the same argument written down; the
+-- default answer for a partial index is that it does not count.
 --
 -- Every index is built CONCURRENTLY and this migration runs outside a
 -- transaction: a plain CREATE INDEX takes a SHARE lock that blocks all writes
--- to the table for the length of the build, and this builds 55 of them. The
+-- to the table for the length of the build, and this builds 57 of them. The
 -- cost is that a CONCURRENTLY build which fails leaves an invalid index behind,
 -- so the block below drops any invalid leftovers from an earlier attempt before
 -- rebuilding -- the same recovery the existing concurrent-index migrations do,
@@ -97,6 +139,7 @@ BEGIN
               'idx_notification_deliveries_release_event_id',
               'idx_notification_discord_link_state_user_id',
               'idx_notification_webhooks_user_id',
+              'idx_page_sections_library_id',
               'idx_playback_route_events_user_id',
               'idx_playback_sessions_sync_user_id',
               'idx_playback_v3_attempts_effective_media_file_id',
@@ -112,6 +155,7 @@ BEGIN
               'idx_user_profile_allowed_libraries_library_id',
               'idx_watch_provider_auth_sessions_user_id',
               'idx_watch_provider_connections_user_id',
+              'idx_watch_provider_scrobble_sessions_connection_id',
               'idx_watch_together_rooms_host_user_id',
               'idx_watch_together_suggestions_suggester_user_id',
               'idx_web_push_subscriptions_user_id'
@@ -234,6 +278,12 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_discord_link_state_user
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_webhooks_user_id
     ON public.notification_webhooks (user_id);
 
+-- page_sections.library_id: idx_page_sections_library leads on this column but
+-- is partial (WHERE enabled = true AND library_id IS NOT NULL), so it cannot
+-- serve the CASCADE from media_folders for disabled sections.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_page_sections_library_id
+    ON public.page_sections (library_id);
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_playback_route_events_user_id
     ON public.playback_route_events (user_id);
 
@@ -279,6 +329,13 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_provider_auth_sessions_user_id
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_provider_connections_user_id
     ON public.watch_provider_connections (user_id);
 
+-- watch_provider_scrobble_sessions.connection_id: second in the primary key,
+-- and the only index leading on it is partial (WHERE stop_sent_at IS NULL).
+-- Ended sessions are never swept, so the CASCADE from watch_provider_connections
+-- seq-scans an ever-growing table on every provider disconnect.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_provider_scrobble_sessions_connection_id
+    ON public.watch_provider_scrobble_sessions (connection_id);
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_watch_together_rooms_host_user_id
     ON public.watch_together_rooms (host_user_id);
 
@@ -289,11 +346,12 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_web_push_subscriptions_user_id
     ON public.web_push_subscriptions (user_id);
 
 -- +goose Down
--- Drop the 55 indexes again. Nothing else in the schema depends on them: the
+-- Drop the 57 indexes again. Nothing else in the schema depends on them: the
 -- foreign keys they serve remain valid, they just go back to scanning.
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_web_push_subscriptions_user_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_together_suggestions_suggester_user_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_together_rooms_host_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_provider_scrobble_sessions_connection_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_provider_connections_user_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_watch_provider_auth_sessions_user_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_user_profile_allowed_libraries_library_id;
@@ -309,6 +367,7 @@ DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_v3_attempts_requested_medi
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_v3_attempts_effective_media_file_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_sessions_sync_user_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_playback_route_events_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_page_sections_library_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_notification_webhooks_user_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_notification_discord_link_state_user_id;
 DROP INDEX CONCURRENTLY IF EXISTS public.idx_notification_deliveries_release_event_id;

--- a/migrations/sql/20260901161700_user_fk_integrity.sql
+++ b/migrations/sql/20260901161700_user_fk_integrity.sql
@@ -1,0 +1,310 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Constrain the user references that were never declared as foreign keys.
+--
+-- auth.UserRepository.Delete is a bare "DELETE FROM users WHERE id = $1": every
+-- row that survives a user deletion survives because a foreign key said so. A
+-- user column with no constraint therefore leaks rows on every account deletion
+-- -- push tokens that keep receiving notifications, cached recommendations,
+-- notification preferences, live Jellyfin compat sessions -- and nothing ever
+-- collects them, because nothing knows they are garbage.
+--
+-- The list was derived on a scratch database with the full chain applied:
+--
+--   WITH fk_cols AS (
+--     SELECT con.conrelid AS relid, unnest(con.conkey) AS attnum
+--     FROM pg_constraint con WHERE con.contype = 'f'
+--   )
+--   SELECT c.relname, a.attname, format_type(a.atttypid, a.atttypmod), a.attnotnull
+--   FROM pg_class c
+--   JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+--   JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+--   WHERE c.relkind IN ('r', 'p')
+--     AND a.attname ~ '(^|_)(user_id|created_by|updated_by|requested_by|actor|owner)'
+--     AND NOT EXISTS (
+--       SELECT 1 FROM fk_cols f WHERE f.relid = c.oid AND f.attnum = a.attnum
+--     );
+--
+-- and then read against the code that owns each table. Three groups of
+-- candidates are deliberately left alone:
+--
+--   * Columns holding a foreign system's identity rather than a users.id:
+--     history_import_*.connect_user_id / external_user_id,
+--     webhook_sync_*.external_user_id, notification_discord_prefs.discord_user_id,
+--     jellycompat_sessions.pseudo_user_id. Also jellycompat_playback_sessions.user_id
+--     and oauth_session.linking_user_id, which do carry a Silo user id but store
+--     it as text (the latter is strconv.Atoi'd in internal/auth/oauth_handler.go);
+--     constraining those means retyping the column, which is not this change.
+--   * policy_decisions.user_id and its partitions. Exempt on purpose: it is the
+--     policy audit trail, written on the hottest evaluation path and aged out by
+--     dropping partitions. A parent lookup per inserted row and a rewrite of
+--     history on every account deletion both cost more than the constraint is
+--     worth, and the row is evidence of what was decided about a user -- it
+--     stays true after the account is gone.
+--   * notification_server_channels.created_by_user_id. Migration
+--     20260612020209 states the intent in the table's own comment: no FK, the
+--     column is informational. A server-wide notification channel is server
+--     configuration that must outlive the admin who created it, and the column
+--     is NOT NULL, so neither CASCADE (deletes the channel) nor SET NULL (not
+--     permitted) expresses that. Left alone.
+--
+-- ON DELETE follows the existing shape of this schema (56 CASCADE, 16 SET NULL,
+-- every SET NULL on a nullable column) and the meaning of each row: CASCADE
+-- where the row belongs to the account and is meaningless without it, SET NULL
+-- where the row records something that happened and the user is attribution.
+--
+-- Orphans. An upgraded database can already hold rows whose user_id no longer
+-- exists -- that is the leak being closed -- and ADD CONSTRAINT refuses to
+-- validate against them. Each constraint is therefore preceded by a statement
+-- scoped to exactly those rows: a targeted DELETE where the column is NOT NULL
+-- (the row belongs to an account that no longer exists and can never be reached
+-- again), or an UPDATE ... SET NULL where the column is nullable by meaning and
+-- the row is a record worth keeping. Nothing else is touched, and neither is
+-- reversible; see the Down section.
+--
+-- The migration runs in one transaction, so it is all-or-nothing, at the cost of
+-- holding the ALTER TABLE locks on all seventeen child tables and on users for
+-- its duration. ADD CONSTRAINT validates by scanning the child table and blocks
+-- writes to both sides while it does, so on a large deployment this belongs in
+-- the same maintenance window as any other table-scanning schema change.
+
+-- 1) User-owned rows: the row exists only to serve one account. CASCADE.
+
+-- push_devices: APNs/FCM tokens for one account's devices. An orphan is a live
+-- push route to a deleted account.
+DELETE FROM public.push_devices t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.push_devices
+    ADD CONSTRAINT push_devices_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- web_push_subscriptions: the same, for browser push endpoints.
+DELETE FROM public.web_push_subscriptions t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.web_push_subscriptions
+    ADD CONSTRAINT web_push_subscriptions_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- notification_webhooks: outbound webhooks owned by one account's profiles.
+DELETE FROM public.notification_webhooks t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.notification_webhooks
+    ADD CONSTRAINT notification_webhooks_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- notification_email_prefs: one account's email notification settings.
+DELETE FROM public.notification_email_prefs t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.notification_email_prefs
+    ADD CONSTRAINT notification_email_prefs_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- notification_discord_prefs: one account's Discord notification settings;
+-- user_id is the primary key.
+DELETE FROM public.notification_discord_prefs t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.notification_discord_prefs
+    ADD CONSTRAINT notification_discord_prefs_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- notification_discord_link_state: an in-flight Discord account-link handshake.
+DELETE FROM public.notification_discord_link_state t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.notification_discord_link_state
+    ADD CONSTRAINT notification_discord_link_state_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- notification_deliveries: the per-profile notification inbox.
+DELETE FROM public.notification_deliveries t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.notification_deliveries
+    ADD CONSTRAINT notification_deliveries_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- profile_series_interest: which series a profile follows, which decides who
+-- receives a new-episode notification.
+DELETE FROM public.profile_series_interest t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.profile_series_interest
+    ADD CONSTRAINT profile_series_interest_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- user_audio_preferences: per user/profile/series audio track choice. Its
+-- neighbours user_subtitle_preferences and user_series_playback_preferences
+-- already CASCADE.
+DELETE FROM public.user_audio_preferences t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.user_audio_preferences
+    ADD CONSTRAINT user_audio_preferences_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- recommendation_cache: derived per-user recommendations, rebuildable.
+DELETE FROM public.recommendation_cache t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.recommendation_cache
+    ADD CONSTRAINT recommendation_cache_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- playback_sessions_sync: durable playback session state keyed to the account
+-- playing. Its admin-history sibling playback_history_admin.user_id already
+-- CASCADEs.
+DELETE FROM public.playback_sessions_sync t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.user_id);
+
+ALTER TABLE public.playback_sessions_sync
+    ADD CONSTRAINT playback_sessions_sync_user_id_fkey FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- jellycompat_sessions.streamapp_user_id: the Silo account behind a Jellyfin
+-- compat session. The row carries that session's token, so it must not outlive
+-- the account. (pseudo_user_id on the same table is the synthetic id handed to
+-- the Jellyfin client and is deliberately not a reference.)
+DELETE FROM public.jellycompat_sessions t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.streamapp_user_id);
+
+ALTER TABLE public.jellycompat_sessions
+    ADD CONSTRAINT jellycompat_sessions_streamapp_user_id_fkey FOREIGN KEY (streamapp_user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- admin_jobs.created_by_user_id: not merely informational -- canReadAdminJob in
+-- internal/api/handlers/admin_jobs.go compares it against the caller to decide
+-- who may read an item-refresh job. Jobs are ephemeral (they carry expires_at
+-- and are swept), so a job whose requesting admin is gone goes with them.
+DELETE FROM public.admin_jobs t
+WHERE NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.created_by_user_id);
+
+ALTER TABLE public.admin_jobs
+    ADD CONSTRAINT admin_jobs_created_by_user_id_fkey FOREIGN KEY (created_by_user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- auth_sessions.impersonator_user_id: nullable, but CASCADE rather than SET NULL
+-- on purpose. The column is what makes the session an impersonation; nulling it
+-- would silently turn a live admin-impersonation session into an ordinary
+-- session for the impersonated user. Once the impersonating admin's account is
+-- deleted the authority behind the session is gone and the session must go with
+-- it -- the same thing SessionRepository.RevokeAllByImpersonator does
+-- explicitly. The orphan sweep removes those rows for the same reason.
+DELETE FROM public.auth_sessions t
+WHERE t.impersonator_user_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.impersonator_user_id);
+
+ALTER TABLE public.auth_sessions
+    ADD CONSTRAINT auth_sessions_impersonator_user_id_fkey FOREIGN KEY (impersonator_user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE;
+
+-- 2) Attribution on a record that outlives the account: nullable columns, SET
+-- NULL, and an orphan sweep that nulls instead of deleting.
+
+-- activity_log.impersonator_user_id: the request audit log. Its sibling
+-- activity_log.user_id has carried ON DELETE SET NULL since the 001 baseline;
+-- impersonator_user_id was added later without one, so the same table enforces
+-- one of its two user references and not the other. This is a partitioned table:
+-- the constraint is declared on the parent and Postgres applies it to every
+-- existing partition and to future ones, including the partitions
+-- internal/partman creates and ATTACHes. The existing partial index
+-- idx_activity_log_impersonator_user_id (WHERE impersonator_user_id IS NOT NULL)
+-- covers exactly the rows a SET NULL action visits, so both the sweep below and
+-- the action itself are index-driven.
+UPDATE public.activity_log t
+SET impersonator_user_id = NULL
+WHERE t.impersonator_user_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.impersonator_user_id);
+
+ALTER TABLE public.activity_log
+    ADD CONSTRAINT activity_log_impersonator_user_id_fkey FOREIGN KEY (impersonator_user_id)
+    REFERENCES public.users(id) ON DELETE SET NULL;
+
+-- subtitle_ai_jobs.requested_by: nullable because a job can be system-initiated.
+-- It drives the per-user quota window in internal/subtitles/ai/pgrepo.go, but
+-- the job row and its output stay useful once the requester is gone.
+UPDATE public.subtitle_ai_jobs t
+SET requested_by = NULL
+WHERE t.requested_by IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.requested_by);
+
+ALTER TABLE public.subtitle_ai_jobs
+    ADD CONSTRAINT subtitle_ai_jobs_requested_by_fkey FOREIGN KEY (requested_by)
+    REFERENCES public.users(id) ON DELETE SET NULL;
+
+-- metadata_translation_jobs.requested_by: the same shape as subtitle_ai_jobs.
+UPDATE public.metadata_translation_jobs t
+SET requested_by = NULL
+WHERE t.requested_by IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id = t.requested_by);
+
+ALTER TABLE public.metadata_translation_jobs
+    ADD CONSTRAINT metadata_translation_jobs_requested_by_fkey FOREIGN KEY (requested_by)
+    REFERENCES public.users(id) ON DELETE SET NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Drop the seventeen constraints. The columns keep their values and their types;
+-- only the enforcement goes away.
+--
+-- Lossy in reverse, deliberately: the Up deleted the rows that pointed at
+-- accounts which no longer exist and nulled the attribution columns that did the
+-- same, and archived neither. Rolling back restores the schema's ability to hold
+-- such rows, not the rows themselves. Restore from a backup if the orphans
+-- mattered.
+ALTER TABLE public.metadata_translation_jobs
+    DROP CONSTRAINT IF EXISTS metadata_translation_jobs_requested_by_fkey;
+
+ALTER TABLE public.subtitle_ai_jobs
+    DROP CONSTRAINT IF EXISTS subtitle_ai_jobs_requested_by_fkey;
+
+ALTER TABLE public.activity_log
+    DROP CONSTRAINT IF EXISTS activity_log_impersonator_user_id_fkey;
+
+ALTER TABLE public.auth_sessions
+    DROP CONSTRAINT IF EXISTS auth_sessions_impersonator_user_id_fkey;
+
+ALTER TABLE public.admin_jobs
+    DROP CONSTRAINT IF EXISTS admin_jobs_created_by_user_id_fkey;
+
+ALTER TABLE public.jellycompat_sessions
+    DROP CONSTRAINT IF EXISTS jellycompat_sessions_streamapp_user_id_fkey;
+
+ALTER TABLE public.playback_sessions_sync
+    DROP CONSTRAINT IF EXISTS playback_sessions_sync_user_id_fkey;
+
+ALTER TABLE public.recommendation_cache
+    DROP CONSTRAINT IF EXISTS recommendation_cache_user_id_fkey;
+
+ALTER TABLE public.user_audio_preferences
+    DROP CONSTRAINT IF EXISTS user_audio_preferences_user_id_fkey;
+
+ALTER TABLE public.profile_series_interest
+    DROP CONSTRAINT IF EXISTS profile_series_interest_user_id_fkey;
+
+ALTER TABLE public.notification_deliveries
+    DROP CONSTRAINT IF EXISTS notification_deliveries_user_id_fkey;
+
+ALTER TABLE public.notification_discord_link_state
+    DROP CONSTRAINT IF EXISTS notification_discord_link_state_user_id_fkey;
+
+ALTER TABLE public.notification_discord_prefs
+    DROP CONSTRAINT IF EXISTS notification_discord_prefs_user_id_fkey;
+
+ALTER TABLE public.notification_email_prefs
+    DROP CONSTRAINT IF EXISTS notification_email_prefs_user_id_fkey;
+
+ALTER TABLE public.notification_webhooks
+    DROP CONSTRAINT IF EXISTS notification_webhooks_user_id_fkey;
+
+ALTER TABLE public.web_push_subscriptions
+    DROP CONSTRAINT IF EXISTS web_push_subscriptions_user_id_fkey;
+
+ALTER TABLE public.push_devices
+    DROP CONSTRAINT IF EXISTS push_devices_user_id_fkey;
+-- +goose StatementEnd

--- a/migrations/sql/20260901161702_users_role_enabled_not_null.sql
+++ b/migrations/sql/20260901161702_users_role_enabled_not_null.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+-- +goose StatementBegin
+-- users.role and users.enabled are nullable in the schema and non-nullable
+-- everywhere else.
+--
+-- models.User declares Role as string and Enabled as bool, and
+-- auth.UserRepository selects both in allColumns and scans them straight into
+-- those fields. A NULL in either column does not degrade gracefully: pgx cannot
+-- scan NULL into string or bool, so the row fails to scan -- and because
+-- scanUsers iterates one result set, a single NULL row breaks the whole admin
+-- user list, not just that account. Every read path already assumes NOT NULL;
+-- this makes the schema say so.
+--
+-- Backfill values are the ones the rest of the system already treats as the
+-- default for a row that does not specify:
+--
+--   * role -> 'user'. UserRepository.Create always writes role explicitly, and
+--     every caller passes models.RoleUser or models.RoleAdmin, so a NULL can
+--     only come from a hand-edited or pre-role row. 'user' is also the
+--     fail-closed choice: every privileged path in internal/auth tests
+--     role == "admin", so a recovered row gets the unprivileged role.
+--   * enabled -> true. The column has carried DEFAULT true since the 001
+--     baseline and Create never writes it, relying on that default; true is
+--     therefore what the schema itself says an unspecified row means.
+--
+-- No DEFAULT is added for role, deliberately. enabled keeps the DEFAULT true it
+-- already has because Create depends on it, but role has never had one and every
+-- insert supplies it; a default would turn a caller that forgot the column into
+-- a silently created ordinary account instead of an error.
+UPDATE public.users SET role = 'user' WHERE role IS NULL;
+UPDATE public.users SET enabled = true WHERE enabled IS NULL;
+
+ALTER TABLE public.users ALTER COLUMN role SET NOT NULL;
+ALTER TABLE public.users ALTER COLUMN enabled SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- Restore nullability. enabled keeps its DEFAULT true, which the Up did not
+-- touch.
+--
+-- Lossy in reverse, deliberately: the Up overwrote the NULLs in place and
+-- recorded nothing about which rows they were, so rolling back allows NULLs
+-- again but does not put them back. The distinction only matters if something
+-- depended on telling "never set" apart from 'user'/true, which nothing does.
+ALTER TABLE public.users ALTER COLUMN enabled DROP NOT NULL;
+ALTER TABLE public.users ALTER COLUMN role DROP NOT NULL;
+-- +goose StatementEnd


### PR DESCRIPTION
## Problem

Related issue: #135 (schema workstream: #888)

Account deletion is a bare `DELETE FROM users WHERE id=$1`, but 17 user-referencing columns had no foreign key — every deletion leaks rows (live push routes, webhooks, notification prefs, cached recommendations, in-flight Discord link state, and more). Separately, 46 FK leading columns had no usable index (so FK cascade checks sequential-scan child tables, worst on `auth_sessions.user_id` and `downloads.media_file_id`), and `users.role`/`users.enabled` allowed NULL that no code path writes or handles. The 1.0 squashed baseline should not inherit any of this.

**Base branch: `schema/hygiene-drop-dead-tables` (PR #879)** — second PR in the schema-hygiene stack; only the last two commits are new here.

## Approach

Three migrations, all derived from an empirical audit of the migrated schema (audit queries are committed in the migration comments):

1. **`20260901161657_fk_leading_indexes.sql`** — 57 `CREATE INDEX CONCURRENTLY` (`-- +goose NO TRANSACTION`), covering the 46 audited unindexed FK leading columns, 10 newly constrained columns, and 2 columns whose only leading index is partial with a predicate on a *different* column (`watch_provider_scrobble_sessions.connection_id`, `page_sections.library_id`). The audit rule is strict: partial indexes never count as FK coverage unless their predicate is `<column> IS NOT NULL` (nine such documented exceptions, argued in the migration).
2. **`20260901161700_user_fk_integrity.sql`** — 17 FKs to `users(id)`: 14 `ON DELETE CASCADE` (row belongs to the account) and 3 `ON DELETE SET NULL` (attribution on records that outlive the account: `activity_log.impersonator_user_id`, `subtitle_ai_jobs.requested_by`, `metadata_translation_jobs.requested_by`). `auth_sessions.impersonator_user_id` is deliberately CASCADE — SET NULL would silently convert a live impersonation session into an ordinary session for the impersonated user. Each `ADD CONSTRAINT` is preceded by an orphan sweep scoped exactly to rows whose parent no longer exists (targeted `DELETE`, or `UPDATE … SET NULL` for the attribution columns). Documented exclusions: `policy_decisions*` (per program plan: hottest write path, rows are historical evidence), `notification_server_channels.created_by_user_id` (informational-only by that table's recorded convention), foreign-system identity columns, and two text-typed Silo user-id columns that need a retype first (noted in #888).
3. **`20260901161702_users_role_enabled_not_null.sql`** — backfills `role='user'` / `enabled=true` (the code-side defaults), then `SET NOT NULL`.

`migrations/schema_integrity_test.go` (new, in the established migrations contract-test style) pins the 17 exact `ON DELETE` actions, each paired orphan sweep, the backfill values, the 57 index names, and that no `CREATE INDEX` statement gains a `WHERE` predicate (case-insensitive) — mutation-tested: flipping a CASCADE or lowercasing a predicate fails the test.

## Validation

- Full chain from an empty scratch DB (including the PR #879 drops): clean apply; migrate-status captured; down → re-up of all three migrations clean.
- Orphan-seeded upgrade run: orphan rows planted in representative tables plus NULL `role`/`enabled`; migration sweeps exactly the orphans, constraints then hold. Independently reproduced by the destructive-safety reviewer with its own seed data (parents/children/orphans) — only orphans touched.
- `EXPLAIN` confirms the prioritized indexes are present and usable.
- `make migrate-validate`, `make embed-stub`, `go build ./...`, `gofmt` (empty), `go vet`: pass.
- `golangci-lint run --new-from-merge-base="origin/main"`: 0 issues.
- `make test-go`: all packages ok (includes the new contract tests). `make verify-settings-bindings-all`, `verify-playback-fixtures`, `verify-local-paths`: pass.
- Web untouched on this branch (same web tree as PR #879, whose Web CI is green).

## Risks

- The FK migration runs transactionally and holds `SHARE ROW EXCLUSIVE` on `users` and each child during validation — on large tables that blocks writes for the duration. Accepted as documented maintenance-window behavior per the program's upgrade posture (a `NOT VALID`/`VALIDATE` split was considered and declined for pre-1.0 simplicity; the migration comments note it).
- The index migration uses `CONCURRENTLY` outside a transaction; the Up includes recovery handling for invalid leftover indexes if a run is interrupted.
- Orphan sweeps delete garbage rows (unreachable by any code path since their account is gone) and null out attribution for deleted accounts; the Down restores constraints/nullability but deleted rows are not restorable — restore from backup, as the migration states.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code
- Tool(s): Claude Code (orchestrator session driving implementation and review subagents)
- Model(s): claude-opus-5 (implementation), claude-fable-5 (orchestration and all review agents)
- Involvement: Fully AI-generated; maintainer review pending (opened by the orchestrating agent under the maintainer's program instruction)
- Adversarial review: two rounds of independent blind panels (destructive-safety at maximum effort, migration discipline, audit fidelity, test adequacy). Round 1 found one major (the index audit counted partial indexes as FK coverage — `watch_provider_scrobble_sessions.connection_id` was uncovered on an unboundedly-growing table) and three minors; all fixed. Round 2 verified closure and mutation-tested the new contract tests, yielding two minor prescriptions (partition-aware audit-count comment; case-insensitive predicate guard), both applied. The `NOT VALID` lock-window suggestion was declined with a written reason (documented maintenance-window posture).
