### PR TITLE
fix(web): reveal hover affordances on hybrid-pointer devices

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1,5 +1,17 @@
 @import "tailwindcss";
 
+/* Tailwind v4 wraps every `hover:` and `group-hover:` utility in
+   `@media (hover: hover)`. That feature is false on Windows machines whose
+   Chromium under-reports pointer capability — the same devices the card
+   controls gate works around — so every hover style in the app is silently
+   inert there, not just the card controls.
+
+   Gate on the observed-pointer attribute instead (see lib/pointerCapability.ts,
+   which seeds it from the equivalent media query at boot). Behaviour is
+   unchanged wherever the media query was already right; touch devices still
+   get no hover styling, because a touch press clears the attribute. */
+@custom-variant hover (:root[data-fine-pointer="true"] &:hover);
+
 /* ================================================================
    § 1  THEME BRIDGE — Tailwind ↔ CSS Custom Properties
    ================================================================

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -9,8 +9,15 @@
    Gate on the observed-pointer attribute instead (see lib/pointerCapability.ts,
    which seeds it from the equivalent media query at boot). Behaviour is
    unchanged wherever the media query was already right; touch devices still
-   get no hover styling, because a touch press clears the attribute. */
-@custom-variant hover (:root[data-fine-pointer="true"] &:hover);
+   get no hover styling, because a touch press clears the attribute.
+
+   The gate MUST stay inside :where(). Tailwind orders its state variants by
+   specificity, so an unwrapped `:root[data-fine-pointer="true"]` prefix would
+   make every hover: utility 0-4-0 against 0-2-0 for disabled:, active: and
+   focus-visible: — hover would then beat them on every device, not just the
+   ones this works around. :where() contributes nothing, leaving the compiled
+   selectors at exactly the specificity Tailwind intends. */
+@custom-variant hover (:where(:root[data-fine-pointer="true"]) &:hover);
 
 /* ================================================================
    § 1  THEME BRIDGE — Tailwind ↔ CSS Custom Properties
@@ -1641,11 +1648,11 @@ html[data-navigation-direction]::view-transition-new(main-content) {
      back to 0: at this specificity it would out-weigh the `[data-state="open"]`
      and `:focus-visible` rules above and hide the trigger while its own menu is
      open on a touch device. Rest state is the base rule's job. */
-  :root[data-fine-pointer="true"] .group\/media:hover .media-card-hover-dim {
+  :where(:root[data-fine-pointer="true"]) .group\/media:hover .media-card-hover-dim {
     opacity: 1;
   }
-  :root[data-fine-pointer="true"] .group\/card:hover .media-card-action-trigger,
-  :root[data-fine-pointer="true"] .group\/media:hover .media-card-play-trigger {
+  :where(:root[data-fine-pointer="true"]) .group\/card:hover .media-card-action-trigger,
+  :where(:root[data-fine-pointer="true"]) .group\/media:hover .media-card-play-trigger {
     opacity: 1;
     pointer-events: auto;
   }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1617,15 +1617,25 @@ html[data-navigation-direction]::view-transition-new(main-content) {
   .group\/media:focus-within .media-card-hover-dim {
     opacity: 1;
   }
-  @media (any-hover: hover) and (any-pointer: fine) {
-    .group\/media:hover .media-card-hover-dim {
-      opacity: 1;
-    }
-    .group\/card:hover .media-card-action-trigger,
-    .group\/media:hover .media-card-play-trigger {
-      opacity: 1;
-      pointer-events: auto;
-    }
+  /* Gated on an attribute set from observed pointer events
+     (lib/pointerCapability.ts), not on a media query. Chromium on some Windows
+     hybrid machines reports `any-hover: none` and `any-pointer: coarse` even
+     while a mouse is actively hovering the card, so this block never matched
+     and the controls stayed at `opacity: 0` permanently. The attribute is
+     seeded from that same media query at boot, so behaviour is unchanged
+     wherever it was already right.
+
+     Deliberately no `[data-fine-pointer="false"]` counterpart forcing opacity
+     back to 0: at this specificity it would out-weigh the `[data-state="open"]`
+     and `:focus-visible` rules above and hide the trigger while its own menu is
+     open on a touch device. Rest state is the base rule's job. */
+  :root[data-fine-pointer="true"] .group\/media:hover .media-card-hover-dim {
+    opacity: 1;
+  }
+  :root[data-fine-pointer="true"] .group\/card:hover .media-card-action-trigger,
+  :root[data-fine-pointer="true"] .group\/media:hover .media-card-play-trigger {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   /* A long press on a card opens the action sheet, so the browser's own image

--- a/web/src/components/MediaItemMenu.test.tsx
+++ b/web/src/components/MediaItemMenu.test.tsx
@@ -1126,6 +1126,7 @@ describe("MediaItemMenu long-press action sheet", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    document.documentElement.removeAttribute("data-fine-pointer");
   });
 
   it("opens the sheet with the full action set after a touch hold", () => {
@@ -1205,14 +1206,10 @@ describe("MediaItemMenu long-press action sheet", () => {
   });
 
   it("keeps long press while omitting desktop-only shortcut trees on coarse-pointer devices", () => {
-    vi.stubGlobal(
-      "matchMedia",
-      vi.fn(() => ({
-        matches: false,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      })),
-    );
+    // A coarse-pointer device is now declared by the published capability
+    // rather than by the media query: the component follows the pointer that
+    // was actually observed, because the query is unreliable on hybrids.
+    document.documentElement.setAttribute("data-fine-pointer", "false");
 
     render(<LongPressCard />);
 

--- a/web/src/components/MediaItemMenu.tsx
+++ b/web/src/components/MediaItemMenu.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { useLocation } from "react-router";
 import { useViewTransitionNavigate } from "@/hooks/useViewTransition";
+import { useFinePointer } from "@/hooks/useFinePointer";
 import type { ItemDetail, MediaItemUserState } from "@/api/types";
 import { useOptionalAuth } from "@/hooks/useAuth";
 import { useCurrentProfile } from "@/hooks/useCurrentProfile";
@@ -58,7 +59,6 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { useLongPress } from "@/hooks/useLongPress";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { cn } from "@/lib/utils";
 import { useWatchPlaybackController } from "@/playback/watchPlaybackContext";
 import { buildMediaPlayHref } from "@/lib/mediaNavigation";
@@ -78,12 +78,13 @@ import {
 
 type MediaItemType = ItemDetail["type"];
 
-const FINE_POINTER_QUERY = "(any-hover: hover) and (any-pointer: fine)";
-
 function useHasFinePointer() {
-  // Preserve the established quick actions in SSR, tests, and older browsers
-  // without matchMedia. Touch-capable modern browsers report this accurately.
-  return useMediaQuery(FINE_POINTER_QUERY, true);
+  // Reads the observed pointer, not the media query: Chromium on some Windows
+  // machines with a touchscreen reports no fine pointer while a mouse is in
+  // use, which withheld these shortcuts from the very devices this gate is
+  // meant to serve. The `true` fallback preserves the established quick
+  // actions in SSR, tests, and browsers where init has not run.
+  return useFinePointer(true);
 }
 
 type MediaItemMenuEntry =

--- a/web/src/hooks/useFinePointer.test.tsx
+++ b/web/src/hooks/useFinePointer.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFinePointer } from "./useFinePointer";
+import { initPointerCapability } from "@/lib/pointerCapability";
+
+const ATTR = "data-fine-pointer";
+const cleanups: Array<() => void> = [];
+
+function init(matches: boolean) {
+  const win = { matchMedia: () => ({ matches, addEventListener() {}, removeEventListener() {} }) };
+  const stop = initPointerCapability({ doc: document, win: win as unknown as Window });
+  cleanups.push(stop);
+}
+
+function mouseMove() {
+  const event = new Event("pointermove", { bubbles: true }) as PointerEvent;
+  Object.defineProperty(event, "pointerType", { value: "mouse" });
+  document.dispatchEvent(event);
+}
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+  document.documentElement.removeAttribute(ATTR);
+});
+
+describe("useFinePointer", () => {
+  it("falls back when no capability has been published", () => {
+    expect(renderHook(() => useFinePointer(true)).result.current).toBe(true);
+    expect(renderHook(() => useFinePointer(false)).result.current).toBe(false);
+  });
+
+  it("reports the published capability over the fallback", () => {
+    init(false);
+    expect(renderHook(() => useFinePointer(true)).result.current).toBe(false);
+  });
+
+  it("re-renders when an observed mouse overrides the media query", () => {
+    // The regression test for the React half of this bug: on the affected
+    // machines the query says no fine pointer, so anything mounted from it
+    // stayed absent even after a mouse was in use.
+    init(false);
+    const { result } = renderHook(() => useFinePointer(true));
+    expect(result.current).toBe(false);
+    act(() => mouseMove());
+    expect(result.current).toBe(true);
+  });
+});

--- a/web/src/hooks/useFinePointer.ts
+++ b/web/src/hooks/useFinePointer.ts
@@ -1,0 +1,21 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { readFinePointer, subscribeFinePointer } from "@/lib/pointerCapability";
+
+/**
+ * Whether the pointer in use is a precise, hover-capable one, as observed by
+ * `lib/pointerCapability.ts`.
+ *
+ * Prefer this over reading `(any-hover: hover) and (any-pointer: fine)`
+ * directly: Chromium on some Windows machines with a touchscreen answers that
+ * query `false` while a mouse is actively in use, so a component gating on it
+ * withholds its hover affordances on exactly the devices that can use them.
+ *
+ * `fallback` answers where no capability has been published — server
+ * rendering, tests, and browsers where init has not run — so a caller can keep
+ * whatever default it had before.
+ */
+export function useFinePointer(fallback = false): boolean {
+  const getSnapshot = useCallback(() => readFinePointer() ?? fallback, [fallback]);
+  const getServerSnapshot = useCallback(() => fallback, [fallback]);
+  return useSyncExternalStore(subscribeFinePointer, getSnapshot, getServerSnapshot);
+}

--- a/web/src/lib/pointerCapability.test.ts
+++ b/web/src/lib/pointerCapability.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { initPointerCapability } from "./pointerCapability";
+import { initPointerCapability, readFinePointer, subscribeFinePointer } from "./pointerCapability";
 
 const ATTR = "data-fine-pointer";
 
@@ -85,6 +85,37 @@ describe("initPointerCapability", () => {
     expect(document.documentElement.getAttribute(ATTR)).toBe("false");
     document.dispatchEvent(pointer("mouse"));
     expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("keeps an observed touch when the media query later promotes", () => {
+    // The query is the signal already known to be unreliable on these
+    // machines; once a real pointer has been seen it stops being evidence.
+    const { emit } = start(false);
+    document.dispatchEvent(pointer("touch", "pointerdown"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+    emit(true);
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+  });
+
+  it("keeps an observed mouse when the media query later promotes", () => {
+    const { emit } = start(false);
+    document.dispatchEvent(pointer("mouse"));
+    emit(true);
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("publishes the value to subscribers", () => {
+    const seen: Array<boolean | undefined> = [];
+    const unsubscribe = subscribeFinePointer(() => seen.push(readFinePointer()));
+    start(false);
+    document.dispatchEvent(pointer("mouse"));
+    unsubscribe();
+    document.dispatchEvent(pointer("touch", "pointerdown"));
+    expect(seen).toEqual([false, true]);
+  });
+
+  it("reports undefined before anything has been published", () => {
+    expect(readFinePointer()).toBeUndefined();
   });
 
   it("promotes when the media query starts reporting a fine pointer", () => {

--- a/web/src/lib/pointerCapability.test.ts
+++ b/web/src/lib/pointerCapability.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initPointerCapability } from "./pointerCapability";
+
+const ATTR = "data-fine-pointer";
+
+/** A window stub whose matchMedia answer is ours to choose — jsdom has none. */
+function windowWith(matches: boolean | undefined) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const win = {
+    matchMedia:
+      matches === undefined
+        ? undefined
+        : () => ({
+            matches,
+            addEventListener: (_: string, fn: (event: MediaQueryListEvent) => void) =>
+              listeners.add(fn),
+            removeEventListener: (_: string, fn: (event: MediaQueryListEvent) => void) =>
+              listeners.delete(fn),
+          }),
+  } as unknown as Window;
+  return {
+    win,
+    emit: (value: boolean) =>
+      listeners.forEach((fn) => fn({ matches: value } as MediaQueryListEvent)),
+  };
+}
+
+function pointer(type: string, eventType = "pointermove") {
+  const event = new Event(eventType, { bubbles: true }) as PointerEvent;
+  Object.defineProperty(event, "pointerType", { value: type });
+  return event;
+}
+
+const cleanups: Array<() => void> = [];
+function start(matches: boolean | undefined) {
+  const { win, emit } = windowWith(matches);
+  const stop = initPointerCapability({ doc: document, win });
+  cleanups.push(stop);
+  return { stop, emit };
+}
+
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()?.();
+  document.documentElement.removeAttribute(ATTR);
+});
+
+describe("initPointerCapability", () => {
+  it("seeds from the media query when it reports a fine pointer", () => {
+    start(true);
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("seeds false when the media query reports no fine pointer", () => {
+    start(false);
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+  });
+
+  it("lets an observed mouse override a media query that says no fine pointer", () => {
+    // The regression test for this bug: on the affected Windows hybrids the
+    // media query answers false while a mouse is genuinely in use, and the
+    // hover controls must still be revealed.
+    start(false);
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+    document.dispatchEvent(pointer("mouse"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("treats a pen as a fine pointer", () => {
+    start(false);
+    document.dispatchEvent(pointer("pen"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("clears the flag again on touch so a tap cannot strand the controls visible", () => {
+    start(true);
+    document.dispatchEvent(pointer("touch", "pointerdown"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+  });
+
+  it("follows the last pointer used across a switch", () => {
+    start(false);
+    document.dispatchEvent(pointer("mouse"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+    document.dispatchEvent(pointer("touch", "pointerdown"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+    document.dispatchEvent(pointer("mouse"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("promotes when the media query starts reporting a fine pointer", () => {
+    const { emit } = start(false);
+    emit(true);
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("ignores a media query that stops reporting a fine pointer", () => {
+    // A detached device says nothing about the pointer in the user's hand, and
+    // on the machines this exists for the query is the unreliable signal.
+    const { emit } = start(true);
+    emit(false);
+    expect(document.documentElement.getAttribute(ATTR)).toBe("true");
+  });
+
+  it("stops listening after cleanup", () => {
+    const { stop } = start(false);
+    stop();
+    document.dispatchEvent(pointer("mouse"));
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+  });
+
+  it("does not throw when matchMedia is unavailable", () => {
+    expect(() => start(undefined)).not.toThrow();
+    expect(document.documentElement.getAttribute(ATTR)).toBe("false");
+  });
+
+  it("writes the attribute only when the value actually changes", () => {
+    start(false);
+    const spy = vi.spyOn(document.documentElement, "setAttribute");
+    document.dispatchEvent(pointer("mouse"));
+    document.dispatchEvent(pointer("mouse"));
+    expect(spy.mock.calls.filter(([name]) => name === ATTR)).toHaveLength(1);
+    spy.mockRestore();
+  });
+});

--- a/web/src/lib/pointerCapability.test.ts
+++ b/web/src/lib/pointerCapability.test.ts
@@ -118,6 +118,17 @@ describe("initPointerCapability", () => {
     expect(readFinePointer()).toBeUndefined();
   });
 
+  it("reports undefined where there is no document at all", () => {
+    // A default parameter would be evaluated at the call site and throw here,
+    // which is what the documented server-rendering fallback forbids.
+    vi.stubGlobal("document", undefined);
+    try {
+      expect(readFinePointer()).toBeUndefined();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("promotes when the media query starts reporting a fine pointer", () => {
     const { emit } = start(false);
     emit(true);

--- a/web/src/lib/pointerCapability.ts
+++ b/web/src/lib/pointerCapability.ts
@@ -1,0 +1,76 @@
+// Whether the app may reveal hover-only affordances, published as
+// `data-fine-pointer` on <html> for CSS to gate on.
+//
+// The hover/pointer media features are the obvious way to ask this, and they
+// are wrong on some Windows hybrid machines: Chromium there reports
+// `any-hover: none` and `any-pointer: coarse` even while a mouse is attached
+// and actively hovering, because it has enumerated the touch digitizer and
+// nothing else. The `any-*` features exist precisely to describe *any*
+// attached device, so there is nothing more permissive left to widen to — the
+// answer itself is wrong, and a media query cannot recover from it. Users on
+// those machines are left with controls stuck at `opacity: 0`.
+//
+// So observe rather than ask. A `pointermove` carrying `pointerType: "mouse"`
+// is ground truth: whatever the OS claims, a mouse is being used. The media
+// query still seeds the initial value — it is correct on the vast majority of
+// devices, and it is the only answer available before the first pointer event
+// — and observed events override it from there.
+//
+// Last pointer wins in both directions. A touch press clears the flag again so
+// tap-emulated `:hover` on a hybrid cannot uncover the controls and strand
+// them visible, which is what the media-query gate was protecting against.
+
+const FINE_POINTER_ATTR = "data-fine-pointer";
+const FINE_POINTER_QUERY = "(any-hover: hover) and (any-pointer: fine)";
+
+interface PointerCapabilityDeps {
+  doc: Document;
+  win: Window;
+}
+
+export function initPointerCapability(deps?: Partial<PointerCapabilityDeps>): () => void {
+  const doc = deps?.doc ?? document;
+  const win = deps?.win ?? window;
+  const root = doc.documentElement;
+
+  const set = (fine: boolean) => {
+    const next = fine ? "true" : "false";
+    if (root.getAttribute(FINE_POINTER_ATTR) !== next) root.setAttribute(FINE_POINTER_ATTR, next);
+  };
+
+  // Seeded synchronously, before first paint, so a mouse-only desktop never
+  // flashes its hover controls hidden while waiting for a pointer event.
+  // jsdom has no matchMedia, hence the optional call rather than a stub.
+  const query = win.matchMedia?.(FINE_POINTER_QUERY);
+  set(query?.matches ?? false);
+
+  // Only ever promotes. A media query that flips to `false` says a device was
+  // detached, which tells us nothing about the pointer in the user's hand, and
+  // on the machines this exists for it is the untrustworthy signal to begin
+  // with.
+  const onQueryChange = (event: MediaQueryListEvent) => {
+    if (event.matches) set(true);
+  };
+  query?.addEventListener?.("change", onQueryChange);
+
+  const onPointer = (event: PointerEvent) => {
+    if (event.pointerType === "mouse" || event.pointerType === "pen") set(true);
+    else if (event.pointerType === "touch") set(false);
+  };
+
+  // `pointerdown` as well as `pointermove` so a mouse that clicks without
+  // moving is still seen, and so a touch press clears the flag before
+  // Chromium's emulated `:hover` lands on the tapped card.
+  //
+  // Capture phase: a `stopPropagation()` anywhere in the tree would otherwise
+  // blind this, and the app cannot know which handler that might be.
+  const opts = { passive: true, capture: true } as const;
+  doc.addEventListener("pointermove", onPointer, opts);
+  doc.addEventListener("pointerdown", onPointer, opts);
+
+  return () => {
+    query?.removeEventListener?.("change", onQueryChange);
+    doc.removeEventListener("pointermove", onPointer, opts);
+    doc.removeEventListener("pointerdown", onPointer, opts);
+  };
+}

--- a/web/src/lib/pointerCapability.ts
+++ b/web/src/lib/pointerCapability.ts
@@ -31,9 +31,16 @@ const listeners = new Set<() => void>();
  * The published capability, or undefined when nothing has published one —
  * server rendering, tests, and any browser where init has not run. Callers keep
  * their own established default in that case rather than being told "coarse".
+ *
+ * The document is resolved inside the function rather than as a default
+ * parameter: a default is evaluated at the call site, so `readFinePointer()`
+ * where no document exists would throw before it could answer undefined,
+ * contradicting the line above.
  */
-export function readFinePointer(doc: Document = document): boolean | undefined {
-  const value = doc.documentElement.getAttribute(FINE_POINTER_ATTR);
+export function readFinePointer(doc?: Document): boolean | undefined {
+  const target = doc ?? (typeof document === "undefined" ? undefined : document);
+  if (target === undefined) return undefined;
+  const value = target.documentElement.getAttribute(FINE_POINTER_ATTR);
   return value === null ? undefined : value === "true";
 }
 

--- a/web/src/lib/pointerCapability.ts
+++ b/web/src/lib/pointerCapability.ts
@@ -23,6 +23,27 @@
 const FINE_POINTER_ATTR = "data-fine-pointer";
 const FINE_POINTER_QUERY = "(any-hover: hover) and (any-pointer: fine)";
 
+// Components decide what to mount from this too, not just CSS, so the value has
+// to be subscribable rather than only readable off the DOM.
+const listeners = new Set<() => void>();
+
+/**
+ * The published capability, or undefined when nothing has published one —
+ * server rendering, tests, and any browser where init has not run. Callers keep
+ * their own established default in that case rather than being told "coarse".
+ */
+export function readFinePointer(doc: Document = document): boolean | undefined {
+  const value = doc.documentElement.getAttribute(FINE_POINTER_ATTR);
+  return value === null ? undefined : value === "true";
+}
+
+export function subscribeFinePointer(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+  };
+}
+
 interface PointerCapabilityDeps {
   doc: Document;
   win: Window;
@@ -35,8 +56,16 @@ export function initPointerCapability(deps?: Partial<PointerCapabilityDeps>): ()
 
   const set = (fine: boolean) => {
     const next = fine ? "true" : "false";
-    if (root.getAttribute(FINE_POINTER_ATTR) !== next) root.setAttribute(FINE_POINTER_ATTR, next);
+    if (root.getAttribute(FINE_POINTER_ATTR) === next) return;
+    root.setAttribute(FINE_POINTER_ATTR, next);
+    listeners.forEach((listener) => listener());
   };
+
+  // Once a real pointer has been seen, the media query stops being evidence:
+  // it is the signal already known to be wrong here, and letting a later
+  // change event promote would overwrite an observed touch and re-enable
+  // tap-emulated hover on a hybrid.
+  let observedPointer = false;
 
   // Seeded synchronously, before first paint, so a mouse-only desktop never
   // flashes its hover controls hidden while waiting for a pointer event.
@@ -44,18 +73,22 @@ export function initPointerCapability(deps?: Partial<PointerCapabilityDeps>): ()
   const query = win.matchMedia?.(FINE_POINTER_QUERY);
   set(query?.matches ?? false);
 
-  // Only ever promotes. A media query that flips to `false` says a device was
-  // detached, which tells us nothing about the pointer in the user's hand, and
-  // on the machines this exists for it is the untrustworthy signal to begin
-  // with.
+  // Only ever promotes, and only until a real pointer is seen. A query that
+  // flips to `false` says a device was detached, which tells us nothing about
+  // the pointer in the user's hand.
   const onQueryChange = (event: MediaQueryListEvent) => {
-    if (event.matches) set(true);
+    if (!observedPointer && event.matches) set(true);
   };
   query?.addEventListener?.("change", onQueryChange);
 
   const onPointer = (event: PointerEvent) => {
-    if (event.pointerType === "mouse" || event.pointerType === "pen") set(true);
-    else if (event.pointerType === "touch") set(false);
+    if (event.pointerType === "mouse" || event.pointerType === "pen") {
+      observedPointer = true;
+      set(true);
+    } else if (event.pointerType === "touch") {
+      observedPointer = true;
+      set(false);
+    }
   };
 
   // `pointerdown` as well as `pointermove` so a mouse that clicks without

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,9 +1,12 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import { installPreloadErrorReload } from "./lib/reloadOnPreloadError";
+import { initPointerCapability } from "./lib/pointerCapability";
 import "./app.css";
 
 installPreloadErrorReload();
+// Before render, so the first paint already knows whether hover reveals apply.
+initPointerCapability();
 
 const root = document.getElementById("root");
 if (root === null) throw new Error("Root element #root not found");

--- a/web/src/pointerGateCss.test.ts
+++ b/web/src/pointerGateCss.test.ts
@@ -28,14 +28,26 @@ describe("pointer-capability gating", () => {
   it("overrides Tailwind's hover variant onto the attribute", () => {
     // Without this, every `hover:` and `group-hover:` utility compiles into
     // `@media (hover: hover)` and is inert on the affected devices.
-    expect(css).toMatch(/@custom-variant hover \(:root\[data-fine-pointer="true"\] &:hover\);/);
+    expect(css).toMatch(
+      /@custom-variant hover \(:where\(:root\[data-fine-pointer="true"\]\) &:hover\);/,
+    );
+  });
+
+  it("keeps the gate at zero specificity everywhere it appears", () => {
+    // Tailwind orders its state variants by specificity. An unwrapped gate
+    // would make every hover: utility out-weigh disabled:, active: and
+    // focus-visible: on every device, not just the ones this works around.
+    const all = css.match(/:root\[data-fine-pointer="true"\]/g) ?? [];
+    const wrapped = css.match(/:where\(:root\[data-fine-pointer="true"\]\)/g) ?? [];
+    expect(all.length).toBeGreaterThan(0);
+    expect(wrapped).toHaveLength(all.length);
   });
 
   it("gates the card reveals on the attribute", () => {
     for (const selector of [
-      String.raw`:root\[data-fine-pointer="true"\] \.group\\/card:hover \.media-card-action-trigger`,
-      String.raw`:root\[data-fine-pointer="true"\] \.group\\/media:hover \.media-card-play-trigger`,
-      String.raw`:root\[data-fine-pointer="true"\] \.group\\/media:hover \.media-card-hover-dim`,
+      String.raw`:where\(:root\[data-fine-pointer="true"\]\) \.group\\/card:hover \.media-card-action-trigger`,
+      String.raw`:where\(:root\[data-fine-pointer="true"\]\) \.group\\/media:hover \.media-card-play-trigger`,
+      String.raw`:where\(:root\[data-fine-pointer="true"\]\) \.group\\/media:hover \.media-card-hover-dim`,
     ]) {
       expect(css).toMatch(new RegExp(selector));
     }

--- a/web/src/pointerGateCss.test.ts
+++ b/web/src/pointerGateCss.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Hover reveals are gated in CSS on `data-fine-pointer`, which
+ * `lib/pointerCapability.ts` publishes from observed pointer events. These are
+ * contract tests over app.css, the same shape as
+ * `navigationTransitionCss.test.ts`.
+ *
+ * What matters: nothing here may fall back to a hover/pointer media feature.
+ * Chromium on some Windows machines with a touchscreen reports
+ * `any-hover: none` and `any-pointer: coarse` while a mouse is actively
+ * hovering, so any rule left behind such a query is silently dead on exactly
+ * the devices this gate exists to serve.
+ */
+const source = readFileSync(fileURLToPath(new URL("./app.css", import.meta.url)), "utf8");
+
+/**
+ * Comments here discuss the very media features these tests forbid, so the
+ * negative assertions below run against declarations only.
+ */
+const css = source.replace(/\/\*[\s\S]*?\*\//g, "");
+
+describe("pointer-capability gating", () => {
+  it("overrides Tailwind's hover variant onto the attribute", () => {
+    // Without this, every `hover:` and `group-hover:` utility compiles into
+    // `@media (hover: hover)` and is inert on the affected devices.
+    expect(css).toMatch(/@custom-variant hover \(:root\[data-fine-pointer="true"\] &:hover\);/);
+  });
+
+  it("gates the card reveals on the attribute", () => {
+    for (const selector of [
+      String.raw`:root\[data-fine-pointer="true"\] \.group\\/card:hover \.media-card-action-trigger`,
+      String.raw`:root\[data-fine-pointer="true"\] \.group\\/media:hover \.media-card-play-trigger`,
+      String.raw`:root\[data-fine-pointer="true"\] \.group\\/media:hover \.media-card-hover-dim`,
+    ]) {
+      expect(css).toMatch(new RegExp(selector));
+    }
+  });
+
+  it("leaves no hover or pointer media query gating a reveal", () => {
+    expect(css).not.toMatch(/@media[^{]*\bany-hover\b/);
+    expect(css).not.toMatch(/@media[^{]*\bany-pointer\b/);
+    expect(css).not.toMatch(/@media[^{]*\(\s*hover\s*:/);
+  });
+
+  it("never forces the controls back to hidden on a coarse pointer", () => {
+    // Such a rule would out-specify the `[data-state="open"]` and
+    // `:focus-visible` reveals and hide the trigger while its own menu is open
+    // on a touch device.
+    expect(css).not.toMatch(/\[data-fine-pointer="false"\]/);
+  });
+});


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow bug fix. Follow-up to the gate introduced in #715.

Card hover controls never appear on some Windows machines with a touchscreen, in
Chrome, Brave and Edge. The three-dot "More actions" and play triggers rest at
`opacity: 0; pointer-events: none` and are revealed by a rule behind
`@media (any-hover: hover) and (any-pointer: fine)`. On those machines Chromium
reports **`any-hover: none` and `any-pointer: coarse` while a mouse is attached and
actively hovering the card** — it has enumerated the touch digitizer and nothing
else — so the query never matches and the controls stay hidden permanently.

Measured on an affected machine, normal window, mouse hovering the page:

| feature | affected machine | ordinary desktop |
|---|---|---|
| `(hover: hover)` | `false` | `true` |
| `(any-hover: hover)` | **`false`** | `true` |
| `(pointer: fine)` | `false` | `true` |
| `(any-pointer: fine)` | **`false`** | `true` |
| `navigator.maxTouchPoints` | `10` | `0` |

The `any-*` features exist to describe *any* attached device, so there is nothing
more permissive to widen to: the answer itself is wrong. #715 already moved this
gate from `hover` to `any-hover` for this class of device, which was the right
instinct and is not enough.

Keyboard and open-menu reveals were never affected — those paths are unconditional,
which is why the component always tested fine. `Tab` + `Enter` opens the menu
correctly on the affected machine.

Tailwind v4 compiles every `hover:` and `group-hover:` utility into
`@media (hover: hover)`, which is false there too, so **all** hover styling in the
app is inert on these machines, not just the card controls.

## Approach

Observe the pointer rather than ask the OS about it. A `pointermove` carrying
`pointerType: "mouse"` is ground truth whatever the media query claims.

`lib/pointerCapability.ts` publishes `data-fine-pointer` on `<html>`: seeded
synchronously at boot from the same media query, then driven by observed
`pointermove` / `pointerdown` — mouse and pen set it, touch clears it, last pointer
wins. Behaviour is unchanged wherever the media query was already correct. Touch
devices keep clean artwork and the long-press sheet, because a touch press clears
the flag before Chromium's emulated `:hover` lands.

Three consumers follow it:

- the bespoke card reveal rules in `app.css`
- `@custom-variant hover`, so every Tailwind `hover:` / `group-hover:` utility is
  gated on the same signal instead of `@media (hover: hover)`
- `MediaItemMenu`, via the `useFinePointer` hook, since whether the watched and
  favorite shortcut trees are *mounted* is a JavaScript decision
- the `.pointer-reveal` row-action rule that `main` added in 2112f0752, merged
  into this branch so it follows the same gate

**The gate must contribute zero specificity.** Tailwind orders state variants by
specificity, so an unwrapped `:root[data-fine-pointer="true"]` prefix made `hover:`
utilities 0-4-0 against 0-2-0 for `disabled:`, `active:` and `focus-visible:` —
hover then won regardless of intended ordering, on every device. `:where()` fixes
this. That was caught in review; see the third commit.

Alternatives rejected: widening the media query further (nothing left to widen to);
bare `:hover` with no gate (reintroduces tap-emulated sticky hover on phones);
Tailwind `pointer-fine:` variants (compile to `@media (pointer: fine)`, also false
here, and blocked by the existing className assertions).

## Validation

```
$ npx tsc -b                    # clean
$ npx vite build                # ✓ built in 23.70s
$ npx eslint <changed files>    # 0 errors (1 pre-existing react-refresh warning
                                #   on MediaItemMenu.tsx, unrelated to this diff)
$ npx prettier --check <changed files>
Checking formatting...
All matched files use Prettier code style!

$ npx vitest run
 Test Files  3 failed | 363 passed (366)
      Tests  5 failed | 3131 passed (3136)
```

The 5 failures are pre-existing and unrelated: `PersonDetail > formatBirthDate` ×3,
`SectionItemCard > renders premiere metadata`, `CardOverlays > scales legacy
browsers`. I reran those three files against a clean `main` and got the identical 5;
they look locale/timezone dependent.

Specificity verified on the production build:

```
$ grep -o ':root\[data-fine-pointer=true\]' index-*.css | wc -l          264
$ grep -o ':where(:root\[data-fine-pointer=true\])' index-*.css | wc -l  264
$ grep -o '@media *(hover:hover)' index-*.css | wc -l                      0
```

All 264 gates inside `:where()`, none leaking specificity. `hover:` utilities are
0-2-0, matching `active:` and `disabled:`. `group-hover:` composes correctly as
`.group-hover\:scale-105:is(:where(:root[data-fine-pointer=true]) :where(.group):hover *)`.

24 tests added across three suites, each mutation-checked rather than assumed:
reverting `pointerCapability` to media-query-only fails 5 of its 15; removing the
`@custom-variant` override fails the CSS guard; unwrapping `:where()` fails the
zero-specificity guard.

Verified on an affected machine against a running instance: the attribute seeds
`"false"` (the media query being wrong) and **a real mouse move flips it to `"true"`
while the query still reports `false`** — the exact path the fix depends on. The
reporter confirmed the controls then appear on hover.

**UI evidence not yet attached.** The visible change is a hover state on hardware
that reproduces the bug, which I cannot capture as a still from this environment. I
can attach a recording from the affected machine if that is required before merge.

## Risks

- **Scope.** The `@custom-variant` override changes how every `hover:` and
  `group-hover:` utility compiles — 264 rules. Behaviour is unchanged wherever the
  media query was already correct, since the attribute is seeded from that query,
  but the blast radius is app-wide and worth weighing. The first commit stands
  alone if you would rather take only the narrow card fix.
- **JS dependency.** Hover reveals now require `initPointerCapability` to have run.
  It is called before `createRoot(...).render(...)` and this is a React SPA, so
  there is no meaningful no-JS path to preserve. If it never ran, `readFinePointer`
  reports undefined and callers keep their prior defaults.
- **Migration / security / operational:** none identified.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- **Harness:** Claude Code
- **Tool(s):** Claude Code
- **Model(s):** claude-opus-5
- **Involvement:** AI-assisted — the diagnosis, patch, tests and this description
  were AI-authored and human-verified. The original bug report came from a human
  reproducing it on their own machine, and a human confirmed the fix there.
- **Adversarial review:** The bug brief backing this change was produced in a
  separate session with browser access but no repository access; several of its
  stated file facts (line counts and line numbers) were wrong and were corrected
  against the source before implementation. Review findings on this PR — the
  specificity inflation, the unmigrated `MediaItemMenu` media-query read, and the
  media-query-overwrites-touch case — were each independently reproduced against
  the code and the compiled stylesheet before being fixed in the third commit,
  rather than applied on assertion.
- **Maintainer review follow-up:** Claude Code (claude-opus-5-5), run by a
  maintainer, merged current `main` into the branch. It moved `.pointer-reveal`
  onto the gate after the branch's guard test failed on the merge, and reworded
  two stale comments. Validation on the merged tree: the full web suite passed
  with the Makefile exclusions (4639 tests), and `tsc -b`, `eslint` and `vite build`
  were clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover behavior on touchscreen and hybrid devices by detecting the pointer currently in use.
  * Prevented hover styles from overriding disabled, active, and keyboard focus states.
  * Ensured hover-dependent controls are correctly initialized before the first screen render.

* **Tests**
  * Added coverage for pointer detection, capability changes, cleanup, hover gating, and long-press interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
