### PR TITLE
fix(web): repair high contrast tokens dropped as cyclic CSS

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -457,6 +457,12 @@ html[data-navigation-direction]::view-transition-new(main-content) {
      It reads `--border-base` instead.
      ───────────────────────────────────────────────────────── */
   :root {
+    /* The direction high contrast pushes toward: away from the page. White on
+       the dark themes, black on a light one. Defaulting here means a theme
+       that forgets to set it degrades to the dark-theme behaviour rather than
+       to an invalid value. */
+    --contrast-boost: #ffffff;
+
     --muted-foreground: var(--muted-foreground-base);
     --border: var(--border-base);
     --input: var(--input-base);
@@ -476,6 +482,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --font-display: "Outfit", sans-serif;
 
     /* Surfaces: near-black with subtle cool undertone */
+    --contrast-boost: #ffffff;
     --background: #141417;
     --foreground: #e8e8ec;
     --card: #1c1c20;
@@ -540,6 +547,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --font-display: "Outfit", sans-serif;
 
     /* Surfaces: warm off-white with cool undertone */
+    --contrast-boost: #000000;
     --background: #f4f4f6;
     --foreground: #1a1a1e;
     --card: #ffffff;
@@ -609,6 +617,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --radius: 0.75rem;
     --font-body: "Outfit", sans-serif;
     --font-display: "Outfit", sans-serif;
+    --contrast-boost: #ffffff;
     --background: #101722;
     --foreground: #f4f8ff;
     --card: #151e2b;
@@ -654,6 +663,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --radius: 0.75rem;
     --font-body: "Outfit", sans-serif;
     --font-display: "Outfit", sans-serif;
+    --contrast-boost: #ffffff;
     --background: #171113;
     --foreground: #f8f2f3;
     --card: #20181b;
@@ -699,6 +709,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --radius: 0.75rem;
     --font-body: "Outfit", sans-serif;
     --font-display: "Outfit", sans-serif;
+    --contrast-boost: #ffffff;
     --background: #101715;
     --foreground: #f2f8f5;
     --card: #16201d;
@@ -774,16 +785,22 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --font-weight-semibold-ui: 600;
     --font-weight-bold-ui: 700;
   }
+  /* Every token here pushes toward --contrast-boost, never toward white
+     directly. Hard-coded white raises contrast on a dark theme and destroys it
+     on a light one: on cinema-light it drove --muted-foreground to 1.36:1 and
+     --foreground to 1.10:1 against the page, i.e. high contrast mode made the
+     theme unreadable. Mixing toward the boost gives 15.49:1 and 19.12:1 there
+     while leaving the dark themes as they were. */
   html[data-high-contrast="true"] {
-    --foreground: #ffffff;
-    --ring: oklch(0.95 0 0);
-    --muted-foreground: color-mix(in srgb, white 72%, var(--muted-foreground-base));
-    --border: color-mix(in srgb, white 34%, var(--border-base));
-    --input: color-mix(in srgb, white 16%, var(--input-base));
-    --surface: color-mix(in srgb, white 10%, var(--surface-base));
-    --surface-hover: color-mix(in srgb, white 16%, var(--surface-hover-base));
-    --surface-raised: color-mix(in srgb, white 20%, var(--surface-raised-base));
-    --accent: color-mix(in srgb, white 14%, var(--accent-base));
+    --foreground: var(--contrast-boost);
+    --ring: var(--contrast-boost);
+    --muted-foreground: color-mix(in srgb, var(--contrast-boost) 72%, var(--muted-foreground-base));
+    --border: color-mix(in srgb, var(--contrast-boost) 34%, var(--border-base));
+    --input: color-mix(in srgb, var(--contrast-boost) 16%, var(--input-base));
+    --surface: color-mix(in srgb, var(--contrast-boost) 10%, var(--surface-base));
+    --surface-hover: color-mix(in srgb, var(--contrast-boost) 16%, var(--surface-hover-base));
+    --surface-raised: color-mix(in srgb, var(--contrast-boost) 20%, var(--surface-raised-base));
+    --accent: color-mix(in srgb, var(--contrast-boost) 14%, var(--accent-base));
     --ambient-glow-opacity: 0.04;
   }
   html[data-high-contrast="true"] .surface-panel-subtle,

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -447,6 +447,25 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --info-foreground: oklch(0.98 0.01 250);
   }
 
+  /* ── Contrast-adjustable tokens ─────────────────────────────
+     These seven tokens are the ones high contrast mode lightens.
+     Themes define the literal under `--<token>-base`; the semantic
+     token is an alias. The indirection is required, not stylistic:
+     a custom property whose value references itself is a dependency
+     cycle and is invalid at computed-value time, so the high-contrast
+     block cannot write `--border: color-mix(..., var(--border))`.
+     It reads `--border-base` instead.
+     ───────────────────────────────────────────────────────── */
+  :root {
+    --muted-foreground: var(--muted-foreground-base);
+    --border: var(--border-base);
+    --input: var(--input-base);
+    --surface: var(--surface-base);
+    --surface-hover: var(--surface-hover-base);
+    --surface-raised: var(--surface-raised-base);
+    --accent: var(--accent-base);
+  }
+
   /* ── Midnight Cinema ────────────────────────────────────── */
   /* Inspired by premium streaming UIs: monochromatic, cinematic,
      content-focused. White primary creates an elegant, theater-like
@@ -474,8 +493,8 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --muted: #1c1c20;
     /* Lightened from #6e6e78 (~3.4:1) to meet WCAG AA: ~6.3:1 on --background,
        ~5.3:1 even on the lightest chip surface (#232328). */
-    --muted-foreground: #9696a0;
-    --accent: #232328;
+    --muted-foreground-base: #9696a0;
+    --accent-base: #232328;
     --accent-foreground: #e8e8ec;
 
     /* Destructive: warm red for danger actions */
@@ -483,8 +502,8 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --destructive-foreground: #ffffff;
 
     /* Borders: barely visible, just enough structure */
-    --border: #28282e;
-    --input: #1c1c20;
+    --border-base: #28282e;
+    --input-base: #1c1c20;
     --ring: #e8e8ec;
 
     /* Charts: categorical set validated on this theme's card surface —
@@ -508,9 +527,9 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --sidebar-ring: #e8e8ec;
 
     /* Surfaces: layered depth */
-    --surface: #1c1c20;
-    --surface-hover: #232328;
-    --surface-raised: #28282e;
+    --surface-base: #1c1c20;
+    --surface-hover-base: #232328;
+    --surface-raised-base: #28282e;
     --ambient: #e8e8ec;
     --ambient-glow-opacity: 0.08;
   }
@@ -538,8 +557,8 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --muted: #ebebef;
     /* Darkened from #78787f (~4.0:1) to meet WCAG AA on light surfaces
        (~4.9:1 on the #e8e8ec chip, ~5.4:1 on --background). */
-    --muted-foreground: #63636b;
-    --accent: #e8e8ec;
+    --muted-foreground-base: #63636b;
+    --accent-base: #e8e8ec;
     --accent-foreground: #1a1a1e;
 
     /* Destructive: warm red for danger actions */
@@ -547,8 +566,8 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --destructive-foreground: #ffffff;
 
     /* Borders: soft gray, enough structure without weight */
-    --border: #d8d8de;
-    --input: #e8e8ec;
+    --border-base: #d8d8de;
+    --input-base: #e8e8ec;
     --ring: #1a1a1e;
 
     /* Charts: light-mode steps of the same categorical set, validated against
@@ -571,9 +590,9 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --sidebar-ring: #1a1a1e;
 
     /* Surfaces: layered depth */
-    --surface: #ebebef;
-    --surface-hover: #e0e0e6;
-    --surface-raised: #ffffff;
+    --surface-base: #ebebef;
+    --surface-hover-base: #e0e0e6;
+    --surface-raised-base: #ffffff;
     --ambient: #1a1a1e;
     --ambient-glow-opacity: 0.05;
 
@@ -601,13 +620,13 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --secondary: #1b2634;
     --secondary-foreground: #d7e2f1;
     --muted: #151e2b;
-    --muted-foreground: #90a0b5;
-    --accent: #203043;
+    --muted-foreground-base: #90a0b5;
+    --accent-base: #203043;
     --accent-foreground: #f4f8ff;
     --destructive: #ef6b73;
     --destructive-foreground: #ffffff;
-    --border: #28384d;
-    --input: #182231;
+    --border-base: #28384d;
+    --input-base: #182231;
     --ring: #78aefc;
     /* Shared dark categorical set (see midnight-cinema). */
     --chart-1: #5f74ee;
@@ -624,9 +643,9 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --sidebar-border: #1f2a39;
     --sidebar-section-divider: #283a4e;
     --sidebar-ring: #78aefc;
-    --surface: #151e2b;
-    --surface-hover: #1d2a3b;
-    --surface-raised: #223245;
+    --surface-base: #151e2b;
+    --surface-hover-base: #1d2a3b;
+    --surface-raised-base: #223245;
     --ambient: #78aefc;
     --ambient-glow-opacity: 0.11;
   }
@@ -646,13 +665,13 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --secondary: #281d21;
     --secondary-foreground: #decfd2;
     --muted: #20181b;
-    --muted-foreground: #a28e95;
-    --accent: #322228;
+    --muted-foreground-base: #a28e95;
+    --accent-base: #322228;
     --accent-foreground: #f8f2f3;
     --destructive: #f08080;
     --destructive-foreground: #ffffff;
-    --border: #3b2830;
-    --input: #251a1f;
+    --border-base: #3b2830;
+    --input-base: #251a1f;
     --ring: #d16a78;
     /* Shared dark categorical set (see midnight-cinema). */
     --chart-1: #5f74ee;
@@ -669,9 +688,9 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --sidebar-border: #2c1d23;
     --sidebar-section-divider: #3a252e;
     --sidebar-ring: #d16a78;
-    --surface: #20181b;
-    --surface-hover: #2a2025;
-    --surface-raised: #34262c;
+    --surface-base: #20181b;
+    --surface-hover-base: #2a2025;
+    --surface-raised-base: #34262c;
     --ambient: #d16a78;
     --ambient-glow-opacity: 0.11;
   }
@@ -691,13 +710,13 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --secondary: #1b2824;
     --secondary-foreground: #d1e0d9;
     --muted: #16201d;
-    --muted-foreground: #91a39c;
-    --accent: #20322d;
+    --muted-foreground-base: #91a39c;
+    --accent-base: #20322d;
     --accent-foreground: #f2f8f5;
     --destructive: #f07a7a;
     --destructive-foreground: #ffffff;
-    --border: #284038;
-    --input: #182420;
+    --border-base: #284038;
+    --input-base: #182420;
     --ring: #5bc39d;
     /* Shared dark categorical set (see midnight-cinema). */
     --chart-1: #5f74ee;
@@ -714,9 +733,9 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     --sidebar-border: #1d2f2a;
     --sidebar-section-divider: #253d35;
     --sidebar-ring: #5bc39d;
-    --surface: #16201d;
-    --surface-hover: #1e2b27;
-    --surface-raised: #263732;
+    --surface-base: #16201d;
+    --surface-hover-base: #1e2b27;
+    --surface-raised-base: #263732;
     --ambient: #5bc39d;
     --ambient-glow-opacity: 0.1;
   }
@@ -758,13 +777,13 @@ html[data-navigation-direction]::view-transition-new(main-content) {
   html[data-high-contrast="true"] {
     --foreground: #ffffff;
     --ring: oklch(0.95 0 0);
-    --muted-foreground: color-mix(in srgb, white 72%, var(--muted-foreground));
-    --border: color-mix(in srgb, white 34%, var(--border));
-    --input: color-mix(in srgb, white 16%, var(--input));
-    --surface: color-mix(in srgb, white 10%, var(--surface));
-    --surface-hover: color-mix(in srgb, white 16%, var(--surface-hover));
-    --surface-raised: color-mix(in srgb, white 20%, var(--surface-raised));
-    --accent: color-mix(in srgb, white 14%, var(--accent));
+    --muted-foreground: color-mix(in srgb, white 72%, var(--muted-foreground-base));
+    --border: color-mix(in srgb, white 34%, var(--border-base));
+    --input: color-mix(in srgb, white 16%, var(--input-base));
+    --surface: color-mix(in srgb, white 10%, var(--surface-base));
+    --surface-hover: color-mix(in srgb, white 16%, var(--surface-hover-base));
+    --surface-raised: color-mix(in srgb, white 20%, var(--surface-raised-base));
+    --accent: color-mix(in srgb, white 14%, var(--accent-base));
     --ambient-glow-opacity: 0.04;
   }
   html[data-high-contrast="true"] .surface-panel-subtle,

--- a/web/src/highContrastContrast.test.ts
+++ b/web/src/highContrastContrast.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Computed WCAG contrast for the tokens high contrast mode rewrites, per theme.
+ *
+ * Asserting that the declarations merely exist is not enough: the block used to
+ * push every token toward white, which raises contrast on a dark theme and
+ * destroys it on a light one. On cinema-light that drove `--muted-foreground`
+ * to 1.36:1 and `--foreground` to 1.10:1 against the page — high contrast mode
+ * made the theme unreadable, and nothing in the suite noticed. These tests do
+ * the colour maths so a future theme, or a changed mix percentage, cannot
+ * reintroduce that silently.
+ */
+const css = readFileSync(fileURLToPath(new URL("./app.css", import.meta.url)), "utf8");
+
+const THEMES = [
+  "midnight-cinema",
+  "cinema-light",
+  "cobalt-studio",
+  "oxblood-noir",
+  "evergreen-studio",
+] as const;
+
+/** WCAG 2.1 AA for normal-size body text. */
+const AA_TEXT = 4.5;
+
+function themeBlock(theme: string): string {
+  const match = new RegExp(String.raw`\[data-theme="${theme}"\] \{([\s\S]*?)\n {2}\}`).exec(css);
+  const body = match?.[1];
+  if (body === undefined) throw new Error(`no block for theme ${theme}`);
+  return body;
+}
+
+function token(body: string, name: string): string {
+  const match = new RegExp(String.raw`^\s*--${name}:\s*([^;]+);`, "m").exec(body);
+  const value = match?.[1];
+  if (value === undefined) throw new Error(`no --${name}`);
+  return value.trim();
+}
+
+function rgb(hex: string): [number, number, number] {
+  const h = hex.replace("#", "");
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+function luminance(hex: string): number {
+  const channel = (c: number) => {
+    const v = c / 255;
+    return v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  };
+  const [r, g, b] = rgb(hex);
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+function contrast(a: string, b: string): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** srgb color-mix of `pct`% `toward` into `base`, matching the CSS. */
+function mix(pct: number, base: string, toward: string): string {
+  const [br, bg, bb] = rgb(base);
+  const [tr, tg, tb] = rgb(toward);
+  const p = pct / 100;
+  const channel = (t: number, b: number) =>
+    Math.round(t * p + b * (1 - p))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${channel(tr, br)}${channel(tg, bg)}${channel(tb, bb)}`;
+}
+
+describe.each(THEMES)("high contrast on %s", (theme) => {
+  const body = themeBlock(theme);
+  const background = token(body, "background");
+  const boost = token(body, "contrast-boost");
+
+  it("pushes away from the page, not toward white regardless of theme", () => {
+    // The whole bug in one assertion: the boost must contrast with the page.
+    expect(contrast(boost, background)).toBeGreaterThan(AA_TEXT);
+  });
+
+  it("keeps body text readable", () => {
+    expect(contrast(boost, background)).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it("does not make muted text worse than it already was", () => {
+    const base = token(body, "muted-foreground-base");
+    const normal = contrast(base, background);
+    const boosted = contrast(mix(72, base, boost), background);
+    expect(boosted).toBeGreaterThanOrEqual(normal);
+    expect(boosted).toBeGreaterThanOrEqual(AA_TEXT);
+  });
+
+  it("does not make borders less visible than they already were", () => {
+    const base = token(body, "border-base");
+    expect(contrast(mix(34, base, boost), background)).toBeGreaterThanOrEqual(
+      contrast(base, background),
+    );
+  });
+});

--- a/web/src/highContrastCss.test.ts
+++ b/web/src/highContrastCss.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * High contrast lives entirely in CSS — the app only writes
+ * `html[data-high-contrast]` — so these are contract tests over app.css, the
+ * same shape as `navigationTransitionCss.test.ts`.
+ *
+ * What matters: none of these tokens may reference themselves. A custom
+ * property whose value references itself is a dependency cycle and is invalid
+ * at computed-value time, so the declaration is discarded and the token
+ * computes to nothing. That failed silently for the lifetime of the repo —
+ * panels lost their background entirely and every border fell back to
+ * `currentColor`, i.e. the pure white this block sets as `--foreground`.
+ * High contrast made contrast worse.
+ */
+const css = readFileSync(fileURLToPath(new URL("./app.css", import.meta.url)), "utf8");
+
+/** The seven tokens high contrast lightens off a theme value. */
+const CONTRAST_TOKENS = [
+  "muted-foreground",
+  "border",
+  "input",
+  "surface",
+  "surface-hover",
+  "surface-raised",
+  "accent",
+] as const;
+
+/** Body of the `html[data-high-contrast="true"]` token block. */
+function highContrastBlock(): string {
+  const start = css.indexOf('html[data-high-contrast="true"] {');
+  expect(start).toBeGreaterThan(-1);
+  let depth = 0;
+  for (let i = css.indexOf("{", start); i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}" && --depth === 0) return css.slice(start, i + 1);
+  }
+  throw new Error("unterminated high-contrast block");
+}
+
+describe("high-contrast CSS", () => {
+  it("declares no custom property that references itself", () => {
+    // Guards the whole stylesheet, not just this block: the same mistake
+    // anywhere else is the same silent failure.
+    const selfReferencing: string[] = [];
+    for (const line of css.split("\n")) {
+      const decl = /^\s*--([A-Za-z0-9-]+)\s*:\s*(.*)$/.exec(line);
+      if (!decl) continue;
+      const [, name, value] = decl;
+      if (new RegExp(String.raw`var\(\s*--${name}\s*[,)]`).test(value)) {
+        selfReferencing.push(line.trim());
+      }
+    }
+    expect(selfReferencing).toEqual([]);
+  });
+
+  it("lightens each contrast token off its -base input", () => {
+    const block = highContrastBlock();
+    for (const token of CONTRAST_TOKENS) {
+      expect(block).toMatch(
+        new RegExp(String.raw`--${token}:\s*color-mix\([^;]*var\(--${token}-base\)\)`),
+      );
+    }
+  });
+
+  it("aliases every contrast token to its -base input", () => {
+    // Without the alias the semantic token is never defined outside high
+    // contrast, and standard mode loses the token entirely.
+    for (const token of CONTRAST_TOKENS) {
+      expect(css).toMatch(new RegExp(String.raw`--${token}:\s*var\(--${token}-base\);`));
+    }
+  });
+
+  it("defines every -base input in all five themes", () => {
+    const themes = [...css.matchAll(/\[data-theme="([a-z-]+)"\] \{([\s\S]*?)\n {2}\}/g)];
+    expect(themes).toHaveLength(5);
+    for (const [, name, body] of themes) {
+      for (const token of CONTRAST_TOKENS) {
+        expect(
+          new RegExp(String.raw`^\s*--${token}-base:`, "m").test(body),
+          `theme ${name} is missing --${token}-base`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/web/src/highContrastCss.test.ts
+++ b/web/src/highContrastCss.test.ts
@@ -50,7 +50,8 @@ describe("high-contrast CSS", () => {
     for (const line of css.split("\n")) {
       const decl = /^\s*--([A-Za-z0-9-]+)\s*:\s*(.*)$/.exec(line);
       if (!decl) continue;
-      const [, name, value] = decl;
+      const name = decl[1] ?? "";
+      const value = decl[2] ?? "";
       if (new RegExp(String.raw`var\(\s*--${name}\s*[,)]`).test(value)) {
         selfReferencing.push(line.trim());
       }
@@ -78,7 +79,9 @@ describe("high-contrast CSS", () => {
   it("defines every -base input in all five themes", () => {
     const themes = [...css.matchAll(/\[data-theme="([a-z-]+)"\] \{([\s\S]*?)\n {2}\}/g)];
     expect(themes).toHaveLength(5);
-    for (const [, name, body] of themes) {
+    for (const theme of themes) {
+      const name = theme[1] ?? "";
+      const body = theme[2] ?? "";
       for (const token of CONTRAST_TOKENS) {
         expect(
           new RegExp(String.raw`^\s*--${token}-base:`, "m").test(body),


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow bug fix.

High contrast mode has never worked. Seven of the ten declarations in the
`html[data-high-contrast="true"]` block referenced **themselves**:

```css
--border: color-mix(in srgb, white 34%, var(--border));
```

Per [CSS Custom Properties L1 §3](https://www.w3.org/TR/css-variables-1/#cycles) a
custom property whose value references itself is in a dependency cycle and is
invalid at computed-value time, so the declaration is discarded and the token
computes to nothing. This holds **even though an inherited value exists** — the
inherited value is not consulted — so the intended mix never resolved.

Themes and this block both match `<html>` and both live in `@layer base`, so
`html[data-high-contrast="true"]` (0,1,1) wins over `[data-theme="…"]` (0,1,0) and
replaced each theme's good value with nothing.

Measured on a running instance (`midnight-cinema`, Chrome), reading computed values
off `document.documentElement` with high contrast on: all seven self-referencing
tokens computed **empty** (`--border --input --surface --surface-hover
--surface-raised --accent --muted-foreground`), while the non-self-referencing
`--foreground` and `--ambient-glow-opacity` applied correctly. The split falls
exactly along the self-reference line.

Two visible consequences, both making high contrast *worse* than standard mode:

1. **Panels lost their background.** `--surface` invalid, so `.surface-panel` /
   `.surface-panel-subtle` / `.surface-panel-raised` computed
   `background-color: rgba(0, 0, 0, 0)` and rendered transparent.
2. **Every border turned pure white.** `border-color` fell back to `currentColor`,
   and the block sets `--foreground: #ffffff`, so borders rendered
   `rgb(255, 255, 255)` instead of `rgb(40, 40, 46)`.

`git log -L` traces the block unchanged to c085b12f, so this never worked. It likely
went unreported because any profile with a stored `ui.custom_theme_vars` override
never sees it: those are injected unlayered by `CustomThemeProvider` and win over
this block.

**Second defect, found in review.** Every override mixed toward hard-coded white,
which raises contrast on a dark theme and destroys it on a light one. Computed
against cinema-light's `#f4f4f6` page:

| token | normal | high contrast |
|---|---|---|
| `--muted-foreground` | 5.42:1 | **1.36:1** |
| `--foreground` | — | **1.10:1** (`#ffffff` on `#f4f4f6`) |

The accessibility mode drove body text to near-invisible on that theme. The
`--foreground` half was already live before this PR, since it never self-referenced;
repairing the cycle would have activated the rest.

## Approach

**The cycle.** The mix needs an input that is not the property being assigned. Each
theme defines the literal under `--<token>-base`, the semantic token is an alias,
and high contrast mixes from the base.

Three shapes were tried in a browser; only the base token works:

```css
/* A — current shape */   html[data-x] { --border: color-mix(in srgb, white 34%, var(--border)); }
/* → (empty)  ✗ */
/* B — base token (this PR) */
html[data-x] { --border-base: #28282e; --border: color-mix(in srgb, white 34%, var(--border-base)); }
/* → color-mix(in srgb, white 34%, #28282e)  ✓ */
/* C — move to a descendant so var() inherits */
body[data-x] { --border: color-mix(in srgb, white 34%, var(--border)); }
/* → (empty)  ✗ still cyclic */
```

C is worth recording because it is the intuitive fix and does **not** work.

The alternative — dropping `color-mix` and hardcoding a lightened value per theme —
also works, but it is 7 × 5 hand-computed literals that drift as themes change.

**The direction.** Each theme declares `--contrast-boost` — white on the four dark
themes, black on cinema-light — and every override mixes toward that. On
cinema-light this yields 15.49:1 for muted text and 19.12:1 for body text. Dark
themes are unchanged except `--ring`, which moves from `oklch(0.95 0 0)` to the
boost: negligible there, and the difference between a visible and an invisible focus
ring on the light theme. `:root` defaults the boost to white so a theme that omits
it degrades to the previous behaviour rather than to an invalid value.

## Validation

```
$ npx tsc -b                    # clean
$ npx vite build                # ✓ built in 25.11s
$ npx eslint <changed files>    # clean
$ npx prettier --check <changed files>
Checking formatting...
All matched files use Prettier code style!

$ npx vitest run
 Test Files  3 failed | 362 passed (365)
      Tests  5 failed | 3132 passed (3137)
```

The 5 failures are pre-existing and unrelated: `PersonDetail > formatBirthDate` ×3,
`SectionItemCard > renders premiere metadata`, `CardOverlays > scales legacy
browsers`. I reran those three files against a clean `main` and got the identical 5;
they look locale/timezone dependent.

Compiled output loaded into a real document root: all seven tokens resolve with high
contrast both off and on. No self-referencing declaration remains anywhere under
`web/src`.

Two suites, both mutation-checked rather than assumed:

- `highContrastCss.test.ts` — fails the whole stylesheet on any self-referencing
  custom property, checks the mix, the aliases, and that every theme defines every
  base token. Reintroducing the old declaration fails 2 of 4.
- `highContrastContrast.test.ts` — computed WCAG ratios per theme: the boost must
  contrast with its own page, body text must clear AA, and neither muted text nor
  borders may come out worse in high contrast than without it. Reverting
  cinema-light to boosting toward white fails 4 of 20. Asserting the declarations
  merely exist could never have caught the direction bug — the tokens were all
  present and correct-looking.

**UI evidence not attached.** The visible change is a theme-wide colour shift behind
an accessibility toggle; I can attach before/after captures per theme if that is
required before merge.

## Risks

- **Token rename.** `--<token>-base` is introduced for seven tokens across five
  themes. Anything outside `app.css` referencing those seven names directly would
  need updating; nothing does, and the semantic names are unchanged for consumers.
- **`--ring` on dark themes** shifts from `oklch(0.95 0 0)` to `#ffffff` in high
  contrast only. Called out above rather than buried.
- **Migration / security / operational:** none identified.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- **Harness:** Claude Code
- **Tool(s):** Claude Code
- **Model(s):** claude-opus-5
- **Involvement:** AI-assisted — diagnosis, patch, tests and this description were
  AI-authored and human-verified. The bug was found while diagnosing an unrelated
  theming problem on a live instance.
- **Adversarial review:** The three candidate fixes were tested in a real browser
  rather than reasoned about, which is how the plausible-but-wrong descendant-element
  fix was rejected. Review findings on this PR — the light-theme contrast inversion
  and two `tsc` errors in the test added by the first commit — were reproduced and
  quantified against the code before being fixed in the second commit. I had not run
  `tsc -b` on this branch before opening the PR; `vite build` does not typecheck,
  which is why the errors were not caught earlier.
