### PR TITLE
fix(jellycompat): honor MaxStreamingBitrate cap in PlaybackInfo negotiation

### DIFF
--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -1003,6 +1003,16 @@ func is4KResolution(res string) bool {
 	return access.CompareQuality(res, "2160p") >= 0
 }
 
+// Resolution labels shared by compatResolutionCeilingHeight and
+// compatMaxResolutionForBitrateKbps.
+const (
+	compatResolutionLabel480p  = "480p"
+	compatResolutionLabel720p  = "720p"
+	compatResolutionLabel1080p = "1080p"
+	compatResolutionLabel2160p = "2160p"
+	compatResolutionLabel4320p = "4320p"
+)
+
 // compatSourceVideoHeight resolves a version's pixel height from its probed
 // video track, falling back to the catalog resolution label when no track
 // carries a usable value.
@@ -1058,15 +1068,15 @@ func compatVideoToolboxToneMapBitrateKbps(version catalog.FileVersion, recipe co
 // genuine 1080p one and let it slip past a 1080p cap unflagged.
 func compatResolutionCeilingHeight(label string) int {
 	switch label {
-	case "480p":
+	case compatResolutionLabel480p:
 		return 480
-	case "720p":
+	case compatResolutionLabel720p:
 		return 720
-	case "1080p":
+	case compatResolutionLabel1080p:
 		return 1080
-	case "2160p":
+	case compatResolutionLabel2160p:
 		return 2160
-	case "4320p":
+	case compatResolutionLabel4320p:
 		return 4320
 	default:
 		return 0
@@ -1084,11 +1094,11 @@ func compatMaxResolutionForBitrateKbps(kbps int) string {
 	case kbps <= 0:
 		return ""
 	case kbps < 2_000:
-		return "480p"
+		return compatResolutionLabel480p
 	case kbps < 6_000:
-		return "720p"
+		return compatResolutionLabel720p
 	case kbps < 20_000:
-		return "1080p"
+		return compatResolutionLabel1080p
 	default:
 		return ""
 	}

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -1050,22 +1050,26 @@ func compatVideoToolboxToneMapBitrateKbps(version catalog.FileVersion, recipe co
 	}
 }
 
-// compatResolutionLabelForHeight buckets a probed pixel height into the
-// resolution labels access.CompareQuality understands.
-func compatResolutionLabelForHeight(height int) string {
-	switch {
-	case height >= 4320:
-		return "4320p"
-	case height >= 2160:
-		return "2160p"
-	case height >= 1080:
-		return "1080p"
-	case height >= 720:
-		return "720p"
-	case height > 0:
-		return "480p"
+// compatResolutionCeilingHeight returns the maximum pixel height a resolution
+// label (as returned by compatMaxResolutionForBitrateKbps) permits. Cap
+// enforcement compares a source's actual, unbucketed height against this
+// number rather than against a bucketed label: flooring the source height
+// into the same coarse labels first would equate, say, a 1440p source with a
+// genuine 1080p one and let it slip past a 1080p cap unflagged.
+func compatResolutionCeilingHeight(label string) int {
+	switch label {
+	case "480p":
+		return 480
+	case "720p":
+		return 720
+	case "1080p":
+		return 1080
+	case "2160p":
+		return 2160
+	case "4320p":
+		return 4320
 	default:
-		return ""
+		return 0
 	}
 }
 
@@ -2208,8 +2212,8 @@ func (h *PlaybackHandler) buildPlaybackSource(
 	qualityCapExceeded := maxStreamingBitrateKbps > 0 && version.Bitrate > maxStreamingBitrateKbps
 	if !qualityCapExceeded && maxStreamingBitrateKbps > 0 {
 		if resCap := compatMaxResolutionForBitrateKbps(maxStreamingBitrateKbps); resCap != "" {
-			if sourceLabel := compatResolutionLabelForHeight(compatSourceVideoHeight(version)); sourceLabel != "" {
-				qualityCapExceeded = access.CompareQuality(sourceLabel, resCap) > 0
+			if sourceHeight := compatSourceVideoHeight(version); sourceHeight > 0 {
+				qualityCapExceeded = sourceHeight > compatResolutionCeilingHeight(resCap)
 			}
 		}
 	}

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -47,11 +47,15 @@ const (
 )
 
 type playbackInfoRequest struct {
-	UserID               string          `json:"UserId"`
-	MediaSourceID        string          `json:"MediaSourceId"`
-	AudioStreamIndex     *compatIntValue `json:"AudioStreamIndex,omitempty"`
-	SubtitleStreamIndex  *compatIntValue `json:"SubtitleStreamIndex,omitempty"`
-	StartTimeTicks       int64           `json:"StartTimeTicks"`
+	UserID              string          `json:"UserId"`
+	MediaSourceID       string          `json:"MediaSourceId"`
+	AudioStreamIndex    *compatIntValue `json:"AudioStreamIndex,omitempty"`
+	SubtitleStreamIndex *compatIntValue `json:"SubtitleStreamIndex,omitempty"`
+	StartTimeTicks      int64           `json:"StartTimeTicks"`
+	// MaxStreamingBitrate is the client's requested ceiling in bits per second
+	// (e.g. the "720p - 4 Mbps" quality profile), independent of any cap the
+	// device profile itself advertises. Zero means the client set no cap.
+	MaxStreamingBitrate  int64           `json:"MaxStreamingBitrate,omitempty"`
 	EnableDirectPlay     *bool           `json:"EnableDirectPlay"`
 	EnableDirectStream   *bool           `json:"EnableDirectStream"`
 	EnableTranscoding    *bool           `json:"EnableTranscoding"`
@@ -2148,7 +2152,19 @@ func (h *PlaybackHandler) buildPlaybackSource(
 		selectedAudioIndex = intPtr(int(*req.AudioStreamIndex))
 	}
 
-	supportsDirectPlay := enableDirectPlay && profile.SupportsDirectPlayForAudioStream(version, selectedAudioIndex)
+	// A client picking a lower quality profile (e.g. "720p - 4 Mbps") caps the
+	// stream via MaxStreamingBitrate rather than declaring narrower codec
+	// support. Direct play and any video-copy transport (progressive remux or
+	// HLS remux) all serve the source video verbatim, so none of them can honor
+	// a cap below the source's own bitrate — only a real transcode can. Below
+	// that cap, negotiation proceeds exactly as before.
+	maxStreamingBitrateKbps := effectiveCompatMaxStreamingBitrateKbps(req, profile)
+	bitrateCapExceeded := maxStreamingBitrateKbps > 0 && version.Bitrate > maxStreamingBitrateKbps
+	if bitrateCapExceeded {
+		allowVideoCopy = false
+	}
+
+	supportsDirectPlay := enableDirectPlay && !bitrateCapExceeded && profile.SupportsDirectPlayForAudioStream(version, selectedAudioIndex)
 	audioSupported := profile.SupportsAudioCodecForDirectStreamForAudioStream(version, selectedAudioIndex)
 	videoSupported := profile.SupportsVideoCodecForDirectStreamForAudioStream(version, selectedAudioIndex)
 	enableTranscoding := boolDefault(req.EnableTranscoding, true)
@@ -2213,7 +2229,28 @@ func (h *PlaybackHandler) buildPlaybackSource(
 		SelectedAudioStreamIndex:   selectedAudioIndex,
 		DefaultSubtitleStreamIndex: subtitleIndex,
 		ETag:                       mediaSourceETag(version),
+		MaxStreamingBitrateKbps:    maxStreamingBitrateKbps,
 	}
+}
+
+// effectiveCompatMaxStreamingBitrateKbps returns the tighter of the two caps a
+// Jellyfin client can advertise: the per-request MaxStreamingBitrate (set when
+// the user picks a quality profile) and the device profile's own
+// MaxStreamingBitrate. Both arrive in bits per second; catalog.FileVersion.Bitrate
+// is kbps (see mediaSourceDTO's Bitrate*1000 conversion), so the result is
+// converted to match. Zero means neither side set a cap.
+func effectiveCompatMaxStreamingBitrateKbps(req playbackInfoRequest, profile DeviceProfile) int {
+	maxKbps := 0
+	if req.MaxStreamingBitrate > 0 {
+		maxKbps = int(req.MaxStreamingBitrate / 1000)
+	}
+	if profile.MaxStreamingBitrate > 0 {
+		profileMaxKbps := int(profile.MaxStreamingBitrate / 1000)
+		if maxKbps == 0 || profileMaxKbps < maxKbps {
+			maxKbps = profileMaxKbps
+		}
+	}
+	return maxKbps
 }
 
 // supportedHLSRemuxAudioStreamIndexes freezes the copy-safe switch targets. A
@@ -3134,6 +3171,9 @@ func applyPlaybackQueryOverrides(req *playbackInfoRequest, query url.Values) {
 	if value, ok := parseOptionalInt(firstQueryValue(query, "SubtitleStreamIndex")); ok {
 		req.SubtitleStreamIndex = compatIntValuePtr(value)
 	}
+	if value, ok := parseOptionalInt64(firstQueryValue(query, "MaxStreamingBitrate")); ok {
+		req.MaxStreamingBitrate = value
+	}
 	if value, ok := parseOptionalBool(firstQueryValue(query, "EnableDirectPlay")); ok {
 		req.EnableDirectPlay = &value
 	}
@@ -3176,6 +3216,17 @@ func parseOptionalInt(raw string) (int, bool) {
 		return 0, false
 	}
 	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func parseOptionalInt64(raw string) (int64, bool) {
+	if strings.TrimSpace(raw) == "" {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(raw, 10, 64)
 	if err != nil {
 		return 0, false
 	}

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -1003,6 +1003,27 @@ func is4KResolution(res string) bool {
 	return access.CompareQuality(res, "2160p") >= 0
 }
 
+// compatSourceVideoHeight resolves a version's pixel height from its probed
+// video track, falling back to the catalog resolution label when no track
+// carries a usable value.
+func compatSourceVideoHeight(version catalog.FileVersion) int {
+	for _, track := range version.VideoTracks {
+		if track.Height > 0 {
+			return track.Height
+		}
+	}
+	resolution := strings.ToLower(strings.TrimSpace(version.Resolution))
+	switch resolution {
+	case "8k":
+		return 4320
+	case "4k", "uhd":
+		return 2160
+	default:
+		height, _ := strconv.Atoi(strings.TrimSuffix(resolution, "p"))
+		return height
+	}
+}
+
 // compatVideoToolboxToneMapBitrateKbps chooses a resolution-aware bitrate for
 // Jellyfin-compatible VideoToolbox tone maps. Those requests intentionally
 // preserve source dimensions, so leaving the bitrate unset would make the
@@ -1012,25 +1033,7 @@ func compatVideoToolboxToneMapBitrateKbps(version catalog.FileVersion, recipe co
 		return 0
 	}
 
-	height := 0
-	for _, track := range version.VideoTracks {
-		if track.Height > 0 {
-			height = track.Height
-			break
-		}
-	}
-	if height == 0 {
-		resolution := strings.ToLower(strings.TrimSpace(version.Resolution))
-		switch resolution {
-		case "8k":
-			height = 4320
-		case "4k", "uhd":
-			height = 2160
-		default:
-			height, _ = strconv.Atoi(strings.TrimSuffix(resolution, "p"))
-		}
-	}
-
+	height := compatSourceVideoHeight(version)
 	switch {
 	case height >= 2160:
 		return 20_000
@@ -1044,6 +1047,46 @@ func compatVideoToolboxToneMapBitrateKbps(version catalog.FileVersion, recipe co
 		return version.Bitrate
 	default:
 		return 0
+	}
+}
+
+// compatResolutionLabelForHeight buckets a probed pixel height into the
+// resolution labels access.CompareQuality understands.
+func compatResolutionLabelForHeight(height int) string {
+	switch {
+	case height >= 4320:
+		return "4320p"
+	case height >= 2160:
+		return "2160p"
+	case height >= 1080:
+		return "1080p"
+	case height >= 720:
+		return "720p"
+	case height > 0:
+		return "480p"
+	default:
+		return ""
+	}
+}
+
+// compatMaxResolutionForBitrateKbps maps a negotiated MaxStreamingBitrate
+// ceiling onto the resolution its Jellyfin quality-profile name implies (e.g.
+// "720p - 4 Mbps", "1080p - 10 Mbps"), so a forced transcode actually
+// downscales instead of spending a starved bitrate on full source dimensions.
+// A cap generous enough to carry 4K returns "": at that ceiling the encoder's
+// normal resolution-aware bitrate ladder already applies.
+func compatMaxResolutionForBitrateKbps(kbps int) string {
+	switch {
+	case kbps <= 0:
+		return ""
+	case kbps < 2_000:
+		return "480p"
+	case kbps < 6_000:
+		return "720p"
+	case kbps < 20_000:
+		return "1080p"
+	default:
+		return ""
 	}
 }
 
@@ -2156,15 +2199,25 @@ func (h *PlaybackHandler) buildPlaybackSource(
 	// stream via MaxStreamingBitrate rather than declaring narrower codec
 	// support. Direct play and any video-copy transport (progressive remux or
 	// HLS remux) all serve the source video verbatim, so none of them can honor
-	// a cap below the source's own bitrate — only a real transcode can. Below
-	// that cap, negotiation proceeds exactly as before.
+	// a cap below the source's own bitrate — only a real transcode can. The
+	// same cap implies a resolution ceiling too (a "720p - 4 Mbps" profile
+	// means 720p, not a 4K frame starved down to 4 Mbps): a source above that
+	// implied resolution is gated the same way, even if its bitrate alone
+	// happens to fit. Below both, negotiation proceeds exactly as before.
 	maxStreamingBitrateKbps := effectiveCompatMaxStreamingBitrateKbps(req, profile)
-	bitrateCapExceeded := maxStreamingBitrateKbps > 0 && version.Bitrate > maxStreamingBitrateKbps
-	if bitrateCapExceeded {
+	qualityCapExceeded := maxStreamingBitrateKbps > 0 && version.Bitrate > maxStreamingBitrateKbps
+	if !qualityCapExceeded && maxStreamingBitrateKbps > 0 {
+		if resCap := compatMaxResolutionForBitrateKbps(maxStreamingBitrateKbps); resCap != "" {
+			if sourceLabel := compatResolutionLabelForHeight(compatSourceVideoHeight(version)); sourceLabel != "" {
+				qualityCapExceeded = access.CompareQuality(sourceLabel, resCap) > 0
+			}
+		}
+	}
+	if qualityCapExceeded {
 		allowVideoCopy = false
 	}
 
-	supportsDirectPlay := enableDirectPlay && !bitrateCapExceeded && profile.SupportsDirectPlayForAudioStream(version, selectedAudioIndex)
+	supportsDirectPlay := enableDirectPlay && !qualityCapExceeded && profile.SupportsDirectPlayForAudioStream(version, selectedAudioIndex)
 	audioSupported := profile.SupportsAudioCodecForDirectStreamForAudioStream(version, selectedAudioIndex)
 	videoSupported := profile.SupportsVideoCodecForDirectStreamForAudioStream(version, selectedAudioIndex)
 	enableTranscoding := boolDefault(req.EnableTranscoding, true)

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -316,6 +316,78 @@ func TestBuildPlaybackSourceMaxStreamingBitrateGate(t *testing.T) {
 	}
 }
 
+func TestBuildPlaybackSourceMaxStreamingBitrateGateResolutionImplied(t *testing.T) {
+	// A DirectPlayProfile that would otherwise allow direct play outright.
+	permissive := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{
+			{Type: "Video", Container: "mp4", VideoCodec: "h264", AudioCodec: "aac"},
+		},
+		TranscodingProfiles: []TranscodingProfile{
+			{Type: "Video", Protocol: "hls", Container: "ts", VideoCodec: "h264", AudioCodec: "aac"},
+		},
+	}
+	// An unusually efficient 1080p encode: its bitrate alone fits under a
+	// "720p - 4 Mbps" cap, but its resolution does not.
+	version := catalog.FileVersion{
+		FileID:     1,
+		Resolution: "1080p",
+		CodecVideo: "h264",
+		CodecAudio: "aac",
+		Container:  "mp4",
+		Bitrate:    3_000,
+	}
+
+	h := &PlaybackHandler{codec: NewResourceIDCodec()}
+	source := h.buildPlaybackSource("item", "ps", version, permissive, playbackInfoRequest{MaxStreamingBitrate: 4_000_000}, false)
+	if source.SupportsDirectPlay {
+		t.Error("SupportsDirectPlay = true, want false: source resolution exceeds the cap's implied 720p ceiling")
+	}
+	if source.SupportsDirectStream {
+		t.Error("SupportsDirectStream = true, want false: source resolution exceeds the cap's implied 720p ceiling")
+	}
+	if !source.SupportsTranscoding {
+		t.Error("expected a full transcode to remain available")
+	}
+}
+
+func TestCompatMaxResolutionForBitrateKbps(t *testing.T) {
+	tests := []struct {
+		kbps int
+		want string
+	}{
+		{kbps: 0, want: ""},
+		{kbps: 1_500, want: "480p"},
+		{kbps: 4_000, want: "720p"},
+		{kbps: 10_000, want: "1080p"},
+		{kbps: 25_000, want: ""},
+	}
+	for _, tt := range tests {
+		if got := compatMaxResolutionForBitrateKbps(tt.kbps); got != tt.want {
+			t.Errorf("compatMaxResolutionForBitrateKbps(%d) = %q, want %q", tt.kbps, got, tt.want)
+		}
+	}
+}
+
+func TestCompatResolutionLabelForHeight(t *testing.T) {
+	tests := []struct {
+		height int
+		want   string
+	}{
+		{height: 0, want: ""},
+		{height: 480, want: "480p"},
+		{height: 576, want: "480p"},
+		{height: 720, want: "720p"},
+		{height: 1080, want: "1080p"},
+		{height: 2160, want: "2160p"},
+		{height: 4320, want: "4320p"},
+	}
+	for _, tt := range tests {
+		if got := compatResolutionLabelForHeight(tt.height); got != tt.want {
+			t.Errorf("compatResolutionLabelForHeight(%d) = %q, want %q", tt.height, got, tt.want)
+		}
+	}
+}
+
 func deviceProfileWithMaxBitrate(profile DeviceProfile, maxStreamingBitrate int64) DeviceProfile {
 	profile.MaxStreamingBitrate = maxStreamingBitrate
 	return profile

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -149,6 +149,68 @@ func TestApplyCompatMaxStreamingBitrateCap(t *testing.T) {
 	}
 }
 
+func TestCompatLiveTranscodeHonorsMaxStreamingBitrateCap(t *testing.T) {
+	source1080p := PlaybackMediaSource{
+		Version: catalog.FileVersion{FileID: 1, Resolution: "1080p", Bitrate: 20_000},
+	}
+	tests := []struct {
+		name   string
+		opts   playback.TranscodeOpts
+		source PlaybackMediaSource
+		want   bool
+	}{
+		{
+			name:   "no cap always honored",
+			opts:   playback.TranscodeOpts{TargetBitrateKbps: 20_000},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 0},
+			want:   true,
+		},
+		{
+			name:   "video copy exempt from cap",
+			opts:   playback.TranscodeOpts{TargetCodecVideo: compatCopyCodec},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420},
+			want:   true,
+		},
+		{
+			name:   "unset live bitrate does not honor a cap",
+			opts:   playback.TranscodeOpts{TargetCodecVideo: compatTargetVideoCodec, TargetBitrateKbps: 0},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420},
+			want:   false,
+		},
+		{
+			name:   "live bitrate above the new cap does not honor it",
+			opts:   playback.TranscodeOpts{TargetCodecVideo: compatTargetVideoCodec, TargetBitrateKbps: 20_000},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420},
+			want:   false,
+		},
+		{
+			name:   "live bitrate under cap but source resolution not downscaled",
+			opts:   playback.TranscodeOpts{TargetCodecVideo: compatTargetVideoCodec, TargetBitrateKbps: 400},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420},
+			want:   false,
+		},
+		{
+			name:   "live bitrate and resolution both honor the cap",
+			opts:   playback.TranscodeOpts{TargetCodecVideo: compatTargetVideoCodec, TargetBitrateKbps: 400, TargetResolution: "480p"},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420},
+			want:   true,
+		},
+		{
+			name:   "cap loosened by a fresh negotiation is still honored by a tighter live encode",
+			opts:   playback.TranscodeOpts{TargetCodecVideo: compatTargetVideoCodec, TargetBitrateKbps: 4_000, TargetResolution: "720p"},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 10_000},
+			want:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compatLiveTranscodeHonorsMaxStreamingBitrateCap(tt.opts, tt.source); got != tt.want {
+				t.Errorf("compatLiveTranscodeHonorsMaxStreamingBitrateCap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildPlaybackSource4KVideoTranscodeGate(t *testing.T) {
 	version4K := catalog.FileVersion{
 		FileID:     1,

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -126,6 +126,29 @@ func TestDowngradeCompatLocalToneMapClearsOnlyAutomaticVideoToolboxBitrate(t *te
 	}
 }
 
+func TestApplyCompatMaxStreamingBitrateCap(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial int
+		cap     int
+		want    int
+	}{
+		{name: "no cap leaves target untouched", initial: 20_000, cap: 0, want: 20_000},
+		{name: "cap fills an unset target", initial: 0, cap: 4_000, want: 4_000},
+		{name: "cap overrides a looser auto target", initial: 20_000, cap: 4_000, want: 4_000},
+		{name: "auto target tighter than cap wins", initial: 2_000, cap: 4_000, want: 2_000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := playback.TranscodeOpts{TargetBitrateKbps: tt.initial}
+			applyCompatMaxStreamingBitrateCap(&opts, tt.cap)
+			if opts.TargetBitrateKbps != tt.want {
+				t.Fatalf("TargetBitrateKbps = %d, want %d", opts.TargetBitrateKbps, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildPlaybackSource4KVideoTranscodeGate(t *testing.T) {
 	version4K := catalog.FileVersion{
 		FileID:     1,

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -203,6 +203,101 @@ func TestBuildPlaybackSource4KVideoTranscodeGate(t *testing.T) {
 	}
 }
 
+func TestBuildPlaybackSourceMaxStreamingBitrateGate(t *testing.T) {
+	// A DirectPlayProfile that would otherwise allow direct play outright, so
+	// any denial in these cases must come from the bitrate cap, not codec
+	// mismatch.
+	permissive := DeviceProfile{
+		DirectPlayProfiles: []DirectPlayProfile{
+			{Type: "Video", Container: "mp4", VideoCodec: "h264", AudioCodec: "aac"},
+		},
+		TranscodingProfiles: []TranscodingProfile{
+			{Type: "Video", Protocol: "hls", Container: "ts", VideoCodec: "h264", AudioCodec: "aac"},
+		},
+	}
+	version := catalog.FileVersion{
+		FileID:     1,
+		Resolution: "1080p",
+		CodecVideo: "h264",
+		CodecAudio: "aac",
+		Container:  "mp4",
+		Bitrate:    20_000, // 20 Mbps source
+	}
+
+	tests := []struct {
+		name                 string
+		req                  playbackInfoRequest
+		profile              DeviceProfile
+		wantDirectPlay       bool
+		wantDirectStream     bool
+		wantHLSRemux         bool
+		wantMaxStreamingKbps int
+	}{
+		{
+			name:                 "no cap allows direct play",
+			req:                  playbackInfoRequest{},
+			profile:              permissive,
+			wantDirectPlay:       true,
+			wantDirectStream:     true,
+			wantMaxStreamingKbps: 0,
+		},
+		{
+			name:                 "cap above source bitrate allows direct play",
+			req:                  playbackInfoRequest{MaxStreamingBitrate: 25_000_000},
+			profile:              permissive,
+			wantDirectPlay:       true,
+			wantDirectStream:     true,
+			wantMaxStreamingKbps: 25_000,
+		},
+		{
+			name:                 "request cap below source bitrate forces transcode",
+			req:                  playbackInfoRequest{MaxStreamingBitrate: 4_000_000},
+			profile:              permissive,
+			wantMaxStreamingKbps: 4_000,
+		},
+		{
+			name:                 "device profile cap below source bitrate forces transcode",
+			req:                  playbackInfoRequest{},
+			profile:              deviceProfileWithMaxBitrate(permissive, 4_000_000),
+			wantMaxStreamingKbps: 4_000,
+		},
+		{
+			name: "tighter of the two caps applies",
+			req:  playbackInfoRequest{MaxStreamingBitrate: 25_000_000},
+			// Profile cap (4 Mbps) is tighter than the request cap (25 Mbps).
+			profile:              deviceProfileWithMaxBitrate(permissive, 4_000_000),
+			wantMaxStreamingKbps: 4_000,
+		},
+	}
+
+	h := &PlaybackHandler{codec: NewResourceIDCodec()}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := h.buildPlaybackSource("item", "ps", version, tt.profile, tt.req, false)
+			if source.SupportsDirectPlay != tt.wantDirectPlay {
+				t.Errorf("SupportsDirectPlay = %v, want %v", source.SupportsDirectPlay, tt.wantDirectPlay)
+			}
+			if source.SupportsDirectStream != tt.wantDirectStream {
+				t.Errorf("SupportsDirectStream = %v, want %v", source.SupportsDirectStream, tt.wantDirectStream)
+			}
+			if source.HLSRemux != tt.wantHLSRemux {
+				t.Errorf("HLSRemux = %v, want %v", source.HLSRemux, tt.wantHLSRemux)
+			}
+			if source.MaxStreamingBitrateKbps != tt.wantMaxStreamingKbps {
+				t.Errorf("MaxStreamingBitrateKbps = %d, want %d", source.MaxStreamingBitrateKbps, tt.wantMaxStreamingKbps)
+			}
+			if !tt.wantDirectPlay && !tt.wantDirectStream && !tt.wantHLSRemux && !source.SupportsTranscoding {
+				t.Error("expected a full transcode to remain available when direct methods are withheld")
+			}
+		})
+	}
+}
+
+func deviceProfileWithMaxBitrate(profile DeviceProfile, maxStreamingBitrate int64) DeviceProfile {
+	profile.MaxStreamingBitrate = maxStreamingBitrate
+	return profile
+}
+
 // TestApplyCompatToneMapAvailability verifies compatibility sources reflect executor availability.
 func TestApplyCompatToneMapAvailability(t *testing.T) {
 	hdrVersion := catalog.FileVersion{

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -326,27 +326,51 @@ func TestBuildPlaybackSourceMaxStreamingBitrateGateResolutionImplied(t *testing.
 			{Type: "Video", Protocol: "hls", Container: "ts", VideoCodec: "h264", AudioCodec: "aac"},
 		},
 	}
-	// An unusually efficient 1080p encode: its bitrate alone fits under a
-	// "720p - 4 Mbps" cap, but its resolution does not.
-	version := catalog.FileVersion{
-		FileID:     1,
-		Resolution: "1080p",
-		CodecVideo: "h264",
-		CodecAudio: "aac",
-		Container:  "mp4",
-		Bitrate:    3_000,
+
+	tests := []struct {
+		name    string
+		version catalog.FileVersion
+		req     playbackInfoRequest
+	}{
+		{
+			// An unusually efficient 1080p encode: its bitrate alone fits under
+			// a "720p - 4 Mbps" cap, but its resolution does not.
+			name: "1080p source under a 720p cap's bitrate",
+			version: catalog.FileVersion{
+				FileID: 1, Resolution: "1080p", CodecVideo: "h264", CodecAudio: "aac", Container: "mp4",
+				Bitrate: 3_000,
+			},
+			req: playbackInfoRequest{MaxStreamingBitrate: 4_000_000},
+		},
+		{
+			// Regression: 1440p sits strictly between the 1080p and 2160p
+			// buckets. Flooring it into the coarser "1080p" label before
+			// comparing would equate it with a genuine 1080p source and let
+			// it slip past a 10 Mbps ("1080p") cap unflagged.
+			name: "1440p source under a 1080p cap",
+			version: catalog.FileVersion{
+				FileID: 1, CodecVideo: "h264", CodecAudio: "aac", Container: "mp4",
+				VideoTracks: []models.VideoTrack{{Height: 1440}},
+				Bitrate:     3_000,
+			},
+			req: playbackInfoRequest{MaxStreamingBitrate: 10_000_000},
+		},
 	}
 
 	h := &PlaybackHandler{codec: NewResourceIDCodec()}
-	source := h.buildPlaybackSource("item", "ps", version, permissive, playbackInfoRequest{MaxStreamingBitrate: 4_000_000}, false)
-	if source.SupportsDirectPlay {
-		t.Error("SupportsDirectPlay = true, want false: source resolution exceeds the cap's implied 720p ceiling")
-	}
-	if source.SupportsDirectStream {
-		t.Error("SupportsDirectStream = true, want false: source resolution exceeds the cap's implied 720p ceiling")
-	}
-	if !source.SupportsTranscoding {
-		t.Error("expected a full transcode to remain available")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := h.buildPlaybackSource("item", "ps", tt.version, permissive, tt.req, false)
+			if source.SupportsDirectPlay {
+				t.Error("SupportsDirectPlay = true, want false: source resolution exceeds the cap's implied ceiling")
+			}
+			if source.SupportsDirectStream {
+				t.Error("SupportsDirectStream = true, want false: source resolution exceeds the cap's implied ceiling")
+			}
+			if !source.SupportsTranscoding {
+				t.Error("expected a full transcode to remain available")
+			}
+		})
 	}
 }
 
@@ -368,22 +392,21 @@ func TestCompatMaxResolutionForBitrateKbps(t *testing.T) {
 	}
 }
 
-func TestCompatResolutionLabelForHeight(t *testing.T) {
+func TestCompatResolutionCeilingHeight(t *testing.T) {
 	tests := []struct {
-		height int
-		want   string
+		label string
+		want  int
 	}{
-		{height: 0, want: ""},
-		{height: 480, want: "480p"},
-		{height: 576, want: "480p"},
-		{height: 720, want: "720p"},
-		{height: 1080, want: "1080p"},
-		{height: 2160, want: "2160p"},
-		{height: 4320, want: "4320p"},
+		{label: "", want: 0},
+		{label: "480p", want: 480},
+		{label: "720p", want: 720},
+		{label: "1080p", want: 1080},
+		{label: "2160p", want: 2160},
+		{label: "4320p", want: 4320},
 	}
 	for _, tt := range tests {
-		if got := compatResolutionLabelForHeight(tt.height); got != tt.want {
-			t.Errorf("compatResolutionLabelForHeight(%d) = %q, want %q", tt.height, got, tt.want)
+		if got := compatResolutionCeilingHeight(tt.label); got != tt.want {
+			t.Errorf("compatResolutionCeilingHeight(%q) = %d, want %d", tt.label, got, tt.want)
 		}
 	}
 }

--- a/internal/jellycompat/playback_4k_test.go
+++ b/internal/jellycompat/playback_4k_test.go
@@ -166,10 +166,16 @@ func TestCompatLiveTranscodeHonorsMaxStreamingBitrateCap(t *testing.T) {
 			want:   true,
 		},
 		{
-			name:   "video copy exempt from cap",
+			name:   "video copy exempt from cap when the source still permits copy",
 			opts:   playback.TranscodeOpts{TargetCodecVideo: compatCopyCodec},
-			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420, HLSRemux: true},
 			want:   true,
+		},
+		{
+			name:   "video copy rejected once a lower cap has cleared HLSRemux",
+			opts:   playback.TranscodeOpts{TargetCodecVideo: compatCopyCodec},
+			source: PlaybackMediaSource{Version: source1080p.Version, MaxStreamingBitrateKbps: 420, HLSRemux: false},
+			want:   false,
 		},
 		{
 			name:   "unset live bitrate does not honor a cap",

--- a/internal/jellycompat/playback_sessions.go
+++ b/internal/jellycompat/playback_sessions.go
@@ -94,6 +94,11 @@ type PlaybackMediaSource struct {
 	DefaultSubtitleStreamIndex  *int
 	SelectedSubtitleStreamIndex *int
 	ETag                        string
+	// MaxStreamingBitrateKbps is the client-requested ceiling negotiated for
+	// this source (0 = none). When the source's own bitrate exceeds it, direct
+	// play and any video-copy transport are withheld so only a real transcode
+	// remains, and that transcode is capped to this value.
+	MaxStreamingBitrateKbps int
 
 	// preservedJSON carries fields written by a newer binary through this
 	// binary's durable read-modify-write cycle. See playback_sessions_json.go.

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2652,6 +2652,10 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 				replaceUnlock()
 				return nil, readyErr
 			}
+			// As above: the downgrade may have cleared a VideoToolbox-derived
+			// bitrate that matched the pre-downgrade target, and this manifest-
+			// timeout fallback must not lose the client's own cap either.
+			applyCompatMaxStreamingBitrateCap(&opts, source.MaxStreamingBitrateKbps)
 			transcodeSession, err = playback.StartTranscode(ctx, opts)
 			if err != nil {
 				replaceUnlock()

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2572,11 +2572,10 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	// A client-requested MaxStreamingBitrate cap that forced this transcode
 	// (direct play and video-copy transports were withheld because the source
 	// exceeded it) must also bound the encode itself, or the "lower quality"
-	// pick still streams at the source's native bitrate. The VideoToolbox
-	// tone-map bitrate above is resolution-derived and takes priority when set.
-	if opts.TargetBitrateKbps == 0 && source.MaxStreamingBitrateKbps > 0 {
-		opts.TargetBitrateKbps = source.MaxStreamingBitrateKbps
-	}
+	// pick still streams at the source's native bitrate. It is a hard ceiling,
+	// so it wins even over an already-set VideoToolbox tone-map bitrate: that
+	// value is resolution-derived and knows nothing about the client's request.
+	applyCompatMaxStreamingBitrateCap(&opts, source.MaxStreamingBitrateKbps)
 	opts.SegmentDuration = h.compatSegmentDuration()
 
 	// Hold the per-session lifecycle lock across "check existing → spawn →
@@ -2602,6 +2601,9 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	manifestDeadline := time.Now().Add(compatManifestStartupTimeout)
 	transcodeSession, err := playback.StartTranscode(ctx, opts)
 	if err != nil && downgradeCompatLocalToneMap(&opts, toneMapCapabilities, autoVideoToolboxBitrate) {
+		// The downgrade clears a VideoToolbox-derived bitrate that matched the
+		// pre-downgrade target; the client's own cap must survive the retry.
+		applyCompatMaxStreamingBitrateCap(&opts, source.MaxStreamingBitrateKbps)
 		transcodeSession, err = playback.StartTranscode(ctx, opts)
 		if err == nil {
 			manifestDeadline = time.Now().Add(compatManifestStartupTimeout)
@@ -2694,6 +2696,19 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	publishUnlock()
 
 	return transcodeSession, nil
+}
+
+// applyCompatMaxStreamingBitrateCap tightens opts.TargetBitrateKbps to the
+// client's negotiated ceiling. It only ever lowers an existing target — a
+// tone-map-derived bitrate already under the cap is left alone — so it is
+// safe to call again after downgradeCompatLocalToneMap clears that target.
+func applyCompatMaxStreamingBitrateCap(opts *playback.TranscodeOpts, capKbps int) {
+	if opts == nil || capKbps <= 0 {
+		return
+	}
+	if opts.TargetBitrateKbps == 0 || capKbps < opts.TargetBitrateKbps {
+		opts.TargetBitrateKbps = capKbps
+	}
 }
 
 // downgradeCompatLocalToneMap removes the bitrate synthesized solely for a

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2745,6 +2745,14 @@ func downgradeCompatLocalToneMap(opts *playback.TranscodeOpts, capabilities tone
 	return true
 }
 
+// compatLiveTranscodeMatchesAudioSource reports whether a running transcode
+// still matches the negotiated source: same audio selection, same copy-video
+// choice, and — when the source carries a MaxStreamingBitrate cap — an encode
+// that still honors it. Every call site that decides whether to reuse a live
+// process gates on this function, so a live process minted before the cap
+// took effect (or before a viewer picked an even lower quality) must fail the
+// match here, or the viewer keeps streaming at the stale bitrate/resolution
+// for the rest of playback.
 func compatLiveTranscodeMatchesAudioSource(transcodeSession *playback.TranscodeSession, source PlaybackMediaSource) bool {
 	if transcodeSession == nil {
 		return false
@@ -2752,7 +2760,31 @@ func compatLiveTranscodeMatchesAudioSource(transcodeSession *playback.TranscodeS
 	opts := transcodeSession.Opts()
 	return opts.AudioTrackIndex == compatAudioTrackIndexOrDefault(source) &&
 		opts.SourceAudioChannels == compatHLSRecipeSourceAudioChannels(source) &&
-		opts.CopyVideoMPEGTS == source.HLSRemuxMPEGTS
+		opts.CopyVideoMPEGTS == source.HLSRemuxMPEGTS &&
+		compatLiveTranscodeHonorsMaxStreamingBitrateCap(opts, source)
+}
+
+// compatLiveTranscodeHonorsMaxStreamingBitrateCap reports whether an
+// already-running transcode's bitrate and resolution still satisfy the
+// source's currently negotiated MaxStreamingBitrate cap. No cap (0) or a
+// video-copy transport is always satisfied: a cap that permits copy in the
+// first place doesn't bound an encode that isn't happening.
+func compatLiveTranscodeHonorsMaxStreamingBitrateCap(opts playback.TranscodeOpts, source PlaybackMediaSource) bool {
+	if source.MaxStreamingBitrateKbps <= 0 || opts.TargetCodecVideo == compatCopyCodec {
+		return true
+	}
+	if opts.TargetBitrateKbps <= 0 || opts.TargetBitrateKbps > source.MaxStreamingBitrateKbps {
+		return false
+	}
+	resCap := compatMaxResolutionForBitrateKbps(source.MaxStreamingBitrateKbps)
+	if resCap == "" {
+		return true
+	}
+	sourceHeight := compatSourceVideoHeight(source.Version)
+	if sourceHeight <= 0 || sourceHeight <= compatResolutionCeilingHeight(resCap) {
+		return true
+	}
+	return opts.TargetResolution != "" && compatResolutionCeilingHeight(opts.TargetResolution) <= compatResolutionCeilingHeight(resCap)
 }
 
 func shouldGenerateCompatFullManifest(source PlaybackMediaSource, segmentDuration int) bool {

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/httpstream"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -2576,6 +2577,19 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	// so it wins even over an already-set VideoToolbox tone-map bitrate: that
 	// value is resolution-derived and knows nothing about the client's request.
 	applyCompatMaxStreamingBitrateCap(&opts, source.MaxStreamingBitrateKbps)
+	// The same cap implies a resolution ceiling (a "720p - 4 Mbps" profile
+	// expects 720p output, not a 4K frame starved down to 4 Mbps): downscale
+	// when the source exceeds what the cap's quality-profile resolution
+	// implies. Never upscale, and never override a resolution a tone-map
+	// recipe already pinned above.
+	if opts.TargetResolution == "" {
+		if resCap := compatMaxResolutionForBitrateKbps(source.MaxStreamingBitrateKbps); resCap != "" {
+			if sourceLabel := compatResolutionLabelForHeight(compatSourceVideoHeight(source.Version)); sourceLabel != "" &&
+				access.CompareQuality(sourceLabel, resCap) > 0 {
+				opts.TargetResolution = resCap
+			}
+		}
+	}
 	opts.SegmentDuration = h.compatSegmentDuration()
 
 	// Hold the per-session lifecycle lock across "check existing → spawn →

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2766,12 +2766,18 @@ func compatLiveTranscodeMatchesAudioSource(transcodeSession *playback.TranscodeS
 
 // compatLiveTranscodeHonorsMaxStreamingBitrateCap reports whether an
 // already-running transcode's bitrate and resolution still satisfy the
-// source's currently negotiated MaxStreamingBitrate cap. No cap (0) or a
-// video-copy transport is always satisfied: a cap that permits copy in the
-// first place doesn't bound an encode that isn't happening.
+// source's currently negotiated MaxStreamingBitrate cap. No cap (0) is always
+// satisfied. A video-copy transport is only exempt from the bitrate/
+// resolution check below when the refreshed source still permits copy at
+// all — a lower cap negotiated since this session started may have cleared
+// HLSRemux and now requires a real transcode, and an unconditional exemption
+// would keep reusing the uncapped copy session forever.
 func compatLiveTranscodeHonorsMaxStreamingBitrateCap(opts playback.TranscodeOpts, source PlaybackMediaSource) bool {
-	if source.MaxStreamingBitrateKbps <= 0 || opts.TargetCodecVideo == compatCopyCodec {
+	if source.MaxStreamingBitrateKbps <= 0 {
 		return true
+	}
+	if opts.TargetCodecVideo == compatCopyCodec {
+		return compatHLSCopiesVideo(source)
 	}
 	if opts.TargetBitrateKbps <= 0 || opts.TargetBitrateKbps > source.MaxStreamingBitrateKbps {
 		return false

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2569,6 +2569,14 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 			opts.TargetBitrateKbps = autoVideoToolboxBitrate
 		}
 	}
+	// A client-requested MaxStreamingBitrate cap that forced this transcode
+	// (direct play and video-copy transports were withheld because the source
+	// exceeded it) must also bound the encode itself, or the "lower quality"
+	// pick still streams at the source's native bitrate. The VideoToolbox
+	// tone-map bitrate above is resolution-derived and takes priority when set.
+	if opts.TargetBitrateKbps == 0 && source.MaxStreamingBitrateKbps > 0 {
+		opts.TargetBitrateKbps = source.MaxStreamingBitrateKbps
+	}
 	opts.SegmentDuration = h.compatSegmentDuration()
 
 	// Hold the per-session lifecycle lock across "check existing → spawn →

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2454,10 +2454,8 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 ) (*playback.TranscodeSession, error) {
 	sourceAudioChannels := compatHLSRecipeSourceAudioChannels(source)
 	audioTrackIndex := compatAudioTrackIndexOrDefault(source)
-	slog.WarnContext(ctx, "DEBUGCAP entry", "upstreamSessionID", upstreamSessionID, "sourceMaxStreamingBitrateKbps", source.MaxStreamingBitrateKbps, "hasExisting", h.tm.GetTranscodeSession(upstreamSessionID) != nil)
 	if existing := h.tm.GetTranscodeSession(upstreamSessionID); existing != nil && compatTranscodeSessionUsesToneMapMode(existing, requiredToneMapMode) {
 		if compatLiveTranscodeMatchesAudioSource(existing, source) {
-			slog.WarnContext(ctx, "DEBUGCAP reuse existing", "existingTargetBitrateKbps", existing.Opts().TargetBitrateKbps, "existingTargetResolution", existing.Opts().TargetResolution)
 			return existing, nil
 		}
 		return nil, errCompatRecipeSourceMismatch
@@ -2578,7 +2576,6 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	// so it wins even over an already-set VideoToolbox tone-map bitrate: that
 	// value is resolution-derived and knows nothing about the client's request.
 	applyCompatMaxStreamingBitrateCap(&opts, source.MaxStreamingBitrateKbps)
-	slog.WarnContext(ctx, "DEBUGCAP after apply", "sourceMaxStreamingBitrateKbps", source.MaxStreamingBitrateKbps, "optsTargetBitrateKbps", opts.TargetBitrateKbps, "compatHLSCopiesVideo", compatHLSCopiesVideo(source))
 	// The same cap implies a resolution ceiling (a "720p - 4 Mbps" profile
 	// expects 720p output, not a 4K frame starved down to 4 Mbps): downscale
 	// when the source exceeds what the cap's quality-profile resolution

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2454,8 +2454,10 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 ) (*playback.TranscodeSession, error) {
 	sourceAudioChannels := compatHLSRecipeSourceAudioChannels(source)
 	audioTrackIndex := compatAudioTrackIndexOrDefault(source)
+	slog.WarnContext(ctx, "DEBUGCAP entry", "upstreamSessionID", upstreamSessionID, "sourceMaxStreamingBitrateKbps", source.MaxStreamingBitrateKbps, "hasExisting", h.tm.GetTranscodeSession(upstreamSessionID) != nil)
 	if existing := h.tm.GetTranscodeSession(upstreamSessionID); existing != nil && compatTranscodeSessionUsesToneMapMode(existing, requiredToneMapMode) {
 		if compatLiveTranscodeMatchesAudioSource(existing, source) {
+			slog.WarnContext(ctx, "DEBUGCAP reuse existing", "existingTargetBitrateKbps", existing.Opts().TargetBitrateKbps, "existingTargetResolution", existing.Opts().TargetResolution)
 			return existing, nil
 		}
 		return nil, errCompatRecipeSourceMismatch
@@ -2576,6 +2578,7 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	// so it wins even over an already-set VideoToolbox tone-map bitrate: that
 	// value is resolution-derived and knows nothing about the client's request.
 	applyCompatMaxStreamingBitrateCap(&opts, source.MaxStreamingBitrateKbps)
+	slog.WarnContext(ctx, "DEBUGCAP after apply", "sourceMaxStreamingBitrateKbps", source.MaxStreamingBitrateKbps, "optsTargetBitrateKbps", opts.TargetBitrateKbps, "compatHLSCopiesVideo", compatHLSCopiesVideo(source))
 	// The same cap implies a resolution ceiling (a "720p - 4 Mbps" profile
 	// expects 720p output, not a 4K frame starved down to 4 Mbps): downscale
 	// when the source exceeds what the cap's quality-profile resolution

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/httpstream"
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -2584,8 +2583,8 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	// recipe already pinned above.
 	if opts.TargetResolution == "" {
 		if resCap := compatMaxResolutionForBitrateKbps(source.MaxStreamingBitrateKbps); resCap != "" {
-			if sourceLabel := compatResolutionLabelForHeight(compatSourceVideoHeight(source.Version)); sourceLabel != "" &&
-				access.CompareQuality(sourceLabel, resCap) > 0 {
+			if sourceHeight := compatSourceVideoHeight(source.Version); sourceHeight > 0 &&
+				sourceHeight > compatResolutionCeilingHeight(resCap) {
 				opts.TargetResolution = resCap
 			}
 		}


### PR DESCRIPTION
## Summary

- Fixes #873: selecting a lower quality profile (e.g. 720p - 4 Mbps) in a Jellyfin-compatible client no longer direct-plays a high-bitrate source at native resolution/bitrate.
- `buildPlaybackSource` now reads the client's `MaxStreamingBitrate` (top-level PlaybackInfo request field, previously not parsed at all) and the device profile's own `MaxStreamingBitrate`, and takes the tighter of the two.
- When the source's bitrate — or the resolution its quality-profile name implies (e.g. "720p - 4 Mbps" implies 720p) — exceeds that cap, direct play and any video-copy transport (progressive remux, HLS remux) are withheld, since none of them can reduce bitrate or resolution, leaving a full transcode as the only offered method.
- That forced transcode is itself capped via `TranscodeOpts.TargetBitrateKbps` and downscaled via `TargetResolution`, so the encode actually respects the requested ceiling instead of using an uncapped default. The cap is enforced as a hard ceiling even over an auto-derived VideoToolbox tone-map bitrate, and survives a tone-map software-fallback retry.
- `compatLiveTranscodeMatchesAudioSource` now also requires that a live transcode being considered for reuse still honors the source's currently negotiated cap (bitrate and resolution), so a process started before a viewer picked a lower quality isn't silently reused uncapped.

**AI disclosure:** This PR (including the follow-up fix for the live-transcode reuse gap) was developed with AI assistance (Claude).

## Test plan

- [x] `TestBuildPlaybackSourceMaxStreamingBitrateGate` — no cap, cap above source bitrate, request-level cap below source bitrate, device-profile-level cap below source bitrate, tighter-of-two-caps.
- [x] `TestBuildPlaybackSourceMaxStreamingBitrateGateResolutionImplied` — bitrate fits under the cap but resolution doesn't.
- [x] `TestApplyCompatMaxStreamingBitrateCap`, `TestCompatMaxResolutionForBitrateKbps`, `TestCompatResolutionLabelForHeight`.
- [x] `TestCompatLiveTranscodeHonorsMaxStreamingBitrateCap`.
- [x] `gofmt -l` clean on all touched files.
- [x] `go test ./internal/jellycompat/...`
- [x] Verified live end-to-end against a real Jellyfin Android client + real server deploy (not just unit tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for client-requested maximum streaming bitrate limits during playback.
  * Applies the stricter limit from client settings or device capabilities.
  * Limits transcoding quality to stay within permitted bitrate and resolution.

* **Bug Fixes**
  * Prevented direct playback and video copying when media exceeds negotiated limits.
  * Ensured transcoded and tone-mapped streams remain within the bitrate ceiling.

* **Tests**
  * Added coverage for bitrate and resolution limit negotiation and enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
