### PR TITLE
fix(notifications): let retention prune release events

### DIFF
--- a/migrations/sql/20260902200000_fix_notification_deliveries_episode_check.sql
+++ b/migrations/sql/20260902200000_fix_notification_deliveries_episode_check.sql
@@ -1,0 +1,52 @@
+-- +goose Up
+-- notification_deliveries has carried two mutually exclusive rules since
+-- 20260611100000_profile_release_notifications.sql created it:
+--
+--   release_event_id text REFERENCES release_events(id) ON DELETE SET NULL
+--   CHECK (type <> 'episode.available' OR (release_event_id IS NOT NULL AND ...))
+--
+-- Deleting a processed release_event sets release_event_id to NULL on its
+-- deliveries, which the CHECK then rejects, so the DELETE aborts. Retention
+-- has therefore never been able to prune release events: the nightly
+-- notifications_retention task fails on
+--
+--   prune release events: ERROR: new row for relation "notification_deliveries"
+--   violates check constraint "notification_deliveries_episode_fields_check"
+--
+-- and every later step in RunRetention is skipped with it. Observed in
+-- production with 148,299 release_events, all processed, none ever pruned.
+--
+-- The original migration's own comment says which rule is the mistake:
+--
+--   "release_event_id is nullable: operational types (e.g.
+--    webhook.auto_disabled) have no release event, and retention pruning of
+--    old release_events must not delete inbox rows."
+--
+-- So ON DELETE SET NULL is the intent and the CHECK contradicts it. Drop only
+-- the release_event_id clause. library_id, series_id and episode_id stay
+-- required: they are stable identifiers, they are what makes an
+-- episode.available row renderable after its event has aged out, and nothing
+-- nulls them.
+ALTER TABLE public.notification_deliveries
+    DROP CONSTRAINT notification_deliveries_episode_fields_check;
+
+ALTER TABLE public.notification_deliveries
+    ADD CONSTRAINT notification_deliveries_episode_fields_check CHECK (
+        type <> 'episode.available'
+        OR (library_id IS NOT NULL
+            AND series_id IS NOT NULL
+            AND episode_id IS NOT NULL)
+    );
+
+-- +goose Down
+ALTER TABLE public.notification_deliveries
+    DROP CONSTRAINT notification_deliveries_episode_fields_check;
+
+ALTER TABLE public.notification_deliveries
+    ADD CONSTRAINT notification_deliveries_episode_fields_check CHECK (
+        type <> 'episode.available'
+        OR (release_event_id IS NOT NULL
+            AND library_id IS NOT NULL
+            AND series_id IS NOT NULL
+            AND episode_id IS NOT NULL)
+    );


### PR DESCRIPTION
## The bug

`notifications_retention` has failed every night for a week on a production instance:

```
notification retention: prune release events: ERROR: new row for relation
"notification_deliveries" violates check constraint
"notification_deliveries_episode_fields_check" (SQLSTATE 23514)
```

`notification_deliveries` has carried two mutually exclusive rules since `20260611100000_profile_release_notifications.sql` created it:

```sql
release_event_id text REFERENCES release_events(id) ON DELETE SET NULL
CHECK (type <> 'episode.available' OR (release_event_id IS NOT NULL AND ...))
```

Deleting a processed `release_event` makes the FK null the column on its deliveries, which the CHECK then rejects, so the `DELETE` aborts. Postgres names the mechanism itself:

```
CONTEXT: SQL statement "UPDATE ONLY "public"."notification_deliveries"
         SET "release_event_id" = NULL WHERE $1 = "release_event_id""
```

`DeleteProcessedBefore` is the **first** prune in `RunRetention`, so every later step is skipped with it — deliveries, stale events, interest rows, webhook and web-push attempts, Discord link states. None of it has ever run.

Production state: **148,299 `release_events`, every one processed, oldest two months old, none ever pruned.**

## Which rule is wrong

The original migration's own comment answers it:

> `release_event_id` is nullable: operational types (e.g. `webhook.auto_disabled`) have no release event, and **retention pruning of old release_events must not delete inbox rows**.

`ON DELETE SET NULL` is the intent. The CHECK, fifteen lines below, defeats it.

So the migration drops only the `release_event_id` clause. `library_id`, `series_id` and `episode_id` stay required — they are stable identifiers, nothing nulls them, and they are what keeps an `episode.available` row renderable after its event has aged out.

## Verification

Run against the live database, both halves inside transactions that were rolled back:

```
--- 1. reproduce the failure as-is ---
BEGIN
ERROR:  new row for relation "notification_deliveries" violates check constraint
        "notification_deliveries_episode_fields_check"
DETAIL:  Failing row contains (..., null, 98, ..., episode.available, ...)
CONTEXT: SQL statement "UPDATE ONLY "public"."notification_deliveries"
         SET "release_event_id" = NULL WHERE $1 = "release_event_id""
ROLLBACK

--- 2. same delete WITH the fix applied ---
BEGIN
ALTER TABLE
ALTER TABLE
DELETE 136122
ROLLBACK
```

136,122 rows prune cleanly with the constraint corrected.

```
$ go build ./internal/...
$ go test -count=1 ./internal/notifications/
ok  	github.com/Silo-Server/silo-server/internal/notifications	0.638s
```

## Note on coverage

There is no test for `RunRetention` anywhere in the repo, which is why a schema contradiction this direct survived. A meaningful regression test needs a database (insert an `episode.available` delivery, delete its release event, assert the delete succeeds) — I have not added one here because I could not tell from the tree which DB-backed harness this package should use. Happy to add it if you point me at the right pattern.

---
This change was written with AI assistance (Claude). The diagnosis and the verification transcript above were produced against a real database, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HubJ45ZJQnPDCfYW7PBhTD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deleting a release event could invalidate associated episode notification deliveries.
  * Episode notifications now remain properly linked to their library, series, and episode details when the related release event is removed.
  * Existing notification delivery records are preserved during release event cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->