### PR TITLE
fix(chapterthumbs): stop mislabeling S3 upload failures as extract failures

### DIFF
--- a/internal/chapterthumbs/extractor.go
+++ b/internal/chapterthumbs/extractor.go
@@ -36,6 +36,7 @@ const (
 	hwAccelVAAPI                = "vaapi"
 	hwAccelVideoToolbox         = "videotoolbox"
 	reasonChapterExtractFailed  = "chapter_extract_failed"
+	reasonChapterUploadFailed   = "chapter_upload_failed"
 	reasonDecodeInvalidData     = "decode_invalid_data"
 	reasonFFmpegProbeFailed     = "ffmpeg_probe_failed"
 	reasonToneMapUnsupported    = "tonemap_unsupported"

--- a/internal/chapterthumbs/service.go
+++ b/internal/chapterthumbs/service.go
@@ -493,11 +493,11 @@ func (s *Service) processRequest(ctx context.Context, req ChapterThumbnailReques
 				"chapter_index",
 				chapter.Index,
 				"reason",
-				reasonChapterExtractFailed,
+				reasonChapterUploadFailed,
 				"error",
 				err,
 			)
-			recordChapterFailure(&updated.Chapters[candidate.offset], now, reasonChapterExtractFailed, err)
+			recordChapterFailure(&updated.Chapters[candidate.offset], now, reasonChapterUploadFailed, err)
 			mutated = true
 			failed++
 			continue

--- a/internal/opslog/handler.go
+++ b/internal/opslog/handler.go
@@ -159,6 +159,9 @@ func attrValue(v slog.Value) any {
 	case slog.KindTime:
 		return v.Time().UTC().Format(time.RFC3339Nano)
 	case slog.KindAny:
+		if err, ok := v.Any().(error); ok {
+			return err.Error()
+		}
 		return v.Any()
 	default:
 		return v.String()

--- a/internal/opslog/handler_test.go
+++ b/internal/opslog/handler_test.go
@@ -1,0 +1,35 @@
+package opslog
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+)
+
+func TestAttrValueError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"plain", errors.New("s3 PutObject failed: AccessDenied"), "s3 PutObject failed: AccessDenied"},
+		{"wrapped", fmt.Errorf("upload chapter-images/1/0/original.webp: %w", errors.New("AccessDenied")), "upload chapter-images/1/0/original.webp: AccessDenied"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := attrValue(slog.AnyValue(tc.err))
+			if got != tc.want {
+				t.Fatalf("attrValue(%v) = %#v, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAttrValueNonError(t *testing.T) {
+	type payload struct{ X int }
+	got := attrValue(slog.AnyValue(payload{X: 1}))
+	if got != (payload{X: 1}) {
+		t.Fatalf("attrValue(non-error) = %#v, want %#v", got, payload{X: 1})
+	}
+}


### PR DESCRIPTION
## Problem

Chapter-thumbnail upload rejections (e.g. an S3 `PutObject` 403) were logged
and recorded with `reason: chapter_extract_failed` — the same code used for
genuine ffmpeg extraction failures — making the two indistinguishable from
the admin log. On top of that, the underlying error string never reached
the admin UI at all: it serialized to `"error": {}`.

## Root cause

- `service.go`'s upload-failure branch hardcoded `reasonChapterExtractFailed`
  instead of a reason describing the upload path.
- opslog's slog handler (`attrValue` in `internal/opslog/handler.go`) stored
  a bare `error` interface value in the JSON attrs map. Standard Go error
  types (`*errors.errorString`, `*fmt.wrapError`) have only unexported
  fields and no `MarshalJSON`, so `encoding/json` silently marshals them as
  `{}` — this is the same choke point every `slog` WARN/ERROR call in the
  codebase goes through on the way into the admin log.

## Fix

- Added a distinct `reasonChapterUploadFailed = "chapter_upload_failed"`
  reason code and used it for `uploadChapterThumbnail` failures.
- `attrValue` now calls `.Error()` on any `slog.KindAny` attr that is an
  `error` before storing it, so the message survives into the captured log
  entry — fixing this for every component, not just chapterthumbs.

## Validation

- `go test ./internal/opslog/...` passes, including new `TestAttrValueError`
  / `TestAttrValueNonError` covering the error-serialization fix.
- `gofmt -l` clean on touched files.
- `internal/chapterthumbs` and `cmd/silo` couldn't be compiled locally
  (this machine lacks the libvips headers `github.com/h2non/bimg` needs at
  build time, unrelated to this change) — CI has the full toolchain.

Related issue: #894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chapter-thumbnail upload failures are now labeled accurately in operational records and logs.
  * Error values in operational logs now display their readable error messages instead of raw values.
  * Preserved existing handling for non-error log values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->