### PR TITLE
fix(historyimport): match localized Plex admin history

### DIFF
--- a/internal/historyimport/plex_admin_provider.go
+++ b/internal/historyimport/plex_admin_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 )
 
 // PlexAdminProvider fetches watch history for a specific Plex account using an admin token.
@@ -133,10 +134,13 @@ func (p *PlexAdminProvider) fetchItemMetadata(
 			noteErr(err, batch)
 			continue
 		}
-		// A batch request fails as a whole (for example when every key in it was
-		// deleted from the library). Retry its keys one at a time so a single bad
-		// key cannot take the rest of the batch down with it.
+		// Plex can return 404 for a whole batch when only one key was deleted.
+		// Retry that case per key, but do not multiply systematic failures such as
+		// authentication errors, outages, or timeouts into one request per item.
 		noteErr(err, batch)
+		if !isPlexHTTPStatus(err, http.StatusNotFound) {
+			continue
+		}
 		for _, key := range batch {
 			meta, err := p.client.FetchMetadata(ctx, p.baseURL, p.token, key)
 			if err != nil {

--- a/internal/historyimport/plex_admin_provider.go
+++ b/internal/historyimport/plex_admin_provider.go
@@ -36,13 +36,17 @@ func (p *PlexAdminProvider) Fetch(ctx context.Context) ([]Record, []string, erro
 	}
 
 	var warnings []string
-
 	// Enrich episodes with series-level metadata (for external IDs on the series).
 	seriesMeta := p.fetchSeriesMetadata(ctx, items, &warnings)
+	itemMeta, err := p.fetchItemMetadata(ctx, items, seriesMeta, &warnings)
+	if err != nil {
+		return nil, warnings, err
+	}
 
 	// Normalize history items to Records, then deduplicate by rating key.
 	merged := make(map[string]Record, len(items))
 	for _, item := range items {
+		item = enrichPlexHistoryItem(item, itemMeta[item.RatingKey])
 		record := NormalizePlexHistoryItem(item, seriesMeta[item.GrandparentRatingKey])
 		if record.ExternalID == "" {
 			continue
@@ -60,6 +64,119 @@ func (p *PlexAdminProvider) Fetch(ctx context.Context) ([]Record, []string, erro
 		records = append(records, record)
 	}
 	return records, warnings, nil
+}
+
+// fetchItemMetadata resolves external provider IDs omitted by Plex's session-history
+// endpoint. Only movies and episodes are looked up: the matcher rejects every other
+// kind, so fetching metadata for music tracks or clips would be wasted requests.
+// Rating keys are fetched once each, in batches, because one item can appear many
+// times in the raw history. Individual failures stay best-effort so exact title/year
+// matching can still run; only context cancellation aborts the sweep.
+func (p *PlexAdminProvider) fetchItemMetadata(
+	ctx context.Context,
+	items []PlexHistoryItem,
+	seriesMeta map[string]*PlexItem,
+	warnings *[]string,
+) (map[string]*PlexItem, error) {
+	// A rating key is resolved when any of its history entries already carries usable
+	// ids (Plex is inconsistent about including Guid on history rows for one item).
+	kinds := make(map[string]string)
+	resolved := make(map[string]struct{})
+	for _, item := range items {
+		if item.RatingKey == "" || (item.Type != KindMovie && item.Type != KindEpisode) {
+			continue
+		}
+		kinds[item.RatingKey] = item.Type
+		if hasMatchablePlexGuidForKind(item.Guid, item.Type) || hasMatchableSeriesFallback(item, seriesMeta) {
+			resolved[item.RatingKey] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{}, len(kinds))
+	var pending []string
+	for _, item := range items {
+		if _, ok := kinds[item.RatingKey]; !ok {
+			continue
+		}
+		if _, ok := resolved[item.RatingKey]; ok {
+			continue
+		}
+		if _, ok := seen[item.RatingKey]; ok {
+			continue
+		}
+		seen[item.RatingKey] = struct{}{}
+		pending = append(pending, item.RatingKey)
+	}
+
+	result := make(map[string]*PlexItem, len(pending))
+	var firstErr error
+	noteErr := func(err error, keys []string) {
+		slog.WarnContext(ctx, "plex admin history import: failed to fetch item metadata",
+			"component", "historyimport", "rating_keys", keys, "error", err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	for start := 0; start < len(pending); start += plexMetadataBatchSize {
+		batch := pending[start:min(start+plexMetadataBatchSize, len(pending))]
+		metas, err := p.client.FetchMetadataBatch(ctx, p.baseURL, p.token, batch)
+		if err == nil {
+			for i := range metas {
+				result[metas[i].RatingKey] = &metas[i]
+			}
+			continue
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if len(batch) == 1 {
+			noteErr(err, batch)
+			continue
+		}
+		// A batch request fails as a whole (for example when every key in it was
+		// deleted from the library). Retry its keys one at a time so a single bad
+		// key cannot take the rest of the batch down with it.
+		noteErr(err, batch)
+		for _, key := range batch {
+			meta, err := p.client.FetchMetadata(ctx, p.baseURL, p.token, key)
+			if err != nil {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				noteErr(err, []string{key})
+				continue
+			}
+			if meta != nil {
+				result[key] = meta
+			}
+		}
+	}
+
+	unresolved := 0
+	for _, key := range pending {
+		meta, ok := result[key]
+		if !ok || !hasMatchablePlexGuidForKind(meta.Guid, kinds[key]) {
+			unresolved++
+		}
+	}
+	if unresolved > 0 {
+		*warnings = append(*warnings, plexUnresolvedIDsWarning(
+			"plex admin history", "unique items", unresolved, len(pending), firstErr))
+	}
+	return result, nil
+}
+
+func enrichPlexHistoryItem(item PlexHistoryItem, meta *PlexItem) PlexHistoryItem {
+	item.Guid, item.Year = applyPlexMetadataFallback(item.Guid, item.Year, item.Type, meta)
+	return item
+}
+
+func hasMatchableSeriesFallback(item PlexHistoryItem, seriesMeta map[string]*PlexItem) bool {
+	if item.Type != KindEpisode || item.Index <= 0 {
+		return false
+	}
+	series := seriesMeta[item.GrandparentRatingKey]
+	return series != nil && hasMatchablePlexGuidForKind(series.Guid, KindSeries)
 }
 
 // fetchSeriesMetadata fetches metadata for all unique series referenced by episode items.

--- a/internal/historyimport/plex_admin_provider_test.go
+++ b/internal/historyimport/plex_admin_provider_test.go
@@ -484,6 +484,82 @@ func TestPlexAdminProviderRetriesFailedBatchPerKey(t *testing.T) {
 	}
 }
 
+func TestPlexAdminProviderDoesNotRetrySystematicBatchFailurePerKey(t *testing.T) {
+	t.Parallel()
+
+	const movieCount = plexMetadataBatchSize*2 + 1
+	var history strings.Builder
+	history.WriteString(`{"MediaContainer":{"totalSize":` + fmt.Sprint(movieCount) + `,"Metadata":[`)
+	for i := 1; i <= movieCount; i++ {
+		if i > 1 {
+			history.WriteByte(',')
+		}
+		_, _ = fmt.Fprintf(&history, `{"ratingKey":"%d","type":"movie","title":"Film %d"}`, i, i)
+	}
+	history.WriteString(`]}}`)
+
+	metadataCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/status/sessions/history/all" {
+			_, _ = fmt.Fprint(w, history.String())
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/library/metadata/") {
+			metadataCalls++
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		t.Errorf("unexpected path %q", r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	wantBatchCalls := (movieCount + plexMetadataBatchSize - 1) / plexMetadataBatchSize
+	if metadataCalls != wantBatchCalls {
+		t.Fatalf("metadata calls = %d, want %d batch requests and no per-key retries", metadataCalls, wantBatchCalls)
+	}
+	if len(records) != movieCount {
+		t.Fatalf("records = %d, want all %d title/year fallback records", len(records), movieCount)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], fmt.Sprintf("%d of %d unique items", movieCount, movieCount)) {
+		t.Fatalf("warnings = %v, want one aggregated warning for all unresolved items", warnings)
+	}
+}
+
+func TestFetchMetadataBatchReadsVideoResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/library/metadata/42" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"MediaContainer":{"Video":[
+			{"ratingKey":"42","type":"movie","Guid":[{"id":"tmdb://278"}]}
+		]}}`)
+	}))
+	defer server.Close()
+
+	items, err := newUnthrottledPlexClient().FetchMetadataBatch(
+		context.Background(), server.URL, "admin-token", []string{"42"},
+	)
+	if err != nil {
+		t.Fatalf("FetchMetadataBatch: %v", err)
+	}
+	if len(items) != 1 || items[0].RatingKey != "42" {
+		t.Fatalf("items = %+v, want metadata returned through Video", items)
+	}
+}
+
 func TestPlexAdminProviderSkipsMetadataForNonVideoItems(t *testing.T) {
 	t.Parallel()
 

--- a/internal/historyimport/plex_admin_provider_test.go
+++ b/internal/historyimport/plex_admin_provider_test.go
@@ -1,0 +1,565 @@
+package historyimport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPlexAdminProviderEnrichesLocalizedMovieForStableMatching(t *testing.T) {
+	t.Parallel()
+
+	metadataCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":1,"Metadata":[
+				{"ratingKey":"42","type":"movie","title":"Skazani na Shawshank","year":1994,"viewedAt":1700000000}
+			]}}`)
+		case "/library/metadata/42":
+			metadataCalls++
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+				{"ratingKey":"42","type":"movie","title":"The Shawshank Redemption","year":1994,
+				 "Guid":[{"id":"imdb://tt0111161"},{"id":"tmdb://278"}]}
+			]}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	provider := NewPlexAdminProvider(newUnthrottledPlexClient(), server.URL, "admin-token", "7")
+	records, warnings, err := provider.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if metadataCalls != 1 {
+		t.Fatalf("metadata calls = %d, want 1", metadataCalls)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record.Title != "Skazani na Shawshank" {
+		t.Fatalf("title = %q, want original localized history title", record.Title)
+	}
+	if record.TMDBID != "278" || record.IMDbID != "tt0111161" {
+		t.Fatalf("ids = tmdb %q imdb %q, want enriched provider ids", record.TMDBID, record.IMDbID)
+	}
+
+	repo := &matcherRepoStub{mediaByExternal: map[string][]mediaLookupRow{
+		"movie:tmdb_id:278": {{ContentID: "movie-278", Title: "The Shawshank Redemption", Year: 1994}},
+	}}
+	match, reason, err := NewMatcher(repo).Match(context.Background(), record)
+	if err != nil || reason != "" || match == nil || match.MediaItemID != "movie-278" {
+		t.Fatalf("match = %+v, reason = %q, err = %v", match, reason, err)
+	}
+}
+
+func TestPlexAdminProviderTreatsPlexOnlyGuidAsUnresolved(t *testing.T) {
+	t.Parallel()
+
+	metadataCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":1,"Metadata":[
+				{"ratingKey":"9","type":"movie","title":"Diuna","year":2021,"Guid":"plex://movie/abc"}
+			]}}`)
+		case "/library/metadata/9":
+			metadataCalls++
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+				{"ratingKey":"9","type":"movie","Guid":[{"id":"tmdb://438631"}]}
+			]}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 || metadataCalls != 1 || len(records) != 1 || records[0].TMDBID != "438631" {
+		t.Fatalf("records = %+v, warnings = %v, metadata calls = %d", records, warnings, metadataCalls)
+	}
+}
+
+func TestPlexAdminProviderTreatsMovieTVDBGuidAsUnresolved(t *testing.T) {
+	t.Parallel()
+
+	metadataCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":1,"Metadata":[
+				{"ratingKey":"9","type":"movie","title":"Diuna","year":2021,"Guid":[{"id":"tvdb://12345"}]}
+			]}}`)
+		case "/library/metadata/9":
+			metadataCalls++
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+				{"ratingKey":"9","type":"movie","Guid":[{"id":"tmdb://438631"}]}
+			]}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 || metadataCalls != 1 || len(records) != 1 ||
+		records[0].TMDBID != "438631" || records[0].TVDBID != "12345" {
+		t.Fatalf("records = %+v, warnings = %v, metadata calls = %d", records, warnings, metadataCalls)
+	}
+}
+
+func TestPlexAdminProviderFetchesMetadataOncePerRatingKey(t *testing.T) {
+	t.Parallel()
+
+	metadataCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":2,"Metadata":[
+				{"ratingKey":"42","type":"movie","title":"Film","viewedAt":100},
+				{"ratingKey":"42","type":"movie","title":"Film","viewedAt":200}
+			]}}`)
+		case "/library/metadata/42":
+			metadataCalls++
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+				{"ratingKey":"42","type":"movie","year":2020,"Guid":[{"id":"tmdb://42"}]}
+			]}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if metadataCalls != 1 {
+		t.Fatalf("metadata calls = %d, want 1", metadataCalls)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want one deduplicated record", len(records))
+	}
+	if records[0].Year != 2020 {
+		t.Fatalf("year = %d, want metadata fallback year", records[0].Year)
+	}
+	wantLastPlayed := time.Unix(200, 0).UTC()
+	if records[0].LastPlayedAt == nil || !records[0].LastPlayedAt.Equal(wantLastPlayed) {
+		t.Fatalf("last played = %v, want %v", records[0].LastPlayedAt, wantLastPlayed)
+	}
+}
+
+func TestPlexAdminProviderSkipsMetadataForStableProviderGuid(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/status/sessions/history/all" {
+			t.Errorf("unexpected metadata request to %q", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":2,"Metadata":[
+			{"ratingKey":"42","type":"movie","title":"Film","year":2020},
+			{"ratingKey":"42","type":"movie","title":"Film","year":2020,"Guid":[{"id":"tmdb://42"}]}
+		]}}`)
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 || len(records) != 1 || records[0].TMDBID != "42" {
+		t.Fatalf("records = %+v, warnings = %v", records, warnings)
+	}
+}
+
+func TestPlexAdminProviderMetadataFailureFallsBackToTitleYear(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response string
+		status   int
+	}{
+		{name: "request failure", status: http.StatusInternalServerError},
+		{name: "empty metadata", status: http.StatusOK, response: `{"MediaContainer":{"Metadata":[]}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/status/sessions/history/all":
+					_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":1,"Metadata":[
+						{"ratingKey":"42","type":"movie","title":"Arrival","year":2016}
+					]}}`)
+				case "/library/metadata/42":
+					w.WriteHeader(tt.status)
+					_, _ = fmt.Fprint(w, tt.response)
+				default:
+					t.Errorf("unexpected path %q", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			records, warnings, err := NewPlexAdminProvider(
+				newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+			).Fetch(context.Background())
+			if err != nil {
+				t.Fatalf("Fetch: %v", err)
+			}
+			if len(records) != 1 || records[0].Title != "Arrival" || records[0].Year != 2016 {
+				t.Fatalf("records = %+v, want title/year fallback record", records)
+			}
+			if len(warnings) != 1 || !strings.Contains(warnings[0], "1 of 1 unique items") {
+				t.Fatalf("warnings = %v, want one aggregated unresolved warning", warnings)
+			}
+			if tt.status != http.StatusOK && !strings.Contains(warnings[0], "plex http 500") {
+				t.Fatalf("warnings = %v, want the first upstream error named", warnings)
+			}
+
+			repo := &matcherRepoStub{mediaByTitleYear: map[string][]mediaLookupRow{
+				"movie:Arrival:2016": {{ContentID: "movie-arrival", Title: "Arrival", Year: 2016}},
+			}}
+			match, reason, err := NewMatcher(repo).Match(context.Background(), records[0])
+			if err != nil || reason != "" || match == nil || match.MediaItemID != "movie-arrival" {
+				t.Fatalf("fallback match = %+v, reason = %q, err = %v", match, reason, err)
+			}
+		})
+	}
+}
+
+func TestPlexAdminProviderPreservesEpisodeSeriesEnrichment(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":1,"Metadata":[
+				{"ratingKey":"episode-1","type":"episode","title":"Pilot","grandparentTitle":"Rozdzielenie",
+				 "grandparentRatingKey":"series-1","parentIndex":1,"index":1,"Guid":[{"id":"tvdb://episode-1"}]}
+			]}}`)
+		case "/library/metadata/series-1":
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+				{"ratingKey":"series-1","type":"show","title":"Severance","year":2022,
+				 "Guid":[{"id":"tvdb://371980"}]}
+			]}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 || len(records) != 1 {
+		t.Fatalf("records = %+v, warnings = %v", records, warnings)
+	}
+	if records[0].SeriesTVDBID != "371980" || records[0].SeriesYear != 2022 {
+		t.Fatalf("series identity = tvdb %q year %d", records[0].SeriesTVDBID, records[0].SeriesYear)
+	}
+}
+
+func TestPlexAdminProviderUsesOneSeriesRequestForEpisodeHistory(t *testing.T) {
+	t.Parallel()
+
+	const episodeCount = 100
+	var history strings.Builder
+	history.WriteString(`{"MediaContainer":{"totalSize":100,"Metadata":[`)
+	for i := 1; i <= episodeCount; i++ {
+		if i > 1 {
+			history.WriteByte(',')
+		}
+		_, _ = fmt.Fprintf(&history,
+			`{"ratingKey":"episode-%d","type":"episode","title":"Odcinek %d","grandparentTitle":"Rozdzielenie","grandparentRatingKey":"series-1","parentIndex":1,"index":%d}`,
+			i, i, i,
+		)
+	}
+	history.WriteString(`]}}`)
+
+	seriesMetadataCalls := 0
+	episodeMetadataCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, history.String())
+		case "/library/metadata/series-1":
+			seriesMetadataCalls++
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+				{"ratingKey":"series-1","type":"show","title":"Severance","year":2022,
+				 "Guid":[{"id":"tvdb://371980"}]}
+			]}}`)
+		default:
+			if strings.HasPrefix(r.URL.Path, "/library/metadata/episode-") {
+				episodeMetadataCalls++
+			}
+			t.Errorf("unexpected metadata request to %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(records) != episodeCount {
+		t.Fatalf("records = %d, want %d", len(records), episodeCount)
+	}
+	if seriesMetadataCalls != 1 || episodeMetadataCalls != 0 {
+		t.Fatalf("series metadata calls = %d, episode metadata calls = %d; want 1 and 0", seriesMetadataCalls, episodeMetadataCalls)
+	}
+	for _, record := range records {
+		if record.SeriesTVDBID != "371980" || record.EpisodeNumber <= 0 {
+			t.Fatalf("record = %+v, want series identity and episode coordinates", record)
+		}
+	}
+}
+
+func TestPlexAdminProviderBatchesItemMetadataRequests(t *testing.T) {
+	t.Parallel()
+
+	const movieCount = plexMetadataBatchSize + 5
+	var history, batchOne, batchTwo strings.Builder
+	history.WriteString(`{"MediaContainer":{"totalSize":` + fmt.Sprint(movieCount) + `,"Metadata":[`)
+	for i := 1; i <= movieCount; i++ {
+		if i > 1 {
+			history.WriteByte(',')
+		}
+		_, _ = fmt.Fprintf(&history, `{"ratingKey":"%d","type":"movie","title":"Film %d","viewedAt":%d}`, i, i, i)
+		target := &batchOne
+		if i > plexMetadataBatchSize {
+			target = &batchTwo
+		}
+		if target.Len() > 0 {
+			target.WriteByte(',')
+		}
+		_, _ = fmt.Fprintf(target, `{"ratingKey":"%d","type":"movie","year":2000,"Guid":[{"id":"tmdb://%d"}]}`, i, i)
+	}
+	history.WriteString(`]}}`)
+
+	var metadataPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, history.String())
+		case strings.HasPrefix(r.URL.Path, "/library/metadata/"):
+			metadataPaths = append(metadataPaths, r.URL.Path)
+			keys := strings.Split(strings.TrimPrefix(r.URL.Path, "/library/metadata/"), ",")
+			body := &batchOne
+			if keys[0] != "1" {
+				body = &batchTwo
+			}
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[`+body.String()+`]}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+	if len(metadataPaths) != 2 {
+		t.Fatalf("metadata requests = %v, want two batches", metadataPaths)
+	}
+	if got := strings.Count(metadataPaths[0], ",") + 1; got != plexMetadataBatchSize {
+		t.Fatalf("first batch carried %d keys, want %d (%s)", got, plexMetadataBatchSize, metadataPaths[0])
+	}
+	if len(records) != movieCount {
+		t.Fatalf("records = %d, want %d", len(records), movieCount)
+	}
+	for _, record := range records {
+		if record.TMDBID != record.ExternalID || record.Year != 2000 {
+			t.Fatalf("record = %+v, want enriched from its batch", record)
+		}
+	}
+}
+
+func TestPlexAdminProviderRetriesFailedBatchPerKey(t *testing.T) {
+	t.Parallel()
+
+	var metadataPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/status/sessions/history/all":
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":2,"Metadata":[
+				{"ratingKey":"1","type":"movie","title":"Kept","year":2001},
+				{"ratingKey":"2","type":"movie","title":"Deleted","year":2002}
+			]}}`)
+		case "/library/metadata/1,2", "/library/metadata/2":
+			metadataPaths = append(metadataPaths, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		case "/library/metadata/1":
+			metadataPaths = append(metadataPaths, r.URL.Path)
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"Metadata":[
+				{"ratingKey":"1","type":"movie","Guid":[{"id":"tmdb://1"}]}
+			]}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(metadataPaths) != 3 {
+		t.Fatalf("metadata requests = %v, want batch then one per key", metadataPaths)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "1 of 2 unique items") || !strings.Contains(warnings[0], "plex http 404") {
+		t.Fatalf("warnings = %v, want one unresolved item with the first error named", warnings)
+	}
+	byKey := map[string]Record{}
+	for _, record := range records {
+		byKey[record.ExternalID] = record
+	}
+	if byKey["1"].TMDBID != "1" || byKey["2"].TMDBID != "" || byKey["2"].Title != "Deleted" {
+		t.Fatalf("records = %+v, want key 1 enriched and key 2 on title/year fallback", records)
+	}
+}
+
+func TestPlexAdminProviderSkipsMetadataForNonVideoItems(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/status/sessions/history/all" {
+			t.Errorf("unexpected metadata request to %q", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":2,"Metadata":[
+			{"ratingKey":"song-1","type":"track","title":"Song","viewedAt":100},
+			{"ratingKey":"clip-1","type":"clip","title":"Trailer","viewedAt":200}
+		]}}`)
+	}))
+	defer server.Close()
+
+	_, warnings, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none for kinds the matcher does not support", warnings)
+	}
+}
+
+func TestPlexAdminProviderAbortsMetadataSweepOnCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	metadataCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/status/sessions/history/all":
+			var history strings.Builder
+			history.WriteString(`{"MediaContainer":{"totalSize":200,"Metadata":[`)
+			for i := 1; i <= 200; i++ {
+				if i > 1 {
+					history.WriteByte(',')
+				}
+				_, _ = fmt.Fprintf(&history, `{"ratingKey":"%d","type":"movie","title":"Film %d"}`, i, i)
+			}
+			history.WriteString(`]}}`)
+			_, _ = fmt.Fprint(w, history.String())
+		case strings.HasPrefix(r.URL.Path, "/library/metadata/"):
+			metadataCalls++
+			// The run is canceled while the first batch is in flight.
+			cancel()
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	records, _, err := NewPlexAdminProvider(
+		newUnthrottledPlexClient(), server.URL, "admin-token", "7",
+	).Fetch(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if records != nil {
+		t.Fatalf("records = %d, want none after cancellation", len(records))
+	}
+	if metadataCalls != 1 {
+		t.Fatalf("metadata calls = %d, want the sweep to stop at the first canceled request", metadataCalls)
+	}
+}
+
+func newUnthrottledPlexClient() *PlexClient {
+	client := NewPlexClient()
+	client.limiter = nil
+	return client
+}

--- a/internal/historyimport/plex_client.go
+++ b/internal/historyimport/plex_client.go
@@ -3,6 +3,7 @@ package historyimport
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -328,10 +329,12 @@ func (c *PlexClient) FetchWatchlist(ctx context.Context, accountToken string) ([
 	var warnings []string
 	var firstErr error
 	unresolved := 0
+	attempted := 0
 	for i := range allItems {
 		if len(allItems[i].Guid) > 0 {
 			continue
 		}
+		attempted++
 		detail, err := c.fetchWatchlistItemMetadata(ctx, base, accountToken, allItems[i].RatingKey)
 		if err != nil && firstErr == nil {
 			firstErr = err
@@ -344,7 +347,7 @@ func (c *PlexClient) FetchWatchlist(ctx context.Context, accountToken string) ([
 			allItems[i].Guid, allItems[i].Year, allItems[i].Type, detail)
 	}
 	if unresolved > 0 {
-		warnings = append(warnings, plexUnresolvedIDsWarning("watchlist", "items", unresolved, len(allItems), firstErr))
+		warnings = append(warnings, plexUnresolvedIDsWarning("watchlist", "items", unresolved, attempted, firstErr))
 	}
 	return allItems, warnings, nil
 }
@@ -414,7 +417,7 @@ func (c *PlexClient) FetchMetadataBatch(ctx context.Context, baseURL, token stri
 	if err := c.doJSON(req, &container); err != nil {
 		return nil, fmt.Errorf("fetching Plex metadata for %s: %w", strings.Join(ratingKeys, ","), err)
 	}
-	return container.MediaContainer.Metadata, nil
+	return container.items(), nil
 }
 
 // Authenticate exchanges Plex account credentials for an auth token via plex.tv.
@@ -472,6 +475,11 @@ func (c *PlexClient) doJSON(req *http.Request, out any) error {
 type plexHTTPError struct {
 	StatusCode int
 	Body       string
+}
+
+func isPlexHTTPStatus(err error, statusCode int) bool {
+	var httpErr *plexHTTPError
+	return errors.As(err, &httpErr) && httpErr.StatusCode == statusCode
 }
 
 func (e *plexHTTPError) Error() string {

--- a/internal/historyimport/plex_client.go
+++ b/internal/historyimport/plex_client.go
@@ -25,6 +25,11 @@ const (
 	// rejects the PMS page size with 400 "Invalid value provided for
 	// x-plex-container-size!".
 	plexWatchlistPageSize = 100
+	// plexMetadataBatchSize caps how many rating keys one /library/metadata/{a,b,c}
+	// request carries. The PMS accepts comma-separated keys; batching keeps a
+	// history sweep of thousands of id-less items to a handful of requests under
+	// the shared upstream rate limit.
+	plexMetadataBatchSize = 50
 )
 
 type PlexClient struct {
@@ -321,25 +326,25 @@ func (c *PlexClient) FetchWatchlist(ctx context.Context, accountToken string) ([
 	}
 
 	var warnings []string
+	var firstErr error
 	unresolved := 0
 	for i := range allItems {
 		if len(allItems[i].Guid) > 0 {
 			continue
 		}
 		detail, err := c.fetchWatchlistItemMetadata(ctx, base, accountToken, allItems[i].RatingKey)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
 		if err != nil || detail == nil {
 			unresolved++
 			continue
 		}
-		allItems[i].Guid = detail.Guid
-		if allItems[i].Year == 0 {
-			allItems[i].Year = detail.Year
-		}
+		allItems[i].Guid, allItems[i].Year = applyPlexMetadataFallback(
+			allItems[i].Guid, allItems[i].Year, allItems[i].Type, detail)
 	}
 	if unresolved > 0 {
-		warnings = append(warnings, fmt.Sprintf(
-			"watchlist: could not resolve external ids for %d of %d items; those fall back to exact title/year matching",
-			unresolved, len(allItems)))
+		warnings = append(warnings, plexUnresolvedIDsWarning("watchlist", "items", unresolved, len(allItems), firstErr))
 	}
 	return allItems, warnings, nil
 }
@@ -378,7 +383,28 @@ func (c *PlexClient) FetchOnDeck(ctx context.Context, baseURL, token string) ([]
 }
 
 func (c *PlexClient) FetchMetadata(ctx context.Context, baseURL, token, ratingKey string) (*PlexItem, error) {
-	reqURL := fmt.Sprintf("%s/library/metadata/%s?includeGuids=1", baseURL, url.PathEscape(ratingKey))
+	items, err := c.FetchMetadataBatch(ctx, baseURL, token, []string{ratingKey})
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return &items[0], nil
+}
+
+// FetchMetadataBatch fetches full metadata for several rating keys in one request
+// (GET /library/metadata/{k1,k2,...}). Keys the server no longer knows are simply
+// absent from the result; callers match returned items on RatingKey.
+func (c *PlexClient) FetchMetadataBatch(ctx context.Context, baseURL, token string, ratingKeys []string) ([]PlexItem, error) {
+	if len(ratingKeys) == 0 {
+		return nil, nil
+	}
+	escaped := make([]string, len(ratingKeys))
+	for i, key := range ratingKeys {
+		escaped[i] = url.PathEscape(key)
+	}
+	reqURL := fmt.Sprintf("%s/library/metadata/%s?includeGuids=1", baseURL, strings.Join(escaped, ","))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
@@ -386,12 +412,9 @@ func (c *PlexClient) FetchMetadata(ctx context.Context, baseURL, token, ratingKe
 	c.setPlexHeaders(req, token)
 	var container plexMediaContainer
 	if err := c.doJSON(req, &container); err != nil {
-		return nil, fmt.Errorf("fetching Plex metadata for %s: %w", ratingKey, err)
+		return nil, fmt.Errorf("fetching Plex metadata for %s: %w", strings.Join(ratingKeys, ","), err)
 	}
-	if len(container.MediaContainer.Metadata) == 0 {
-		return nil, nil
-	}
-	return &container.MediaContainer.Metadata[0], nil
+	return container.MediaContainer.Metadata, nil
 }
 
 // Authenticate exchanges Plex account credentials for an auth token via plex.tv.

--- a/internal/historyimport/plex_normalize.go
+++ b/internal/historyimport/plex_normalize.go
@@ -1,6 +1,7 @@
 package historyimport
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -133,4 +134,61 @@ func ParsePlexGuids(guids PlexGuids, imdbID, tmdbID, tvdbID *string) {
 			}
 		}
 	}
+}
+
+func hasMatchablePlexGuidForKind(guids PlexGuids, kind string) bool {
+	var imdbID, tmdbID, tvdbID string
+	ParsePlexGuids(guids, &imdbID, &tmdbID, &tvdbID)
+	if kind == KindMovie {
+		return imdbID != "" || tmdbID != ""
+	}
+	return imdbID != "" || tmdbID != "" || tvdbID != ""
+}
+
+// applyPlexMetadataFallback fills provider ids and year that a listing omitted from a
+// full metadata record. Ids are only overlaid when the listing carries none the matcher
+// can use for kind, and only the providers still missing are added, so ids Plex did
+// return on the listing always win.
+func applyPlexMetadataFallback(guid PlexGuids, year int, kind string, meta *PlexItem) (PlexGuids, int) {
+	if meta == nil {
+		return guid, year
+	}
+	if !hasMatchablePlexGuidForKind(guid, kind) && hasMatchablePlexGuidForKind(meta.Guid, kind) {
+		guid = overlayMissingPlexGuids(guid, meta.Guid)
+	}
+	if year == 0 {
+		year = meta.Year
+	}
+	return guid, year
+}
+
+func overlayMissingPlexGuids(existing, metadata PlexGuids) PlexGuids {
+	var existingIMDbID, existingTMDBID, existingTVDBID string
+	ParsePlexGuids(existing, &existingIMDbID, &existingTMDBID, &existingTVDBID)
+	var metadataIMDbID, metadataTMDBID, metadataTVDBID string
+	ParsePlexGuids(metadata, &metadataIMDbID, &metadataTMDBID, &metadataTVDBID)
+
+	result := append(PlexGuids(nil), existing...)
+	if existingIMDbID == "" && metadataIMDbID != "" {
+		result = append(result, PlexGuid{ID: "imdb://" + metadataIMDbID})
+	}
+	if existingTMDBID == "" && metadataTMDBID != "" {
+		result = append(result, PlexGuid{ID: "tmdb://" + metadataTMDBID})
+	}
+	if existingTVDBID == "" && metadataTVDBID != "" {
+		result = append(result, PlexGuid{ID: "tvdb://" + metadataTVDBID})
+	}
+	return result
+}
+
+// plexUnresolvedIDsWarning is the shared wording for a best-effort id sweep that left
+// some items on title/year matching. firstErr, when set, names the first upstream
+// failure so a systematic cause (auth, wrong URL) is visible in the run summary.
+func plexUnresolvedIDsWarning(scope, noun string, unresolved, attempted int, firstErr error) string {
+	msg := fmt.Sprintf("%s: could not resolve external ids for %d of %d %s; those fall back to exact title/year matching",
+		scope, unresolved, attempted, noun)
+	if firstErr != nil {
+		msg += fmt.Sprintf(" (first error: %v)", firstErr)
+	}
+	return msg
 }

--- a/internal/historyimport/plex_watchlist_test.go
+++ b/internal/historyimport/plex_watchlist_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -172,7 +173,9 @@ func TestFetchWatchlistWarnsWhenGuidResolutionFails(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/library/sections/watchlist/all":
-			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":1,"Metadata":[
+			_, _ = fmt.Fprint(w, `{"MediaContainer":{"totalSize":2,"Metadata":[
+				{"ratingKey":"wl-resolved","type":"movie","title":"Arrival","year":2016,
+				 "Guid":[{"id":"tmdb://329865"}]},
 				{"ratingKey":"wl-1","type":"movie","title":"Dune: Part Two","year":2024}
 			]}}`)
 		default:
@@ -187,11 +190,11 @@ func TestFetchWatchlistWarnsWhenGuidResolutionFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchWatchlist: %v", err)
 	}
-	if len(items) != 1 || items[0].Title != "Dune: Part Two" {
+	if len(items) != 2 || items[1].Title != "Dune: Part Two" {
 		t.Fatalf("items = %+v, want the listing entry kept", items)
 	}
-	if len(warnings) != 1 {
-		t.Fatalf("warnings = %v, want exactly one unresolved-ids warning", warnings)
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "1 of 1 items") {
+		t.Fatalf("warnings = %v, want one unresolved lookup out of one attempted lookup", warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Hydrate provider IDs omitted by Plex's admin session-history endpoint before matching movies and episodes.
- Match localized Plex titles through IMDb, TMDB, or TVDB identities while retaining exact title/year as a best-effort fallback.
- Resolve episode series metadata first, deduplicate rating keys, and batch unresolved item metadata requests to avoid one rate-limited request per history row.
- Preserve existing history fields and GUIDs while overlaying only missing provider identities and year.

## Why

The profile Plex importer reads library metadata containing stable provider IDs, but the admin remote importer starts from `/status/sessions/history/all`, where those IDs are often absent. When Plex and Silo use different metadata languages, admin imports consequently fall through to exact localized title matching and lose otherwise valid history entries.

## Validation

Focused and changed-code gates passed:

- `go test ./internal/historyimport/...`
- `go test -race ./internal/historyimport/...`
- `go vet ./internal/historyimport/...`
- `go build ./...`
- `golangci-lint run --new-from-merge-base="origin/main" ./internal/historyimport/...` (0 issues)
- `gofmt` and `git diff --check`
- `make verify-local-paths`

Manual end-to-end validation used a mock Plex server, disposable PostgreSQL, a locally launched Silo server, and an ordinary target user. With localized titles absent from Silo's English catalog:

- Baseline `main`: fetched 2, matched 1, unmatched 1.
- This branch: fetched 2, matched 2, unmatched 0, history rows created 2.
- Covered a Polish-titled movie matched by TMDB ID and a Spanish-titled TV episode matched through series/episode identities.

`make test` reached and passed `internal/historyimport`, but the repository-wide run failed in unrelated playback/transcode timing tests:

- `TestGetTranscodeSegment_CopyMPEGTSRecoveryUsesResolvedManifestNumberWithoutLookaheadDelay`
- `TestEnsureTranscodeSessionReplacesRecipeForDifferentSelectedSourceFacts`
- `TestHandleDownloadPrepareTrackingDoesNotBlockAndRemovesAfterTrack`

Frontend lint and format checks were not run because this isolated worktree has no `web/node_modules`; `pnpm run lint` stopped with `eslint: command not found`. No frontend files changed.

## Scope

No HTTP API, schema, frontend, native client, jellycompat, or documentation contract changes.

## AI Disclosure

- Harness: Codex desktop; Claude review in the shared worktree
- Tool(s): Codex coding agent; Claude coding agent
- Model(s): `gpt-5.6-sol` (Codex); Claude model identifier was not provided in this task transcript
- Involvement: AI-assisted
- Adversarial review: Codex reviewed the implementation and found kind-insensitive movie identity handling plus excessive per-episode metadata requests. Both were fixed and covered by regression tests. Claude independently reviewed the combined change and added batching, cancellation behavior, clearer aggregated error reporting, shared fallback logic, and regression coverage. The final combined diff was reread and validated with focused tests, the race detector, vet, build, and diff-scoped lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plex history matching by enriching items with per-item metadata.
  * Preserved localized titles while adding available IMDb, TMDB, and TVDB identifiers.
  * Added title-and-year fallback handling when metadata is unavailable, with warnings for unresolved identifiers.
  * Improved episode matching through series-level metadata fallback.
  * Improved metadata retrieval reliability with batching and targeted retries.
  * Corrected unresolved-identifier warnings to report attempted lookups accurately.
  * Preserved watchlist entries even when identifier resolution fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->