### PR TITLE
fix(clientip): honor Cloudflare Tunnel client IP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,8 @@ POSTGRES_SHM_SIZE=8gb
 # validated and written to server_settings, so the Admin UI shows it). Leave
 # unset to manage it from Admin > Settings > General instead. Defaults trust
 # RFC 1918 private ranges + loopback.
+# When the peer is trusted, Silo accepts X-Forwarded-For, X-Real-IP, and
+# Cloudflare Tunnel's CF-Connecting-IP forwarding headers.
 # SILO_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,::1/128,203.0.113.7/32
 
 # Run from source / advanced overrides

--- a/internal/clientip/resolver.go
+++ b/internal/clientip/resolver.go
@@ -33,6 +33,14 @@ func (r *Resolver) ClientIP(req *http.Request) string {
 		return normalize(remoteIP)
 	}
 
+	// Cloudflare Tunnel preserves the viewer address in CF-Connecting-IP.
+	// This header is trusted only after the peer passed the proxy boundary above.
+	if cloudflareIP := strings.TrimSpace(req.Header.Get("CF-Connecting-IP")); cloudflareIP != "" {
+		if parsed := net.ParseIP(cloudflareIP); parsed != nil {
+			return normalize(parsed)
+		}
+	}
+
 	// Check X-Forwarded-For: walk right-to-left, return first untrusted IP.
 	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
 		ips := strings.Split(xff, ",")

--- a/internal/clientip/resolver_test.go
+++ b/internal/clientip/resolver_test.go
@@ -51,3 +51,35 @@ func TestMiddlewareTrustBoundaryAndHotReload(t *testing.T) {
 		t.Fatalf("hot reload did not narrow trust: %q", got)
 	}
 }
+
+func TestResolverUsesCloudflareConnectingIPFromTrustedPeer(t *testing.T) {
+	trusted, err := ParseCIDRs("10.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewResolver(trusted)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "10.42.0.169:8080"
+	req.Header.Set("CF-Connecting-IP", "198.51.100.42")
+
+	if got := resolver.ClientIP(req); got != "198.51.100.42" {
+		t.Fatalf("Cloudflare connecting IP = %q, want 198.51.100.42", got)
+	}
+}
+
+func TestResolverIgnoresCloudflareConnectingIPFromUntrustedPeer(t *testing.T) {
+	trusted, err := ParseCIDRs("10.0.0.0/8")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := NewResolver(trusted)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "203.0.113.7:8080"
+	req.Header.Set("CF-Connecting-IP", "198.51.100.42")
+
+	if got := resolver.ClientIP(req); got != "203.0.113.7" {
+		t.Fatalf("untrusted Cloudflare connecting IP = %q, want 203.0.113.7", got)
+	}
+}


### PR DESCRIPTION
## Problem
Requests arriving through Cloudflare Tunnel are logged with the cloudflared/Kubernetes peer address (for example, `10.42.0.169`) instead of the viewer address.

## Solution
- accept Cloudflare Tunnel's `CF-Connecting-IP` header after the existing trusted-proxy boundary check
- keep untrusted peers from overriding the transport address with the header
- document the supported forwarding headers alongside `SILO_TRUSTED_PROXIES`

## Validation
- `go test ./internal/clientip` — passed
- `go test -race ./internal/clientip` — passed
- `go vet ./internal/clientip` — passed
- GitHub CI on the fork PR — Go, Web, and Docs hygiene passed

Related issue: #909

## AI Disclosure

- Harness: Codex desktop app
- Tool(s): `exec_command`, `apply_patch`
- Model(s): GPT-5
- Involvement: AI-assisted
- Adversarial review: exercised trusted-peer and untrusted-peer header cases in focused tests; no findings requiring changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trusted proxies can now provide client IP addresses through Cloudflare Tunnel’s `CF-Connecting-IP` header.

* **Documentation**
  * Updated the configuration example to document supported forwarded-IP headers for trusted peers.

* **Bug Fixes**
  * Untrusted peers’ `CF-Connecting-IP` values are ignored, preserving secure client IP detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->