### PR TITLE
fix(sections): encode day lookbacks as intervals, not text

### DIFF
--- a/internal/catalog/discovery_repo.go
+++ b/internal/catalog/discovery_repo.go
@@ -252,7 +252,7 @@ func buildForgottenFavoritesQuery(f ForgottenFavoritesFilter) (string, []any) {
 		WHERE uwh.user_id = $%d
 		  AND uwh.profile_id = $%d
 		  AND uwh.media_item_id = mi.content_id
-		  AND uwh.watched_at >= NOW() - ($%d || ' days')::interval
+		  AND uwh.watched_at >= NOW() - make_interval(days => $%d)
 	)`, argIdx, argIdx+1, argIdx+2))
 	args = append(args, f.UserID, f.ProfileID, f.LookbackDays)
 	argIdx += 3

--- a/internal/catalog/discovery_repo_test.go
+++ b/internal/catalog/discovery_repo_test.go
@@ -278,7 +278,7 @@ func TestForgottenFavorites_BasicQuery(t *testing.T) {
 	if !strings.Contains(query, "uwh.watched_at >= NOW()") {
 		t.Fatalf("expected watched_at recency filter, got:\n%s", query)
 	}
-	if !strings.Contains(query, "$3 || ' days'") {
+	if !strings.Contains(query, "make_interval(days => $3)") {
 		t.Fatalf("expected lookback_days at $3, got:\n%s", query)
 	}
 	if !strings.Contains(query, "ORDER BY mi.rating_imdb DESC NULLS LAST") {
@@ -289,6 +289,13 @@ func TestForgottenFavorites_BasicQuery(t *testing.T) {
 	}
 	if len(args) != 4 {
 		t.Fatalf("expected 4 args (userID, profileID, lookbackDays, limit), got %d: %v", len(args), args)
+	}
+	// The lookback must reach Postgres as an integer. This assertion is the
+	// one that was missing: the query text was checked but never executed, so
+	// `($3 || ' days')::interval` -- which makes Postgres infer $3 as text and
+	// then fails to encode the int at runtime -- passed review and shipped.
+	if _, ok := args[2].(int); !ok {
+		t.Fatalf("expected lookback_days arg to be an int, got %T (%v)", args[2], args[2])
 	}
 }
 

--- a/internal/recommendations/repo.go
+++ b/internal/recommendations/repo.go
@@ -1325,7 +1325,7 @@ func (r *Repo) GetPopularItems(ctx context.Context, days, limit int) ([]ScoredIt
 		watched_items AS (
 			SELECT item_id, watcher_id
 			FROM   watched_activity
-			WHERE  updated_at > NOW() - ($1 || ' days')::interval
+			WHERE  updated_at > NOW() - make_interval(days => $1)
 		)
 		SELECT wi.item_id, COUNT(DISTINCT wi.watcher_id) AS watch_count
 		FROM   watched_items wi
@@ -1333,7 +1333,7 @@ func (r *Repo) GetPopularItems(ctx context.Context, days, limit int) ([]ScoredIt
 		GROUP  BY wi.item_id
 		ORDER  BY watch_count DESC
 		LIMIT  $2`, watchedActivityCTE)
-	rows, err := r.pool.Query(ctx, query, fmt.Sprintf("%d", days), limit)
+	rows, err := r.pool.Query(ctx, query, days, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get popular items: %w", err)
 	}
@@ -1362,10 +1362,10 @@ func (r *Repo) GetRecentlyAddedItems(ctx context.Context, days, limit int) ([]Sc
 		SELECT mi.content_id, mi.created_at
 		FROM   media_items mi
 		WHERE  %s
-		  AND  mi.created_at > NOW() - ($1 || ' days')::interval
+		  AND  mi.created_at > NOW() - make_interval(days => $1)
 		ORDER  BY mi.created_at DESC
 		LIMIT  $2`, recommendationItemEligibilityWhereClause("mi"))
-	rows, err := r.pool.Query(ctx, query, fmt.Sprintf("%d", days), limit)
+	rows, err := r.pool.Query(ctx, query, days, limit)
 	if err != nil {
 		return nil, fmt.Errorf("get recently added: %w", err)
 	}

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -3294,7 +3294,7 @@ func (f *Fetcher) fetchNewToLibrary(ctx context.Context, s ResolvedSection, libr
 
 	conditions = append(conditions, catalog.MangaChapterExclusionWhere("mi"))
 
-	conditions = append(conditions, fmt.Sprintf("mi.created_at > NOW() - ($%d || ' days')::interval", argIdx))
+	conditions = append(conditions, fmt.Sprintf("mi.created_at > NOW() - make_interval(days => $%d)", argIdx))
 	args = append(args, days)
 	argIdx++
 
@@ -3957,7 +3957,7 @@ func (f *Fetcher) fetchReturningShows(ctx context.Context, s ResolvedSection, li
 			FROM episodes ne
 			WHERE ne.series_id = mi.content_id
 			  AND ne.season_number > 0
-			  AND ne.created_at > NOW() - ($3 || ' days')::interval
+			  AND ne.created_at > NOW() - make_interval(days => $3)
 			  AND ne.season_number > COALESCE((
 				SELECT MAX(we2.season_number)
 				FROM episodes we2
@@ -3991,7 +3991,7 @@ func (f *Fetcher) fetchReturningShows(ctx context.Context, s ResolvedSection, li
 			SELECT MAX(ord.created_at)
 			FROM episodes ord
 			WHERE ord.series_id = mi.content_id
-			  AND ord.created_at > NOW() - ($3 || ' days')::interval
+			  AND ord.created_at > NOW() - make_interval(days => $3)
 		) DESC NULLS LAST, mi.content_id ASC
 		LIMIT $%d`,
 		itemColumns("mi"), fromClause, strings.Join(conditions, " AND "), argIdx,


### PR DESCRIPTION
## The bug

`returning_shows` fails on every render in production:

```
fetching section items  component=sections type=returning_shows
error="fetching returning shows: failed to encode args[2]:
       unable to encode 30 into text format for text (OID 25):
       cannot find encode plan"
```

Three queries build the lookback window by concatenating a bind parameter with a string:

```sql
NOW() - ($3 || ' days')::interval
```

Postgres resolves that concatenation by inferring the parameter as `text`, but the Go callers append a plain `int`, so pgx has no encode plan for it.

## Blast radius

| Site | Section | Status |
|---|---|---|
| `internal/sections/fetcher.go` (x2, `$3`) | `returning_shows` | **Live failure** |
| `internal/sections/fetcher.go` (`$N`) | `new_to_library` | Latent — fails once configured |
| `internal/catalog/discovery_repo.go` | forgotten favourites | Latent — passes `LookbackDays` (`int`) identically |

The same expression works in `internal/recommendations` only because those two callers stringify first (`fmt.Sprintf("%d", days)`) to satisfy the inferred `text` type — a workaround that reads as arbitrary unless you know why it is there, and that the sections code did not copy.

## The fix

`make_interval(days => $N)`, which is already the convention in `internal/activitylog/repo.go` and infers an integer. The two `Sprintf` workarounds are dropped now that they have nothing to work around.

Equivalence verified against a live database:

```
SELECT (NOW() - make_interval(days => 30))::date
     = (NOW() - ('30' || ' days')::interval)::date;
 ?column?
----------
 t
```

## On the test

`TestForgottenFavorites_BasicQuery` asserted the literal string `"$3 || ' days'"`, so it pinned the broken form in place — it checked the query text and never executed it. That assertion is updated, and I added the one that would actually have caught this: that the lookback argument reaches the driver as an `int`.

## Verification

```
$ go build ./internal/...
$ go vet ./internal/sections/ ./internal/catalog/ ./internal/recommendations/
$ go test -count=1 ./internal/catalog/ ./internal/sections/ ./internal/recommendations/
ok  	github.com/Silo-Server/silo-server/internal/catalog        3.627s
ok  	github.com/Silo-Server/silo-server/internal/sections       0.926s
ok  	github.com/Silo-Server/silo-server/internal/recommendations 1.078s
```

Build and vet clean. (`go build ./...` needs a built `web/dist`, so the Go packages were built directly.)

Branched from `main` at 90b5c0f4, which is the revision the failure was observed on.

---
This change was written with AI assistance (Claude). The diagnosis, the equivalence check and the test runs above were performed against real systems, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HubJ45ZJQnPDCfYW7PBhTD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-range query handling for forgotten favorites, popular items, recently added items, and library recommendations.
  * Prevented issues caused by interpreting numeric lookback values as text when calculating time intervals.
* **Tests**
  * Added coverage to verify lookback values are passed as integers and interval queries are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->