### PR TITLE
fix(playback): fit transcodes within client bounds

### DIFF
--- a/internal/playback/plan_v3.go
+++ b/internal/playback/plan_v3.go
@@ -1169,7 +1169,7 @@ func ResolveQualityPolicyV3(request StartRequestV3, source SourceDescriptorV3) Q
 		effectiveHeight = source.Height
 		label = resolutionLabelV3(effectiveHeight)
 	}
-	width, bitrate := qualityDimensionsV3(effectiveHeight, source.Width, source.Height)
+	width, effectiveHeight, bitrate := qualityDimensionsV3(effectiveHeight, source.Width, source.Height)
 	if capKbps > 0 && bitrate > capKbps {
 		// The ladder has no rung below 480p, so a cap under the lowest rung's
 		// bitrate is honored by lowering the encode target directly: the cap
@@ -1218,15 +1218,11 @@ func compoundRungQualityResultV3(rung ladderRungV3, source SourceDescriptorV3, c
 			Warnings:        warnings,
 		}
 	}
-	width := 0
-	if source.Width > 0 && source.Height > 0 {
-		width = source.Width * height / source.Height
-		width -= width % 2
+	targetLabel := resolutionLabelV3(rung.Height)
+	width, fittedHeight := fitDimensionsV3(source.Width, source.Height, height)
+	if sameResolutionClass && source.Width > 0 && source.Height > 0 && source.Height != rung.Height {
+		width, fittedHeight = source.Width, source.Height
 	}
-	if width == 0 {
-		width, _ = dimensionsFromResolutionV3(resolutionLabelV3(height))
-	}
-	targetLabel := resolutionLabelV3(height)
 	if sameResolutionClass && source.Height > 0 && source.Height != rung.Height {
 		// The transcoder treats an unknown exact-height label as "do not scale",
 		// which preserves the source's cinema crop while still applying the
@@ -1236,7 +1232,7 @@ func compoundRungQualityResultV3(rung ladderRungV3, source SourceDescriptorV3, c
 	return QualityResultV3{
 		Label:             targetLabel,
 		Width:             width,
-		Height:            height,
+		Height:            fittedHeight,
 		BitrateKbps:       bitrate,
 		RequiresTranscode: true,
 		ExplicitRung:      true,
@@ -1563,17 +1559,38 @@ func ladderRungPublishableV3(rung ladderRungV3, source SourceDescriptorV3) bool 
 	return source.BitrateKbps > 0 && rung.BitrateKbps < source.BitrateKbps
 }
 
-func qualityDimensionsV3(height, sourceWidth, sourceHeight int) (int, int) {
+func qualityDimensionsV3(height, sourceWidth, sourceHeight int) (int, int, int) {
 	rung := resolutionHeightV3(resolutionLabelV3(height))
-	width := 0
-	if sourceWidth > 0 && sourceHeight > 0 {
-		width = sourceWidth * rung / sourceHeight
-		width -= width % 2
+	width, fittedHeight := fitDimensionsV3(sourceWidth, sourceHeight, rung)
+	return width, fittedHeight, ladderBitrateKbpsV3(rung)
+}
+
+// fitDimensionsV3 keeps a transcode inside the ladder's width and height
+// bounds while preserving the source aspect ratio. Cinema-aspect sources must
+// not become wider than the client can decode just because their target height
+// matches a nominal rung.
+func fitDimensionsV3(sourceWidth, sourceHeight, targetHeight int) (int, int) {
+	targetWidth, targetBoundHeight := dimensionsFromResolutionV3(resolutionLabelV3(targetHeight))
+	if targetWidth == 0 || targetBoundHeight == 0 {
+		return sourceWidth, sourceHeight
 	}
-	if width == 0 {
-		width, _ = dimensionsFromResolutionV3(resolutionLabelV3(rung))
+	if sourceWidth <= 0 || sourceHeight <= 0 {
+		return targetWidth, targetBoundHeight
 	}
-	return width, ladderBitrateKbpsV3(rung)
+
+	width, height := sourceWidth, sourceHeight
+	if width > targetWidth {
+		width = targetWidth
+		height = sourceHeight * width / sourceWidth
+	}
+	if height > targetBoundHeight {
+		height = targetBoundHeight
+		width = sourceWidth * height / sourceHeight
+	}
+
+	width -= width % 2
+	height -= height % 2
+	return width, height
 }
 
 func SortedTransformationNamesV3(values []TransformationV3) []string {

--- a/internal/playback/prepare_file_test.go
+++ b/internal/playback/prepare_file_test.go
@@ -72,19 +72,19 @@ func TestBuildPrepareFileArgsSharesHigh10DecodeFallback(t *testing.T) {
 		{
 			name:      "vaapi keeps hardware encode with software decode upload",
 			hwAccel:   "vaapi",
-			want:      []string{"-c:v h264_vaapi", "scale=-2:720,format=nv12,hwupload"},
+			want:      []string{"-c:v h264_vaapi", "scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2,format=nv12,hwupload"},
 			forbidden: []string{"-hwaccel vaapi"},
 		},
 		{
 			name:      "nvenc falls back to software encode",
 			hwAccel:   "nvenc",
-			want:      []string{"-c:v libx264", "-vf scale=-2:720"},
+			want:      []string{"-c:v libx264", "-vf scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2"},
 			forbidden: []string{"-hwaccel cuda", "h264_nvenc", "scale_cuda"},
 		},
 		{
 			name:      "videotoolbox keeps hardware encode with software decode",
 			hwAccel:   "videotoolbox",
-			want:      []string{"-c:v h264_videotoolbox", "-vf scale=-2:720"},
+			want:      []string{"-c:v h264_videotoolbox", "-vf scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2"},
 			forbidden: []string{"-hwaccel videotoolbox"},
 		},
 	}

--- a/internal/playback/protocol_v3_test.go
+++ b/internal/playback/protocol_v3_test.go
@@ -2393,6 +2393,33 @@ func TestResolveQualityPolicyV3PreservesNonStandardSourceHeight(t *testing.T) {
 	}
 }
 
+func TestResolveQualityPolicyV3FitsCinemaSourceWithinRungBounds(t *testing.T) {
+	req := validStartRequestV3()
+	req.QualityPreference = "auto"
+	source := SourceDescriptorV3{Width: 3840, Height: 1600, BitrateKbps: 16_000}
+
+	req.Capabilities.MaxResolution = "1080p"
+	result := ResolveQualityPolicyV3(req, source)
+	if result.Width != 1920 || result.Height != 800 || result.Label != "1080p" {
+		t.Fatalf("1080p quality result = %#v, want 1920x800", result)
+	}
+
+	req.Capabilities.MaxResolution = "720p"
+	result = ResolveQualityPolicyV3(req, source)
+	if result.Width != 1280 || result.Height != 532 || result.Label != "720p" {
+		t.Fatalf("720p quality result = %#v, want 1280x532", result)
+	}
+}
+
+func TestResolveQualityPolicyV3CompoundRungFitsCinemaSource(t *testing.T) {
+	req := validStartRequestV3()
+	req.QualityPreference = QualityRung1080pMediumV3
+	result := ResolveQualityPolicyV3(req, SourceDescriptorV3{Width: 3840, Height: 1600, BitrateKbps: 16_000})
+	if result.Width != 1920 || result.Height != 800 || result.Label != "1080p" {
+		t.Fatalf("compound quality result = %#v, want 1920x800", result)
+	}
+}
+
 func TestPlanPlaybackV3SeekedHLSCopyPreservesVideo(t *testing.T) {
 	file := detailedFixtureFileV3()
 	file.Resolution = "1080p"

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -1630,22 +1630,41 @@ func appendSubtitleBurnInArgs(args []string, opts TranscodeOpts) []string {
 
 // resolutionToScale returns an ffmpeg scale filter string for the target resolution.
 func resolutionToScale(res string) string {
-	switch res {
-	case "2160p":
-		return "scale=-2:2160"
-	case "1080p":
-		return "scale=-2:1080"
-	case "720p":
-		return "scale=-2:720"
-	case "480p":
-		return "scale=-2:480"
-	case transcodeResolution420p:
-		return "scale=-2:420"
-	case transcodeResolution328p:
-		return "scale=-2:328"
-	default:
+	width, height, ok := resolutionScaleBounds(res)
+	if !ok {
 		return ""
 	}
+	return fmt.Sprintf("scale=%d:%d:force_original_aspect_ratio=decrease:force_divisible_by=2", width, height)
+}
+
+func resolutionScaleBounds(res string) (int, int, bool) {
+	switch res {
+	case "2160p":
+		return 3840, 2160, true
+	case "1080p":
+		return 1920, 1080, true
+	case "720p":
+		return 1280, 720, true
+	case "480p":
+		return 854, 480, true
+	case transcodeResolution420p:
+		return 746, 420, true
+	case transcodeResolution328p:
+		return 582, 328, true
+	default:
+		return 0, 0, false
+	}
+}
+
+func hardwareScaleFilter(name, res string) string {
+	width, height, ok := resolutionScaleBounds(res)
+	if !ok {
+		return name + "=format=nv12"
+	}
+	return fmt.Sprintf(
+		"%s=w=%d:h=%d:format=nv12:force_original_aspect_ratio=decrease:force_divisible_by=2",
+		name, width, height,
+	)
 }
 
 // qsvScaleFilter returns the VAAPI→QSV filter chain with optional resolution scaling.
@@ -1658,22 +1677,7 @@ func qsvScaleFilterWithMapMode(res, mapMode string) string {
 	if mapMode != "" {
 		hwmap += ":mode=" + mapMode
 	}
-	switch res {
-	case "2160p":
-		return "scale_vaapi=w=-2:h=2160:format=nv12," + hwmap + ",format=qsv"
-	case "1080p":
-		return "scale_vaapi=w=-2:h=1080:format=nv12," + hwmap + ",format=qsv"
-	case "720p":
-		return "scale_vaapi=w=-2:h=720:format=nv12," + hwmap + ",format=qsv"
-	case "480p":
-		return "scale_vaapi=w=-2:h=480:format=nv12," + hwmap + ",format=qsv"
-	case transcodeResolution420p:
-		return "scale_vaapi=w=-2:h=420:format=nv12," + hwmap + ",format=qsv"
-	case transcodeResolution328p:
-		return "scale_vaapi=w=-2:h=328:format=nv12," + hwmap + ",format=qsv"
-	default:
-		return "scale_vaapi=format=nv12," + hwmap + ",format=qsv"
-	}
+	return hardwareScaleFilter("scale_vaapi", res) + "," + hwmap + ",format=qsv"
 }
 
 // qsvToneMapScaleFilter maps VAAPI tone-map output with read/write access. The default
@@ -1699,22 +1703,7 @@ func qsvSoftwareDecodeFilter(res string) string {
 // browser-compatible encoder format. Using the CPU scale filter on VAAPI frames
 // causes FFmpeg auto_scale format-negotiation failures.
 func vaapiScaleFilter(res string) string {
-	switch res {
-	case "2160p":
-		return "scale_vaapi=w=-2:h=2160:format=nv12"
-	case "1080p":
-		return "scale_vaapi=w=-2:h=1080:format=nv12"
-	case "720p":
-		return "scale_vaapi=w=-2:h=720:format=nv12"
-	case "480p":
-		return "scale_vaapi=w=-2:h=480:format=nv12"
-	case transcodeResolution420p:
-		return "scale_vaapi=w=-2:h=420:format=nv12"
-	case transcodeResolution328p:
-		return "scale_vaapi=w=-2:h=328:format=nv12"
-	default:
-		return "scale_vaapi=format=nv12"
-	}
+	return hardwareScaleFilter("scale_vaapi", res)
 }
 
 func vaapiSoftwareDecodeFilter(res string) string {
@@ -1726,22 +1715,7 @@ func vaapiSoftwareDecodeFilter(res string) string {
 }
 
 func nvencScaleFilter(res string) string {
-	switch res {
-	case "2160p":
-		return "scale_cuda=w=-2:h=2160:format=nv12"
-	case "1080p":
-		return "scale_cuda=w=-2:h=1080:format=nv12"
-	case "720p":
-		return "scale_cuda=w=-2:h=720:format=nv12"
-	case "480p":
-		return "scale_cuda=w=-2:h=480:format=nv12"
-	case transcodeResolution420p:
-		return "scale_cuda=w=-2:h=420:format=nv12"
-	case transcodeResolution328p:
-		return "scale_cuda=w=-2:h=328:format=nv12"
-	default:
-		return "scale_cuda=format=nv12"
-	}
+	return hardwareScaleFilter("scale_cuda", res)
 }
 
 // filterPathReplacer escapes special characters in file paths for ffmpeg filter syntax.

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -238,12 +238,12 @@ func TestToneMapGraphOrdersTextAndBitmapSubtitles(t *testing.T) {
 			last = index
 		}
 	}
-	assertTokenOrder(textGraph, "tonemapx=tonemap=bt2390", "scale=-2:1080", "subtitles=")
+	assertTokenOrder(textGraph, "tonemapx=tonemap=bt2390", "scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2", "subtitles=")
 
 	bitmapOpts := base
 	bitmapOpts.SubtitleCodec = "hdmv_pgs_subtitle"
 	bitmapGraph := strings.Join(buildFFmpegArgs(bitmapOpts), " ")
-	assertTokenOrder(bitmapGraph, "tonemapx=tonemap=bt2390", "overlay=eof_action=pass", "scale=-2:1080")
+	assertTokenOrder(bitmapGraph, "tonemapx=tonemap=bt2390", "overlay=eof_action=pass", "scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2")
 }
 
 func TestVideoToolboxToneMapDownloadsBeforeSubtitleComposition(t *testing.T) {
@@ -272,7 +272,7 @@ func TestVideoToolboxToneMapDownloadsBeforeSubtitleComposition(t *testing.T) {
 			if convert < 0 || download <= convert || compose <= download || metadata <= compose {
 				t.Fatalf("unsafe VideoToolbox subtitle order: %s", graph)
 			}
-			if strings.Contains(graph, "scale=-2:1080") {
+			if strings.Contains(graph, "scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2") {
 				t.Fatalf("VideoToolbox scaling ran a second time on the CPU: %s", graph)
 			}
 		})
@@ -762,7 +762,7 @@ func TestBuildFFmpegArgs_MPEG4Part2DisablesHardwareDecode(t *testing.T) {
 			if !strings.Contains(joined, "-c:v libx264") {
 				t.Fatalf("mpeg4 part 2 source should fall back to libx264: %s", joined)
 			}
-			if !strings.Contains(joined, "-vf scale=-2:420") {
+			if !strings.Contains(joined, "-vf scale=746:420:force_original_aspect_ratio=decrease:force_divisible_by=2") {
 				t.Fatalf("mpeg4 part 2 software fallback should preserve requested scaling: %s", joined)
 			}
 		})
@@ -815,7 +815,7 @@ func TestBuildFFmpegArgs_H264High10QSVUsesSoftwareDecodeUpload(t *testing.T) {
 		"-init_hw_device vaapi=va:",
 		"-init_hw_device qsv=qs@va",
 		"-c:v h264_qsv",
-		"-vf scale=-2:720,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv",
+		"-vf scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv",
 	} {
 		if !strings.Contains(joined, required) {
 			t.Fatalf("High 10 QSV recipe missing %q: %s", required, joined)
@@ -961,7 +961,7 @@ func TestBuildFFmpegArgs_H264High10QSVASSBurnInUsesSoftwareFrames(t *testing.T) 
 	})
 
 	joined := strings.Join(args, " ")
-	want := "-vf format=yuv420p,scale=-2:720,subtitles=filename='/media/high10.mkv':si=0,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv"
+	want := "-vf format=yuv420p,scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2,subtitles=filename='/media/high10.mkv':si=0,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv"
 	if !strings.Contains(joined, want) {
 		t.Fatalf("High 10 ASS burn-in should render on software frames then upload %q: %s", want, joined)
 	}
@@ -988,7 +988,7 @@ func TestBuildFFmpegArgs_H264High10QSVBitmapBurnInUsesSoftwareFrames(t *testing.
 	})
 
 	joined := strings.Join(args, " ")
-	want := "-filter_complex [0:v:0]format=yuv420p[vmain];[vmain][0:s:2]overlay=eof_action=pass,scale=-2:720,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv[vout]"
+	want := "-filter_complex [0:v:0]format=yuv420p[vmain];[vmain][0:s:2]overlay=eof_action=pass,scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2,format=nv12,hwupload,hwmap=derive_device=qsv,format=qsv[vout]"
 	if !strings.Contains(joined, want) {
 		t.Fatalf("High 10 PGS burn-in should composite on software frames then upload %q: %s", want, joined)
 	}
@@ -1015,7 +1015,7 @@ func TestBuildFFmpegArgs_BitmapBurnInCPUUsesOverlayFilterComplex(t *testing.T) {
 
 	joined := strings.Join(args, " ")
 	// Overlay runs at native resolution first, then scales.
-	want := "-filter_complex [0:v:0][0:s:2]overlay=eof_action=pass,scale=-2:1080[vout]"
+	want := "-filter_complex [0:v:0][0:s:2]overlay=eof_action=pass,scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2[vout]"
 	if !strings.Contains(joined, want) {
 		t.Fatalf("bitmap burn-in should use overlay filter_complex %q: %s", want, joined)
 	}
@@ -1077,7 +1077,7 @@ func TestBuildFFmpegArgs_BitmapBurnInVAAPICompositesOnGPU(t *testing.T) {
 	joined := strings.Join(args, " ")
 	// Only the subtitle bitmap is uploaded; the video stays on the VAAPI surface
 	// and is composited with overlay_vaapi — no full-frame hwdownload roundtrip.
-	want := "-filter_complex [0:s:1]format=bgra,hwupload[sub];[0:v:0][sub]overlay_vaapi=eof_action=pass,scale_vaapi=w=-2:h=720:format=nv12[vout]"
+	want := "-filter_complex [0:s:1]format=bgra,hwupload[sub];[0:v:0][sub]overlay_vaapi=eof_action=pass,scale_vaapi=w=1280:h=720:format=nv12:force_original_aspect_ratio=decrease:force_divisible_by=2[vout]"
 	if !strings.Contains(joined, want) {
 		t.Fatalf("vaapi bitmap burn-in should composite on GPU %q: %s", want, joined)
 	}
@@ -1114,7 +1114,7 @@ func TestBuildFFmpegArgs_BitmapBurnInQSVCompositesOnGPU(t *testing.T) {
 	joined := strings.Join(args, " ")
 	// GPU composite via overlay_vaapi, then map the VAAPI surface to QSV for the
 	// encoder — the video never leaves hardware memory.
-	want := "-filter_complex [0:s:1]format=bgra,hwupload[sub];[0:v:0][sub]overlay_vaapi=eof_action=pass,scale_vaapi=w=-2:h=720:format=nv12,hwmap=derive_device=qsv,format=qsv[vout]"
+	want := "-filter_complex [0:s:1]format=bgra,hwupload[sub];[0:v:0][sub]overlay_vaapi=eof_action=pass,scale_vaapi=w=1280:h=720:format=nv12:force_original_aspect_ratio=decrease:force_divisible_by=2,hwmap=derive_device=qsv,format=qsv[vout]"
 	if !strings.Contains(joined, want) {
 		t.Fatalf("qsv bitmap burn-in should composite on GPU %q: %s", want, joined)
 	}
@@ -1148,7 +1148,7 @@ func TestBuildFFmpegArgs_BitmapBurnInNVENCStaysOnCPUOverlay(t *testing.T) {
 	})
 
 	joined := strings.Join(args, " ")
-	want := "-filter_complex [0:v:0]hwdownload,format=yuv420p[vmain];[vmain][0:s:1]overlay=eof_action=pass,scale=-2:720,format=nv12,hwupload_cuda[vout]"
+	want := "-filter_complex [0:v:0]hwdownload,format=yuv420p[vmain];[vmain][0:s:1]overlay=eof_action=pass,scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2,format=nv12,hwupload_cuda[vout]"
 	if !strings.Contains(joined, want) {
 		t.Fatalf("nvenc bitmap burn-in should keep the CPU roundtrip %q: %s", want, joined)
 	}
@@ -1173,7 +1173,7 @@ func TestBuildFFmpegArgs_TextBurnInStillUsesSubtitlesFilter(t *testing.T) {
 	})
 
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "-vf scale=-2:1080,subtitles=filename='/media/movie.mkv':si=1") {
+	if !strings.Contains(joined, "-vf scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2,subtitles=filename='/media/movie.mkv':si=1") {
 		t.Fatalf("text burn-in should keep the libass subtitles -vf path: %s", joined)
 	}
 	if strings.Contains(joined, "-filter_complex") {
@@ -1401,10 +1401,10 @@ func TestBuildFFmpegArgs_NVENCH264UsesCudaPipeline(t *testing.T) {
 	if !strings.Contains(joined, "-c:v h264_nvenc") {
 		t.Fatalf("nvenc args should use h264_nvenc encoder: %s", joined)
 	}
-	if !strings.Contains(joined, "-vf scale_cuda=w=-2:h=720:format=nv12") {
+	if !strings.Contains(joined, "-vf scale_cuda=w=1280:h=720:format=nv12:force_original_aspect_ratio=decrease:force_divisible_by=2") {
 		t.Fatalf("nvenc args should use scale_cuda, not software scale: %s", joined)
 	}
-	if strings.Contains(joined, "-vf scale=-2:720") {
+	if strings.Contains(joined, "-vf scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2") {
 		t.Fatalf("nvenc args must not use software scale on cuda frames: %s", joined)
 	}
 	if !strings.Contains(joined, "-b:v 2000k -maxrate 2000k -bufsize 4000k") {
@@ -1430,10 +1430,10 @@ func TestBuildFFmpegArgs_VAAPIScalingUsesHardwareFilter(t *testing.T) {
 	if !strings.Contains(joined, "-hwaccel vaapi") {
 		t.Fatalf("vaapi args should enable vaapi hwaccel: %s", joined)
 	}
-	if !strings.Contains(joined, "-vf scale_vaapi=w=-2:h=720:format=nv12") {
+	if !strings.Contains(joined, "-vf scale_vaapi=w=1280:h=720:format=nv12:force_original_aspect_ratio=decrease:force_divisible_by=2") {
 		t.Fatalf("vaapi args should use scale_vaapi, not software scale: %s", joined)
 	}
-	if strings.Contains(joined, "-vf scale=-2:720") {
+	if strings.Contains(joined, "-vf scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2") {
 		t.Fatalf("vaapi args must not use software scale on hardware frames: %s", joined)
 	}
 }
@@ -1608,7 +1608,7 @@ func TestBuildFFmpegArgs_VideoToolboxH264UsesSoftwareFilters(t *testing.T) {
 	if !strings.Contains(joined, "-pix_fmt yuv420p") {
 		t.Fatalf("videotoolbox h264 should force 8-bit output: %s", joined)
 	}
-	if !strings.Contains(joined, "-vf scale=-2:720") {
+	if !strings.Contains(joined, "-vf scale=1280:720:force_original_aspect_ratio=decrease:force_divisible_by=2") {
 		t.Fatalf("videotoolbox args should use the software scale filter: %s", joined)
 	}
 	if !strings.Contains(joined, "-b:v 2000k -maxrate 2000k -bufsize 4000k") {


### PR DESCRIPTION
Problem: cinema-aspect 4K sources were scaled to the target height without respecting the target width. An Apple TV HD received 2592x1080 H.264 and could not create a playable track.

Solution: treat each quality rung as a width/height bounding box, preserve source aspect ratio with even dimensions, and apply the same bounded scaling to CPU, QSV, VAAPI, and NVENC paths.

Validation:
- go test ./internal/playback -run 'TestResolveQualityPolicyV3(PreservesNonStandardSourceHeight|FitsCinemaSourceWithinRungBounds|CompoundRungFitsCinemaSource)$' -count=1\n- focused FFmpeg argument tests pass\n- Related issue: N/A — narrow fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Transcoding now fits video within target resolution bounds while preserving the original aspect ratio.
  * Output dimensions are rounded to compatible even values for broader hardware support.
  * Cropped and cinematic sources now produce correctly scaled output at 1080p and 720p quality levels.
* **Bug Fixes**
  * Corrected scaling behavior across software and hardware transcoding paths, including VAAPI, NVENC, QSV, and VideoToolbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->