### PR TITLE
fix(playback): lift negative AAC tfdt in copy-video fMP4 starts

### DIFF
--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -776,7 +776,7 @@ func buildFFmpegArgs(opts TranscodeOpts) []string {
 	// race with fMP4 (hls.js #6337).
 	var segmentPattern string
 	segmentType := "mpegts"
-	copyVideoUsesFMP4 := isVideoCopy && !opts.CopyVideoMPEGTS && !IsMPEG2VideoCodec(opts.SourceVideoCodec)
+	copyVideoUsesFMP4 := copyVideoUsesFMP4(opts)
 	if copyVideoUsesFMP4 {
 		segmentType = "fmp4"
 		segmentPattern = filepath.Join(opts.OutputDir, "seg_%05d.m4s")
@@ -896,6 +896,15 @@ func appendStreamSelectionArgs(args []string, opts TranscodeOpts) []string {
 	return args
 }
 
+// copyVideoUsesFMP4 reports whether copied video is packaged as fragmented MP4
+// rather than MPEG-TS. Shared by segment-type selection and timestamp policy
+// so the two cannot disagree.
+func copyVideoUsesFMP4(opts TranscodeOpts) bool {
+	return strings.EqualFold(opts.TargetCodecVideo, "copy") &&
+		!opts.CopyVideoMPEGTS &&
+		!IsMPEG2VideoCodec(opts.SourceVideoCodec)
+}
+
 // appendTimestampNormalizationArgs selects timestamp handling based on the
 // playback mode. Jellyfin-compatible copy-video fMP4 preserves source timing
 // while start_at_zero makes the output presentation timeline begin at zero.
@@ -910,12 +919,17 @@ func appendStreamSelectionArgs(args []string, opts TranscodeOpts) []string {
 // full-file copy-video start with audio adaptation failed on Android before
 // the first frame. make_non_negative shifts all streams by the same minimal
 // offset only when a timestamp is negative; resumes and audio-copy starts
-// carry no negative timestamps and are therefore unaffected.
+// carry no negative timestamps and are therefore unaffected. MPEG-TS copy
+// output has no tfdt and keeps the source timestamps untouched.
 func appendTimestampNormalizationArgs(args []string, opts TranscodeOpts) []string {
 	if strings.EqualFold(opts.TargetCodecVideo, "copy") {
+		negativeTS := "disabled"
+		if copyVideoUsesFMP4(opts) {
+			negativeTS = "make_non_negative"
+		}
 		return append(args,
 			"-copyts",
-			"-avoid_negative_ts", "make_non_negative",
+			"-avoid_negative_ts", negativeTS,
 			"-start_at_zero",
 		)
 	}

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -901,11 +901,21 @@ func appendStreamSelectionArgs(args []string, opts TranscodeOpts) []string {
 // while start_at_zero makes the output presentation timeline begin at zero.
 // This keeps initial fragments decodable without losing the source-relative
 // timing required by segment-driven resume restarts.
+//
+// Negative timestamps must still be lifted. When the audio is re-encoded to
+// AAC the encoder's 1024-sample priming delay places the first audio packet
+// before zero, and with "disabled" the mov muxer writes that value straight
+// into the first fragment's tfdt (baseMediaDecodeTime -1024). ExoPlayer/Media3
+// rejects any tfdt with the sign bit set ("Top bit not zero"), so every
+// full-file copy-video start with audio adaptation failed on Android before
+// the first frame. make_non_negative shifts all streams by the same minimal
+// offset only when a timestamp is negative; resumes and audio-copy starts
+// carry no negative timestamps and are therefore unaffected.
 func appendTimestampNormalizationArgs(args []string, opts TranscodeOpts) []string {
 	if strings.EqualFold(opts.TargetCodecVideo, "copy") {
 		return append(args,
 			"-copyts",
-			"-avoid_negative_ts", "disabled",
+			"-avoid_negative_ts", "make_non_negative",
 			"-start_at_zero",
 		)
 	}

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -576,8 +576,11 @@ func TestBuildFFmpegArgs_CopyVideoFromStartUsesJellyfinTimestamps(t *testing.T) 
 	if !strings.Contains(joined, "-copyts") {
 		t.Fatalf("copy-video from-start should preserve source timestamps: %s", joined)
 	}
-	if !strings.Contains(joined, "-avoid_negative_ts disabled") {
-		t.Fatalf("copy-video from-start should disable timestamp rewriting: %s", joined)
+	if !strings.Contains(joined, "-avoid_negative_ts make_non_negative") {
+		t.Fatalf("copy-video from-start must lift the AAC priming delay out of the first tfdt: %s", joined)
+	}
+	if strings.Contains(joined, "-avoid_negative_ts disabled") {
+		t.Fatalf("copy-video from-start must not write negative tfdt values: %s", joined)
 	}
 	if !strings.Contains(joined, "-start_at_zero") {
 		t.Fatalf("copy-video from-start should start its output timeline at zero: %s", joined)
@@ -641,8 +644,8 @@ func TestBuildFFmpegArgs_CopyVideoResumePreservesSourceTimestamps(t *testing.T) 
 	if !strings.Contains(joined, "-copyts") {
 		t.Fatalf("copy-video resume should preserve source timestamps: %s", joined)
 	}
-	if !strings.Contains(joined, "-avoid_negative_ts disabled") {
-		t.Fatalf("copy-video resume should disable negative-ts adjustment: %s", joined)
+	if !strings.Contains(joined, "-avoid_negative_ts make_non_negative") {
+		t.Fatalf("copy-video resume should only lift genuinely negative timestamps: %s", joined)
 	}
 	if !strings.Contains(joined, "-start_at_zero") {
 		t.Fatalf("copy-video resume should start its output timeline at zero: %s", joined)

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -703,6 +703,28 @@ func TestBuildFFmpegArgs_CopyVideoSeekPreservesCodecCopy(t *testing.T) {
 	}
 }
 
+func TestBuildFFmpegArgs_MPEGTSCopyVideoKeepsSourceTimestamps(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:        "/media/movie.mkv",
+		OutputDir:        "/tmp/out",
+		SessionID:        "session-copy-ts",
+		SourceVideoCodec: "hevc",
+		TargetCodecVideo: "copy",
+		TargetCodecAudio: "aac",
+		CopyVideoMPEGTS:  true,
+		SegmentDuration:  2,
+	})
+
+	joined := strings.Join(args, " ")
+	// MPEG-TS has no tfdt, so the fMP4 negative-timestamp lift does not apply.
+	if !strings.Contains(joined, "-copyts -avoid_negative_ts disabled -start_at_zero") {
+		t.Fatalf("MPEG-TS copy-video should keep source timestamps untouched: %s", joined)
+	}
+	if strings.Contains(joined, "make_non_negative") {
+		t.Fatalf("MPEG-TS copy-video must not apply the fMP4 timestamp lift: %s", joined)
+	}
+}
+
 func TestBuildFFmpegArgs_MPEG2CopyVideoUsesMPEGTS(t *testing.T) {
 	args := buildFFmpegArgs(TranscodeOpts{
 		InputPath:        "/media/movie.mkv",


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Every full-file copy-video HLS start with AAC audio adaptation fails on Android before the first frame. The AAC encoder's 1024-sample priming delay puts the first audio packet at DTS -1024. Since #5e1752985 (webOS Dolby Vision remux repair) the copy-video path uses `-copyts -avoid_negative_ts disabled -start_at_zero`, so the mov muxer writes that negative value into the first fragment's audio `tfdt`. Media3's `FragmentedMp4Extractor` rejects any `tfdt` with the sign bit set:

```
java.lang.IllegalStateException: Top bit not zero: -1024
    at androidx.media3.common.util.ParsableByteArray.readUnsignedLongToLong(ParsableByteArray.java:543)
    at androidx.media3.extractor.mp4.FragmentedMp4Extractor.parseTfdt(FragmentedMp4Extractor.java:1321)
```

Reproduced on an onn 4K box with both Media3 1.10.1 and 1.11.0 builds of the Android TV app playing a 4K HEVC DV DTS-HD MA MKV from position zero (plan `server_remux_hls`, reason `hls_audio_adaptation`). Resumes from a non-zero position work because the seek offset keeps timestamps positive. The client's failure replan then surfaced an unrelated "did not keep subtitles off" banner, which is what the user saw.

## Approach

Switch copy-video output to `-avoid_negative_ts make_non_negative`. It shifts all streams by the same minimal offset only when a timestamp is negative, so resumes and audio-copy starts, which have no negative timestamps, keep the source-relative timing the webOS fix depends on. `make_zero` (the pre-#5e1752985 value) would rewrite timing on every start and reintroduce the resume drift that commit fixed.

Encoded transcodes (MPEG-TS) are unchanged.

## Validation

First-fragment `tfdt` values from the exact session ffmpeg command, run in the dev container against the same source:

| Flags | video tfdt | audio tfdt |
| --- | --- | --- |
| `-copyts -avoid_negative_ts disabled -start_at_zero` (main) | 0 | -1024 |
| `-copyts -avoid_negative_ts make_non_negative -start_at_zero` (this PR) | 2000 | 4976 |
| same, audio copy | 2000 | 6000 |

```
go test ./internal/playback/... ./internal/transcodenode/... ./internal/jellycompat/... ./internal/api/handlers/...
ok  	github.com/Silo-Server/silo-server/internal/playback	16.396s
ok  	github.com/Silo-Server/silo-server/internal/playback/contract	0.254s
ok  	github.com/Silo-Server/silo-server/internal/playback/planstore	0.233s
ok  	github.com/Silo-Server/silo-server/internal/transcodenode	11.331s
ok  	github.com/Silo-Server/silo-server/internal/jellycompat	48.303s
ok  	github.com/Silo-Server/silo-server/internal/api/handlers	154.262s

golangci-lint run --new-from-merge-base=origin/main ./internal/playback/...
0 issues.
```

Deployed to shared dev and replayed the failing title from Start Over on the onn 4K box: `server_remux_hls` mounted, played 2m41s, 3 dropped of 3863 frames, no player errors. The full `make test`/`make lint` gate was not run; the four packages above cover the changed code.

## Risks

Copy-video HLS fragments now carry a small positive timestamp offset (one AAC frame at the source rate) on zero-start sessions. webOS and Jellyfin-client copy-video resume paths are unaffected because their timestamps are already non-negative. No migration or config change.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code (CLI)
- Tool(s): Claude Code agent tools, GitHub CLI, adb, silo-runtime helper
- Model(s): `claude-fable-5-1`
- Involvement: Fully AI-generated, human verified
- Adversarial review: Root cause confirmed by bytecode diff of Media3 1.10.1 vs 1.11.0 (`parseTfdt` unchanged) and by A/B playback on both client versions; fix verified by parsing muxer output for three flag variants and by device playback against the deployed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HLS copy-video timestamp handling to prevent negative decode times in fragmented MP4 playback.
  * Preserved accurate timestamps when starting playback from the beginning or resuming.
  * Reduced playback issues related to negative audio priming timestamps.
  * Preserved source timestamp behavior for MPEG-TS copy-video playback.

* **Tests**
  * Updated timestamp validation across fragmented MP4 and MPEG-TS playback workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->