### PR TITLE
fix(playback): make GPU transcoding adaptive, bounded, and observable

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -2961,6 +2961,7 @@ func main() {
 			// transcode node that restarts can rebuild a jellycompat session.
 			RecipeNodeStore: noderecipe.NewStore(apiRedisClient, 0),
 			SessionSyncer:   deps.SessionSyncer,
+			FFmpegLogSink:   playback.NewSlogFFmpegLogSink(slog.Default(), nodeID),
 		}
 
 		// Wire direct dependencies when DB is available.

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -2039,19 +2039,14 @@ func (h *PlaybackHandler) proxyToTranscodeNode(w http.ResponseWriter, r *http.Re
 
 // maybeStartThrottler reads throttle settings and starts the throttler if enabled.
 func (h *PlaybackHandler) maybeStartThrottler(ctx context.Context, session *playback.TranscodeSession) {
-	if h.SettingsRepo == nil {
-		return
-	}
-	enableThrottle, _ := h.SettingsRepo.Get(ctx, "enable_transcode_throttle")
-	if enableThrottle != "true" {
-		return
-	}
-	thresholdStr, _ := h.SettingsRepo.Get(ctx, "transcode_throttle_seconds")
-	threshold := 300 // default
-	if v, err := strconv.Atoi(thresholdStr); err == nil && v > 0 {
-		threshold = v
-	}
-	session.StartThrottler(threshold)
+	enabled, thresholdSeconds := h.transcodeThrottleSettings(ctx)
+	session.ConfigureThrottler(ctx, enabled, thresholdSeconds)
+}
+
+// transcodeThrottleSettings resolves live values while keeping protective
+// defaults when the settings store is absent, unavailable, or incomplete.
+func (h *PlaybackHandler) transcodeThrottleSettings(ctx context.Context) (bool, int) {
+	return config.ResolveTranscodeThrottleSettings(ctx, h.SettingsRepo)
 }
 
 // findAlternateFile finds another file version for the same content. It

--- a/internal/api/handlers/playback_test.go
+++ b/internal/api/handlers/playback_test.go
@@ -239,6 +239,38 @@ func (r testPlaybackSettingsRepo) Get(_ context.Context, key string) (string, er
 	return r.values[key], nil
 }
 
+func TestTranscodeThrottleSettingsUseProtectiveDefaults(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+
+	enabled, thresholdSeconds := handler.transcodeThrottleSettings(context.Background())
+	if !enabled {
+		t.Fatal("transcode throttle defaulted to disabled")
+	}
+	if thresholdSeconds != config.DefaultTranscodeThrottleSeconds {
+		t.Fatalf(
+			"transcode throttle threshold = %d, want %d",
+			thresholdSeconds,
+			config.DefaultTranscodeThrottleSeconds,
+		)
+	}
+}
+
+func TestTranscodeThrottleSettingsPreserveExplicitValues(t *testing.T) {
+	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
+	handler.SettingsRepo = testPlaybackSettingsRepo{values: map[string]string{
+		config.TranscodeThrottleEnabledSettingKey: "false",
+		config.TranscodeThrottleSecondsSettingKey: "240",
+	}}
+
+	enabled, thresholdSeconds := handler.transcodeThrottleSettings(context.Background())
+	if enabled {
+		t.Fatal("transcode throttle ignored explicit opt-out")
+	}
+	if thresholdSeconds != 240 {
+		t.Fatalf("transcode throttle threshold = %d, want 240", thresholdSeconds)
+	}
+}
+
 type allowAllPlaybackItemAccess struct{}
 
 func (allowAllPlaybackItemAccess) EnsureAccessible(

--- a/internal/api/handlers/playback_v3.go
+++ b/internal/api/handlers/playback_v3.go
@@ -3413,6 +3413,37 @@ type localTransportStartupFailureV3 struct {
 	failedDevice  string
 }
 
+type automaticLocalTransportPipelineV3 interface {
+	Current() playback.TranscodeOpts
+	AdvanceAfterFailure(string) bool
+}
+
+// retryAutomaticLocalPlaybackTransportV3 advances through the remaining
+// automatic execution paths while failures happen before media becomes ready.
+// A running process is terminal because starting another one would duplicate
+// work that may still produce a manifest.
+func retryAutomaticLocalPlaybackTransportV3(
+	ctx context.Context,
+	sessionID string,
+	pipeline automaticLocalTransportPipelineV3,
+	failure *localTransportStartupFailureV3,
+	start func(context.Context, playback.TranscodeOpts) (*playback.TranscodeSession, *localTransportStartupFailureV3),
+) (*playback.TranscodeSession, *localTransportStartupFailureV3) {
+	var session *playback.TranscodeSession
+	for failure != nil && !failure.wasRunning && pipeline.AdvanceAfterFailure(failure.failedDevice) {
+		opts := pipeline.Current()
+		slog.WarnContext(ctx, "automatic transcode path failed during startup; trying next path",
+			logComponentKey, playbackLogValueV3,
+			"playback_session_id", sessionID,
+			"failed_device", failure.failedDevice,
+			"next_hw_accel", opts.HWAccel,
+			"next_software_decode", opts.SoftwareVideoDecode,
+			"error", failure.cause)
+		session, failure = start(ctx, opts)
+	}
+	return session, failure
+}
+
 // startReadyLocalPlaybackTransportV3 returns only after the first manifest is
 // safe to serve. A session that fails readiness is closed before the failure is
 // returned so every caller gets the same startup cleanup behavior.
@@ -3480,7 +3511,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 	sourceMetadata := sourceExecutionMetadataV3(file, result)
 	sourceProfile, sourceBitDepth := sourceVideoTranscodeFactsV3(file, result)
 	unlock := h.tm.LockSessionLifecycle(session.ID)
-	opts := playback.TranscodeOpts{InputPath: file.FilePath, OutputDir: outputDir, OutputSubdir: outputSubdir, SessionID: session.ID, SourceVideoCodec: sourceMetadata.VideoCodec, SourceVideoProfile: sourceProfile, SourceVideoBitDepth: sourceBitDepth, SourceAudioChannels: result.SourceAudioChannels, SoftwareVideoDecode: sourceMetadata.SoftwareVideoDecode, ToneMapPolicy: result.ToneMapPolicy, ToneMapMode: result.ToneMapMode, ToneMapSourceKind: result.ToneMapSourceKind, ToneMapRecipeVersion: result.ToneMapRecipeVersion, ToneMapPreflightRequired: result.ToneMapPreflightRequired, ToneMapSourceRevision: result.ToneMapSourceRevision, VideoBitstreamFilter: videoBitstreamFilterForPlanV3(result.Plan), VideoSampleEntry: videoSampleEntryForPlanV3(result.Plan), SeekSeconds: timeline.seekSeconds, StreamOriginSeconds: timeline.streamOriginSeconds, CopySeekAnchorResolved: timeline.copySeekAnchorResolved, StartSegmentNumber: timeline.startSegmentNumber, TargetResolution: result.TargetResolution, TargetCodecVideo: videoCodec, TargetCodecAudio: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetBitrateKbps: result.TargetBitrateKbps, SegmentDuration: playback.DefaultSegmentDuration, SegmentRetentionSeconds: cfg.SegmentRetentionSeconds, FFmpegPath: cfg.FFmpegPath, HWAccel: cfg.HWAccel, HWDevice: cfg.HWDevice, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn, SubtitleCodec: result.SubtitleCodec, TotalDuration: sourceMetadata.DurationSeconds, FastStart: true, NodeType: playbackNodeIntegratedV3, ExecutionMode: playbackNodeIntegratedV3, FFmpegLogSink: h.FFmpegLogSink}
+	opts := playback.TranscodeOpts{InputPath: file.FilePath, OutputDir: outputDir, OutputSubdir: outputSubdir, SessionID: session.ID, SourceVideoCodec: sourceMetadata.VideoCodec, SourceVideoProfile: sourceProfile, SourceVideoBitDepth: sourceBitDepth, SourceVideoResolution: file.Resolution, SourceAudioChannels: result.SourceAudioChannels, SoftwareVideoDecode: sourceMetadata.SoftwareVideoDecode, ToneMapPolicy: result.ToneMapPolicy, ToneMapMode: result.ToneMapMode, ToneMapSourceKind: result.ToneMapSourceKind, ToneMapRecipeVersion: result.ToneMapRecipeVersion, ToneMapPreflightRequired: result.ToneMapPreflightRequired, ToneMapSourceRevision: result.ToneMapSourceRevision, VideoBitstreamFilter: videoBitstreamFilterForPlanV3(result.Plan), VideoSampleEntry: videoSampleEntryForPlanV3(result.Plan), SeekSeconds: timeline.seekSeconds, StreamOriginSeconds: timeline.streamOriginSeconds, CopySeekAnchorResolved: timeline.copySeekAnchorResolved, StartSegmentNumber: timeline.startSegmentNumber, TargetResolution: result.TargetResolution, TargetCodecVideo: videoCodec, TargetCodecAudio: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetBitrateKbps: result.TargetBitrateKbps, SegmentDuration: playback.DefaultSegmentDuration, SegmentRetentionSeconds: cfg.SegmentRetentionSeconds, FFmpegPath: cfg.FFmpegPath, HWAccel: cfg.HWAccel, HWDevice: cfg.HWDevice, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn, SubtitleCodec: result.SubtitleCodec, TotalDuration: sourceMetadata.DurationSeconds, FastStart: true, NodeType: playbackNodeIntegratedV3, ExecutionMode: playbackNodeIntegratedV3, FFmpegLogSink: h.FFmpegLogSink}
 	if opts.ToneMapMode != "" {
 		opts.ToneMapDVConfigPresent = sourceMetadata.ToneMapDVConfigPresent
 		opts.ToneMapDVBLCompatIDPresent = sourceMetadata.ToneMapDVBLCompatIDPresent
@@ -3498,6 +3529,8 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 			opts.HWAccel = playback.HWAccelNone
 		}
 	}
+	autoPipeline := playback.NewAutoTranscodePipeline(r.Context(), opts)
+	opts = autoPipeline.Current()
 	usedToneMapFallback := false
 	ts, startupFailure := h.startReadyLocalPlaybackTransportV3(r.Context(), opts)
 	if startupFailure != nil && startupFailure.failedToStart {
@@ -3509,7 +3542,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 			ts, startupFailure = h.startReadyLocalPlaybackTransportV3(r.Context(), opts)
 		}
 	}
-	if startupFailure != nil && startupFailure.failedToStart {
+	if startupFailure != nil && startupFailure.failedToStart && !autoPipeline.Enabled() {
 		unlock()
 		return preparedTransportV3{}, toneMapExecutionTransportErrorV3(startupFailure.cause, "Failed to start the playback transport.")
 	}
@@ -3539,6 +3572,16 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 		} else if startupFailure.wasRunning {
 			unlock()
 			return preparedTransportV3{}, transportErr
+		} else if autoPipeline.Enabled() {
+			ts, startupFailure = retryAutomaticLocalPlaybackTransportV3(
+				r.Context(), session.ID, autoPipeline, startupFailure, h.startReadyLocalPlaybackTransportV3)
+			if startupFailure != nil {
+				unlock()
+				if startupFailure.failedToStart {
+					return preparedTransportV3{}, toneMapExecutionTransportErrorV3(startupFailure.cause, "Failed to start the playback transport.")
+				}
+				return preparedTransportV3{}, manifestStartupTransportErrorV3(startupFailure.wasRunning, startupFailure.cause)
+			}
 		} else {
 			// FFmpeg and GPU drivers can fail before producing their first segment
 			// even though the recipe is valid. Retry one clean generation, preferring
@@ -3564,6 +3607,7 @@ func (h *PlaybackHandler) prepareLocalTransportV3(r *http.Request, session *play
 			}
 		}
 	}
+	autoPipeline.RememberSuccess()
 	url := fmt.Sprintf("/playback/transcode/%s/master.m3u8", session.ID)
 	if !mode.headerAuth {
 		card := playback.NewRecipeCard(session.UserID, session.ProfileID, file.ID, "", ts.Opts())
@@ -3677,6 +3721,10 @@ func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *pla
 		}
 	}
 	req := transcodenode.TranscodeStartRequest{SessionID: transportID, InputPath: file.FilePath, SourceVideoCodec: sourceMetadata.VideoCodec, SourceVideoProfile: sourceProfile, SourceVideoBitDepth: sourceBitDepth, SourceAudioChannels: result.SourceAudioChannels, SoftwareVideoDecode: sourceMetadata.SoftwareVideoDecode, ToneMapPolicy: result.ToneMapPolicy, ToneMapMode: result.ToneMapMode, ToneMapSourceKind: result.ToneMapSourceKind, ToneMapRecipeVersion: result.ToneMapRecipeVersion, ToneMapPreflightRequired: result.ToneMapPreflightRequired, ToneMapSourceRevision: result.ToneMapSourceRevision, VideoBitstreamFilter: videoBitstreamFilterForPlanV3(result.Plan), VideoSampleEntry: videoSampleEntryForPlanV3(result.Plan), SeekSeconds: timeline.seekSeconds, StreamOriginSeconds: timeline.streamOriginSeconds, CopySeekAnchorResolved: timeline.copySeekAnchorResolved, StartSegmentNumber: timeline.startSegmentNumber, TargetResolution: result.TargetResolution, TargetCodecVideo: videoCodec, TargetCodecAudio: result.TargetAudioCodec, TargetAudioChannels: result.TargetAudioChannels, TargetAudioBitrateKbps: result.TargetAudioBitrateKbps, TargetBitrateKbps: result.TargetBitrateKbps, SegmentDuration: playback.DefaultSegmentDuration, HWAccel: hwAccel, AudioTrackIndex: plannedAudioTrackIndexV3(result, session.AudioTrackIndex), SubtitleTrackIndex: result.SubtitleTransportTrackIndex, SubtitleBurnIn: result.SubtitleBurnIn, SubtitleCodec: result.SubtitleCodec, TotalDuration: sourceMetadata.DurationSeconds, RequireReady: true}
+	req.PlaybackSessionID = session.ID
+	req.SourceVideoResolution = file.Resolution
+	req.ThrottlePolicyConfigured = true
+	req.ThrottleEnabled, req.ThrottleThresholdSeconds = h.transcodeThrottleSettings(r.Context())
 	if strings.EqualFold(videoCodec, "copy") {
 		req.CopyFMP4RecipeVersion = playback.CopyFMP4RecipeVersion
 	}
@@ -3870,7 +3918,11 @@ func (h *PlaybackHandler) prepareRemoteTransportV3(r *http.Request, session *pla
 // not part of the node's request/response contract, so the caller supplies it.
 func remoteTranscodeRecipeCardV3(session *playback.Session, file *models.MediaFile, nodeURL, transportID string, req transcodenode.TranscodeStartRequest, nodeResp transcodenode.TranscodeStartResponse, toneMapFilter string) playback.RecipeCard {
 	hw := firstNonEmptyHandlerV3(strings.TrimSpace(nodeResp.HWAccel), strings.TrimSpace(req.HWAccel))
-	card := playback.NewRecipeCard(session.UserID, session.ProfileID, file.ID, nodeURL, playback.TranscodeOpts{InputPath: req.InputPath, SessionID: session.ID, TranscodeTransportID: transportID, SourceVideoCodec: req.SourceVideoCodec, SourceVideoProfile: req.SourceVideoProfile, SourceVideoBitDepth: req.SourceVideoBitDepth, SourceAudioChannels: req.SourceAudioChannels, SoftwareVideoDecode: req.SoftwareVideoDecode, ToneMapPolicy: req.ToneMapPolicy, ToneMapMode: req.ToneMapMode, ToneMapSourceKind: req.ToneMapSourceKind, ToneMapFilter: toneMapFilter, ToneMapRecipeVersion: req.ToneMapRecipeVersion, ToneMapPreflightRequired: req.ToneMapPreflightRequired, ToneMapSourceRevision: req.ToneMapSourceRevision, VideoBitstreamFilter: req.VideoBitstreamFilter, VideoSampleEntry: req.VideoSampleEntry, SeekSeconds: req.SeekSeconds, StreamOriginSeconds: req.StreamOriginSeconds, CopySeekAnchorResolved: req.CopySeekAnchorResolved, StartSegmentNumber: req.StartSegmentNumber, TargetResolution: req.TargetResolution, TargetCodecVideo: req.TargetCodecVideo, TargetCodecAudio: req.TargetCodecAudio, TargetAudioChannels: req.TargetAudioChannels, TargetAudioBitrateKbps: req.TargetAudioBitrateKbps, TargetBitrateKbps: req.TargetBitrateKbps, SegmentDuration: req.SegmentDuration, HWAccel: hw, AudioTrackIndex: req.AudioTrackIndex, SubtitleTrackIndex: req.SubtitleTrackIndex, SubtitleBurnIn: req.SubtitleBurnIn, SubtitleCodec: req.SubtitleCodec, TotalDuration: req.TotalDuration})
+	softwareVideoDecode := nodeResp.SoftwareVideoDecode
+	if strings.TrimSpace(nodeResp.HWAccel) == "" {
+		softwareVideoDecode = req.SoftwareVideoDecode
+	}
+	card := playback.NewRecipeCard(session.UserID, session.ProfileID, file.ID, nodeURL, playback.TranscodeOpts{InputPath: req.InputPath, SessionID: session.ID, TranscodeTransportID: transportID, SourceVideoCodec: req.SourceVideoCodec, SourceVideoProfile: req.SourceVideoProfile, SourceVideoBitDepth: req.SourceVideoBitDepth, SourceVideoResolution: req.SourceVideoResolution, SourceAudioChannels: req.SourceAudioChannels, SoftwareVideoDecode: softwareVideoDecode, ToneMapPolicy: req.ToneMapPolicy, ToneMapMode: req.ToneMapMode, ToneMapSourceKind: req.ToneMapSourceKind, ToneMapFilter: toneMapFilter, ToneMapRecipeVersion: req.ToneMapRecipeVersion, ToneMapPreflightRequired: req.ToneMapPreflightRequired, ToneMapSourceRevision: req.ToneMapSourceRevision, VideoBitstreamFilter: req.VideoBitstreamFilter, VideoSampleEntry: req.VideoSampleEntry, SeekSeconds: req.SeekSeconds, StreamOriginSeconds: req.StreamOriginSeconds, CopySeekAnchorResolved: req.CopySeekAnchorResolved, StartSegmentNumber: req.StartSegmentNumber, TargetResolution: req.TargetResolution, TargetCodecVideo: req.TargetCodecVideo, TargetCodecAudio: req.TargetCodecAudio, TargetAudioChannels: req.TargetAudioChannels, TargetAudioBitrateKbps: req.TargetAudioBitrateKbps, TargetBitrateKbps: req.TargetBitrateKbps, SegmentDuration: req.SegmentDuration, ThrottlePolicyConfigured: req.ThrottlePolicyConfigured, ThrottleEnabled: req.ThrottleEnabled, ThrottleThresholdSeconds: req.ThrottleThresholdSeconds, HWAccel: hw, AudioTrackIndex: req.AudioTrackIndex, SubtitleTrackIndex: req.SubtitleTrackIndex, SubtitleBurnIn: req.SubtitleBurnIn, SubtitleCodec: req.SubtitleCodec, TotalDuration: req.TotalDuration})
 	card.ToneMapDVConfigPresent = req.ToneMapDVConfigPresent
 	card.ToneMapDVBLCompatIDPresent = req.ToneMapDVBLCompatIDPresent
 	card.ToneMapDVBLPresent = req.ToneMapDVBLPresent

--- a/internal/api/handlers/playback_v3_test.go
+++ b/internal/api/handlers/playback_v3_test.go
@@ -3640,6 +3640,59 @@ func TestPrepareLocalTransportV3ReturnsStableTerminalWhenFFmpegExitsBeforeReady(
 	}
 }
 
+type automaticLocalTransportPipelineStubV3 struct {
+	stages []playback.TranscodeOpts
+	index  int
+}
+
+func (pipeline *automaticLocalTransportPipelineStubV3) Current() playback.TranscodeOpts {
+	return pipeline.stages[pipeline.index]
+}
+
+func (pipeline *automaticLocalTransportPipelineStubV3) AdvanceAfterFailure(string) bool {
+	if pipeline.index+1 >= len(pipeline.stages) {
+		return false
+	}
+	pipeline.index++
+	return true
+}
+
+func TestRetryAutomaticLocalPlaybackTransportV3ContinuesAfterSpawnFailures(t *testing.T) {
+	pipeline := &automaticLocalTransportPipelineStubV3{stages: []playback.TranscodeOpts{
+		{HWAccel: "nvenc"},
+		{HWAccel: "nvenc", SoftwareVideoDecode: true},
+		{HWAccel: playback.HWAccelNone, SoftwareVideoDecode: true},
+	}}
+	initialFailure := &localTransportStartupFailureV3{cause: errors.New("full hardware spawn failed"), failedToStart: true}
+	attempts := make([]playback.TranscodeOpts, 0, 2)
+	wantSession := &playback.TranscodeSession{}
+	start := func(_ context.Context, opts playback.TranscodeOpts) (*playback.TranscodeSession, *localTransportStartupFailureV3) {
+		attempts = append(attempts, opts)
+		if len(attempts) == 1 {
+			return nil, &localTransportStartupFailureV3{cause: errors.New("hybrid spawn failed"), failedToStart: true}
+		}
+		return wantSession, nil
+	}
+
+	session, failure := retryAutomaticLocalPlaybackTransportV3(
+		context.Background(), "session-auto-spawn", pipeline, initialFailure, start)
+	if failure != nil {
+		t.Fatalf("retry automatic transport: %v", failure.cause)
+	}
+	if session != wantSession {
+		t.Fatal("retry returned the wrong successful session")
+	}
+	if len(attempts) != 2 {
+		t.Fatalf("attempt count = %d, want 2 fallback attempts", len(attempts))
+	}
+	if !attempts[0].SoftwareVideoDecode || attempts[0].HWAccel != "nvenc" {
+		t.Fatalf("first fallback = %+v, want CPU decode with GPU encode", attempts[0])
+	}
+	if !attempts[1].SoftwareVideoDecode || attempts[1].HWAccel != playback.HWAccelNone {
+		t.Fatalf("second fallback = %+v, want full software", attempts[1])
+	}
+}
+
 func TestPrepareLocalTransportV3RemuxOmitsToneMapOnlyDolbyVisionEvidence(t *testing.T) {
 	handler := NewPlaybackHandler(playback.NewSessionManager(0, 0))
 	handler.PlaybackConfig = playbackTestConfig(writePlaybackTestFFmpeg(t), t.TempDir())

--- a/internal/config/admin_settings.go
+++ b/internal/config/admin_settings.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	cloudflareURLMode                  = "cloudflare_token"
-	playbackSegmentRetentionSettingKey = "playback.segment_retention_seconds"
 	chapterThumbnailSoftwareToneMapKey = "playback.chapter_thumbnail_software_tone_map_enabled"
 )
 
@@ -87,7 +86,7 @@ var adminSettingDefaults = map[string]string{
 
 	"playback.ffmpeg_path":                           "",
 	playbackTranscodeDirSettingKey:                   DefaultTranscodeDir,
-	playbackSegmentRetentionSettingKey:               "600",
+	PlaybackSegmentRetentionSettingKey:               strconv.Itoa(DefaultPlaybackSegmentRetentionSeconds),
 	"playback.hw_accel":                              "auto",
 	"playback.transcode_enabled":                     "true",
 	PlaybackRoutingDirectPlayEgressSettingKey:        string(PlaybackEgressPreferProxy),
@@ -105,8 +104,8 @@ var adminSettingDefaults = map[string]string{
 	"playback.watched_threshold":                     "90",
 	"playback.min_resume_threshold":                  "5",
 	Allow4KTranscodeSettingKey:                       "false",
-	"enable_transcode_throttle":                      "false",
-	"transcode_throttle_seconds":                     "300",
+	TranscodeThrottleEnabledSettingKey:               strconv.FormatBool(DefaultTranscodeThrottleEnabled),
+	TranscodeThrottleSecondsSettingKey:               strconv.Itoa(DefaultTranscodeThrottleSeconds),
 
 	"audiobookshelf_compat.enabled":           "true",
 	"jellyfin_compat.enabled":                 "true",
@@ -324,7 +323,7 @@ func NormalizeAdminSetting(key, raw string) (string, error) {
 	case "metadata.cache_images", "playback.transcode_enabled",
 		chapterThumbnailSoftwareToneMapKey, PlaybackTranscodeHardwareToneMapSettingKey,
 		PlaybackTranscodeSoftwareToneMapSettingKey,
-		Allow4KTranscodeSettingKey, "enable_transcode_throttle", "audiobookshelf_compat.enabled",
+		Allow4KTranscodeSettingKey, TranscodeThrottleEnabledSettingKey, "audiobookshelf_compat.enabled",
 		"jellyfin_compat.enabled", "jellyfin_compat.web_enabled", "recommendations.enabled",
 		"subtitle_ai.enabled", "subtitle_ai.transcribe_enabled", "metadata_ai.enabled",
 		"download.enabled", "download.transcode_enabled", DownloadLocalTranscodeFallbackSettingKey,
@@ -357,9 +356,9 @@ func NormalizeAdminSetting(key, raw string) (string, error) {
 		return normalizeAdminInt(key, value, 1, 100)
 	case "playback.min_resume_threshold":
 		return normalizeAdminInt(key, value, 1, 99)
-	case "transcode_throttle_seconds":
+	case TranscodeThrottleSecondsSettingKey:
 		return normalizeAdminInt(key, value, 60, 86400)
-	case playbackSegmentRetentionSettingKey:
+	case PlaybackSegmentRetentionSettingKey:
 		normalized, err := normalizeAdminInt(key, value, 0, 86400)
 		if err != nil {
 			return "", err

--- a/internal/config/admin_settings_test.go
+++ b/internal/config/admin_settings_test.go
@@ -186,6 +186,28 @@ func TestChapterThumbnailSoftwareToneMapDefaultsDisabled(t *testing.T) {
 	}
 }
 
+func TestTranscodeResourceBoundsDefaultEnabled(t *testing.T) {
+	effective := EffectiveAdminSettings(nil)
+	if got := effective[TranscodeThrottleEnabledSettingKey]; got != "true" {
+		t.Fatalf("transcode throttle default = %q, want true", got)
+	}
+	if got := effective[TranscodeThrottleSecondsSettingKey]; got != "120" {
+		t.Fatalf("transcode throttle buffer = %q, want 120", got)
+	}
+	if got := effective[PlaybackSegmentRetentionSettingKey]; got != "120" {
+		t.Fatalf("transcode segment retention = %q, want 120", got)
+	}
+}
+
+func TestTranscodeThrottleExplicitOptOutIsPreserved(t *testing.T) {
+	effective := EffectiveAdminSettings(map[string]string{
+		TranscodeThrottleEnabledSettingKey: "false",
+	})
+	if got := effective[TranscodeThrottleEnabledSettingKey]; got != "false" {
+		t.Fatalf("transcode throttle = %q, want explicit false", got)
+	}
+}
+
 // TestTranscodeToneMapPoliciesDefaultDisabled verifies tone mapping remains opt-in.
 func TestTranscodeToneMapPoliciesDefaultDisabled(t *testing.T) {
 	effective := EffectiveAdminSettings(nil)
@@ -241,7 +263,7 @@ func TestNormalizeAdminSettingRejectsInvalidValues(t *testing.T) {
 		{key: "theme.catalog_url", value: "http://raw.githubusercontent.com/Silo-Server/silo-themes/main/catalog.json"},
 		{key: "theme.catalog_url", value: "https://example.com/catalog.json"},
 		{key: "redis.url", value: "not-a-url"},
-		{key: "playback.segment_retention_seconds", value: "119"},
+		{key: PlaybackSegmentRetentionSettingKey, value: "119"},
 		{key: "scanner.max_concurrent_libraries", value: "0"},
 		{key: "scanner.max_concurrent_scoped", value: "-1"},
 		{key: "scanner.empty_trash_after_scan", value: "sometimes"},
@@ -267,7 +289,7 @@ func TestNormalizeAdminSettingRejectsInvalidValues(t *testing.T) {
 func TestNormalizeAdminSettingAcceptsSegmentRetentionBounds(t *testing.T) {
 	for _, value := range []string{"0", "120", "86400"} {
 		t.Run(value, func(t *testing.T) {
-			got, err := NormalizeAdminSetting("playback.segment_retention_seconds", value)
+			got, err := NormalizeAdminSetting(PlaybackSegmentRetentionSettingKey, value)
 			if err != nil {
 				t.Fatalf("NormalizeAdminSetting: %v", err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -413,6 +413,19 @@ var defaultJellyfinCompatServerID = uuid.NewSHA1(
 const playbackTranscodeDirSettingKey = "playback.transcode_dir"
 const downloadArtifactDirSettingKey = "download.artifact_dir"
 
+// Playback segment retention and throttling settings are shared by the
+// configuration loader and the live playback handlers. Keep their safe
+// defaults here so every execution path applies the same resource bounds.
+const (
+	PlaybackSegmentRetentionSettingKey = "playback.segment_retention_seconds"
+	TranscodeThrottleEnabledSettingKey = "enable_transcode_throttle"
+	TranscodeThrottleSecondsSettingKey = "transcode_throttle_seconds"
+
+	DefaultPlaybackSegmentRetentionSeconds = 120
+	DefaultTranscodeThrottleEnabled        = true
+	DefaultTranscodeThrottleSeconds        = 120
+)
+
 // DefaultTranscodeDir is the fallback playback.transcode_dir; download
 // artifacts default to a sibling directory (see EffectiveDownloadArtifactDir).
 const DefaultTranscodeDir = "/tmp/silo-transcode"
@@ -502,7 +515,7 @@ func setDefaults() *configRaw {
 		Playback: PlaybackConfig{
 			FFmpegPath:                   "",
 			TranscodeDir:                 DefaultTranscodeDir,
-			SegmentRetentionSeconds:      600,
+			SegmentRetentionSeconds:      DefaultPlaybackSegmentRetentionSeconds,
 			HWAccel:                      "auto",
 			ChapterThumbnailWorkers:      1,
 			ChapterThumbnailExecution:    "local",

--- a/internal/config/db_loader.go
+++ b/internal/config/db_loader.go
@@ -319,12 +319,16 @@ func LoadFromDB(m map[string]string) (*Config, error) {
 	// Playback
 	cfg.Playback.FFmpegPath = stringOr(m, "playback.ffmpeg_path", "")
 	cfg.Playback.TranscodeDir = stringOr(m, playbackTranscodeDirSettingKey, DefaultTranscodeDir)
-	segmentRetentionSeconds, err := intOr(m, playbackSegmentRetentionSettingKey, 600)
+	segmentRetentionSeconds, err := intOr(
+		m,
+		PlaybackSegmentRetentionSettingKey,
+		DefaultPlaybackSegmentRetentionSeconds,
+	)
 	if err != nil {
 		return nil, err
 	}
 	if segmentRetentionSeconds != 0 && (segmentRetentionSeconds < 120 || segmentRetentionSeconds > 86400) {
-		return nil, fmt.Errorf("%s must be 0 or between 120 and 86400", playbackSegmentRetentionSettingKey)
+		return nil, fmt.Errorf("%s must be 0 or between 120 and 86400", PlaybackSegmentRetentionSettingKey)
 	}
 	cfg.Playback.SegmentRetentionSeconds = segmentRetentionSeconds
 	cfg.Playback.HWAccel = stringOr(m, "playback.hw_accel", "auto")

--- a/internal/config/db_loader_test.go
+++ b/internal/config/db_loader_test.go
@@ -38,8 +38,8 @@ func TestLoadFromDBMetadataPresignExpiryRejectsInvalidDuration(t *testing.T) {
 func TestLoadFromDBRejectsInvalidSegmentRetention(t *testing.T) {
 	for _, value := range []string{"-1", "119", "86401"} {
 		t.Run(value, func(t *testing.T) {
-			_, err := LoadFromDB(map[string]string{playbackSegmentRetentionSettingKey: value})
-			if err == nil || !strings.Contains(err.Error(), playbackSegmentRetentionSettingKey) {
+			_, err := LoadFromDB(map[string]string{PlaybackSegmentRetentionSettingKey: value})
+			if err == nil || !strings.Contains(err.Error(), PlaybackSegmentRetentionSettingKey) {
 				t.Fatalf("LoadFromDB() error = %v, want retention bounds error", err)
 			}
 		})
@@ -217,7 +217,7 @@ func TestYAMLToSettingsMapPreservesExplicitlyDisabledSegmentRetention(t *testing
 playback:
   segment_retention_seconds: 0
 `)
-	if got := m[playbackSegmentRetentionSettingKey]; got != "0" {
+	if got := m[PlaybackSegmentRetentionSettingKey]; got != "0" {
 		t.Fatalf("segment retention = %q, want explicit disable", got)
 	}
 }

--- a/internal/config/transcode_resource_policy.go
+++ b/internal/config/transcode_resource_policy.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"context"
+	"strconv"
+)
+
+// SettingReader is the settings-store capability needed to resolve the live
+// transcode resource policy.
+type SettingReader interface {
+	Get(ctx context.Context, key string) (string, error)
+}
+
+// ResolveTranscodeThrottleSettings returns the live forward-buffer policy.
+// Missing, invalid, or unavailable settings retain the protective defaults.
+func ResolveTranscodeThrottleSettings(ctx context.Context, reader SettingReader) (bool, int) {
+	enabled := DefaultTranscodeThrottleEnabled
+	thresholdSeconds := DefaultTranscodeThrottleSeconds
+	if reader == nil {
+		return enabled, thresholdSeconds
+	}
+
+	if rawEnabled, err := reader.Get(ctx, TranscodeThrottleEnabledSettingKey); err == nil && rawEnabled != "" {
+		if configured, parseErr := strconv.ParseBool(rawEnabled); parseErr == nil {
+			enabled = configured
+		}
+	}
+	if rawThreshold, err := reader.Get(ctx, TranscodeThrottleSecondsSettingKey); err == nil && rawThreshold != "" {
+		if configured, parseErr := strconv.Atoi(rawThreshold); parseErr == nil && configured > 0 {
+			thresholdSeconds = configured
+		}
+	}
+
+	return enabled, thresholdSeconds
+}

--- a/internal/config/transcode_resource_policy_test.go
+++ b/internal/config/transcode_resource_policy_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type transcodePolicySettings map[string]string
+
+func (settings transcodePolicySettings) Get(_ context.Context, key string) (string, error) {
+	value, found := settings[key]
+	if !found {
+		return "", errors.New("setting unavailable")
+	}
+	return value, nil
+}
+
+func TestResolveTranscodeThrottleSettings(t *testing.T) {
+	tests := []struct {
+		name          string
+		settings      transcodePolicySettings
+		wantEnabled   bool
+		wantThreshold int
+	}{
+		{
+			name:          "defaults",
+			wantEnabled:   DefaultTranscodeThrottleEnabled,
+			wantThreshold: DefaultTranscodeThrottleSeconds,
+		},
+		{
+			name: "explicit values",
+			settings: transcodePolicySettings{
+				TranscodeThrottleEnabledSettingKey: "false",
+				TranscodeThrottleSecondsSettingKey: "240",
+			},
+			wantEnabled: false, wantThreshold: 240,
+		},
+		{
+			name: "invalid values",
+			settings: transcodePolicySettings{
+				TranscodeThrottleEnabledSettingKey: "sometimes",
+				TranscodeThrottleSecondsSettingKey: "-1",
+			},
+			wantEnabled:   DefaultTranscodeThrottleEnabled,
+			wantThreshold: DefaultTranscodeThrottleSeconds,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			enabled, threshold := ResolveTranscodeThrottleSettings(context.Background(), test.settings)
+			if enabled != test.wantEnabled || threshold != test.wantThreshold {
+				t.Fatalf("policy = (%v, %d), want (%v, %d)", enabled, threshold, test.wantEnabled, test.wantThreshold)
+			}
+		})
+	}
+}

--- a/internal/config/yaml_import.go
+++ b/internal/config/yaml_import.go
@@ -209,7 +209,7 @@ func YAMLToSettingsMap(path string) (map[string]string, error) {
 	// Playback
 	setIfNonEmpty(m, "playback.ffmpeg_path", raw.Playback.FFmpegPath)
 	setIfNonEmpty(m, playbackTranscodeDirSettingKey, raw.Playback.TranscodeDir)
-	m[playbackSegmentRetentionSettingKey] = strconv.Itoa(raw.Playback.SegmentRetentionSeconds)
+	m[PlaybackSegmentRetentionSettingKey] = strconv.Itoa(raw.Playback.SegmentRetentionSeconds)
 	setIfNonEmpty(m, "playback.hw_accel", raw.Playback.HWAccel)
 	if raw.Playback.ChapterThumbnailWorkers != 0 {
 		m["playback.chapter_thumbnail_workers"] = strconv.Itoa(raw.Playback.ChapterThumbnailWorkers)

--- a/internal/jellycompat/handlers_playback.go
+++ b/internal/jellycompat/handlers_playback.go
@@ -280,6 +280,7 @@ type PlaybackHandler struct {
 	TranscodeDir            string
 	SegmentRetentionSeconds func() int
 	PlaybackConfig          func() config.PlaybackConfig
+	FFmpegLogSink           playback.FFmpegLogSink
 	// tm is the shared transcode-session lifecycle (live map, reconstruct) — the
 	// same type the native handler uses, so jellycompat gets the reconstruct cap
 	// and node-affinity rule for free. The reconstruction recipe is carried in the
@@ -1057,7 +1058,7 @@ func NewPlaybackHandler(
 	transcodeDir := filepath.Join(os.TempDir(), "silo-transcode")
 	ffmpegPath := ""
 	hwAccel := ""
-	segmentRetentionSeconds := 600
+	segmentRetentionSeconds := config.DefaultPlaybackSegmentRetentionSeconds
 	if cfg != nil {
 		if cfg.Playback.TranscodeDir != "" {
 			transcodeDir = cfg.Playback.TranscodeDir
@@ -1085,6 +1086,7 @@ func NewPlaybackHandler(
 	// Wire the shared transcode manager with closures so it reads the handler's
 	// (late-set) JWTSecret lazily, matching the native handler.
 	h.tm.JWTSecretFn = func() string { return h.JWTSecret }
+	h.tm.LogSinkFn = func() playback.FFmpegLogSink { return h.FFmpegLogSink }
 	h.tm.Config = func() playback.TranscodeRuntimeConfig {
 		return playback.TranscodeRuntimeConfig{
 			TranscodeDir:            h.TranscodeDir,
@@ -1127,6 +1129,9 @@ func NewPlaybackHandler(
 			_ = h.sessionMgr.StopSession(sessionID)
 		}
 	}
+	h.tm.StartThrottler = func(ctx context.Context, session *playback.TranscodeSession) {
+		h.maybeStartThrottler(ctx, session)
+	}
 	return h
 }
 
@@ -1134,7 +1139,12 @@ func (h *PlaybackHandler) segmentRetentionSeconds() int {
 	if h.SegmentRetentionSeconds != nil {
 		return h.SegmentRetentionSeconds()
 	}
-	return 600
+	return config.DefaultPlaybackSegmentRetentionSeconds
+}
+
+func (h *PlaybackHandler) maybeStartThrottler(ctx context.Context, session *playback.TranscodeSession) {
+	enabled, thresholdSeconds := config.ResolveTranscodeThrottleSettings(ctx, h.SettingsRepo)
+	session.ConfigureThrottler(ctx, enabled, thresholdSeconds)
 }
 
 func (h *PlaybackHandler) playbackRoutingPolicy() config.PlaybackRoutingPolicy {
@@ -1478,22 +1488,26 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 	}
 
 	reqBody := transcodenode.TranscodeStartRequest{
-		SessionID:           upstreamSessionID,
-		InputPath:           file.FilePath,
-		SourceVideoCodec:    sourceVideoCodec,
-		SourceVideoProfile:  sourceVideoProfile,
-		SourceVideoBitDepth: sourceVideoBitDepth,
-		SeekSeconds:         initialSeekSeconds,
-		StartSegmentNumber:  startSegmentNumber,
-		TargetCodecVideo:    compatTargetVideoCodec,
-		TargetCodecAudio:    compatTargetAudioCodec,
-		SegmentDuration:     segmentDuration,
-		HWAccel:             h.remoteDispatchHWAccel(transcodeNodeURL),
-		AudioTrackIndex:     compatAudioTrackIndexOrDefault(source),
-		SourceAudioChannels: compatHLSRecipeSourceAudioChannels(source),
-		TotalDuration:       float64(source.Version.Duration),
-		RequireReady:        toneMapRecipe.mode != "",
+		SessionID:             upstreamSessionID,
+		PlaybackSessionID:     upstreamSessionID,
+		InputPath:             file.FilePath,
+		SourceVideoCodec:      sourceVideoCodec,
+		SourceVideoProfile:    sourceVideoProfile,
+		SourceVideoBitDepth:   sourceVideoBitDepth,
+		SourceVideoResolution: source.Version.Resolution,
+		SeekSeconds:           initialSeekSeconds,
+		StartSegmentNumber:    startSegmentNumber,
+		TargetCodecVideo:      compatTargetVideoCodec,
+		TargetCodecAudio:      compatTargetAudioCodec,
+		SegmentDuration:       segmentDuration,
+		HWAccel:               h.remoteDispatchHWAccel(transcodeNodeURL),
+		AudioTrackIndex:       compatAudioTrackIndexOrDefault(source),
+		SourceAudioChannels:   compatHLSRecipeSourceAudioChannels(source),
+		TotalDuration:         float64(source.Version.Duration),
+		RequireReady:          true,
 	}
+	reqBody.ThrottlePolicyConfigured = true
+	reqBody.ThrottleEnabled, reqBody.ThrottleThresholdSeconds = config.ResolveTranscodeThrottleSettings(ctx, h.SettingsRepo)
 	if playback.IsAudioToAACStereoDownmixV3(reqBody.SourceAudioChannels, reqBody.TargetCodecAudio, reqBody.TargetAudioChannels) {
 		reqBody.AudioRecipeVersion = playback.TransformationAudioToAACRecipeVersionV3
 		reqBody.TargetAudioChannels = 2
@@ -1700,28 +1714,38 @@ func (h *PlaybackHandler) startRemoteTranscodeWithToneMapMode(
 	// internal/noderecipe), and central serves Jellyfin clients that carry no native
 	// token of their own, so without a persisted recipe a node or central restart
 	// cannot rebuild ffmpeg and segment serves 404.
+	effectiveHWAccel := strings.TrimSpace(nodeResponse.HWAccel)
+	softwareVideoDecode := nodeResponse.SoftwareVideoDecode
+	if effectiveHWAccel == "" {
+		softwareVideoDecode = reqBody.SoftwareVideoDecode
+	}
 	opts := playback.TranscodeOpts{
-		SessionID:           upstreamSessionID,
-		InputPath:           reqBody.InputPath,
-		SourceVideoCodec:    reqBody.SourceVideoCodec,
-		SourceVideoProfile:  reqBody.SourceVideoProfile,
-		SourceVideoBitDepth: reqBody.SourceVideoBitDepth,
-		SeekSeconds:         reqBody.SeekSeconds,
-		StartSegmentNumber:  reqBody.StartSegmentNumber,
-		TargetCodecVideo:    reqBody.TargetCodecVideo,
-		TargetCodecAudio:    reqBody.TargetCodecAudio,
-		TargetResolution:    reqBody.TargetResolution,
-		TargetBitrateKbps:   reqBody.TargetBitrateKbps,
-		VideoSampleEntry:    reqBody.VideoSampleEntry,
-		CopyVideoMPEGTS:     reqBody.CopyVideoMPEGTS,
-		SegmentDuration:     reqBody.SegmentDuration,
-		AudioTrackIndex:     reqBody.AudioTrackIndex,
-		SourceAudioChannels: reqBody.SourceAudioChannels,
-		TargetAudioChannels: reqBody.TargetAudioChannels,
-		TotalDuration:       reqBody.TotalDuration,
+		SessionID:                upstreamSessionID,
+		InputPath:                reqBody.InputPath,
+		SourceVideoCodec:         reqBody.SourceVideoCodec,
+		SourceVideoProfile:       reqBody.SourceVideoProfile,
+		SourceVideoBitDepth:      reqBody.SourceVideoBitDepth,
+		SourceVideoResolution:    reqBody.SourceVideoResolution,
+		SoftwareVideoDecode:      softwareVideoDecode,
+		SeekSeconds:              reqBody.SeekSeconds,
+		StartSegmentNumber:       reqBody.StartSegmentNumber,
+		TargetCodecVideo:         reqBody.TargetCodecVideo,
+		TargetCodecAudio:         reqBody.TargetCodecAudio,
+		TargetResolution:         reqBody.TargetResolution,
+		TargetBitrateKbps:        reqBody.TargetBitrateKbps,
+		VideoSampleEntry:         reqBody.VideoSampleEntry,
+		CopyVideoMPEGTS:          reqBody.CopyVideoMPEGTS,
+		SegmentDuration:          reqBody.SegmentDuration,
+		ThrottlePolicyConfigured: reqBody.ThrottlePolicyConfigured,
+		ThrottleEnabled:          reqBody.ThrottleEnabled,
+		ThrottleThresholdSeconds: reqBody.ThrottleThresholdSeconds,
+		AudioTrackIndex:          reqBody.AudioTrackIndex,
+		SourceAudioChannels:      reqBody.SourceAudioChannels,
+		TargetAudioChannels:      reqBody.TargetAudioChannels,
+		TotalDuration:            reqBody.TotalDuration,
 	}
 	toneMapRecipe.apply(&opts)
-	opts.HWAccel = strings.TrimSpace(nodeResponse.HWAccel)
+	opts.HWAccel = effectiveHWAccel
 	opts.ToneMapMode = nodeResponse.ToneMapMode
 	if compatHLSCopiesVideo(source) {
 		opts.TargetCodecVideo = compatCopyCodec

--- a/internal/jellycompat/router.go
+++ b/internal/jellycompat/router.go
@@ -124,6 +124,7 @@ func NewRouter(deps Dependencies) chi.Router {
 	}
 	playbackHandler.NodePlanner = deps.NodePlanner
 	playbackHandler.JWTSecret = deps.JWTSecret
+	playbackHandler.FFmpegLogSink = deps.FFmpegLogSink
 	// Compat transcode reconstruct is driven by the recipe carried in the durable
 	// compat playback store (jellycompat_playback_sessions); no separate native
 	// recipe table is needed.

--- a/internal/jellycompat/server.go
+++ b/internal/jellycompat/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/config"
 	"github.com/Silo-Server/silo-server/internal/nodepool"
+	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/recommendations"
 	"github.com/Silo-Server/silo-server/internal/scantrigger"
 	"github.com/Silo-Server/silo-server/internal/secret"
@@ -92,7 +93,8 @@ type Dependencies struct {
 	PresignTTL      time.Duration
 
 	// Playback
-	SessionMgr SessionManagerInterface
+	SessionMgr    SessionManagerInterface
+	FFmpegLogSink playback.FFmpegLogSink
 	// SessionSyncer flushes native session-manager state into the shared
 	// admin live-session table right after compat playback starts/stops, so
 	// the activity dashboard doesn't wait for the periodic reconciler tick.

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2516,22 +2516,26 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	}
 
 	opts := playback.TranscodeOpts{
-		SessionID:           upstreamSessionID,
-		InputPath:           file.FilePath,
-		SourceVideoCodec:    sourceVideoCodec,
-		SourceVideoProfile:  sourceVideoProfile,
-		SourceVideoBitDepth: sourceVideoBitDepth,
-		OutputDir:           filepath.Join(h.TranscodeDir, upstreamSessionID),
-		SeekSeconds:         initialSeekSeconds,
-		StartSegmentNumber:  startSegmentNumber,
-		TargetCodecVideo:    compatTargetVideoCodec,
-		TargetCodecAudio:    compatTargetAudioCodec,
-		FFmpegPath:          h.FFmpegPath,
-		HWAccel:             h.HWAccel,
-		AudioTrackIndex:     audioTrackIndex,
-		SourceAudioChannels: sourceAudioChannels,
-		TotalDuration:       float64(source.Version.Duration),
-		FastStart:           true,
+		SessionID:             upstreamSessionID,
+		InputPath:             file.FilePath,
+		SourceVideoCodec:      sourceVideoCodec,
+		SourceVideoProfile:    sourceVideoProfile,
+		SourceVideoBitDepth:   sourceVideoBitDepth,
+		SourceVideoResolution: file.Resolution,
+		OutputDir:             filepath.Join(h.TranscodeDir, upstreamSessionID),
+		SeekSeconds:           initialSeekSeconds,
+		StartSegmentNumber:    startSegmentNumber,
+		TargetCodecVideo:      compatTargetVideoCodec,
+		TargetCodecAudio:      compatTargetAudioCodec,
+		FFmpegPath:            h.FFmpegPath,
+		HWAccel:               h.HWAccel,
+		AudioTrackIndex:       audioTrackIndex,
+		SourceAudioChannels:   sourceAudioChannels,
+		TotalDuration:         float64(source.Version.Duration),
+		FastStart:             true,
+		NodeType:              "integrated",
+		ExecutionMode:         "jellyfin_compat",
+		FFmpegLogSink:         h.FFmpegLogSink,
 	}
 	opts.SegmentRetentionSeconds = h.segmentRetentionSeconds()
 	if sourceAudioChannels > 0 {
@@ -2592,6 +2596,8 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 		h.tm.CloseTranscodeSessionIf(upstreamSessionID, existing, "")
 	}
 	manifestDeadline := time.Now().Add(compatManifestStartupTimeout)
+	autoPipeline := playback.NewAutoTranscodePipeline(ctx, opts)
+	opts = autoPipeline.Current()
 	transcodeSession, err := playback.StartTranscode(ctx, opts)
 	if err != nil && downgradeCompatLocalToneMap(&opts, toneMapCapabilities, autoVideoToolboxBitrate) {
 		transcodeSession, err = playback.StartTranscode(ctx, opts)
@@ -2643,7 +2649,23 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 				return nil, fallbackErr
 			}
 		}
+	} else if autoPipeline.Enabled() {
+		var adopted bool
+		transcodeSession, adopted, err = h.waitForAutoTranscodeSession(
+			ctx,
+			upstreamSessionID,
+			source,
+			autoPipeline,
+			transcodeSession,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if adopted {
+			return transcodeSession, nil
+		}
 	}
+	h.maybeStartThrottler(ctx, transcodeSession)
 	if h.compatLocalTranscodeReady != nil {
 		h.compatLocalTranscodeReady(transcodeSession)
 	}
@@ -2676,6 +2698,10 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	// Register the exit monitor and persist the reconstruction recipe (shared with
 	// the remote path). On a failed compat-store write roll back this abandoned
 	// transcode rather than leaking it.
+	transcodeSession.SetRestartHook(func(ctx context.Context) {
+		h.maybeStartThrottler(ctx, transcodeSession)
+		h.tm.MonitorLocalTranscodeExit(upstreamSessionID, transcodeSession)
+	})
 	h.tm.MonitorLocalTranscodeExit(upstreamSessionID, transcodeSession)
 
 	if err := h.persistTranscodeRecipe(ctx, playSessionID, upstreamSessionID, effectiveOpts); err != nil {
@@ -2686,6 +2712,65 @@ func (h *PlaybackHandler) ensureTranscodeSessionWithToneMapMode(
 	publishUnlock()
 
 	return transcodeSession, nil
+}
+
+func (h *PlaybackHandler) waitForAutoTranscodeSession(
+	ctx context.Context,
+	upstreamSessionID string,
+	source PlaybackMediaSource,
+	pipeline *playback.AutoTranscodePipeline,
+	session *playback.TranscodeSession,
+) (*playback.TranscodeSession, bool, error) {
+	for {
+		if _, err := session.WaitForManifest(compatManifestStartupTimeout); err == nil {
+			pipeline.RememberSuccess()
+			return session, false, nil
+		} else if session.IsRunning() {
+			cleanupUnlock := h.tm.LockSessionLifecycle(upstreamSessionID)
+			h.tm.CloseTranscodeSessionIf(upstreamSessionID, session, "")
+			cleanupUnlock()
+			return nil, false, err
+		} else {
+			failedDevice := session.Opts().HWDevice
+			if !pipeline.AdvanceAfterFailure(failedDevice) {
+				cleanupUnlock := h.tm.LockSessionLifecycle(upstreamSessionID)
+				h.tm.CloseTranscodeSessionIf(upstreamSessionID, session, "")
+				cleanupUnlock()
+				return nil, false, err
+			}
+
+			replaceUnlock := h.tm.LockSessionLifecycle(upstreamSessionID)
+			if live := h.tm.GetTranscodeSession(upstreamSessionID); live != session {
+				replaceUnlock()
+				if live != nil && compatTranscodeSessionUsesToneMapMode(live, "") {
+					if compatLiveTranscodeMatchesAudioSource(live, source) {
+						return live, true, nil
+					}
+					return nil, false, errCompatRecipeSourceMismatch
+				}
+				return nil, false, playback.ErrSessionSuperseded
+			}
+
+			h.tm.CloseTranscodeSessionIf(upstreamSessionID, session, "")
+			nextOpts := pipeline.Current()
+			slog.WarnContext(ctx, "automatic compat transcode failed during startup; trying safer path",
+				"component", "jellycompat",
+				"playback_session_id", upstreamSessionID,
+				"failed_device", failedDevice,
+				"next_hw_accel", nextOpts.HWAccel,
+				"next_software_decode", nextOpts.SoftwareVideoDecode,
+				"error", err,
+			)
+			replacement, startErr := playback.StartTranscode(ctx, nextOpts)
+			if startErr != nil {
+				replaceUnlock()
+				return nil, false, startErr
+			}
+			h.tm.RegisterTranscodeSession(upstreamSessionID, replacement)
+			replaceUnlock()
+			session = replacement
+		}
+	}
 }
 
 // downgradeCompatLocalToneMap removes the bitrate synthesized solely for a

--- a/internal/playback/auto_transcode_pipeline.go
+++ b/internal/playback/auto_transcode_pipeline.go
@@ -1,0 +1,252 @@
+package playback
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+type autoTranscodeStage uint8
+
+const (
+	autoTranscodeFullHardware autoTranscodeStage = iota
+	autoTranscodeSoftwareDecode
+	autoTranscodeSoftware
+)
+
+const (
+	autoTranscodePreferenceTTL  = 15 * time.Minute
+	maxAutoTranscodePreferences = 256
+)
+
+type autoTranscodePreference struct {
+	stage       autoTranscodeStage
+	avoidDevice string
+	expiresAt   time.Time
+}
+
+type autoTranscodePipelineCache struct {
+	mu        sync.Mutex
+	preferred map[string]autoTranscodePreference
+	now       func() time.Time
+}
+
+var sharedAutoTranscodePipelineCache = newAutoTranscodePipelineCache()
+
+// AutoTranscodePipeline walks the safe execution paths for an automatic
+// hardware selection. A successful fallback is remembered briefly for the
+// same media file, avoiding repeated failed starts without permanently hiding
+// a recovered GPU or affecting unrelated media.
+type AutoTranscodePipeline struct {
+	base     TranscodeOpts
+	cache    *autoTranscodePipelineCache
+	cacheKey string
+	stages   []autoTranscodeStage
+	index    int
+	enabled  bool
+}
+
+// NewAutoTranscodePipeline resolves auto once and prepares the fallback order
+// full GPU, CPU decode with GPU encode, then full software. It launches no
+// additional FFmpeg process: the real manifest startup validates each path.
+func NewAutoTranscodePipeline(ctx context.Context, opts TranscodeOpts) *AutoTranscodePipeline {
+	autoRequested := strings.EqualFold(strings.TrimSpace(opts.HWAccel), hwAccelAuto)
+	normalized := normalizeTranscodeOptsContext(ctx, opts)
+	return newAutoTranscodePipeline(normalized, autoRequested, sharedAutoTranscodePipelineCache)
+}
+
+// newAutoTranscodePipeline builds a pipeline from an already-resolved backend.
+func newAutoTranscodePipeline(opts TranscodeOpts, autoRequested bool, cache *autoTranscodePipelineCache) *AutoTranscodePipeline {
+	pipeline := &AutoTranscodePipeline{
+		base:   opts,
+		cache:  cache,
+		stages: []autoTranscodeStage{stageForTranscodeOpts(opts)},
+	}
+	if !autoRequested || opts.ToneMapMode != "" || strings.EqualFold(opts.TargetCodecVideo, "copy") || !isHardwareTranscodeBackend(opts.HWAccel) {
+		return pipeline
+	}
+
+	pipeline.enabled = true
+	if opts.SoftwareVideoDecode {
+		pipeline.stages = []autoTranscodeStage{autoTranscodeSoftwareDecode, autoTranscodeSoftware}
+	} else {
+		pipeline.stages = []autoTranscodeStage{autoTranscodeFullHardware, autoTranscodeSoftwareDecode, autoTranscodeSoftware}
+	}
+	pipeline.cacheKey = autoTranscodePipelineCacheKey(opts)
+	if preferred, found := cache.get(pipeline.cacheKey); found {
+		for index, stage := range pipeline.stages {
+			if stage == preferred.stage {
+				pipeline.index = index
+				if stage != autoTranscodeSoftware {
+					pipeline.base.AvoidHWDevice = preferred.avoidDevice
+				}
+				break
+			}
+		}
+	}
+	return pipeline
+}
+
+// Enabled reports whether this request was an ordinary video transcode using
+// the automatic hardware setting and can therefore move to another path.
+func (pipeline *AutoTranscodePipeline) Enabled() bool {
+	return pipeline != nil && pipeline.enabled
+}
+
+// Current returns the options for the current execution path.
+func (pipeline *AutoTranscodePipeline) Current() TranscodeOpts {
+	if pipeline == nil {
+		return TranscodeOpts{}
+	}
+	opts := pipeline.base
+	switch pipeline.stages[pipeline.index] {
+	case autoTranscodeFullHardware:
+		opts.SoftwareVideoDecode = false
+	case autoTranscodeSoftwareDecode:
+		opts.SoftwareVideoDecode = true
+	case autoTranscodeSoftware:
+		opts.HWAccel = HWAccelNone
+		opts.SoftwareVideoDecode = true
+	}
+	return opts
+}
+
+// AdvanceAfterFailure selects the next less hardware-dependent path after
+// FFmpeg exits before producing its first manifest. A following hardware path
+// avoids the concrete device that just failed when another device is available.
+func (pipeline *AutoTranscodePipeline) AdvanceAfterFailure(failedDevice string) bool {
+	if pipeline == nil || pipeline.index+1 >= len(pipeline.stages) {
+		return false
+	}
+	pipeline.index++
+	if pipeline.stages[pipeline.index] == autoTranscodeSoftware {
+		pipeline.base.AvoidHWDevice = ""
+	} else {
+		pipeline.base.AvoidHWDevice = strings.TrimSpace(failedDevice)
+	}
+	return true
+}
+
+// RememberSuccess caches a fallback only after its real playback manifest was
+// ready. Full-hardware success remains the default and needs no cache entry.
+func (pipeline *AutoTranscodePipeline) RememberSuccess() {
+	if !pipeline.Enabled() || pipeline.cacheKey == "" {
+		return
+	}
+	stage := pipeline.stages[pipeline.index]
+	if stage == pipeline.stages[0] && stage == autoTranscodeFullHardware {
+		pipeline.cache.remove(pipeline.cacheKey)
+		return
+	}
+	pipeline.cache.put(pipeline.cacheKey, stage, pipeline.base.AvoidHWDevice)
+}
+
+// newAutoTranscodePipelineCache returns an empty concurrency-safe cache.
+func newAutoTranscodePipelineCache() *autoTranscodePipelineCache {
+	return &autoTranscodePipelineCache{
+		preferred: make(map[string]autoTranscodePreference),
+		now:       time.Now,
+	}
+}
+
+// get returns the preferred successful stage for a pipeline signature.
+func (cache *autoTranscodePipelineCache) get(key string) (autoTranscodePreference, bool) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	preference, found := cache.preferred[key]
+	if !found {
+		return autoTranscodePreference{}, false
+	}
+	if !cache.now().Before(preference.expiresAt) {
+		delete(cache.preferred, key)
+		return autoTranscodePreference{}, false
+	}
+	return preference, true
+}
+
+// put records the successful stage for a pipeline signature.
+func (cache *autoTranscodePipelineCache) put(key string, stage autoTranscodeStage, avoidDevice string) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	now := cache.now()
+	for candidate, preference := range cache.preferred {
+		if !now.Before(preference.expiresAt) {
+			delete(cache.preferred, candidate)
+		}
+	}
+	if _, exists := cache.preferred[key]; !exists && len(cache.preferred) >= maxAutoTranscodePreferences {
+		cache.removeOldestLocked()
+	}
+	cache.preferred[key] = autoTranscodePreference{
+		stage:       stage,
+		avoidDevice: strings.TrimSpace(avoidDevice),
+		expiresAt:   now.Add(autoTranscodePreferenceTTL),
+	}
+}
+
+// remove restores full hardware as the default for a pipeline signature.
+func (cache *autoTranscodePipelineCache) remove(key string) {
+	cache.mu.Lock()
+	delete(cache.preferred, key)
+	cache.mu.Unlock()
+}
+
+func (cache *autoTranscodePipelineCache) removeOldestLocked() {
+	oldestKey := ""
+	var oldestExpiry time.Time
+	for key, preference := range cache.preferred {
+		if oldestKey == "" || preference.expiresAt.Before(oldestExpiry) {
+			oldestKey = key
+			oldestExpiry = preference.expiresAt
+		}
+	}
+	if oldestKey != "" {
+		delete(cache.preferred, oldestKey)
+	}
+}
+
+// stageForTranscodeOpts describes the execution path already selected by opts.
+func stageForTranscodeOpts(opts TranscodeOpts) autoTranscodeStage {
+	if !isHardwareTranscodeBackend(opts.HWAccel) {
+		return autoTranscodeSoftware
+	}
+	if opts.SoftwareVideoDecode {
+		return autoTranscodeSoftwareDecode
+	}
+	return autoTranscodeFullHardware
+}
+
+// isHardwareTranscodeBackend reports whether a backend can encode on a GPU.
+func isHardwareTranscodeBackend(hwAccel string) bool {
+	switch hwAccel {
+	case transcodeHWQSV, transcodeHWVAAPI, transcodeHWNVENC, transcodeHWVideoToolbox:
+		return true
+	default:
+		return false
+	}
+}
+
+// autoTranscodePipelineCacheKey keeps a fallback local to one source file and
+// executable recipe. File-specific corruption or unusual stream metadata must
+// never downgrade another title that happens to share the same codec label.
+func autoTranscodePipelineCacheKey(opts TranscodeOpts) string {
+	return strings.Join([]string{
+		ffmpegIdentityKey(opts.FFmpegPath),
+		strings.TrimSpace(opts.InputPath),
+		opts.HWAccel,
+		strings.Join(ParseHWDeviceSet(opts.HWDevice).List(), ","),
+		normalizeCodecV3(opts.SourceVideoCodec),
+		normalizeVideoProfile(opts.SourceVideoProfile),
+		strconv.Itoa(opts.SourceVideoBitDepth),
+		strings.ToLower(strings.TrimSpace(opts.SourceVideoResolution)),
+		normalizeCodecV3(opts.TargetCodecVideo),
+		strings.ToLower(strings.TrimSpace(opts.TargetResolution)),
+		strconv.Itoa(opts.TargetBitrateKbps),
+		strconv.FormatBool(opts.SubtitleBurnIn),
+		normalizeCodecV3(opts.SubtitleCodec),
+	}, "\x00")
+}

--- a/internal/playback/auto_transcode_pipeline_test.go
+++ b/internal/playback/auto_transcode_pipeline_test.go
@@ -1,0 +1,195 @@
+package playback
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestAutoTranscodePipelineWalksFallbacksAndCachesSuccess(t *testing.T) {
+	cache := newAutoTranscodePipelineCache()
+	opts := TranscodeOpts{
+		FFmpegPath:            "/usr/bin/ffmpeg",
+		HWAccel:               transcodeHWNVENC,
+		SourceVideoCodec:      "hevc",
+		SourceVideoProfile:    "Main",
+		SourceVideoBitDepth:   8,
+		SourceVideoResolution: "1080p",
+		TargetCodecVideo:      "h264",
+		TargetResolution:      "720p",
+	}
+
+	pipeline := newAutoTranscodePipeline(opts, true, cache)
+	assertAutoTranscodePath(t, pipeline.Current(), transcodeHWNVENC, false)
+	if !pipeline.AdvanceAfterFailure("0") {
+		t.Fatal("expected hybrid fallback")
+	}
+	hybrid := pipeline.Current()
+	assertAutoTranscodePath(t, hybrid, transcodeHWNVENC, true)
+	if hybrid.AvoidHWDevice != "0" {
+		t.Fatalf("hybrid AvoidHWDevice = %q, want failed device", hybrid.AvoidHWDevice)
+	}
+	pipeline.RememberSuccess()
+
+	second := opts
+	second.SessionID = "another-session"
+	cached := newAutoTranscodePipeline(second, true, cache)
+	cachedOpts := cached.Current()
+	assertAutoTranscodePath(t, cachedOpts, transcodeHWNVENC, true)
+	if cachedOpts.AvoidHWDevice != "0" {
+		t.Fatalf("cached AvoidHWDevice = %q, want failed device", cachedOpts.AvoidHWDevice)
+	}
+	if !cached.AdvanceAfterFailure("1") {
+		t.Fatal("expected software fallback after cached hybrid path")
+	}
+	software := cached.Current()
+	assertAutoTranscodePath(t, software, HWAccelNone, true)
+	if software.AvoidHWDevice != "" {
+		t.Fatalf("software AvoidHWDevice = %q, want empty", software.AvoidHWDevice)
+	}
+	cached.RememberSuccess()
+
+	softwareCached := newAutoTranscodePipeline(opts, true, cache)
+	assertAutoTranscodePath(t, softwareCached.Current(), HWAccelNone, true)
+	if softwareCached.AdvanceAfterFailure("1") {
+		t.Fatal("software path must be the final fallback")
+	}
+
+	anotherFile := opts
+	anotherFile.InputPath = "/media/another-file.mkv"
+	assertAutoTranscodePath(t, newAutoTranscodePipeline(anotherFile, true, cache).Current(), transcodeHWNVENC, false)
+}
+
+func TestAutoTranscodePipelineCacheExpiresAndRetriesHardware(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	cache := newAutoTranscodePipelineCache()
+	cache.now = func() time.Time { return now }
+	opts := TranscodeOpts{
+		InputPath:        "/media/movie.mkv",
+		HWAccel:          transcodeHWNVENC,
+		SourceVideoCodec: "hevc",
+		TargetCodecVideo: "h264",
+	}
+
+	fallback := newAutoTranscodePipeline(opts, true, cache)
+	if !fallback.AdvanceAfterFailure("0") {
+		t.Fatal("expected hybrid fallback")
+	}
+	fallback.RememberSuccess()
+	assertAutoTranscodePath(t, newAutoTranscodePipeline(opts, true, cache).Current(), transcodeHWNVENC, true)
+
+	now = now.Add(autoTranscodePreferenceTTL)
+	assertAutoTranscodePath(t, newAutoTranscodePipeline(opts, true, cache).Current(), transcodeHWNVENC, false)
+}
+
+func TestAutoTranscodePipelineCacheIsBounded(t *testing.T) {
+	cache := newAutoTranscodePipelineCache()
+	for index := 0; index <= maxAutoTranscodePreferences; index++ {
+		opts := TranscodeOpts{
+			InputPath:        fmt.Sprintf("/media/%d.mkv", index),
+			HWAccel:          transcodeHWNVENC,
+			SourceVideoCodec: "hevc",
+			TargetCodecVideo: "h264",
+		}
+		pipeline := newAutoTranscodePipeline(opts, true, cache)
+		if !pipeline.AdvanceAfterFailure("0") {
+			t.Fatal("expected hybrid fallback")
+		}
+		pipeline.RememberSuccess()
+	}
+	if got := len(cache.preferred); got != maxAutoTranscodePreferences {
+		t.Fatalf("cache size = %d, want %d", got, maxAutoTranscodePreferences)
+	}
+}
+
+func TestAutoTranscodePipelineDoesNotCacheFailure(t *testing.T) {
+	cache := newAutoTranscodePipelineCache()
+	opts := TranscodeOpts{
+		FFmpegPath:          "/usr/bin/ffmpeg",
+		HWAccel:             transcodeHWNVENC,
+		SourceVideoCodec:    "hevc",
+		TargetCodecVideo:    "h264",
+		TargetResolution:    "720p",
+		SourceVideoBitDepth: 8,
+	}
+
+	failed := newAutoTranscodePipeline(opts, true, cache)
+	if !failed.AdvanceAfterFailure("0") {
+		t.Fatal("expected hybrid fallback")
+	}
+
+	next := newAutoTranscodePipeline(opts, true, cache)
+	assertAutoTranscodePath(t, next.Current(), transcodeHWNVENC, false)
+}
+
+func TestAutoTranscodePipelineStartsSafelyForKnownUnsupportedDecode(t *testing.T) {
+	cache := newAutoTranscodePipelineCache()
+	opts := TranscodeOpts{
+		FFmpegPath:          "/usr/bin/ffmpeg",
+		HWAccel:             transcodeHWNVENC,
+		SourceVideoCodec:    "h264",
+		SourceVideoProfile:  "High 10",
+		SourceVideoBitDepth: 10,
+		TargetCodecVideo:    "h264",
+		TargetResolution:    "720p",
+		SoftwareVideoDecode: true,
+	}
+
+	pipeline := newAutoTranscodePipeline(opts, true, cache)
+	assertAutoTranscodePath(t, pipeline.Current(), transcodeHWNVENC, true)
+	if !pipeline.AdvanceAfterFailure("0") {
+		t.Fatal("expected software fallback")
+	}
+	assertAutoTranscodePath(t, pipeline.Current(), HWAccelNone, true)
+}
+
+func TestAutoTranscodePipelineKeepsExplicitBackendFixed(t *testing.T) {
+	cache := newAutoTranscodePipelineCache()
+	opts := TranscodeOpts{
+		HWAccel:             transcodeHWNVENC,
+		SourceVideoCodec:    "h264",
+		TargetCodecVideo:    "h264",
+		TargetResolution:    "720p",
+		SoftwareVideoDecode: true,
+	}
+
+	pipeline := newAutoTranscodePipeline(opts, false, cache)
+	if pipeline.Enabled() {
+		t.Fatal("explicit backend must not enable automatic fallback")
+	}
+	assertAutoTranscodePath(t, pipeline.Current(), transcodeHWNVENC, true)
+	if pipeline.AdvanceAfterFailure("0") {
+		t.Fatal("explicit backend must keep its selected path")
+	}
+}
+
+func TestAutoTranscodePipelineSeparatesSourceResolutions(t *testing.T) {
+	cache := newAutoTranscodePipelineCache()
+	base := TranscodeOpts{
+		FFmpegPath:            "/usr/bin/ffmpeg",
+		HWAccel:               transcodeHWNVENC,
+		SourceVideoCodec:      "hevc",
+		SourceVideoResolution: "1080p",
+		TargetCodecVideo:      "h264",
+		TargetResolution:      "720p",
+	}
+
+	fullHD := newAutoTranscodePipeline(base, true, cache)
+	if !fullHD.AdvanceAfterFailure("0") {
+		t.Fatal("expected hybrid fallback")
+	}
+	fullHD.RememberSuccess()
+
+	ultraHDOpts := base
+	ultraHDOpts.SourceVideoResolution = "2160p"
+	ultraHD := newAutoTranscodePipeline(ultraHDOpts, true, cache)
+	assertAutoTranscodePath(t, ultraHD.Current(), transcodeHWNVENC, false)
+}
+
+func assertAutoTranscodePath(t *testing.T, opts TranscodeOpts, wantHWAccel string, wantSoftwareDecode bool) {
+	t.Helper()
+	if opts.HWAccel != wantHWAccel || opts.SoftwareVideoDecode != wantSoftwareDecode {
+		t.Fatalf("path = hw_accel %q, software_decode %v; want %q, %v",
+			opts.HWAccel, opts.SoftwareVideoDecode, wantHWAccel, wantSoftwareDecode)
+	}
+}

--- a/internal/playback/ffmpeg_diagnostics.go
+++ b/internal/playback/ffmpeg_diagnostics.go
@@ -1,0 +1,209 @@
+package playback
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+const pipelineSoftwareDecodeHardwareEncode = "software_decode_hardware_encode"
+
+// FFmpegDiagnostics is the complete, event-only snapshot of the recipe and
+// runtime policy behind one FFmpeg process. Stderr rows deliberately omit it:
+// repeating the command and recipe on every line would inflate operational log
+// storage without adding information.
+type FFmpegDiagnostics struct {
+	FFmpegPath               string
+	FFmpegArgs               []string
+	Pipeline                 string
+	VideoEncoder             string
+	AudioEncoder             string
+	VideoFilter              string
+	VideoPixelFormats        []string
+	SegmentType              string
+	SourceVideoCodec         string
+	SourceVideoProfile       string
+	SourceVideoBitDepth      int
+	SourceVideoResolution    string
+	SourceAudioChannels      int
+	SoftwareVideoDecode      bool
+	HWDevice                 string
+	TargetAudioChannels      int
+	TargetAudioBitrateKbps   int
+	TargetBitrateKbps        int
+	ToneMapPolicy            string
+	ToneMapMode              string
+	ToneMapSourceKind        string
+	ToneMapFilter            string
+	ToneMapRecipeVersion     string
+	ToneMapPreflightRequired bool
+	VideoBitstreamFilter     string
+	VideoSampleEntry         string
+	AudioTrackIndex          int
+	SubtitleTrackIndex       int
+	SubtitleBurnIn           bool
+	SubtitleCodec            string
+	SegmentDuration          int
+	SegmentRetentionSeconds  int
+	TotalDuration            float64
+	FastStart                bool
+	SegmentGeneration        uint64
+	LastRequestedSegment     int
+	LastCompletedSegment     int
+	ThrottleConfigured       bool
+	ThrottleEnabled          bool
+	ThrottleThresholdSeconds int
+	ThrottlePaused           bool
+}
+
+// ffmpegDiagnosticsOf describes the exact executable recipe selected for a
+// process. It derives encoder, filter, pixel, and segment facts from the same
+// argument list passed to FFmpeg so the admin debug view cannot drift from the
+// command that actually ran.
+func ffmpegDiagnosticsOf(opts TranscodeOpts, args []string) FFmpegDiagnostics {
+	return FFmpegDiagnostics{
+		FFmpegPath:               opts.FFmpegPath,
+		FFmpegArgs:               append([]string(nil), args...),
+		Pipeline:                 transcodePipelineName(opts),
+		VideoEncoder:             ffmpegOptionValue(args, "-c:v"),
+		AudioEncoder:             ffmpegOptionValue(args, "-c:a"),
+		VideoFilter:              ffmpegVideoFilter(args),
+		VideoPixelFormats:        ffmpegVideoPixelFormats(args),
+		SegmentType:              ffmpegOptionValue(args, "-hls_segment_type"),
+		SourceVideoCodec:         opts.SourceVideoCodec,
+		SourceVideoProfile:       opts.SourceVideoProfile,
+		SourceVideoBitDepth:      opts.SourceVideoBitDepth,
+		SourceVideoResolution:    opts.SourceVideoResolution,
+		SourceAudioChannels:      opts.SourceAudioChannels,
+		SoftwareVideoDecode:      opts.SoftwareVideoDecode,
+		HWDevice:                 opts.HWDevice,
+		TargetAudioChannels:      effectiveFFmpegInt(args, "-ac", opts.TargetAudioChannels),
+		TargetAudioBitrateKbps:   effectiveFFmpegBitrateKbps(args, "-b:a", opts.TargetAudioBitrateKbps),
+		TargetBitrateKbps:        effectiveFFmpegBitrateKbps(args, "-maxrate", opts.TargetBitrateKbps),
+		ToneMapPolicy:            string(opts.ToneMapPolicy),
+		ToneMapMode:              string(opts.ToneMapMode),
+		ToneMapSourceKind:        string(opts.ToneMapSourceKind),
+		ToneMapFilter:            opts.ToneMapFilter,
+		ToneMapRecipeVersion:     opts.ToneMapRecipeVersion,
+		ToneMapPreflightRequired: opts.ToneMapPreflightRequired,
+		VideoBitstreamFilter:     opts.VideoBitstreamFilter,
+		VideoSampleEntry:         opts.VideoSampleEntry,
+		AudioTrackIndex:          opts.AudioTrackIndex,
+		SubtitleTrackIndex:       opts.SubtitleTrackIndex,
+		SubtitleBurnIn:           opts.SubtitleBurnIn,
+		SubtitleCodec:            opts.SubtitleCodec,
+		SegmentDuration:          opts.SegmentDuration,
+		SegmentRetentionSeconds:  opts.SegmentRetentionSeconds,
+		TotalDuration:            opts.TotalDuration,
+		FastStart:                opts.FastStart,
+	}
+}
+
+// effectiveFFmpegInt returns the generated integer option when it is valid,
+// otherwise preserving the configured diagnostic value.
+func effectiveFFmpegInt(args []string, option string, configured int) int {
+	value := ffmpegOptionValue(args, option)
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return configured
+	}
+	return parsed
+}
+
+// effectiveFFmpegBitrateKbps returns a generated FFmpeg bitrate in kbps.
+// Unsuffixed FFmpeg values are bits per second; k, M, and G use SI units.
+func effectiveFFmpegBitrateKbps(args []string, option string, configured int) int {
+	value := strings.TrimSpace(ffmpegOptionValue(args, option))
+	if value == "" {
+		return configured
+	}
+
+	multiplier := float64(1)
+	if suffix := value[len(value)-1]; suffix == 'k' || suffix == 'K' || suffix == 'm' || suffix == 'M' || suffix == 'g' || suffix == 'G' {
+		value = value[:len(value)-1]
+		switch suffix {
+		case 'k', 'K':
+			multiplier = 1_000
+		case 'm', 'M':
+			multiplier = 1_000_000
+		case 'g', 'G':
+			multiplier = 1_000_000_000
+		}
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil || parsed < 0 {
+		return configured
+	}
+	return int(math.Round(parsed * multiplier / 1_000))
+}
+
+// transcodePipelineName names which stages run on CPU or GPU after all
+// automatic fallbacks and source-safety rules have been applied.
+func transcodePipelineName(opts TranscodeOpts) string {
+	if strings.EqualFold(strings.TrimSpace(opts.TargetCodecVideo), "copy") {
+		if TranscodesAudio(opts.TargetCodecAudio) {
+			return "video_copy_audio_transcode"
+		}
+		return string(PlayRemux)
+	}
+	if !isHardwareTranscodeBackend(opts.HWAccel) {
+		return "software_decode_software_encode"
+	}
+	if opts.SoftwareVideoDecode {
+		return pipelineSoftwareDecodeHardwareEncode
+	}
+	return "hardware_decode_hardware_encode"
+}
+
+// ffmpegOptionValue returns the final value of a repeatable FFmpeg option.
+func ffmpegOptionValue(args []string, option string) string {
+	for index := len(args) - 2; index >= 0; index-- {
+		if args[index] == option {
+			return args[index+1]
+		}
+	}
+	return ""
+}
+
+// ffmpegVideoFilter returns the effective simple or complex video graph.
+func ffmpegVideoFilter(args []string) string {
+	if value := ffmpegOptionValue(args, "-filter_complex"); value != "" {
+		return value
+	}
+	return ffmpegOptionValue(args, "-vf")
+}
+
+// ffmpegVideoPixelFormats reports each explicit pixel format in execution
+// order, including CPU frames and uploaded hardware surfaces.
+func ffmpegVideoPixelFormats(args []string) []string {
+	formats := make([]string, 0, 3)
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range formats {
+			if existing == value {
+				return
+			}
+		}
+		formats = append(formats, value)
+	}
+
+	add(ffmpegOptionValue(args, "-pix_fmt"))
+	for remaining := ffmpegVideoFilter(args); ; {
+		marker := strings.Index(remaining, "format=")
+		if marker < 0 {
+			break
+		}
+		remaining = remaining[marker+len("format="):]
+		end := strings.IndexAny(remaining, ",:;[]")
+		if end < 0 {
+			add(remaining)
+			break
+		}
+		add(remaining[:end])
+		remaining = remaining[end+1:]
+	}
+	return formats
+}

--- a/internal/playback/ffmpeg_diagnostics_test.go
+++ b/internal/playback/ffmpeg_diagnostics_test.go
@@ -1,0 +1,186 @@
+package playback
+
+import (
+	"context"
+	"testing"
+)
+
+type recordingFFmpegLogSink struct {
+	sessionID string
+	events    int
+	message   string
+}
+
+func (sink *recordingFFmpegLogSink) WriteLine(_ context.Context, sessionID string, _ FFmpegLogAttrs, _ string) {
+	sink.sessionID = sessionID
+}
+
+func (sink *recordingFFmpegLogSink) WriteEvent(_ context.Context, sessionID string, _ FFmpegLogAttrs, message string) {
+	sink.sessionID = sessionID
+	sink.events++
+	sink.message = message
+}
+
+func TestFFmpegDiagnosticsDescribeSoftwareDecodeNVENCPipeline(t *testing.T) {
+	opts := TranscodeOpts{
+		FFmpegPath:            "/usr/bin/ffmpeg",
+		InputPath:             "/media/anime.mkv",
+		OutputDir:             t.TempDir(),
+		SourceVideoCodec:      "h264",
+		SourceVideoProfile:    "high 10",
+		SourceVideoBitDepth:   10,
+		SourceVideoResolution: "1080p",
+		SoftwareVideoDecode:   true,
+		TargetResolution:      "720p",
+		TargetCodecVideo:      "h264",
+		TargetCodecAudio:      "aac",
+		TargetAudioChannels:   6,
+		TargetBitrateKbps:     4_000,
+		SegmentDuration:       2,
+		HWAccel:               transcodeHWNVENC,
+		HWDevice:              "0",
+	}
+
+	diagnostics := ffmpegDiagnosticsOf(opts, buildFFmpegArgs(opts))
+	if diagnostics.Pipeline != pipelineSoftwareDecodeHardwareEncode {
+		t.Fatalf("Pipeline = %q, want software decode with hardware encode", diagnostics.Pipeline)
+	}
+	if diagnostics.VideoEncoder != "h264_nvenc" {
+		t.Fatalf("VideoEncoder = %q, want h264_nvenc", diagnostics.VideoEncoder)
+	}
+	if diagnostics.VideoFilter != "format=nv12,hwupload_cuda,scale_cuda=w=-2:h=720:format=nv12" {
+		t.Fatalf("VideoFilter = %q", diagnostics.VideoFilter)
+	}
+	if len(diagnostics.VideoPixelFormats) != 1 || diagnostics.VideoPixelFormats[0] != "nv12" {
+		t.Fatalf("VideoPixelFormats = %v, want [nv12]", diagnostics.VideoPixelFormats)
+	}
+	if diagnostics.SegmentType != "mpegts" {
+		t.Fatalf("SegmentType = %q, want mpegts", diagnostics.SegmentType)
+	}
+	if len(diagnostics.FFmpegArgs) == 0 {
+		t.Fatal("FFmpegArgs is empty")
+	}
+}
+
+func TestFFmpegDiagnosticsReportsEffectiveGeneratedLimits(t *testing.T) {
+	configured := TranscodeOpts{
+		TargetAudioChannels:    6,
+		TargetAudioBitrateKbps: 320,
+		TargetBitrateKbps:      4_000,
+	}
+	withoutOverrides := ffmpegDiagnosticsOf(configured, nil)
+	if withoutOverrides.TargetAudioChannels != 6 || withoutOverrides.TargetAudioBitrateKbps != 320 || withoutOverrides.TargetBitrateKbps != 4_000 {
+		t.Fatalf("configured limits were not preserved: %+v", withoutOverrides)
+	}
+
+	generated := ffmpegDiagnosticsOf(configured, []string{
+		"-ac", "2",
+		"-b:a", "192k",
+		"-maxrate", "6000k",
+	})
+	if generated.TargetAudioChannels != 2 || generated.TargetAudioBitrateKbps != 192 || generated.TargetBitrateKbps != 6_000 {
+		t.Fatalf("effective generated limits = channels %d, audio %d kbps, video %d kbps",
+			generated.TargetAudioChannels, generated.TargetAudioBitrateKbps, generated.TargetBitrateKbps)
+	}
+}
+
+func TestFFmpegEventAttrsIncludeRuntimeResourcePolicy(t *testing.T) {
+	session := &TranscodeSession{
+		opts: TranscodeOpts{
+			FFmpegPath:              "/usr/bin/ffmpeg",
+			OutputDir:               t.TempDir(),
+			TargetCodecVideo:        "h264",
+			TargetCodecAudio:        "aac",
+			SegmentDuration:         2,
+			SegmentRetentionSeconds: 120,
+			HWAccel:                 HWAccelNone,
+		},
+		segmentGeneration:    3,
+		lastRequestedSegment: 42,
+		lastCompletedSegment: 41,
+		throttleConfigured:   true,
+		throttleEnabled:      true,
+		throttleThreshold:    120,
+		throttlePaused:       true,
+	}
+
+	attrs := session.ffmpegEventAttrsLocked()
+	if attrs.Diagnostics == nil {
+		t.Fatal("Diagnostics is nil")
+	}
+	diagnostics := attrs.Diagnostics
+	if diagnostics.SegmentGeneration != 3 || diagnostics.LastRequestedSegment != 42 || diagnostics.LastCompletedSegment != 41 {
+		t.Fatalf("segment runtime = generation %d requested %d completed %d",
+			diagnostics.SegmentGeneration, diagnostics.LastRequestedSegment, diagnostics.LastCompletedSegment)
+	}
+	if !diagnostics.ThrottleConfigured || !diagnostics.ThrottleEnabled || !diagnostics.ThrottlePaused || diagnostics.ThrottleThresholdSeconds != 120 {
+		t.Fatalf("throttle diagnostics = %+v", diagnostics)
+	}
+	if diagnostics.SegmentRetentionSeconds != 120 {
+		t.Fatalf("SegmentRetentionSeconds = %d, want 120", diagnostics.SegmentRetentionSeconds)
+	}
+}
+
+func TestFFmpegDiagnosticLogArgsCarryStructuredRecipe(t *testing.T) {
+	args := appendFFmpegDiagnosticArgs(nil, FFmpegDiagnostics{
+		FFmpegPath:               "/usr/bin/ffmpeg",
+		FFmpegArgs:               []string{"-i", "/media/anime.mkv"},
+		Pipeline:                 pipelineSoftwareDecodeHardwareEncode,
+		VideoPixelFormats:        []string{"nv12"},
+		SoftwareVideoDecode:      true,
+		SegmentRetentionSeconds:  120,
+		ThrottleConfigured:       true,
+		ThrottleEnabled:          true,
+		ThrottleThresholdSeconds: 120,
+	})
+	attrs := make(map[string]any, len(args)/2)
+	for index := 0; index < len(args); index += 2 {
+		attrs[args[index].(string)] = args[index+1]
+	}
+
+	if attrs["transcode_pipeline"] != pipelineSoftwareDecodeHardwareEncode {
+		t.Fatalf("transcode_pipeline = %v", attrs["transcode_pipeline"])
+	}
+	if attrs["software_video_decode"] != true || attrs["throttle_enabled"] != true {
+		t.Fatalf("boolean diagnostics = decode %v throttle %v",
+			attrs["software_video_decode"], attrs["throttle_enabled"])
+	}
+	if attrs["segment_retention_seconds"] != 120 || attrs["throttle_threshold_seconds"] != 120 {
+		t.Fatalf("resource diagnostics = retention %v threshold %v",
+			attrs["segment_retention_seconds"], attrs["throttle_threshold_seconds"])
+	}
+}
+
+func TestFFmpegThrottleLogArgsStayLightweight(t *testing.T) {
+	paused := true
+	sink := NewSlogFFmpegLogSink(nil, "node-1")
+	args := sink.baseArgs("session-1", FFmpegLogAttrs{
+		ThrottlePaused:     &paused,
+		ThrottleGapSeconds: 125,
+	})
+	attrs := make(map[string]any, len(args)/2)
+	for index := 0; index < len(args); index += 2 {
+		attrs[args[index].(string)] = args[index+1]
+	}
+
+	if attrs["throttle_paused"] != true || attrs["throttle_gap_seconds"] != 125 {
+		t.Fatalf("throttle attrs = paused %v gap %v", attrs["throttle_paused"], attrs["throttle_gap_seconds"])
+	}
+	if _, found := attrs["ffmpeg_args"]; found {
+		t.Fatal("lightweight throttle event duplicated FFmpeg arguments")
+	}
+}
+
+func TestFFmpegLogsPreferPlaybackSessionIDOverTransportID(t *testing.T) {
+	sink := &recordingFFmpegLogSink{}
+	session := &TranscodeSession{opts: TranscodeOpts{
+		SessionID:         "transport-1",
+		PlaybackSessionID: "playback-1",
+		FFmpegLogSink:     sink,
+	}}
+
+	session.logFFmpegEvent(context.Background(), "ffmpeg diagnostic snapshot", "")
+	if sink.sessionID != "playback-1" {
+		t.Fatalf("log session ID = %q, want playback-1", sink.sessionID)
+	}
+}

--- a/internal/playback/ffmpeg_log_sink.go
+++ b/internal/playback/ffmpeg_log_sink.go
@@ -38,6 +38,9 @@ type FFmpegLogAttrs struct {
 	DroppedLines       int
 	LineIndex          int
 	ExitError          string
+	ThrottlePaused     *bool
+	ThrottleGapSeconds int
+	Diagnostics        *FFmpegDiagnostics
 }
 
 // SlogFFmpegLogSink emits ffmpeg logs through slog so the existing opslog
@@ -81,7 +84,10 @@ func (s *SlogFFmpegLogSink) WriteEvent(ctx context.Context, sessionID string, at
 	if attrs.DroppedLines > 0 {
 		args = append(args, ffmpegDroppedLinesKey, attrs.DroppedLines)
 	}
-	s.logger.InfoContext(ctx, "ffmpeg event", args...)
+	if attrs.Diagnostics != nil {
+		args = appendFFmpegDiagnosticArgs(args, *attrs.Diagnostics)
+	}
+	s.logger.InfoContext(ctx, message, args...)
 }
 
 func (s *SlogFFmpegLogSink) baseArgs(sessionID string, attrs FFmpegLogAttrs) []any {
@@ -104,6 +110,73 @@ func (s *SlogFFmpegLogSink) baseArgs(sessionID string, attrs FFmpegLogAttrs) []a
 	}
 	if v := strings.TrimSpace(attrs.OutputDir); v != "" {
 		args = append(args, "output_dir", v)
+	}
+	if attrs.ThrottlePaused != nil {
+		args = append(args,
+			"throttle_paused", *attrs.ThrottlePaused,
+			"throttle_gap_seconds", attrs.ThrottleGapSeconds,
+		)
+	}
+	return args
+}
+
+// appendFFmpegDiagnosticArgs expands the event-only snapshot into stable slog
+// keys consumed by the operational log API and Activity debug panel.
+func appendFFmpegDiagnosticArgs(args []any, diagnostics FFmpegDiagnostics) []any {
+	args = append(args,
+		"ffmpeg_path", diagnostics.FFmpegPath,
+		"ffmpeg_args", diagnostics.FFmpegArgs,
+		"transcode_pipeline", diagnostics.Pipeline,
+		"video_encoder", diagnostics.VideoEncoder,
+		"audio_encoder", diagnostics.AudioEncoder,
+		"video_pixel_formats", diagnostics.VideoPixelFormats,
+		"segment_type", diagnostics.SegmentType,
+		"source_video_bit_depth", diagnostics.SourceVideoBitDepth,
+		"source_audio_channels", diagnostics.SourceAudioChannels,
+		"software_video_decode", diagnostics.SoftwareVideoDecode,
+		"target_audio_channels", diagnostics.TargetAudioChannels,
+		"target_audio_bitrate_kbps", diagnostics.TargetAudioBitrateKbps,
+		"target_bitrate_kbps", diagnostics.TargetBitrateKbps,
+		"audio_track_index", diagnostics.AudioTrackIndex,
+		"subtitle_track_index", diagnostics.SubtitleTrackIndex,
+		"subtitle_burn_in", diagnostics.SubtitleBurnIn,
+		"segment_duration_seconds", diagnostics.SegmentDuration,
+		"segment_retention_seconds", diagnostics.SegmentRetentionSeconds,
+		"total_duration_seconds", diagnostics.TotalDuration,
+		"fast_start", diagnostics.FastStart,
+		"segment_generation", diagnostics.SegmentGeneration,
+		"last_requested_segment", diagnostics.LastRequestedSegment,
+		"last_completed_segment", diagnostics.LastCompletedSegment,
+		"throttle_configured", diagnostics.ThrottleConfigured,
+		"throttle_enabled", diagnostics.ThrottleEnabled,
+		"throttle_threshold_seconds", diagnostics.ThrottleThresholdSeconds,
+		"throttle_paused", diagnostics.ThrottlePaused,
+	)
+	if diagnostics.ToneMapPolicy != "" || diagnostics.ToneMapMode != "" ||
+		diagnostics.ToneMapSourceKind != "" || diagnostics.ToneMapPreflightRequired {
+		args = append(args, "tone_map_preflight_required", diagnostics.ToneMapPreflightRequired)
+	}
+	for _, field := range [...]struct {
+		key   string
+		value string
+	}{
+		{"video_filter", diagnostics.VideoFilter},
+		{"source_video_codec", diagnostics.SourceVideoCodec},
+		{"source_video_profile", diagnostics.SourceVideoProfile},
+		{"source_video_resolution", diagnostics.SourceVideoResolution},
+		{"hw_device", diagnostics.HWDevice},
+		{"tone_map_policy", diagnostics.ToneMapPolicy},
+		{"tone_map_mode", diagnostics.ToneMapMode},
+		{"tone_map_source_kind", diagnostics.ToneMapSourceKind},
+		{"tone_map_filter", diagnostics.ToneMapFilter},
+		{"tone_map_recipe_version", diagnostics.ToneMapRecipeVersion},
+		{"video_bitstream_filter", diagnostics.VideoBitstreamFilter},
+		{"video_sample_entry", diagnostics.VideoSampleEntry},
+		{"subtitle_codec", diagnostics.SubtitleCodec},
+	} {
+		if value := strings.TrimSpace(field.value); value != "" {
+			args = append(args, field.key, value)
+		}
 	}
 	return args
 }

--- a/internal/playback/prepare_file_test.go
+++ b/internal/playback/prepare_file_test.go
@@ -76,10 +76,10 @@ func TestBuildPrepareFileArgsSharesHigh10DecodeFallback(t *testing.T) {
 			forbidden: []string{"-hwaccel vaapi"},
 		},
 		{
-			name:      "nvenc falls back to software encode",
+			name:      "nvenc keeps hardware encode with software decode upload",
 			hwAccel:   "nvenc",
-			want:      []string{"-c:v libx264", "-vf scale=-2:720"},
-			forbidden: []string{"-hwaccel cuda", "h264_nvenc", "scale_cuda"},
+			want:      []string{"-c:v h264_nvenc", "format=nv12,hwupload_cuda,scale_cuda=w=-2:h=720:format=nv12"},
+			forbidden: []string{"-hwaccel cuda", "libx264", "hwdownload"},
 		},
 		{
 			name:      "videotoolbox keeps hardware encode with software decode",

--- a/internal/playback/recipecard.go
+++ b/internal/playback/recipecard.go
@@ -75,6 +75,7 @@ type RecipeCard struct {
 	SourceVideoCodec           string                 `json:"source_video_codec,omitempty"`
 	SourceVideoProfile         string                 `json:"source_video_profile,omitempty"`
 	SourceVideoBitDepth        int                    `json:"source_video_bit_depth,omitempty"`
+	SourceVideoResolution      string                 `json:"source_video_resolution,omitempty"`
 	SourceAudioChannels        int                    `json:"source_audio_channels,omitempty"`
 	SoftwareVideoDecode        bool                   `json:"software_video_decode,omitempty"`
 	ToneMapPolicy              tonemap.Policy         `json:"tone_map_policy,omitempty"`
@@ -101,6 +102,9 @@ type RecipeCard struct {
 	TargetAudioChannels        int                    `json:"target_audio_channels,omitempty"`
 	TargetAudioBitrateKbps     int                    `json:"target_audio_bitrate_kbps,omitempty"`
 	SegmentDuration            int                    `json:"segment_duration"`
+	ThrottlePolicyConfigured   bool                   `json:"throttle_policy_configured,omitempty"`
+	ThrottleEnabled            bool                   `json:"throttle_enabled,omitempty"`
+	ThrottleThresholdSeconds   int                    `json:"throttle_threshold_seconds,omitempty"`
 	StartSegmentNumber         int                    `json:"start_segment_number"`
 	HWAccel                    string                 `json:"hw_accel,omitempty"`
 	HWDevice                   string                 `json:"hw_device,omitempty"`
@@ -169,6 +173,7 @@ func NewRecipeCard(userID int, profileID string, mediaFileID int, transcodeNodeU
 		SourceVideoCodec:           opts.SourceVideoCodec,
 		SourceVideoProfile:         opts.SourceVideoProfile,
 		SourceVideoBitDepth:        opts.SourceVideoBitDepth,
+		SourceVideoResolution:      opts.SourceVideoResolution,
 		SourceAudioChannels:        opts.SourceAudioChannels,
 		SoftwareVideoDecode:        opts.SoftwareVideoDecode,
 		ToneMapPolicy:              opts.ToneMapPolicy,
@@ -194,6 +199,9 @@ func NewRecipeCard(userID int, profileID string, mediaFileID int, transcodeNodeU
 		TargetAudioChannels:        opts.TargetAudioChannels,
 		TargetAudioBitrateKbps:     opts.TargetAudioBitrateKbps,
 		SegmentDuration:            opts.SegmentDuration,
+		ThrottlePolicyConfigured:   opts.ThrottlePolicyConfigured,
+		ThrottleEnabled:            opts.ThrottleEnabled,
+		ThrottleThresholdSeconds:   opts.ThrottleThresholdSeconds,
 		StartSegmentNumber:         opts.StartSegmentNumber,
 		HWAccel:                    opts.HWAccel,
 		HWDevice:                   opts.HWDevice,
@@ -253,21 +261,23 @@ func (c RecipeCard) VideoStreamCopy() bool {
 	return strings.EqualFold(strings.TrimSpace(c.TargetCodecVideo), "copy")
 }
 
-// TranscodeOpts rebuilds the encode parameters for a reconstruct. outputDir,
-// ffmpegPath and logSink are supplied by the caller from live config because
-// they are environment-specific and not pinned in the card. ToneMapFilter may
-// also be empty after token reconstruction and is resolved from live capability
-// data before the transcode starts.
+// TranscodeOpts rebuilds the encode parameters and resource policy for a
+// reconstruct. outputDir, ffmpegPath and logSink are supplied by the caller
+// from live config because they are environment-specific and not pinned in the
+// card. ToneMapFilter may also be empty after token reconstruction and is
+// resolved from live capability data before the transcode starts.
 func (c RecipeCard) TranscodeOpts(outputDir, ffmpegPath string, logSink FFmpegLogSink) TranscodeOpts {
 	return TranscodeOpts{
 		InputPath:                  c.InputPath,
 		OutputSubdir:               c.OutputSubdir,
 		OutputDir:                  outputDir,
 		SessionID:                  c.SessionID,
+		PlaybackSessionID:          c.SessionID,
 		TranscodeTransportID:       c.TranscodeTransportID,
 		SourceVideoCodec:           c.SourceVideoCodec,
 		SourceVideoProfile:         c.SourceVideoProfile,
 		SourceVideoBitDepth:        c.SourceVideoBitDepth,
+		SourceVideoResolution:      c.SourceVideoResolution,
 		SourceAudioChannels:        c.SourceAudioChannels,
 		SoftwareVideoDecode:        c.SoftwareVideoDecode,
 		ToneMapPolicy:              c.ToneMapPolicy,
@@ -294,6 +304,9 @@ func (c RecipeCard) TranscodeOpts(outputDir, ffmpegPath string, logSink FFmpegLo
 		TargetAudioChannels:        c.TargetAudioChannels,
 		TargetAudioBitrateKbps:     c.TargetAudioBitrateKbps,
 		SegmentDuration:            c.SegmentDuration,
+		ThrottlePolicyConfigured:   c.ThrottlePolicyConfigured,
+		ThrottleEnabled:            c.ThrottleEnabled,
+		ThrottleThresholdSeconds:   c.ThrottleThresholdSeconds,
 		StartSegmentNumber:         c.StartSegmentNumber,
 		FFmpegPath:                 ffmpegPath,
 		HWAccel:                    c.HWAccel,
@@ -376,8 +389,12 @@ func (c RecipeCard) ToClaims() streamtoken.Claims {
 		SourceVideoCodec:           c.SourceVideoCodec,
 		SourceVideoProfile:         c.SourceVideoProfile,
 		SourceVideoBitDepth:        c.SourceVideoBitDepth,
+		SourceVideoResolution:      c.SourceVideoResolution,
 		SourceAudioChannels:        sourceAudioChannels,
 		SoftwareVideoDecode:        c.SoftwareVideoDecode,
+		ThrottlePolicyConfigured:   c.ThrottlePolicyConfigured,
+		ThrottleEnabled:            c.ThrottleEnabled,
+		ThrottleThresholdSeconds:   c.ThrottleThresholdSeconds,
 		ToneMapPolicy:              string(c.ToneMapPolicy),
 		ToneMapMode:                string(c.ToneMapMode),
 		ToneMapSourceKind:          string(c.ToneMapSourceKind),
@@ -458,8 +475,12 @@ func RecipeCardFromClaims(c *streamtoken.Claims) RecipeCard {
 		SourceVideoCodec:           c.SourceVideoCodec,
 		SourceVideoProfile:         c.SourceVideoProfile,
 		SourceVideoBitDepth:        c.SourceVideoBitDepth,
+		SourceVideoResolution:      c.SourceVideoResolution,
 		SourceAudioChannels:        c.SourceAudioChannels,
 		SoftwareVideoDecode:        c.SoftwareVideoDecode,
+		ThrottlePolicyConfigured:   c.ThrottlePolicyConfigured,
+		ThrottleEnabled:            c.ThrottleEnabled,
+		ThrottleThresholdSeconds:   c.ThrottleThresholdSeconds,
 		ToneMapPolicy:              tonemap.Policy(c.ToneMapPolicy),
 		ToneMapMode:                tonemap.Mode(c.ToneMapMode),
 		ToneMapSourceKind:          tonemap.SourceKind(c.ToneMapSourceKind),

--- a/internal/playback/recipecard_test.go
+++ b/internal/playback/recipecard_test.go
@@ -20,6 +20,7 @@ func TestRecipeCardRoundTripOpts(t *testing.T) {
 		SourceVideoCodec:         "hevc",
 		SourceVideoProfile:       "Main 10",
 		SourceVideoBitDepth:      10,
+		SourceVideoResolution:    "1920x800",
 		SoftwareVideoDecode:      true,
 		ToneMapPolicy:            tonemap.PolicyHardwareThenSoftware,
 		ToneMapMode:              tonemap.ModeHardware,
@@ -29,28 +30,31 @@ func TestRecipeCardRoundTripOpts(t *testing.T) {
 		ToneMapPreflightRequired: true,
 		ToneMapSourceRevision:    revision,
 		ToneMapDVConfigPresent:   true, ToneMapDVBLCompatIDPresent: true, ToneMapDVBLPresent: true, ToneMapDVRPUPresent: true,
-		VideoBitstreamFilter:   "dovi_rpu=strip=1",
-		VideoSampleEntry:       VideoSampleEntryDVH1,
-		SeekSeconds:            900,
-		StreamOriginSeconds:    896,
-		CopySeekAnchorResolved: true,
-		TargetResolution:       "1080p",
-		TargetCodecVideo:       "h264",
-		TargetCodecAudio:       "aac",
-		SourceAudioChannels:    6,
-		TargetAudioChannels:    1,
-		TargetAudioBitrateKbps: 96,
-		SegmentDuration:        2,
-		StartSegmentNumber:     450,
-		HWAccel:                "qsv",
-		HWDevice:               "/dev/dri/renderD128",
-		SubtitleTrackIndex:     3,
-		SubtitleBurnIn:         true,
-		SubtitleCodec:          "hdmv_pgs_subtitle",
-		AudioTrackIndex:        1,
-		TargetBitrateKbps:      8000,
-		TotalDuration:          7200,
-		FastStart:              true,
+		VideoBitstreamFilter:     "dovi_rpu=strip=1",
+		VideoSampleEntry:         VideoSampleEntryDVH1,
+		SeekSeconds:              900,
+		StreamOriginSeconds:      896,
+		CopySeekAnchorResolved:   true,
+		TargetResolution:         "1080p",
+		TargetCodecVideo:         "h264",
+		TargetCodecAudio:         "aac",
+		SourceAudioChannels:      6,
+		TargetAudioChannels:      1,
+		TargetAudioBitrateKbps:   96,
+		SegmentDuration:          2,
+		ThrottlePolicyConfigured: true,
+		ThrottleEnabled:          true,
+		ThrottleThresholdSeconds: 120,
+		StartSegmentNumber:       450,
+		HWAccel:                  "qsv",
+		HWDevice:                 "/dev/dri/renderD128",
+		SubtitleTrackIndex:       3,
+		SubtitleBurnIn:           true,
+		SubtitleCodec:            "hdmv_pgs_subtitle",
+		AudioTrackIndex:          1,
+		TargetBitrateKbps:        8000,
+		TotalDuration:            7200,
+		FastStart:                true,
 	}
 
 	card := NewRecipeCard(42, "profile-1", 77, "", opts)
@@ -104,8 +108,33 @@ func TestRecipeCardRoundTripOpts(t *testing.T) {
 	if got.SourceVideoProfile != "Main 10" || got.SourceVideoBitDepth != 10 {
 		t.Errorf("source video facts lost in round trip: profile=%q bit_depth=%d", got.SourceVideoProfile, got.SourceVideoBitDepth)
 	}
+	if got.SourceVideoResolution != "1920x800" {
+		t.Errorf("SourceVideoResolution = %q, want 1920x800", got.SourceVideoResolution)
+	}
+	if !got.ThrottlePolicyConfigured || !got.ThrottleEnabled || got.ThrottleThresholdSeconds != 120 {
+		t.Errorf("throttle policy lost in round trip: %+v", got)
+	}
 	if got.FFmpegPath != "/usr/bin/ffmpeg" {
 		t.Errorf("FFmpegPath not re-supplied: %q", got.FFmpegPath)
+	}
+}
+
+func TestRecipeCardTokenPreservesTranscodeResourceFacts(t *testing.T) {
+	card := NewRecipeCard(42, "profile-1", 77, "http://node", TranscodeOpts{
+		SessionID:                "session-1",
+		InputPath:                "/media/movie.mkv",
+		SourceVideoResolution:    "1920x800",
+		ThrottlePolicyConfigured: true,
+		ThrottleEnabled:          true,
+		ThrottleThresholdSeconds: 120,
+	})
+
+	restored := RecipeCardFromClaims(ptr(card.ToClaims()))
+	if restored.SourceVideoResolution != "1920x800" {
+		t.Fatalf("SourceVideoResolution = %q, want 1920x800", restored.SourceVideoResolution)
+	}
+	if !restored.ThrottlePolicyConfigured || !restored.ThrottleEnabled || restored.ThrottleThresholdSeconds != 120 {
+		t.Fatalf("throttle policy lost in token: %+v", restored)
 	}
 }
 

--- a/internal/playback/throttle.go
+++ b/internal/playback/throttle.go
@@ -2,6 +2,7 @@
 package playback
 
 import (
+	"context"
 	"io"
 	"log"
 	"sync"
@@ -14,6 +15,10 @@ const (
 
 	// minThresholdSeconds is the minimum allowed throttle threshold.
 	minThresholdSeconds = 60
+
+	// throttleResumeDivisor creates enough hysteresis that a fast encoder does
+	// not bounce between pause and resume around the forward-buffer boundary.
+	throttleResumeDivisor = 2
 )
 
 // TranscodeThrottler pauses and resumes an FFmpeg process by sending
@@ -100,7 +105,7 @@ func (t *TranscodeThrottler) CheckOnce() {
 	gap := gapSegments * segmentDuration
 
 	t.mu.Lock()
-	defer t.mu.Unlock()
+	event := ""
 
 	// Never pause on output the current ffmpeg process did not produce. A
 	// manifest left behind by an earlier generation in the same output
@@ -114,18 +119,31 @@ func (t *TranscodeThrottler) CheckOnce() {
 			log.Printf("playback: throttler resuming ffmpeg (produced output predates current generation)")
 			t.sendResume()
 			t.paused = false
+			event = "ffmpeg throttle resumed"
+		}
+		t.mu.Unlock()
+		if event != "" {
+			t.session.publishThrottleState(context.Background(), t, event, false, gap)
 		}
 		return
 	}
 
+	resumeThresholdSeconds := t.thresholdSeconds / throttleResumeDivisor
 	if gap >= t.thresholdSeconds && !t.paused {
 		log.Printf("playback: throttler pausing ffmpeg (gap=%ds, threshold=%ds)", gap, t.thresholdSeconds)
 		t.sendPause()
 		t.paused = true
-	} else if gap < t.thresholdSeconds && t.paused {
+		event = "ffmpeg throttle paused"
+	} else if gap <= resumeThresholdSeconds && t.paused {
 		log.Printf("playback: throttler resuming ffmpeg (gap=%ds, threshold=%ds)", gap, t.thresholdSeconds)
 		t.sendResume()
 		t.paused = false
+		event = "ffmpeg throttle resumed"
+	}
+	paused := t.paused
+	t.mu.Unlock()
+	if event != "" {
+		t.session.publishThrottleState(context.Background(), t, event, paused, gap)
 	}
 }
 

--- a/internal/playback/transcode.go
+++ b/internal/playback/transcode.go
@@ -40,14 +40,16 @@ type TranscodeOpts struct {
 	subtitleFilterInputPath string
 	// OutputSubdir is the signed, root-relative reconstruction directory. Empty
 	// retains the legacy flat {session_id} layout.
-	OutputSubdir         string
-	TranscodeTransportID string
-	SessionID            string
-	SourceVideoCodec     string
-	SourceVideoProfile   string
-	SourceVideoBitDepth  int
-	VideoBitstreamFilter string // validated copy-mode BSF, e.g. dovi_rpu=strip=1
-	VideoSampleEntry     string // allowlisted copy-HLS sample entry: dvh1 or hvc1
+	OutputSubdir          string
+	TranscodeTransportID  string
+	SessionID             string
+	PlaybackSessionID     string
+	SourceVideoCodec      string
+	SourceVideoProfile    string
+	SourceVideoBitDepth   int
+	SourceVideoResolution string
+	VideoBitstreamFilter  string // validated copy-mode BSF, e.g. dovi_rpu=strip=1
+	VideoSampleEntry      string // allowlisted copy-HLS sample entry: dvh1 or hvc1
 	// CopyVideoMPEGTS packages copied video in MPEG-TS instead of fMP4. It is
 	// durable because the segment extension and bytes must survive restarts.
 	CopyVideoMPEGTS bool
@@ -59,26 +61,28 @@ type TranscodeOpts struct {
 	StreamOriginSeconds float64
 	// CopySeekAnchorResolved distinguishes a valid zero-second origin from
 	// older/shared recipes that never resolved a copy seek anchor.
-	CopySeekAnchorResolved  bool
-	TargetResolution        string // e.g., 1080p, 720p
-	TargetCodecVideo        string // e.g., h264 (or hevc if allowed)
-	TargetCodecAudio        string // e.g., aac
-	SegmentDuration         int    // seconds, default 6
-	SegmentRetentionSeconds int    // downloaded media retained behind the client; 0 disables pruning
-	StartSegmentNumber      int    // -hls_segment_start_number, default 0
-	FFmpegPath              string // optional explicit ffmpeg binary path
-	HWAccel                 string // auto, qsv, vaapi, nvenc, videotoolbox, none
-	HWDevice                string // e.g., /dev/dri/renderD128 (default if empty)
+	CopySeekAnchorResolved   bool
+	TargetResolution         string // e.g., 1080p, 720p
+	TargetCodecVideo         string // e.g., h264 (or hevc if allowed)
+	TargetCodecAudio         string // e.g., aac
+	SegmentDuration          int    // seconds, default 6
+	SegmentRetentionSeconds  int    // downloaded media retained behind the client; 0 disables pruning
+	ThrottlePolicyConfigured bool
+	ThrottleEnabled          bool
+	ThrottleThresholdSeconds int
+	StartSegmentNumber       int    // -hls_segment_start_number, default 0
+	FFmpegPath               string // optional explicit ffmpeg binary path
+	HWAccel                  string // auto, qsv, vaapi, nvenc, videotoolbox, none
+	HWDevice                 string // e.g., /dev/dri/renderD128 (default if empty)
 	// AvoidHWDevice asks the initial multi-device allocator to prefer any other
 	// present render device. It is a process-local startup hint used after an
 	// early GPU failure; the selected concrete device remains fully reserved and
 	// is the value frozen into the session recipe.
 	AvoidHWDevice string
 	// SoftwareVideoDecode keeps a hardware encoder while decoding the source
-	// on the CPU. Intel's VAAPI/QSV decoders cannot accept 10-bit AVC, but the
-	// decoded frames can still be converted to NV12, uploaded, and encoded by
-	// QSV/VAAPI. The flag is frozen into recipe cards so restarts do not put the
-	// unsupported hardware decoder back.
+	// on the CPU. Unsupported decoder inputs can still be converted to NV12,
+	// uploaded, and encoded by QSV, VAAPI, NVENC, or VideoToolbox. The flag is
+	// frozen into recipe cards so restarts do not restore the failed decoder.
 	SoftwareVideoDecode        bool
 	ToneMapPolicy              tonemap.Policy
 	ToneMapMode                tonemap.Mode
@@ -199,6 +203,11 @@ type TranscodeSession struct {
 	restartCount         int
 	stderrLineIndex      int
 	stderrWriter         *ffmpegStderrWriter
+	ffmpegArgs           []string
+	throttleConfigured   bool
+	throttleEnabled      bool
+	throttleThreshold    int
+	throttlePaused       bool
 	restartHook          func(context.Context)
 	// generationStartedAt is when the currently-owning ffmpeg process was
 	// spawned. Output in the shared directory older than this timestamp was
@@ -369,6 +378,7 @@ func StartTranscode(ctx context.Context, opts TranscodeOpts) (*TranscodeSession,
 	}
 
 	args := buildFFmpegArgs(opts)
+	s.ffmpegArgs = append([]string(nil), args...)
 	bin := opts.FFmpegPath
 	if bin == "" {
 		bin = ffmpegBinary()
@@ -853,11 +863,10 @@ func resolveEffectiveTranscodeHWAccelContext(ctx context.Context, opts Transcode
 			return transcodeHWNone
 		}
 	}
-	// The bundled CUDA software-decode upload path has not been validated.
-	// Prefer the established libx264 fallback over selecting a decoder known
-	// not to accept this source. Intel QSV/VAAPI have the explicit upload paths
-	// below and retain hardware encoding.
-	if opts.SoftwareVideoDecode && hwAccel == transcodeHWNVENC {
+	// Hardware tone-map recipes are capability-validated as a complete decode,
+	// filter, and encode graph. Do not splice the ordinary CUDA upload path into
+	// that frozen graph; its owner must replan a complete software recipe.
+	if opts.SoftwareVideoDecode && hwAccel == transcodeHWNVENC && opts.ToneMapMode != "" {
 		return HWAccelNone
 	}
 	return hwAccel
@@ -1009,6 +1018,12 @@ func appendHWAccelArgs(args []string, opts TranscodeOpts) []string {
 			args = append(args, "-hwaccel", "vaapi", "-hwaccel_output_format", "vaapi")
 		}
 	case transcodeHWNVENC:
+		if opts.SoftwareVideoDecode {
+			if hwDevice := strings.TrimSpace(opts.HWDevice); hwDevice != "" {
+				args = append(args, "-init_hw_device", "cuda=cu:"+hwDevice, "-filter_hw_device", "cu")
+			}
+			return append(args, "-noautorotate")
+		}
 		args = append(args,
 			"-hwaccel", "cuda",
 			"-hwaccel_output_format", "cuda",
@@ -1206,6 +1221,8 @@ func appendVideoFilterArgs(args []string, opts TranscodeOpts) []string {
 		return append(args, "-vf", qsvSoftwareDecodeFilter(opts.TargetResolution))
 	case opts.HWAccel == "vaapi" && opts.SoftwareVideoDecode:
 		return append(args, "-vf", vaapiSoftwareDecodeFilter(opts.TargetResolution))
+	case opts.HWAccel == transcodeHWNVENC && opts.SoftwareVideoDecode:
+		return append(args, "-vf", nvencSoftwareDecodeFilter(opts.TargetResolution))
 	case opts.HWAccel == "qsv":
 		return append(args, "-vf", qsvScaleFilter(opts.TargetResolution))
 	case opts.HWAccel == "vaapi":
@@ -1570,9 +1587,14 @@ func appendBitmapSubtitleBurnInArgs(args []string, opts TranscodeOpts) []string 
 			cpuFilters += "," + scale
 		}
 		if opts.HWAccel == transcodeHWNVENC {
-			// Download to CPU for the overlay, then re-upload to CUDA.
-			graph = "[0:v:0]hwdownload,format=yuv420p[vmain];[vmain]" + cpuFilters +
-				",format=nv12,hwupload_cuda[vout]"
+			if opts.SoftwareVideoDecode {
+				graph = "[0:v:0]format=yuv420p[vmain];[vmain]" + cpuFilters +
+					",format=nv12,hwupload_cuda[vout]"
+			} else {
+				// Download to CPU for the overlay, then re-upload to CUDA.
+				graph = "[0:v:0]hwdownload,format=yuv420p[vmain];[vmain]" + cpuFilters +
+					",format=nv12,hwupload_cuda[vout]"
+			}
 		} else {
 			// CPU encoding: overlay directly on decoded frames.
 			graph = "[0:v:0]" + cpuFilters + "[vout]"
@@ -1641,8 +1663,13 @@ func appendSubtitleBurnInArgs(args []string, opts TranscodeOpts) []string {
 		vf := "hwdownload,format=yuv420p," + cpuFilters + ",format=nv12,hwupload"
 		args = append(args, "-vf", vf)
 	case transcodeHWNVENC:
-		// NVENC/CUDA: download to CPU for subtitle rendering, then upload back.
-		vf := "hwdownload,format=yuv420p," + cpuFilters + ",format=nv12,hwupload_cuda"
+		// NVENC/CUDA renders subtitles on the CPU and uploads the result. A
+		// software-decoded source is already in CPU memory and needs no download.
+		prefix := "hwdownload,format=yuv420p,"
+		if opts.SoftwareVideoDecode {
+			prefix = "format=yuv420p,"
+		}
+		vf := prefix + cpuFilters + ",format=nv12,hwupload_cuda"
 		args = append(args, "-vf", vf)
 	default:
 		// CPU encoding: filters run directly on decoded frames.
@@ -1766,6 +1793,13 @@ func nvencScaleFilter(res string) string {
 	default:
 		return "scale_cuda=format=nv12"
 	}
+}
+
+// nvencSoftwareDecodeFilter uploads CPU-decoded NV12 frames before CUDA scale
+// and NVENC encode, avoiding hardware decoder limitations without losing GPU
+// acceleration for the expensive output stages.
+func nvencSoftwareDecodeFilter(res string) string {
+	return "format=nv12,hwupload_cuda," + nvencScaleFilter(res)
 }
 
 // filterPathReplacer escapes special characters in file paths for ffmpeg filter syntax.
@@ -2966,7 +3000,7 @@ func (s *TranscodeSession) restart(
 	}
 
 	log.Printf("playback: ffmpeg restart cmd: %s %s", bin, strings.Join(args, " "))
-	s.logFFmpegEvent(ctx, "ffmpeg process restart", "")
+	s.logFFmpegAttemptEvent(ctx, opts, args, "ffmpeg process restart", "")
 
 	// As on initial start, the caller bounds synchronous validation; the new
 	// FFmpeg process keeps running after the segment request completes.
@@ -3006,7 +3040,7 @@ func (s *TranscodeSession) restart(
 		s.waitErr = err
 		s.mu.Unlock()
 		close(flight.done)
-		s.logFFmpegEvent(ctx, "ffmpeg process exit error", err.Error())
+		s.logFFmpegAttemptEvent(ctx, opts, args, "ffmpeg process exit error", err.Error())
 		return fmt.Errorf("restart ffmpeg: %w", err)
 	}
 
@@ -3017,6 +3051,7 @@ func (s *TranscodeSession) restart(
 	s.cmd = cmd
 	s.cancel = cancel
 	s.opts = opts
+	s.ffmpegArgs = append(s.ffmpegArgs[:0], args...)
 	s.running = true
 	s.restarting = nil
 	s.stdinPipe = stdinPipe
@@ -3517,13 +3552,39 @@ func (s *TranscodeSession) LastRequestedSegment() int {
 func (s *TranscodeSession) StartThrottler(thresholdSeconds int) {
 	s.mu.Lock()
 	if s.stdinPipe == nil || thresholdSeconds <= 0 {
+		s.throttleEnabled = false
+		s.throttleThreshold = 0
 		s.mu.Unlock()
 		return
 	}
 	t := NewTranscodeThrottler(s, s.stdinPipe, thresholdSeconds, s.opts.SegmentDuration)
 	s.throttler = t
+	s.throttleEnabled = true
+	s.throttleThreshold = t.thresholdSeconds
+	s.throttlePaused = false
 	s.mu.Unlock()
 	t.Start()
+}
+
+// ConfigureThrottler applies the resolved live resource policy and records one
+// diagnostic event. Recording disabled policies matters: an absent throttler
+// and an old server otherwise look identical in the Activity debug view.
+func (s *TranscodeSession) ConfigureThrottler(ctx context.Context, enabled bool, thresholdSeconds int) {
+	s.StopThrottler()
+	s.mu.Lock()
+	s.throttleConfigured = true
+	s.mu.Unlock()
+
+	if enabled {
+		s.StartThrottler(thresholdSeconds)
+	} else {
+		s.mu.Lock()
+		s.throttleEnabled = false
+		s.throttleThreshold = 0
+		s.throttlePaused = false
+		s.mu.Unlock()
+	}
+	s.logFFmpegEvent(ctx, "ffmpeg diagnostic snapshot", "")
 }
 
 // StopThrottler stops the throttler if one is running.
@@ -3535,6 +3596,42 @@ func (s *TranscodeSession) StopThrottler() {
 	if t != nil {
 		t.Stop()
 	}
+	s.mu.Lock()
+	if s.throttler == nil {
+		s.throttlePaused = false
+	}
+	s.mu.Unlock()
+}
+
+// publishThrottleState records a transition only while owner is still the
+// session's active throttler. This prevents a stopped goroutine from restoring
+// stale paused state or emitting a misleading Activity event.
+func (s *TranscodeSession) publishThrottleState(
+	ctx context.Context,
+	owner *TranscodeThrottler,
+	message string,
+	paused bool,
+	gapSeconds int,
+) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	if s.throttler != owner {
+		s.mu.Unlock()
+		return false
+	}
+	s.throttlePaused = paused
+	sink := s.opts.FFmpegLogSink
+	sessionID := s.ffmpegLogSessionIDLocked()
+	attrs := s.ffmpegAttrsLocked()
+	attrs.ThrottlePaused = &paused
+	attrs.ThrottleGapSeconds = gapSeconds
+	s.mu.Unlock()
+	if sink != nil {
+		sink.WriteEvent(ctx, sessionID, attrs, message)
+	}
+	return true
 }
 
 type ffmpegStderrWriter struct {
@@ -3590,7 +3687,7 @@ func (s *TranscodeSession) flushStderr(ctx context.Context) {
 }
 
 func (s *TranscodeSession) logFFmpegLine(ctx context.Context, line string) {
-	if s == nil || s.opts.FFmpegLogSink == nil {
+	if s == nil {
 		return
 	}
 
@@ -3604,7 +3701,12 @@ func (s *TranscodeSession) logFFmpegLine(ctx context.Context, line string) {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	sink := s.opts.FFmpegLogSink
+	sessionID := s.ffmpegLogSessionIDLocked()
+	if sink == nil {
+		s.mu.Unlock()
+		return
+	}
 
 	if s.stderrLinesLogged >= maxPersistedFFmpegLines || s.stderrBytesLogged+len(trimmed) > maxPersistedFFmpegBytes {
 		s.stderrDroppedLines++
@@ -3612,8 +3714,11 @@ func (s *TranscodeSession) logFFmpegLine(ctx context.Context, line string) {
 			s.stderrCapLogged = true
 			attrs := s.ffmpegAttrsLocked()
 			attrs.DroppedLines = s.stderrDroppedLines
-			s.opts.FFmpegLogSink.WriteEvent(ctx, s.opts.SessionID, attrs, "ffmpeg stderr logging capped")
+			s.mu.Unlock()
+			sink.WriteEvent(ctx, sessionID, attrs, "ffmpeg stderr logging capped")
+			return
 		}
+		s.mu.Unlock()
 		return
 	}
 
@@ -3622,18 +3727,81 @@ func (s *TranscodeSession) logFFmpegLine(ctx context.Context, line string) {
 	s.stderrLineIndex++
 	attrs := s.ffmpegAttrsLocked()
 	attrs.LineIndex = s.stderrLineIndex
-	s.opts.FFmpegLogSink.WriteLine(ctx, s.opts.SessionID, attrs, trimmed)
+	s.mu.Unlock()
+	sink.WriteLine(ctx, sessionID, attrs, trimmed)
 }
 
 func (s *TranscodeSession) logFFmpegEvent(ctx context.Context, message, exitError string) {
-	if s == nil || s.opts.FFmpegLogSink == nil {
+	if s == nil {
 		return
 	}
 	s.mu.Lock()
-	attrs := s.ffmpegAttrsLocked()
+	sink := s.opts.FFmpegLogSink
+	sessionID := s.ffmpegLogSessionIDLocked()
+	attrs := s.ffmpegEventAttrsLocked()
 	attrs.ExitError = exitError
 	s.mu.Unlock()
-	s.opts.FFmpegLogSink.WriteEvent(ctx, s.opts.SessionID, attrs, message)
+	if sink != nil {
+		sink.WriteEvent(ctx, sessionID, attrs, message)
+	}
+}
+
+// logFFmpegAttemptEvent records a replacement recipe before it becomes the
+// session's active recipe, preserving failed restart commands for diagnosis.
+func (s *TranscodeSession) logFFmpegAttemptEvent(
+	ctx context.Context,
+	opts TranscodeOpts,
+	args []string,
+	message string,
+	exitError string,
+) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	sink := s.opts.FFmpegLogSink
+	sessionID := s.ffmpegLogSessionIDLocked()
+	attrs := s.ffmpegEventAttrsForLocked(opts, args)
+	attrs.ExitError = exitError
+	s.mu.Unlock()
+	if sink != nil {
+		sink.WriteEvent(ctx, sessionID, attrs, message)
+	}
+}
+
+// ffmpegEventAttrsLocked captures the active recipe and runtime state.
+func (s *TranscodeSession) ffmpegEventAttrsLocked() FFmpegLogAttrs {
+	args := s.ffmpegArgs
+	if len(args) == 0 {
+		args = buildFFmpegArgs(s.opts)
+	}
+	return s.ffmpegEventAttrsForLocked(s.opts, args)
+}
+
+// ffmpegEventAttrsForLocked combines an attempted recipe with the session's
+// current segment and resource-policy counters.
+func (s *TranscodeSession) ffmpegEventAttrsForLocked(opts TranscodeOpts, args []string) FFmpegLogAttrs {
+	attrs := s.ffmpegAttrsLocked()
+	attrs.NodeType = opts.NodeType
+	attrs.ExecutionMode = opts.ExecutionMode
+	attrs.InputPath = opts.InputPath
+	attrs.OutputDir = opts.OutputDir
+	attrs.TargetResolution = opts.TargetResolution
+	attrs.TargetVideoCodec = opts.TargetCodecVideo
+	attrs.TargetAudioCodec = opts.TargetCodecAudio
+	attrs.HWAccel = opts.HWAccel
+	attrs.SeekSeconds = opts.SeekSeconds
+	attrs.StartSegmentNumber = opts.StartSegmentNumber
+	diagnostics := ffmpegDiagnosticsOf(opts, args)
+	diagnostics.SegmentGeneration = s.segmentGeneration
+	diagnostics.LastRequestedSegment = s.lastRequestedSegment
+	diagnostics.LastCompletedSegment = s.lastCompletedSegment
+	diagnostics.ThrottleConfigured = s.throttleConfigured
+	diagnostics.ThrottleEnabled = s.throttleEnabled
+	diagnostics.ThrottleThresholdSeconds = s.throttleThreshold
+	diagnostics.ThrottlePaused = s.throttlePaused
+	attrs.Diagnostics = &diagnostics
+	return attrs
 }
 
 func (s *TranscodeSession) logWaitResult(ctx context.Context, waitErr error) {
@@ -3659,6 +3827,13 @@ func (s *TranscodeSession) ffmpegAttrsLocked() FFmpegLogAttrs {
 		RestartCount:       s.restartCount,
 		DroppedLines:       s.stderrDroppedLines,
 	}
+}
+
+func (s *TranscodeSession) ffmpegLogSessionIDLocked() string {
+	if sessionID := strings.TrimSpace(s.opts.PlaybackSessionID); sessionID != "" {
+		return sessionID
+	}
+	return s.opts.SessionID
 }
 
 func formatWaitError(err error) string {

--- a/internal/playback/transcode_args_test.go
+++ b/internal/playback/transcode_args_test.go
@@ -1298,8 +1298,13 @@ func TestResolveEffectiveTranscodeHWAccel(t *testing.T) {
 			want: "qsv",
 		},
 		{
-			name: "unvalidated nvenc upload falls back to software encode",
+			name: "nvenc keeps hardware encode with software decode",
 			opts: TranscodeOpts{HWAccel: "nvenc", SourceVideoCodec: "h264", SoftwareVideoDecode: true, TargetCodecVideo: "h264"},
+			want: "nvenc",
+		},
+		{
+			name: "nvenc keeps frozen tone map fallback unchanged",
+			opts: TranscodeOpts{HWAccel: "nvenc", SourceVideoCodec: "h264", SoftwareVideoDecode: true, TargetCodecVideo: "h264", ToneMapMode: tonemap.ModeHardware},
 			want: "none",
 		},
 	}
@@ -1310,6 +1315,85 @@ func TestResolveEffectiveTranscodeHWAccel(t *testing.T) {
 			t.Parallel()
 			if got := resolveEffectiveTranscodeHWAccel(tt.opts); got != tt.want {
 				t.Fatalf("resolveEffectiveTranscodeHWAccel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildFFmpegArgs_H264High10NVENCUsesSoftwareDecodeUpload(t *testing.T) {
+	args := buildFFmpegArgs(TranscodeOpts{
+		InputPath:           "/media/high10.mkv",
+		OutputDir:           "/tmp/out",
+		SessionID:           "session-high10-nvenc",
+		SourceVideoCodec:    "h264",
+		SourceVideoProfile:  "High 10",
+		SourceVideoBitDepth: 10,
+		TargetCodecVideo:    "h264",
+		TargetCodecAudio:    "aac",
+		SegmentDuration:     2,
+		HWAccel:             "nvenc",
+		HWDevice:            "2",
+		TargetResolution:    "720p",
+	})
+
+	joined := strings.Join(args, " ")
+	for _, required := range []string{
+		"-init_hw_device cuda=cu:2 -filter_hw_device cu",
+		"-c:v h264_nvenc",
+		"-vf format=nv12,hwupload_cuda,scale_cuda=w=-2:h=720:format=nv12",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("High 10 NVENC recipe missing %q: %s", required, joined)
+		}
+	}
+	for _, forbidden := range []string{"-hwaccel cuda", "-c:v libx264", "hwdownload"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("High 10 NVENC recipe unexpectedly contains %q: %s", forbidden, joined)
+		}
+	}
+}
+
+func TestBuildFFmpegArgs_H264High10NVENCBurnInUsesSoftwareFrames(t *testing.T) {
+	for _, subtitle := range []struct {
+		name  string
+		codec string
+		want  string
+	}{
+		{
+			name:  "text",
+			codec: "ass",
+			want:  "-vf format=yuv420p,scale=-2:720,subtitles=filename='/media/high10.mkv':si=0,format=nv12,hwupload_cuda",
+		},
+		{
+			name:  "bitmap",
+			codec: "hdmv_pgs_subtitle",
+			want:  "-filter_complex [0:v:0]format=yuv420p[vmain];[vmain][0:s:0]overlay=eof_action=pass,scale=-2:720,format=nv12,hwupload_cuda[vout]",
+		},
+	} {
+		t.Run(subtitle.name, func(t *testing.T) {
+			args := buildFFmpegArgs(TranscodeOpts{
+				InputPath:           "/media/high10.mkv",
+				OutputDir:           "/tmp/out",
+				SessionID:           "session-high10-nvenc-" + subtitle.name,
+				SourceVideoCodec:    "h264",
+				SourceVideoProfile:  "High 10",
+				SourceVideoBitDepth: 10,
+				TargetCodecVideo:    "h264",
+				TargetCodecAudio:    "aac",
+				SegmentDuration:     2,
+				HWAccel:             "nvenc",
+				TargetResolution:    "720p",
+				SubtitleTrackIndex:  0,
+				SubtitleBurnIn:      true,
+				SubtitleCodec:       subtitle.codec,
+			})
+
+			joined := strings.Join(args, " ")
+			if !strings.Contains(joined, subtitle.want) {
+				t.Fatalf("High 10 NVENC burn-in missing %q: %s", subtitle.want, joined)
+			}
+			if strings.Contains(joined, "hwdownload") || strings.Contains(joined, "-hwaccel cuda") {
+				t.Fatalf("High 10 NVENC burn-in must use software-decoded frames: %s", joined)
 			}
 		})
 	}

--- a/internal/playback/transcode_manager.go
+++ b/internal/playback/transcode_manager.go
@@ -889,7 +889,13 @@ func (m *TranscodeManager) doReconstructTranscode(ctx context.Context, sessionID
 	if startTranscode == nil {
 		startTranscode = StartTranscode
 	}
-	transcodeSession, err := startTranscode(ctx, opts)
+	var transcodeSession *TranscodeSession
+	var err error
+	if strings.EqualFold(strings.TrimSpace(opts.HWAccel), hwAccelAuto) {
+		transcodeSession, err = startReadyTranscode(ctx, opts, ManifestStartupTimeout, startTranscode)
+	} else {
+		transcodeSession, err = startTranscode(ctx, opts)
+	}
 	if err != nil {
 		slog.ErrorContext(ctx, "reconstruct transcode start failed", "component", "playback", "error", err, "session", sessionID, "playback_session_id", sessionID)
 		return nil, err

--- a/internal/playback/transcode_manifest_test.go
+++ b/internal/playback/transcode_manifest_test.go
@@ -1005,11 +1005,42 @@ func TestTranscodeThrottlerUsesProducedHeadForGap(t *testing.T) {
 
 	writeManifestRange(t, tempDir, 225, 254, ".ts")
 	throttler.CheckOnce()
+	if !throttler.paused {
+		t.Fatal("throttler resumed before the hysteresis boundary")
+	}
+	if writer.writes != "p" {
+		t.Fatalf("writes = %q, want p", writer.writes)
+	}
+
+	writeManifestRange(t, tempDir, 225, 240, ".ts")
+	throttler.CheckOnce()
 	if throttler.paused {
 		t.Fatal("expected throttler to resume")
 	}
 	if writer.writes != "pu" {
 		t.Fatalf("writes = %q, want pu", writer.writes)
+	}
+}
+
+func TestPublishThrottleStateRejectsStoppedThrottler(t *testing.T) {
+	sink := &recordingFFmpegLogSink{}
+	session := &TranscodeSession{opts: TranscodeOpts{SessionID: "session-throttle-owner", FFmpegLogSink: sink}}
+	stopped := NewTranscodeThrottler(session, &recordingWriteCloser{}, 60, 2)
+	active := NewTranscodeThrottler(session, &recordingWriteCloser{}, 60, 2)
+	session.throttler = active
+
+	if session.publishThrottleState(context.Background(), stopped, "stale pause", true, 120) {
+		t.Fatal("stopped throttler published a state transition")
+	}
+	if session.throttlePaused || sink.events != 0 {
+		t.Fatalf("stale transition changed paused=%t or emitted %d events", session.throttlePaused, sink.events)
+	}
+
+	if !session.publishThrottleState(context.Background(), active, "active pause", true, 120) {
+		t.Fatal("active throttler did not publish its state transition")
+	}
+	if !session.throttlePaused || sink.events != 1 || sink.message != "active pause" {
+		t.Fatalf("active transition = paused %t, events %d, message %q", session.throttlePaused, sink.events, sink.message)
 	}
 }
 

--- a/internal/playback/transcode_startup.go
+++ b/internal/playback/transcode_startup.go
@@ -1,0 +1,88 @@
+package playback
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type transcodeStarter func(context.Context, TranscodeOpts) (*TranscodeSession, error)
+
+// StartReadyTranscode starts FFmpeg and waits for its first playable manifest.
+// Automatic hardware selection retries progressively safer pipelines only when
+// FFmpeg exits during startup; a merely slow running process is not duplicated.
+func StartReadyTranscode(
+	ctx context.Context,
+	opts TranscodeOpts,
+	timeout time.Duration,
+) (*TranscodeSession, error) {
+	return startReadyTranscode(ctx, opts, timeout, StartTranscode)
+}
+
+func startReadyTranscode(
+	ctx context.Context,
+	opts TranscodeOpts,
+	timeout time.Duration,
+	start transcodeStarter,
+) (*TranscodeSession, error) {
+	return startReadyTranscodePipeline(ctx, NewAutoTranscodePipeline(ctx, opts), timeout, start)
+}
+
+func startReadyTranscodePipeline(
+	ctx context.Context,
+	pipeline *AutoTranscodePipeline,
+	timeout time.Duration,
+	start transcodeStarter,
+) (*TranscodeSession, error) {
+	attempt := pipeline.Current()
+	playbackSessionID := strings.TrimSpace(attempt.PlaybackSessionID)
+	if playbackSessionID == "" {
+		playbackSessionID = attempt.SessionID
+	}
+	legacyRetryUsed := false
+	for {
+		session, err := start(ctx, attempt)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err = session.WaitForManifest(timeout); err == nil {
+			pipeline.RememberSuccess()
+			return session, nil
+		}
+
+		wasRunning := session.IsRunning()
+		failedDevice := session.Opts().HWDevice
+		_ = session.Close()
+		if wasRunning {
+			return nil, fmt.Errorf("transcode did not become ready: %w", err)
+		}
+
+		nextAvailable := pipeline.AdvanceAfterFailure(failedDevice)
+		if nextAvailable {
+			attempt = pipeline.Current()
+		} else if !legacyRetryUsed {
+			retryAccel := StartupRetryHWAccel(attempt)
+			if retryAccel != attempt.HWAccel {
+				legacyRetryUsed = true
+				attempt.HWAccel = retryAccel
+				attempt.AvoidHWDevice = failedDevice
+				nextAvailable = true
+			}
+		}
+		if !nextAvailable {
+			return nil, fmt.Errorf("transcode did not become ready: %w", err)
+		}
+
+		slog.WarnContext(ctx, "transcode path failed during startup; trying safer path",
+			"component", "playback",
+			"playback_session_id", playbackSessionID,
+			"failed_device", failedDevice,
+			"next_hw_accel", attempt.HWAccel,
+			"next_software_decode", attempt.SoftwareVideoDecode,
+			"error", err,
+		)
+	}
+}

--- a/internal/playback/transcode_startup_test.go
+++ b/internal/playback/transcode_startup_test.go
@@ -1,0 +1,83 @@
+package playback
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStartReadyTranscodePipelineAvoidsFailedGPU(t *testing.T) {
+	cache := newAutoTranscodePipelineCache()
+	base := TranscodeOpts{
+		SessionID:           "playback-1",
+		InputPath:           "/media/movie.mkv",
+		HWAccel:             transcodeHWNVENC,
+		HWDevice:            "gpu-0,gpu-1",
+		SourceVideoCodec:    "hevc",
+		TargetCodecVideo:    "h264",
+		TargetCodecAudio:    "aac",
+		SegmentDuration:     2,
+		TargetBitrateKbps:   2_000,
+		SourceVideoBitDepth: 10,
+	}
+	pipeline := newAutoTranscodePipeline(base, true, cache)
+	attempts := make([]TranscodeOpts, 0, 2)
+	start := func(_ context.Context, opts TranscodeOpts) (*TranscodeSession, error) {
+		attempts = append(attempts, opts)
+		selectedDevice := "gpu-0"
+		if opts.AvoidHWDevice == selectedDevice {
+			selectedDevice = "gpu-1"
+		}
+		opts.HWDevice = selectedDevice
+		outputDir := t.TempDir()
+		if len(attempts) == 2 {
+			manifest := []byte("#EXTM3U\n#EXT-X-TARGETDURATION:2\n#EXTINF:2,\nseg_00000.ts\n#EXT-X-ENDLIST\n")
+			if err := os.WriteFile(filepath.Join(outputDir, "stream.m3u8"), manifest, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return &TranscodeSession{opts: opts, outputDir: outputDir, stderr: newBoundedTailBuffer(stderrTailMaxBytes)}, nil
+		}
+		return &TranscodeSession{opts: opts, outputDir: outputDir, stderr: newBoundedTailBuffer(stderrTailMaxBytes), waitErr: errors.New("gpu failed")}, nil
+	}
+
+	session, err := startReadyTranscodePipeline(context.Background(), pipeline, time.Millisecond, start)
+	if err != nil {
+		t.Fatalf("startReadyTranscodePipeline: %v", err)
+	}
+	if len(attempts) != 2 {
+		t.Fatalf("attempt count = %d, want 2", len(attempts))
+	}
+	if attempts[1].AvoidHWDevice != "gpu-0" || !attempts[1].SoftwareVideoDecode {
+		t.Fatalf("fallback = %+v, want hybrid path avoiding gpu-0", attempts[1])
+	}
+	if got := session.Opts().HWDevice; got != "gpu-1" {
+		t.Fatalf("selected device = %q, want gpu-1", got)
+	}
+	_ = session.Close()
+}
+
+func TestStartReadyTranscodePipelineDoesNotDuplicateSlowProcess(t *testing.T) {
+	base := TranscodeOpts{
+		SessionID:        "playback-1",
+		InputPath:        "/media/movie.mkv",
+		HWAccel:          transcodeHWNVENC,
+		SourceVideoCodec: "hevc",
+		TargetCodecVideo: "h264",
+	}
+	pipeline := newAutoTranscodePipeline(base, true, newAutoTranscodePipelineCache())
+	attempts := 0
+	start := func(_ context.Context, opts TranscodeOpts) (*TranscodeSession, error) {
+		attempts++
+		return &TranscodeSession{opts: opts, outputDir: t.TempDir(), running: true, stderr: newBoundedTailBuffer(stderrTailMaxBytes)}, nil
+	}
+
+	if _, err := startReadyTranscodePipeline(context.Background(), pipeline, time.Millisecond, start); err == nil {
+		t.Fatal("expected readiness timeout")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempt count = %d, want 1", attempts)
+	}
+}

--- a/internal/streamtoken/token.go
+++ b/internal/streamtoken/token.go
@@ -93,8 +93,12 @@ type Claims struct {
 	SourceVideoCodec           string  `json:"svc,omitempty"`
 	SourceVideoProfile         string  `json:"svp,omitempty"`
 	SourceVideoBitDepth        int     `json:"svb,omitempty"`
+	SourceVideoResolution      string  `json:"svr,omitempty"`
 	SourceAudioChannels        int     `json:"sach,omitempty"`
 	SoftwareVideoDecode        bool    `json:"svd,omitempty"`
+	ThrottlePolicyConfigured   bool    `json:"tpc,omitempty"`
+	ThrottleEnabled            bool    `json:"tpe,omitempty"`
+	ThrottleThresholdSeconds   int     `json:"tps,omitempty"`
 	ToneMapPolicy              string  `json:"tmp,omitempty"`
 	ToneMapMode                string  `json:"tmm,omitempty"`
 	ToneMapSourceKind          string  `json:"tms,omitempty"`

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -38,10 +38,12 @@ import (
 // TranscodeStartRequest is the JSON body for POST /transcode/start.
 type TranscodeStartRequest struct {
 	SessionID                  string                 `json:"session_id"`
+	PlaybackSessionID          string                 `json:"playback_session_id,omitempty"`
 	InputPath                  string                 `json:"input_path"`
 	SourceVideoCodec           string                 `json:"source_video_codec"`
 	SourceVideoProfile         string                 `json:"source_video_profile,omitempty"`
 	SourceVideoBitDepth        int                    `json:"source_video_bit_depth,omitempty"`
+	SourceVideoResolution      string                 `json:"source_video_resolution,omitempty"`
 	SourceAudioChannels        int                    `json:"source_audio_channels,omitempty"`
 	AudioRecipeVersion         string                 `json:"audio_recipe_version,omitempty"`
 	CopyFMP4RecipeVersion      string                 `json:"copy_fmp4_recipe_version,omitempty"`
@@ -70,6 +72,9 @@ type TranscodeStartRequest struct {
 	TargetAudioBitrateKbps     int                    `json:"target_audio_bitrate_kbps,omitempty"`
 	TargetBitrateKbps          int                    `json:"target_bitrate_kbps"`
 	SegmentDuration            int                    `json:"segment_duration"`
+	ThrottlePolicyConfigured   bool                   `json:"throttle_policy_configured,omitempty"`
+	ThrottleEnabled            bool                   `json:"throttle_enabled,omitempty"`
+	ThrottleThresholdSeconds   int                    `json:"throttle_threshold_seconds,omitempty"`
 	HWAccel                    string                 `json:"hw_accel"`
 	AudioTrackIndex            int                    `json:"audio_track_index"`
 	SubtitleTrackIndex         int                    `json:"subtitle_track_index"`
@@ -81,10 +86,11 @@ type TranscodeStartRequest struct {
 
 // TranscodeStartResponse is the JSON response for POST /transcode/start.
 type TranscodeStartResponse struct {
-	SessionID   string       `json:"session_id"`
-	Status      string       `json:"status"`
-	HWAccel     string       `json:"hw_accel,omitempty"`
-	ToneMapMode tonemap.Mode `json:"tone_map_mode,omitempty"`
+	SessionID           string       `json:"session_id"`
+	Status              string       `json:"status"`
+	HWAccel             string       `json:"hw_accel,omitempty"`
+	SoftwareVideoDecode bool         `json:"software_video_decode,omitempty"`
+	ToneMapMode         tonemap.Mode `json:"tone_map_mode,omitempty"`
 	// AudioRecipeVersion attests the exact byte-affecting audio recipe the node
 	// understood. An old node omits it, allowing current callers to stop the job
 	// before publishing bytes from a silently ignored SourceAudioChannels field.
@@ -534,6 +540,11 @@ func (s *Server) activeSessionIDs() map[string]struct{} {
 
 func (s *Server) SetFFmpegLogSink(sink playback.FFmpegLogSink) {
 	s.ffmpegSink = sink
+}
+
+func (s *Server) configureTranscodeResourcePolicy(ctx context.Context, session *playback.TranscodeSession) {
+	opts := session.Opts()
+	session.ConfigureThrottler(ctx, opts.ThrottleEnabled, opts.ThrottleThresholdSeconds)
 }
 
 // noteSessionAccessLocked records an access for a registered job. Callers must
@@ -1389,9 +1400,11 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		InputPath:                  req.InputPath,
 		OutputDir:                  outputDir,
 		SessionID:                  req.SessionID,
+		PlaybackSessionID:          req.PlaybackSessionID,
 		SourceVideoCodec:           req.SourceVideoCodec,
 		SourceVideoProfile:         req.SourceVideoProfile,
 		SourceVideoBitDepth:        req.SourceVideoBitDepth,
+		SourceVideoResolution:      req.SourceVideoResolution,
 		SourceAudioChannels:        req.SourceAudioChannels,
 		SoftwareVideoDecode:        req.SoftwareVideoDecode,
 		ToneMapPolicy:              req.ToneMapPolicy,
@@ -1419,6 +1432,9 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		TargetBitrateKbps:          req.TargetBitrateKbps,
 		SegmentDuration:            req.SegmentDuration,
 		SegmentRetentionSeconds:    cfg.Playback.SegmentRetentionSeconds,
+		ThrottlePolicyConfigured:   true,
+		ThrottleEnabled:            config.DefaultTranscodeThrottleEnabled,
+		ThrottleThresholdSeconds:   config.DefaultTranscodeThrottleSeconds,
 		FFmpegPath:                 cfg.Playback.FFmpegPath,
 		HWAccel:                    req.HWAccel,
 		// This node's configured device (or device list — StartTranscode
@@ -1435,9 +1451,18 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		ExecutionMode:      "transcode_node",
 		FFmpegLogSink:      s.ffmpegSink,
 	}
+	if opts.PlaybackSessionID == "" {
+		opts.PlaybackSessionID = opts.SessionID
+	}
 
 	if opts.HWAccel == "" && cfg.Playback.HWAccel != "" {
 		opts.HWAccel = cfg.Playback.HWAccel
+	}
+	if req.ThrottlePolicyConfigured {
+		opts.ThrottleEnabled = req.ThrottleEnabled
+		if req.ThrottleThresholdSeconds > 0 {
+			opts.ThrottleThresholdSeconds = req.ThrottleThresholdSeconds
+		}
 	}
 	if toneMapRecipeRequested(opts) {
 		if err := s.resolveToneMapRecipe(r.Context(), &opts); err != nil {
@@ -1479,10 +1504,16 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		s.mu.Unlock()
 	}
 
-	session, err := playback.StartTranscode(r.Context(), opts)
+	var session *playback.TranscodeSession
+	var err error
+	if req.RequireReady {
+		session, err = playback.StartReadyTranscode(r.Context(), opts, TranscodeStartReadinessTimeout)
+	} else {
+		session, err = playback.StartTranscode(r.Context(), opts)
+	}
 	if err != nil {
 		unlock()
-		slog.ErrorContext(r.Context(), "start transcode", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
+		slog.ErrorContext(r.Context(), "start transcode", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", opts.PlaybackSessionID)
 		if isToneMapRecipeError(err) {
 			writeToneMapRecipeError(w, err)
 		} else {
@@ -1490,42 +1521,11 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	if req.RequireReady {
-		if _, err := session.WaitForManifest(TranscodeStartReadinessTimeout); err != nil {
-			wasRunning := session.IsRunning()
-			_ = session.Close()
-			// Mirror the API server's local-transport retry: an early death
-			// under VideoToolbox retries once in software (there is no
-			// alternate render device to move to), so a hardware encoder
-			// session this Mac cannot create does not fail clustered
-			// playback while CPU encoding was available.
-			retryAccel := playback.StartupRetryHWAccel(opts)
-			if wasRunning || retryAccel == opts.HWAccel {
-				unlock()
-				slog.ErrorContext(r.Context(), "transcode failed readiness check", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
-				http.Error(w, "transcode did not become ready", http.StatusInternalServerError)
-				return
-			}
-			slog.WarnContext(r.Context(), "transcode crashed during startup; retrying with software encoding",
-				"component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
-			retryOpts := opts
-			retryOpts.HWAccel = retryAccel
-			session, err = playback.StartTranscode(context.WithoutCancel(r.Context()), retryOpts)
-			if err != nil {
-				unlock()
-				slog.ErrorContext(r.Context(), "start transcode retry", "component", "transcodenode", "error", err, "session", req.SessionID, "playback_session_id", req.SessionID)
-				http.Error(w, "failed to start transcode", http.StatusInternalServerError)
-				return
-			}
-			if _, retryErr := session.WaitForManifest(TranscodeStartReadinessTimeout); retryErr != nil {
-				_ = session.Close()
-				unlock()
-				slog.ErrorContext(r.Context(), "transcode failed readiness check", "component", "transcodenode", "error", retryErr, "session", req.SessionID, "playback_session_id", req.SessionID)
-				http.Error(w, "transcode did not become ready", http.StatusInternalServerError)
-				return
-			}
-		}
-	}
+	effectiveOpts := session.Opts()
+	session.SetRestartHook(func(ctx context.Context) {
+		s.configureTranscodeResourcePolicy(ctx, session)
+	})
+	s.configureTranscodeResourcePolicy(r.Context(), session)
 
 	s.mu.Lock()
 	s.sessions[req.SessionID] = session
@@ -1557,6 +1557,7 @@ func (s *Server) handleStart(w http.ResponseWriter, r *http.Request) {
 		SessionID:             req.SessionID,
 		Status:                "started",
 		HWAccel:               effectiveHWAccel,
+		SoftwareVideoDecode:   effectiveOpts.SoftwareVideoDecode,
 		ToneMapMode:           session.Opts().ToneMapMode,
 		AudioRecipeVersion:    req.AudioRecipeVersion,
 		CopyFMP4RecipeVersion: req.CopyFMP4RecipeVersion,
@@ -1734,6 +1735,11 @@ func (s *Server) spawnReconstruct(r *http.Request, sessionID string, requestedSe
 	opts.HWAccel = cfg.Playback.HWAccel
 	opts.HWDevice = cfg.Playback.HWDevice
 	opts.SegmentRetentionSeconds = cfg.Playback.SegmentRetentionSeconds
+	if !opts.ThrottlePolicyConfigured {
+		opts.ThrottlePolicyConfigured = true
+		opts.ThrottleEnabled = config.DefaultTranscodeThrottleEnabled
+		opts.ThrottleThresholdSeconds = config.DefaultTranscodeThrottleSeconds
+	}
 	opts.NodeType = "transcode"
 	opts.ExecutionMode = "transcode_node"
 	if toneMapRecipeRequested(opts) {
@@ -1790,7 +1796,13 @@ func (s *Server) spawnReconstruct(r *http.Request, sessionID string, requestedSe
 		opts.SeekSeconds = float64(requestedSegment * card.SegmentDuration)
 	}
 
-	session, err := playback.StartTranscode(r.Context(), opts)
+	autoRequested := strings.EqualFold(strings.TrimSpace(opts.HWAccel), "auto")
+	var session *playback.TranscodeSession
+	if autoRequested {
+		session, err = playback.StartReadyTranscode(r.Context(), opts, playback.ManifestStartupTimeout)
+	} else {
+		session, err = playback.StartTranscode(r.Context(), opts)
+	}
 	if err != nil {
 		slog.ErrorContext(r.Context(), "transcode node reconstruct start failed", "component", "transcodenode", "error", err,
 			"session", sessionID, "playback_session_id", sessionID)
@@ -1803,33 +1815,39 @@ func (s *Server) spawnReconstruct(r *http.Request, sessionID string, requestedSe
 	// media as permanently missing. Mirror handleStart's software retry for
 	// the accel StartupRetryHWAccel would change; other accels keep the
 	// existing register-immediately behavior.
-	if retryAccel := playback.StartupRetryHWAccel(opts); retryAccel != opts.HWAccel {
-		if _, waitErr := session.WaitForManifest(playback.ManifestStartupTimeout); waitErr != nil {
-			if session.IsRunning() {
-				slog.WarnContext(r.Context(), "reconstructed transcode slow to produce a manifest", "component", "transcodenode",
-					"error", waitErr, "session", sessionID, "playback_session_id", sessionID)
-			} else {
-				// Keep the shared output directory: the retry writes into it.
-				_ = session.CloseProcess()
-				slog.WarnContext(r.Context(), "reconstructed transcode crashed during startup; retrying with software encoding",
-					"component", "transcodenode", "error", waitErr, "session", sessionID, "playback_session_id", sessionID)
-				retryOpts := opts
-				retryOpts.HWAccel = retryAccel
-				session, err = playback.StartTranscode(context.WithoutCancel(r.Context()), retryOpts)
-				if err != nil {
-					slog.ErrorContext(r.Context(), "transcode node reconstruct retry failed", "component", "transcodenode", "error", err,
-						"session", sessionID, "playback_session_id", sessionID)
-					return nil, err
-				}
-				if _, retryErr := session.WaitForManifest(playback.ManifestStartupTimeout); retryErr != nil {
-					_ = session.Close()
-					slog.ErrorContext(r.Context(), "reconstructed software retry failed readiness check", "component", "transcodenode", "error", retryErr,
-						"session", sessionID, "playback_session_id", sessionID)
-					return nil, retryErr
+	if !autoRequested {
+		if retryAccel := playback.StartupRetryHWAccel(opts); retryAccel != opts.HWAccel {
+			if _, waitErr := session.WaitForManifest(playback.ManifestStartupTimeout); waitErr != nil {
+				if session.IsRunning() {
+					slog.WarnContext(r.Context(), "reconstructed transcode slow to produce a manifest", "component", "transcodenode",
+						"error", waitErr, "session", sessionID, "playback_session_id", sessionID)
+				} else {
+					// Keep the shared output directory: the retry writes into it.
+					_ = session.CloseProcess()
+					slog.WarnContext(r.Context(), "reconstructed transcode crashed during startup; retrying with software encoding",
+						"component", "transcodenode", "error", waitErr, "session", sessionID, "playback_session_id", sessionID)
+					retryOpts := opts
+					retryOpts.HWAccel = retryAccel
+					session, err = playback.StartTranscode(context.WithoutCancel(r.Context()), retryOpts)
+					if err != nil {
+						slog.ErrorContext(r.Context(), "transcode node reconstruct retry failed", "component", "transcodenode", "error", err,
+							"session", sessionID, "playback_session_id", sessionID)
+						return nil, err
+					}
+					if _, retryErr := session.WaitForManifest(playback.ManifestStartupTimeout); retryErr != nil {
+						_ = session.Close()
+						slog.ErrorContext(r.Context(), "reconstructed software retry failed readiness check", "component", "transcodenode", "error", retryErr,
+							"session", sessionID, "playback_session_id", sessionID)
+						return nil, retryErr
+					}
 				}
 			}
 		}
 	}
+	session.SetRestartHook(func(ctx context.Context) {
+		s.configureTranscodeResourcePolicy(ctx, session)
+	})
+	s.configureTranscodeResourcePolicy(r.Context(), session)
 
 	// Yield to a winner registered by another path; close only the duplicate ffmpeg,
 	// never the shared output directory the winner is actively serving.

--- a/web/src/pages/AdminActivity.tsx
+++ b/web/src/pages/AdminActivity.tsx
@@ -41,6 +41,10 @@ import {
   type ToneMapSummary,
 } from "@/pages/adminActivityPresentation";
 import {
+  buildTranscodeDebugModel,
+  type TranscodeDebugModel,
+} from "@/pages/adminActivityTranscodeDebug";
+import {
   Table,
   TableBody,
   TableCell,
@@ -578,15 +582,31 @@ function StreamRow({
   );
   const logsHref = `/admin/logs?playback_session_id=${encodeURIComponent(session.session_id)}&focus=playback`;
   const ffmpegLogsHref = `${logsHref}&component=ffmpeg`;
-  const ffmpegLogs = useOperationalLogs(
+  const ffmpegDiagnostics = useOperationalLogs(
     {
       playback_session_id: session.session_id,
       component: "ffmpeg",
-      limit: 12,
+      q: "ffmpeg diagnostic snapshot",
+      limit: 1,
     },
     ffmpegOpen,
   );
-  const ffmpegRows = ffmpegLogs.data?.entries ?? [];
+  const ffmpegThrottle = useOperationalLogs(
+    {
+      playback_session_id: session.session_id,
+      component: "ffmpeg",
+      q: "ffmpeg throttle",
+      limit: 1,
+    },
+    ffmpegOpen,
+  );
+  const ffmpegRows = [
+    ...(ffmpegThrottle.data?.entries ?? []),
+    ...(ffmpegDiagnostics.data?.entries ?? []),
+  ].sort((left, right) => {
+    const timestampOrder = Date.parse(right.timestamp) - Date.parse(left.timestamp);
+    return timestampOrder || right.id - left.id;
+  });
   const expandedOpen = detailsOpen || ffmpegOpen;
 
   const toggleDetails = () => {
@@ -970,8 +990,8 @@ function StreamRow({
           toneMapping={toneMap?.detail ?? null}
           showFFmpeg={ffmpegOpen}
           rows={ffmpegRows}
-          isLoading={ffmpegLogs.isLoading}
-          isFetching={ffmpegLogs.isFetching}
+          isLoading={ffmpegDiagnostics.isLoading || ffmpegThrottle.isLoading}
+          isFetching={ffmpegDiagnostics.isFetching || ffmpegThrottle.isFetching}
           logsHref={`${logsHref}&component=ffmpeg`}
         />
       )}
@@ -1066,6 +1086,8 @@ function PlaybackExpandedPanel({
   isFetching: boolean;
   logsHref: string;
 }) {
+  const debug = buildTranscodeDebugModel(session, rows);
+
   return (
     <div className="terminal-surface border-border/50 bg-card border-t px-4 py-3">
       <div className="mb-2 flex items-center justify-between gap-3">
@@ -1125,6 +1147,7 @@ function PlaybackExpandedPanel({
               Open full FFmpeg logs
             </Link>
           </div>
+          <TranscodeDebugPanel model={debug} />
           <div className="overflow-hidden rounded-xl border border-[var(--terminal-border)] bg-[var(--terminal-bg)] shadow-[0_18px_60px_rgba(0,0,0,0.35)]">
             {isLoading ? (
               <div className="px-4 py-6 font-mono text-[11px] text-[var(--terminal-muted)]">
@@ -1174,6 +1197,71 @@ function PlaybackExpandedPanel({
           </div>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/** Show operator-friendly diagnostics while preserving the complete raw data. */
+function TranscodeDebugPanel({ model }: { model: TranscodeDebugModel }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-[var(--terminal-border)] bg-[var(--terminal-bg)]">
+      <div className="border-b border-[var(--terminal-border)]/50 px-4 py-3">
+        <div className="text-[10px] font-semibold tracking-[0.18em] text-[var(--terminal-muted)] uppercase">
+          Transcode diagnostics
+        </div>
+        <div className="mt-1 text-[11px] text-[var(--terminal-muted)]">
+          Effective FFmpeg recipe, execution path, and resource policy for this session.
+        </div>
+      </div>
+
+      {model.sections.length > 0 ? (
+        <div className="grid gap-px bg-[var(--terminal-border)]/40 sm:grid-cols-2 xl:grid-cols-3">
+          {model.sections.map((section) => (
+            <div key={section.title} className="bg-[var(--terminal-bg)] px-4 py-3">
+              <div className="mb-2 text-[10px] font-semibold tracking-[0.16em] text-[var(--terminal-muted)] uppercase">
+                {section.title}
+              </div>
+              <div className="grid gap-1.5">
+                {section.facts.map((fact) => (
+                  <div
+                    key={fact.key}
+                    className={`grid min-w-0 gap-2 ${fact.wide ? "grid-cols-1" : "grid-cols-[7rem_1fr]"}`}
+                  >
+                    <span className="text-[10px] text-[var(--terminal-muted)]">{fact.label}</span>
+                    <span className="min-w-0 font-mono text-[10px] leading-4 break-words text-[var(--terminal-fg)]">
+                      {fact.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="px-4 py-4 text-[11px] text-[var(--terminal-muted)]">
+          Waiting for FFmpeg diagnostic events…
+        </div>
+      )}
+
+      {model.command ? (
+        <details className="border-t border-[var(--terminal-border)]/50">
+          <summary className="cursor-pointer px-4 py-2.5 text-[11px] font-medium text-[var(--terminal-fg)]">
+            Exact FFmpeg command
+          </summary>
+          <pre className="max-h-56 overflow-auto border-t border-[var(--terminal-border)]/30 px-4 py-3 font-mono text-[10px] leading-5 break-all whitespace-pre-wrap text-[var(--terminal-fg)]">
+            {model.command}
+          </pre>
+        </details>
+      ) : null}
+
+      <details className="border-t border-[var(--terminal-border)]/50">
+        <summary className="cursor-pointer px-4 py-2.5 text-[11px] font-medium text-[var(--terminal-fg)]">
+          Raw diagnostic attributes
+        </summary>
+        <pre className="max-h-72 overflow-auto border-t border-[var(--terminal-border)]/30 px-4 py-3 font-mono text-[10px] leading-5 break-all whitespace-pre-wrap text-[var(--terminal-fg)]">
+          {JSON.stringify(model.attrs, null, 2)}
+        </pre>
+      </details>
     </div>
   );
 }

--- a/web/src/pages/admin-settings/PlaybackSettings.test.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.test.tsx
@@ -383,6 +383,59 @@ describe("PlaybackSettings transcode tone mapping", () => {
   });
 });
 
+describe("PlaybackSettings transcode resource bounds", () => {
+  beforeEach(expandAdvanced);
+
+  it("keeps the throttle recommendation visible while Advanced is closed", () => {
+    localStorage.clear();
+    useSettingsFormMock.mockReturnValue(
+      makeForm({
+        "playback.hw_accel": "auto",
+        "playback.transcode_enabled": "true",
+        enable_transcode_throttle: "false",
+      }),
+    );
+
+    const text = parse(renderToStaticMarkup(<PlaybackSettings />)).textContent ?? "";
+
+    expect(text).toContain("Resource protection disabled");
+    expect(text).not.toContain("FFmpeg path");
+  });
+
+  it("strongly recommends throttling and segment cleanup when disabled", () => {
+    useSettingsFormMock.mockReturnValue(
+      makeForm({
+        "playback.hw_accel": "auto",
+        enable_transcode_throttle: "false",
+        "playback.segment_retention_seconds": "0",
+      }),
+    );
+
+    const text = parse(renderToStaticMarkup(<PlaybackSettings />)).textContent ?? "";
+
+    expect(text).toContain("Strongly recommended to limit CPU, GPU, and temporary disk usage");
+    expect(text).toContain("temporary transcode storage can grow for the full title");
+  });
+
+  it("explains the bounded session cache when throttling is enabled", () => {
+    useSettingsFormMock.mockReturnValue(
+      makeForm({
+        "playback.hw_accel": "auto",
+        enable_transcode_throttle: "true",
+        transcode_throttle_seconds: "120",
+        "playback.segment_retention_seconds": "120",
+      }),
+    );
+
+    const container = parse(renderToStaticMarkup(<PlaybackSettings />));
+    const text = container.textContent ?? "";
+
+    expect(text).toContain("Recommended protection enabled");
+    expect(text).toContain("The entire temporary cache is deleted when playback ends");
+    expect(labelled(container, "Buffer ahead")).toHaveAttribute("value", "120");
+  });
+});
+
 describe("PlaybackSettings path defaults", () => {
   beforeEach(expandAdvanced);
 

--- a/web/src/pages/admin-settings/PlaybackSettings.tsx
+++ b/web/src/pages/admin-settings/PlaybackSettings.tsx
@@ -266,6 +266,10 @@ export default function PlaybackSettings() {
   const isDirty = form.isDirty;
   const anyDirty = (keys: readonly string[]) => keys.some((key) => isDirty(key));
   const allRestart = (keys: readonly string[]) => keys.every((key) => restartKeys.has(key));
+  const transcodingEnabled = form.getValue("playback.transcode_enabled") === "true";
+  const transcodeThrottleEnabled = form.getValue("enable_transcode_throttle") === "true";
+  const transcodeSegmentCleanupDisabled =
+    form.getValue("playback.segment_retention_seconds") === "0";
 
   const detection = hwAccel === "none" ? undefined : hwDetection.data;
   const detectedLabel = describeDetection(detection);
@@ -315,6 +319,13 @@ export default function PlaybackSettings() {
             label="Transcoding"
             type="toggle"
             description="Off serves only files clients can already play."
+            status={
+              transcodingEnabled && !transcodeThrottleEnabled ? (
+                <SettingFieldStatus tone="warn">
+                  Resource protection disabled — enable Throttle transcoding in Advanced
+                </SettingFieldStatus>
+              ) : undefined
+            }
             value={form.getValue("playback.transcode_enabled")}
             onChange={(v) => form.setValue("playback.transcode_enabled", v)}
             restartRequired={restartKeys.has("playback.transcode_enabled")}
@@ -330,7 +341,7 @@ export default function PlaybackSettings() {
               { value: "videotoolbox", label: "VideoToolbox (macOS)" },
               { value: "none", label: "Software" },
             ]}
-            description="Auto picks the best device this server can see."
+            description="Auto picks the best device. If startup fails, it keeps GPU encoding with CPU decoding before falling back to software."
             status={hwAccelStatus}
             value={hwAccel}
             onChange={(v) => form.setValue("playback.hw_accel", v)}
@@ -451,16 +462,32 @@ export default function PlaybackSettings() {
             <SettingField
               label="Throttle transcoding"
               type="toggle"
-              description="Pause encoding once the client is far enough ahead."
+              description={
+                "Pauses FFmpeg once enough media is ready instead of " +
+                "generating the whole title at once."
+              }
+              status={
+                transcodeThrottleEnabled ? (
+                  <SettingFieldStatus tone="ok">Recommended protection enabled</SettingFieldStatus>
+                ) : (
+                  <SettingFieldStatus tone="warn">
+                    Strongly recommended to limit CPU, GPU, and temporary disk usage
+                  </SettingFieldStatus>
+                )
+              }
               value={form.getValue("enable_transcode_throttle")}
               onChange={(v) => form.setValue("enable_transcode_throttle", v)}
               restartRequired={restartKeys.has("enable_transcode_throttle")}
             />
-            {form.getValue("enable_transcode_throttle") === "true" && (
+            {transcodeThrottleEnabled && (
               <SettingField
                 label="Buffer ahead"
                 type="number"
                 unit="seconds"
+                hint={
+                  "Keeps playback smooth while bounding work done ahead of " +
+                  "the viewer. 120 seconds is recommended."
+                }
                 value={form.getValue("transcode_throttle_seconds")}
                 onChange={(v) => form.setValue("transcode_throttle_seconds", v)}
                 restartRequired={restartKeys.has("transcode_throttle_seconds")}
@@ -470,7 +497,18 @@ export default function PlaybackSettings() {
               label="Transcode back buffer"
               type="number"
               unit="seconds"
-              hint="Keeps this much already-downloaded media for instant backward seeking, then reclaims older transcode segments. Use 0 to disable cleanup; enabled values must be at least 120 seconds. Pair with transcode throttling to bound both behind- and ahead-of-client disk usage."
+              hint={
+                "Keeps a short rewind window, then removes older segments. " +
+                "The entire temporary cache is deleted when playback ends and " +
+                "regenerated next time. 120 seconds is recommended; 0 disables cleanup."
+              }
+              status={
+                transcodeSegmentCleanupDisabled ? (
+                  <SettingFieldStatus tone="warn">
+                    Cleanup disabled: temporary transcode storage can grow for the full title
+                  </SettingFieldStatus>
+                ) : undefined
+              }
               value={form.getValue("playback.segment_retention_seconds")}
               onChange={(v) => form.setValue("playback.segment_retention_seconds", v)}
               restartRequired={restartKeys.has("playback.segment_retention_seconds")}

--- a/web/src/pages/adminActivityTranscodeDebug.test.ts
+++ b/web/src/pages/adminActivityTranscodeDebug.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { AdminSession, OperationalLogEntry } from "@/api/types";
+import {
+  buildTranscodeDebugModel,
+  collectTranscodeDebugAttrs,
+  formatFFmpegCommand,
+} from "./adminActivityTranscodeDebug";
+
+function session(overrides: Partial<AdminSession> = {}): AdminSession {
+  return {
+    session_id: "session-1",
+    user_id: 1,
+    username: "admin",
+    profile_id: "default",
+    media_file_id: 2,
+    requested_media_file_id: 2,
+    media_title: "Example",
+    media_type: "movie",
+    play_method: "transcode",
+    reporting_node: "local",
+    file_duration: 3600,
+    started_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    position_seconds: 10,
+    is_paused: false,
+    audio_track_index: 0,
+    transcode_audio: true,
+    stream_bitrate_kbps: 6000,
+    target_bitrate_kbps: 6000,
+    source_bitrate_kbps: 8000,
+    source_audio_channels: 6,
+    ...overrides,
+  };
+}
+
+function row(attrs: Record<string, unknown>, id = 1): OperationalLogEntry {
+  return {
+    id,
+    timestamp: new Date().toISOString(),
+    level: "info",
+    component: "ffmpeg",
+    message: "ffmpeg event",
+    attrs,
+  };
+}
+
+describe("admin activity transcode debug", () => {
+  it("prefers the newest runtime attributes and keeps session fallbacks", () => {
+    const attrs = collectTranscodeDebugAttrs(
+      session({ source_video_codec: "h264", target_resolution: "720p" }),
+      [
+        row({ throttle_paused: true, restart_count: 2 }, 2),
+        row({ throttle_paused: false, restart_count: 1, video_encoder: "h264_nvenc" }),
+      ],
+    );
+
+    expect(attrs).toMatchObject({
+      source_video_codec: "h264",
+      target_resolution: "720p",
+      throttle_paused: true,
+      restart_count: 2,
+      video_encoder: "h264_nvenc",
+    });
+  });
+
+  it("formats the adaptive pipeline, pixel path, cache, and throttle policy", () => {
+    const model = buildTranscodeDebugModel(session(), [
+      row({
+        transcode_pipeline: "software_decode_hardware_encode",
+        software_video_decode: true,
+        video_pixel_formats: ["yuv420p", "nv12"],
+        segment_retention_seconds: 120,
+        throttle_configured: true,
+        throttle_enabled: true,
+        throttle_threshold_seconds: 120,
+      }),
+      row({ throttle_paused: true, throttle_gap_seconds: 124 }, 2),
+    ]);
+
+    expect(model.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Execution",
+          facts: expect.arrayContaining([
+            expect.objectContaining({ value: "CPU decode → GPU encode" }),
+            expect.objectContaining({ label: "CPU decode", value: "Yes" }),
+          ]),
+        }),
+        expect.objectContaining({
+          title: "Video",
+          facts: expect.arrayContaining([
+            expect.objectContaining({ label: "Pixel formats", value: "yuv420p → nv12" }),
+          ]),
+        }),
+        expect.objectContaining({
+          title: "HLS & cache",
+          facts: expect.arrayContaining([
+            expect.objectContaining({ label: "Back cache", value: "120 s" }),
+            expect.objectContaining({ label: "Forward buffer", value: "120 s" }),
+            expect.objectContaining({ label: "Current lead", value: "124 s" }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it("renders the exact FFmpeg binary and arguments safely", () => {
+    expect(
+      formatFFmpegCommand({
+        ffmpeg_path: "/usr/bin/ffmpeg",
+        ffmpeg_args: ["-i", "/media/My Film.mkv", "-vf", "format=nv12,hwupload_cuda"],
+      }),
+    ).toBe("/usr/bin/ffmpeg -i '/media/My Film.mkv' -vf format=nv12,hwupload_cuda");
+
+    expect(
+      formatFFmpegCommand({
+        ffmpeg_path: "/usr/bin/ffmpeg",
+        ffmpeg_args: ["-i", "/media/$(id) `uname` it's.mkv"],
+      }),
+    ).toBe("/usr/bin/ffmpeg -i '/media/$(id) `uname` it'\"'\"'s.mkv'");
+  });
+});

--- a/web/src/pages/adminActivityTranscodeDebug.ts
+++ b/web/src/pages/adminActivityTranscodeDebug.ts
@@ -1,0 +1,269 @@
+import type { AdminSession, OperationalLogEntry } from "@/api/types";
+
+export interface TranscodeDebugFact {
+  key: string;
+  label: string;
+  value: string;
+  wide?: boolean;
+}
+
+export interface TranscodeDebugSection {
+  title: string;
+  facts: TranscodeDebugFact[];
+}
+
+export interface TranscodeDebugModel {
+  attrs: Record<string, unknown>;
+  command: string | null;
+  sections: TranscodeDebugSection[];
+}
+
+interface DebugField {
+  key: string;
+  label: string;
+  kind?:
+    | "audio_track"
+    | "bit_depth"
+    | "boolean"
+    | "bitrate"
+    | "channels"
+    | "duration"
+    | "pipeline"
+    | "pixel_formats"
+    | "subtitle_track";
+  wide?: boolean;
+}
+
+const DEBUG_SECTIONS: Array<{ title: string; fields: DebugField[] }> = [
+  {
+    title: "Execution",
+    fields: [
+      { key: "execution_mode", label: "Mode" },
+      { key: "node_type", label: "Node type" },
+      { key: "node_id", label: "Node" },
+      { key: "transcode_pipeline", label: "Pipeline", kind: "pipeline" },
+      { key: "hw_accel", label: "Hardware" },
+      { key: "software_video_decode", label: "CPU decode", kind: "boolean" },
+      { key: "hw_device", label: "GPU device" },
+      { key: "video_encoder", label: "Video encoder" },
+      { key: "audio_encoder", label: "Audio encoder" },
+    ],
+  },
+  {
+    title: "Video",
+    fields: [
+      { key: "source_video_codec", label: "Source codec" },
+      { key: "source_video_profile", label: "Source profile" },
+      { key: "source_video_bit_depth", label: "Source depth", kind: "bit_depth" },
+      { key: "source_video_resolution", label: "Source size" },
+      { key: "target_video_codec", label: "Target codec" },
+      { key: "target_resolution", label: "Target size" },
+      { key: "target_bitrate_kbps", label: "Video limit", kind: "bitrate" },
+      { key: "video_pixel_formats", label: "Pixel formats", kind: "pixel_formats" },
+      { key: "video_filter", label: "Filter graph", wide: true },
+      { key: "video_bitstream_filter", label: "Bitstream filter", wide: true },
+      { key: "video_sample_entry", label: "Sample entry" },
+    ],
+  },
+  {
+    title: "Audio & subtitles",
+    fields: [
+      { key: "source_audio_channels", label: "Source channels", kind: "channels" },
+      { key: "target_audio_codec", label: "Target codec" },
+      { key: "target_audio_channels", label: "Target channels", kind: "channels" },
+      { key: "target_audio_bitrate_kbps", label: "Audio limit", kind: "bitrate" },
+      { key: "audio_track_index", label: "Audio track", kind: "audio_track" },
+      { key: "subtitle_track_index", label: "Subtitle track", kind: "subtitle_track" },
+      { key: "subtitle_burn_in", label: "Burn-in", kind: "boolean" },
+      { key: "subtitle_codec", label: "Subtitle codec" },
+    ],
+  },
+  {
+    title: "HDR / tone map",
+    fields: [
+      { key: "tone_map_policy", label: "Policy" },
+      { key: "tone_map_mode", label: "Mode" },
+      { key: "tone_map_source_kind", label: "Source" },
+      { key: "tone_map_filter", label: "Filter", wide: true },
+      { key: "tone_map_recipe_version", label: "Recipe" },
+      { key: "tone_map_preflight_required", label: "Preflight", kind: "boolean" },
+    ],
+  },
+  {
+    title: "HLS & cache",
+    fields: [
+      { key: "segment_type", label: "Segment type" },
+      { key: "segment_duration_seconds", label: "Segment length", kind: "duration" },
+      { key: "segment_retention_seconds", label: "Back cache", kind: "duration" },
+      { key: "throttle_configured", label: "Throttle known", kind: "boolean" },
+      { key: "throttle_enabled", label: "Throttle", kind: "boolean" },
+      { key: "throttle_threshold_seconds", label: "Forward buffer", kind: "duration" },
+      { key: "throttle_paused", label: "FFmpeg paused", kind: "boolean" },
+      { key: "throttle_gap_seconds", label: "Current lead", kind: "duration" },
+      { key: "fast_start", label: "Fast start", kind: "boolean" },
+      { key: "seek_seconds", label: "Seek", kind: "duration" },
+      { key: "start_segment_number", label: "Start segment" },
+      { key: "segment_generation", label: "Generation" },
+      { key: "last_requested_segment", label: "Last requested" },
+      { key: "last_completed_segment", label: "Last delivered" },
+      { key: "restart_count", label: "Restarts" },
+      { key: "total_duration_seconds", label: "Media length", kind: "duration" },
+    ],
+  },
+  {
+    title: "Paths",
+    fields: [
+      { key: "ffmpeg_path", label: "FFmpeg", wide: true },
+      { key: "input_path", label: "Input", wide: true },
+      { key: "output_dir", label: "Output", wide: true },
+    ],
+  },
+];
+
+/** Build the readable sections and raw payload from the newest FFmpeg facts. */
+export function buildTranscodeDebugModel(
+  session: AdminSession,
+  rows: OperationalLogEntry[],
+): TranscodeDebugModel {
+  const attrs = collectTranscodeDebugAttrs(session, rows);
+  return {
+    attrs,
+    command: formatFFmpegCommand(attrs),
+    sections: DEBUG_SECTIONS.map(({ title, fields }) => ({
+      title,
+      facts: fields.flatMap((field) => {
+        const value = formatDebugValue(attrs[field.key], field.kind);
+        return value === null
+          ? []
+          : [{ key: field.key, label: field.label, value, wide: field.wide }];
+      }),
+    })).filter((section) => section.facts.length > 0),
+  };
+}
+
+/** Merge newest-first log attributes, then fill gaps from the live session. */
+export function collectTranscodeDebugAttrs(
+  session: AdminSession,
+  rows: OperationalLogEntry[],
+): Record<string, unknown> {
+  const attrs: Record<string, unknown> = {};
+
+  for (const row of rows) {
+    if (row.node_id && attrs.node_id === undefined) {
+      attrs.node_id = row.node_id;
+    }
+    for (const [key, value] of Object.entries(row.attrs ?? {})) {
+      if (attrs[key] === undefined && value !== undefined && value !== "") {
+        attrs[key] = value;
+      }
+    }
+  }
+
+  const sessionFallbacks: Record<string, unknown> = {
+    target_resolution: session.target_resolution,
+    target_video_codec: session.target_video_codec,
+    target_audio_codec: session.target_audio_codec,
+    target_audio_channels: session.target_audio_channels,
+    target_bitrate_kbps: session.target_bitrate_kbps,
+    hw_accel: session.transcode_hw_accel,
+    tone_map_mode: session.tone_map_mode,
+    source_video_codec: session.source_video_codec,
+    source_video_resolution: session.source_video_resolution,
+    source_audio_channels: session.source_audio_channels,
+  };
+
+  for (const [key, value] of Object.entries(sessionFallbacks)) {
+    if (attrs[key] === undefined) {
+      attrs[key] = value;
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(attrs)
+      .filter(([, value]) => value !== undefined && value !== null && value !== "")
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+/** Render the captured binary and argument vector without losing boundaries. */
+export function formatFFmpegCommand(attrs: Record<string, unknown>): string | null {
+  const path = typeof attrs.ffmpeg_path === "string" ? attrs.ffmpeg_path.trim() : "";
+  const args = Array.isArray(attrs.ffmpeg_args)
+    ? attrs.ffmpeg_args.filter((value): value is string => typeof value === "string")
+    : [];
+  if (!path && args.length === 0) {
+    return null;
+  }
+  return [path || "ffmpeg", ...args].map(quoteCommandPart).join(" ");
+}
+
+/** Quote one argument for lossless copy and paste into a POSIX shell. */
+function quoteCommandPart(value: string): string {
+  return /^[A-Za-z0-9_./:=+,-]+$/.test(value) ? value : `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function formatDebugValue(value: unknown, kind: DebugField["kind"]): string | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  switch (kind) {
+    case "audio_track": {
+      const index = numericValue(value);
+      return index === null ? String(value) : index < 0 ? "Default" : String(index);
+    }
+    case "bit_depth": {
+      const bits = numericValue(value);
+      return bits === null ? String(value) : bits > 0 ? `${bits}-bit` : null;
+    }
+    case "boolean":
+      return value === true ? "Yes" : value === false ? "No" : String(value);
+    case "bitrate": {
+      const bitrate = numericValue(value);
+      if (bitrate === null) return String(value);
+      return bitrate > 0 ? `${bitrate.toLocaleString()} kbps` : "Quality based (uncapped)";
+    }
+    case "channels": {
+      const channels = numericValue(value);
+      if (channels === null) return String(value);
+      return channels > 0 ? String(channels) : "Unknown";
+    }
+    case "duration": {
+      const seconds = numericValue(value);
+      return seconds === null ? String(value) : `${seconds.toLocaleString()} s`;
+    }
+    case "pipeline":
+      return formatPipeline(String(value));
+    case "pixel_formats":
+      return Array.isArray(value) ? value.map(String).join(" → ") : String(value);
+    case "subtitle_track": {
+      const index = numericValue(value);
+      return index === null ? String(value) : index < 0 ? "None" : String(index);
+    }
+    default:
+      return Array.isArray(value) ? value.map(String).join(", ") : String(value);
+  }
+}
+
+function numericValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatPipeline(value: string): string {
+  switch (value) {
+    case "hardware_decode_hardware_encode":
+      return "GPU decode → GPU encode";
+    case "software_decode_hardware_encode":
+      return "CPU decode → GPU encode";
+    case "software_decode_software_encode":
+      return "CPU decode → CPU encode";
+    case "video_copy_audio_transcode":
+      return "Video copy + audio transcode";
+    case "remux":
+      return "Remux / stream copy";
+    default:
+      return value;
+  }
+}


### PR DESCRIPTION
## Problem

Related issue: #918

Automatic hardware selection can abort playback when the selected GPU cannot decode a source even though the same GPU can encode CPU-decoded frames. Transcodes can also run far ahead of the viewer, and the Activity view does not expose enough of the effective FFmpeg recipe to diagnose the selected path.

Fixes #918

## Approach

This change makes automatic FFmpeg hardware transcoding adaptive instead of treating one resolved hardware path as universally compatible.

When <code>playback.hw_accel=auto</code>, Silo now validates the real playback startup and progressively falls back through safer execution paths:

1. GPU decode → GPU encode.
2. CPU decode → GPU encode.
3. CPU decode → CPU encode.

The first path that actually produces a playable manifest is used. This keeps GPU encoding available when a source cannot be decoded or filtered safely on the GPU, while still preserving a final software path for machines or media combinations that cannot use hardware acceleration.

The same behavior is applied consistently to native playback, Jellyfin-compatible playback, local execution, remote transcode nodes, and reconstructed sessions.

The PR also bounds work and temporary storage by enabling transcoding throttling and short segment retention by default, then adds a complete FFmpeg diagnostics panel to Admin → Activity so operators can see exactly which path and recipe were selected.

## Why this is needed

The previous automatic selection resolved one FFmpeg/hardware backend and assumed that the complete pipeline would work for every compatible-looking source.

That assumption is too broad. Hardware support varies independently across:

- decode codec;
- source profile and bit depth;
- pixel format;
- filters and scale path;
- driver;
- FFmpeg build;
- GPU generation;
- output encoder;
- remote-node hardware.

A GPU can often encode the requested output even when it cannot decode the source. For example, rejecting a hardware decode should not immediately discard a working NVENC, QSV, VA-API, or VideoToolbox encoder.

Before this change, such a startup failure could surface to the client as a transport error even though this valid path existed:

~~~text
source → CPU decode → compatible CPU pixel format → GPU upload/filter → GPU encode
~~~

Using full software transcoding immediately would restore playback, but would unnecessarily discard the GPU and create significantly more CPU load. A fixed, GPU-specific workaround would also not be portable across backends and deployments.

The adaptive sequence keeps the fast path first, preserves GPU encoding for the common partial-compatibility case, and only uses full software when both hardware paths fail.

## Scope

This change covers:

- automatic hardware fallback;
- bounded transcode generation and segment retention;
- local/remote/Jellyfin/reconstruction propagation;
- FFmpeg operational diagnostics;
- Admin Playback warnings and Admin Activity diagnostics;
- related tests.


## Automatic pipeline selection

### Eligibility

The adaptive pipeline is intentionally narrow. It is enabled only when all of the following are true:

- the administrator selected <code>auto</code>;
- the request is a video transcode;
- automatic resolution selected a real hardware backend;
- the video target is not stream copy;
- the request is not using a frozen HDR/tone-map recipe.

Explicit administrator selections such as <code>nvenc</code>, <code>qsv</code>, <code>vaapi</code>, <code>videotoolbox</code>, or <code>none</code> keep their existing behavior.

Direct play, remux/video copy, and the existing validated tone-map execution paths are also left unchanged.

### Fallback order

For an eligible request, the server builds the following ordered candidates:

| Stage | Decode | Encode | Purpose |
| --- | --- | --- | --- |
| Full hardware | GPU | GPU | Preferred low-CPU path |
| Mixed | CPU | GPU | Keeps hardware encoding when hardware decode is incompatible |
| Software | CPU | CPU | Last-resort compatibility path |

If source-safety logic has already required software decoding, the sequence begins at the mixed path and then falls back to full software.

### Startup validation

No separate FFmpeg probe or duplicate pre-encode is introduced.

The actual playback FFmpeg process is the validation:

- Silo starts the current candidate.
- It waits for the first playable manifest.
- If the manifest is ready, that candidate is accepted.
- If FFmpeg exited before producing the manifest, the failed process is closed and the next candidate is attempted.
- If FFmpeg is still running but merely slow, Silo does not start a duplicate process and reports the normal readiness timeout.

This distinction prevents multiple encoders from processing the same media concurrently.

An eligible request can make at most two additional startup attempts beyond the preferred full-hardware path.

### Multiple GPU devices

When a concrete hardware device fails during startup, the next hardware-capable attempt records that device as one to avoid.

The existing allocator can therefore prefer another configured device when one is available. The avoidance hint is cleared for the final software path.

This avoids repeatedly selecting the same failing device without permanently disabling it.

## Successful-path cache

A small in-memory cache prevents every playback of the same problematic source from repeating known failed startup paths.

A fallback is cached only after the real FFmpeg process produced a valid manifest. Failed attempts and timeouts are never cached as successes.

The signature includes the byte- and executor-relevant shape:

- FFmpeg executable identity;
- source file path;
- resolved hardware backend;
- configured hardware device set;
- source codec;
- source profile;
- source bit depth;
- source resolution;
- target video codec;
- target resolution;
- target bitrate;
- subtitle burn-in state;
- subtitle codec.

This is deliberately media-specific. One corrupt, unusual, or unsupported file cannot downgrade unrelated titles that happen to use the same codec.

Cache bounds:

- TTL: 15 minutes;
- maximum entries: 256;
- expired entries are removed during access/update;
- the oldest entry is evicted when the bound is reached;
- access is concurrency-safe;
- a later successful full-hardware start clears the previous fallback preference.

The short TTL avoids a permanent software downgrade after a driver, FFmpeg, device, or deployment recovery.

## Playback paths covered

The adaptive startup and resource policy are wired through all relevant execution paths:

- native local playback;
- native remote transcode-node playback;
- Jellyfin-compatible local playback;
- Jellyfin-compatible remote playback;
- local session reconstruction;
- transcode-node session reconstruction;
- restart hooks after seek/audio-track changes.

For remote execution, the API server sends the original playback session identity separately from the node transport identity. FFmpeg logs therefore remain correlated with the user-visible Activity session instead of being split under an internal transport ID.

The source resolution and resolved throttle policy are carried through:

- transcode-node start requests;
- recipe cards;
- stream-token claims;
- reconstructed <code>TranscodeOpts</code>.

This keeps live starts and post-restart reconstruction behavior equivalent.

## Resource protection

### Forward work: throttling

Transcoding throttling is now enabled by default.

Default policy:

- enabled: <code>true</code>;
- forward buffer: 120 seconds;
- accepted configured range: 60–86,400 seconds.

FFmpeg pauses when generated media is at least the configured threshold ahead of the client.

It resumes only when the lead falls to half the threshold or below. For the 120-second default, this means:

- pause at 120 seconds ahead;
- resume at 60 seconds ahead.

The half-threshold hysteresis prevents a fast encoder from repeatedly pausing and resuming around one boundary.

The throttler is reattached after FFmpeg restarts and reconstructed sessions, so seek and audio-track changes retain the same resource policy.

### Backward cache: segment retention

The default HLS segment retention changes from 600 seconds to 120 seconds.

Accepted values:

- <code>0</code>: disable segment cleanup explicitly;
- 120–86,400 seconds: retain a bounded rewind window.

Downloaded segments older than the configured rewind window are pruned during playback. The complete temporary transcode directory is still session-scoped and removed when playback ends, so a later viewing regenerates the media instead of retaining a permanent converted copy.

Together, the two bounds control both sides of the client position:

~~~text
pruned old segments ← 120 s back buffer | viewer | 120 s forward buffer → FFmpeg paused
~~~

This prevents an abandoned playback from encoding an entire title at full speed and consuming unnecessary CPU, GPU time, and temporary disk space.

### Existing installations and explicit opt-outs

The settings remain administrator-controlled:

- an existing explicit throttle value is preserved;
- an existing explicit disabled throttle remains disabled;
- <code>playback.segment_retention_seconds=0</code> remains a valid cleanup opt-out;
- missing, invalid, or temporarily unavailable throttle settings fall back to the protective defaults.

No persistent media copy or long-lived conversion cache is added.

## Admin Playback UI

The Playback settings explain the new behavior and make unsafe resource choices visible.

Changes include:

- the Hardware acceleration description now explains the <code>auto</code> fallback behavior;
- enabled throttling displays “Recommended protection enabled”;
- disabled throttling displays a strong CPU/GPU/disk warning;
- the main Transcoding row warns when transcoding is enabled without throttling;
- Buffer ahead recommends 120 seconds;
- Transcode back buffer explains the rewind window and session cleanup lifecycle;
- disabling segment cleanup displays a temporary-storage growth warning.

The UI does not add another tone-map toggle. The existing hardware and software HDR tone-map settings retain their separate purpose and behavior.

## FFmpeg observability

### Event diagnostics

FFmpeg lifecycle events now include an event-only diagnostic snapshot derived from the exact argument vector passed to the process.

Snapshots are recorded for meaningful lifecycle points such as:

- process starting;
- process started;
- process restart;
- process exit;
- process exit error;
- resource-policy configuration.

The diagnostic payload is intentionally not repeated on every FFmpeg stderr line. This keeps the operational log volume bounded while retaining the complete recipe needed for debugging.

Throttle pause/resume events are lightweight and contain the current paused state and lead in seconds without duplicating the full FFmpeg command.

### Captured fields

The diagnostics include:

- FFmpeg executable path;
- exact FFmpeg argument vector;
- effective execution pipeline;
- node type, node ID, and execution mode;
- resolved hardware backend and concrete device;
- video and audio encoders;
- complete video filter graph;
- explicit pixel-format transitions;
- source codec, profile, bit depth, resolution, and audio channels;
- target codecs, resolution, video bitrate, audio channels, and audio bitrate;
- audio/subtitle track indexes;
- subtitle burn-in and subtitle codec;
- HDR/tone-map policy, mode, source kind, filter, recipe version, and preflight requirement;
- video bitstream filter and sample entry;
- HLS segment type and duration;
- segment retention;
- total media duration;
- fast-start and seek state;
- segment generation;
- last requested and delivered segments;
- restart count;
- throttle configured/enabled/paused state;
- throttle threshold and current lead;
- input and output paths;
- process exit error where applicable.

The pipeline is reported with an operator-readable distinction:

- GPU decode → GPU encode;
- CPU decode → GPU encode;
- CPU decode → CPU encode;
- video copy + audio transcode;
- remux / stream copy.

### Log correlation and safety

Native and Jellyfin-compatible paths now use the same FFmpeg log sink, including integrated and remote nodes.

Logs prefer the original playback session ID for correlation. Internal transport IDs remain available for execution but no longer fragment the Activity view.

Sink calls are made after releasing the transcode-session mutex. This avoids blocking process/session state while the logging backend writes an event.

Existing stderr line and byte bounds remain in place. Once the cap is reached, one capped event records the dropped-line count rather than growing operational storage without limit.

## Admin Activity UI

Expanding a transcoding session in Admin → Activity now displays a dedicated **Transcode diagnostics** panel before the live stderr console.

The panel groups facts into:

- Execution;
- Video;
- Audio & subtitles;
- HDR / tone map;
- HLS & cache;
- Paths.

It also provides two expandable views:

- the exact reconstructed FFmpeg command with argument boundaries safely quoted;
- the complete raw diagnostic attributes as formatted JSON.

The model merges newest-first diagnostic events and fills missing values from the live session summary. This allows partial/older events to remain useful while always preferring the newest concrete runtime facts.

## Implementation notes

The main implementation units are:

- <code>internal/playback/auto_transcode_pipeline.go</code>: candidate ordering and successful-path cache;
- <code>internal/playback/transcode_startup.go</code>: first-manifest startup validation and retries;
- <code>internal/playback/ffmpeg_diagnostics.go</code>: exact recipe/pipeline extraction;
- <code>internal/config/transcode_resource_policy.go</code>: shared live throttle policy;
- <code>internal/playback/transcode.go</code>: session lifecycle, diagnostics, throttle state, and device avoidance;
- <code>internal/playback/throttle.go</code>: pause/resume hysteresis and transition events;
- <code>internal/playback/recipecard.go</code> and <code>internal/streamtoken/token.go</code>: reconstruction persistence;
- native API, Jellyfin compatibility, and transcode-node handlers: consistent propagation;
- <code>web/src/pages/adminActivityTranscodeDebug.ts</code>: presentation model and formatting;
- <code>web/src/pages/AdminActivity.tsx</code>: diagnostics panel;
- <code>web/src/pages/admin-settings/PlaybackSettings.tsx</code>: behavior descriptions and warnings.

## Behavioral examples

### Unsupported GPU decode, working GPU encode

~~~text
Attempt 1: NVDEC/QSV/VA-API/VideoToolbox decode + GPU encode
Result: FFmpeg exits before manifest

Attempt 2: CPU decode + GPU encode
Result: first manifest produced

Playback: starts with GPU encoding
Cache: mixed path preferred for this exact signature for 15 minutes
~~~

### Hardware unavailable for the complete request

~~~text
Attempt 1: full hardware fails before manifest
Attempt 2: CPU decode + GPU encode fails before manifest
Attempt 3: CPU decode + CPU encode produces manifest

Playback: starts in software
Cache: software path preferred briefly for this exact signature
~~~

### Slow but still-running FFmpeg

~~~text
Attempt 1: process remains alive but does not become ready before timeout
Result: readiness error; no duplicate fallback process is started
~~~

### Explicit hardware selection

~~~text
Configuration: playback.hw_accel=nvenc
Result: existing NVENC behavior; adaptive auto fallback is not activated
~~~

## Compatibility and non-goals

- No database migration is required.
- Existing setting keys are reused.
- Existing explicit administrator choices remain authoritative.
- No permanent transcoded-media cache is introduced.
- No per-media probe process is introduced.
- No background conversion of complete titles is introduced.
- Validated HDR/tone-map recipes continue through their existing specialized fallback logic.

## Performance impact

Steady-state overhead is negligible:

- candidate construction and cache lookup are in-memory operations;
- the cache is bounded to 256 small entries;
- no extra FFmpeg process is launched when the preferred path succeeds;
- no media is copied or pre-generated for detection;
- diagnostic parsing scans the already-built FFmpeg argument list only on lifecycle events.

Additional CPU work occurs only when compatibility requires CPU decoding or full software transcoding.

The first unsupported signature can incur one or two failed startup attempts. Later matching sessions can start from the last manifest-producing path during the 15-minute cache lifetime.

Throttling reduces total unnecessary resource use for viewers who stop early by preventing FFmpeg from racing to encode the entire title.

## Validation

### Go tests

Passed locally:

~~~text
go test ./internal/config -count=1
go test ./internal/api/handlers -count=1
go test ./internal/jellycompat -count=1
go test ./internal/transcodenode -count=1
~~~

Focused playback coverage passed for:

- automatic stage ordering;
- eligibility boundaries;
- cache success/expiry/eviction/concurrency behavior;
- failed-device avoidance;
- manifest-ready success;
- startup exit fallback;
- no fallback for a still-running process;
- diagnostic field extraction;
- event-only diagnostic logging;
- recipe-card and stream-token propagation;
- throttle policy defaults;
- pause/resume hysteresis;
- segment progress and retention behavior.

The changed playback tests and <code>go vet</code> checks pass. The complete playback package still has pre-existing macOS GPU-probe timing failures caused by hard 200 ms process timeouts ending in <code>signal: killed</code>; these failures are unrelated to the changed paths.

### Static checks

Passed locally:

~~~text
go vet ./internal/config ./internal/playback ./internal/transcodenode ./internal/jellycompat ./internal/api/handlers ./cmd/silo
tsc -b --pretty false
prettier --check <changed web files>
eslint src/pages/AdminActivity.tsx src/pages/adminActivityTranscodeDebug.ts src/pages/adminActivityTranscodeDebug.test.ts
vite build
git diff --check
~~~

### Frontend tests

The three affected frontend test files pass: 49 tests total.

Coverage includes:

- diagnostic event merging;
- session fallbacks;
- FFmpeg command reconstruction and quoting;
- field formatting;
- readable pipeline labels;
- Playback settings warnings;
- throttle recommendation state;
- disabled segment-cleanup warning.

### Hardware validation

A real Tesla P4 using Jellyfin FFmpeg 7.1.4 successfully ran the intended mixed path:

~~~text
H.264 High 10 1080p
→ CPU decode
→ NV12 CUDA upload
→ scale_cuda to 720p
→ NVENC encode
~~~

This demonstrates the central use case: preserve the GPU encoder even when the hardware decode path cannot accept the source.

## Risks

| Risk | Mitigation |
| --- | --- |
| Longer first startup for an unsupported signature | At most two safer retries; successful fallback cached for 15 minutes |
| CPU increase on the mixed path | CPU performs decode only; GPU still filters/encodes where supported |
| High CPU on final software path | Used only after hardware paths fail |
| A transient GPU failure downgrades future sessions | Cache is media-specific and expires after 15 minutes |
| Cache growth | Hard limit of 256 entries with expiry and oldest-entry eviction |
| Duplicate FFmpeg work | Fallback only after the previous process exited before manifest |
| Temporary disk growth | 120-second forward throttle and 120-second back retention by default |
| Pause/resume oscillation | Resume threshold is half the pause threshold |
| Excess operational-log volume | Full diagnostics only on lifecycle events; stderr remains capped |
| Behavior drift after restart | Resource policy and source facts persist through requests/tokens/recipe cards |
| Impact to explicit recipes | Auto-only eligibility excludes explicit acceleration, copy, and frozen tone-map paths |

## Reviewer guide

The most important properties to verify are:

- automatic fallback activates only for <code>auto</code>;
- a running process is never duplicated because it is slow;
- each failed FFmpeg process is closed before the next attempt;
- a cached fallback is written only after manifest readiness;
- the cache key cannot downgrade unrelated media;
- explicit acceleration and validated tone-map recipes are unchanged;
- local, remote, Jellyfin, and reconstruction paths carry equivalent options;
- throttle settings and source resolution survive node/reconstruction boundaries;
- detailed snapshots are event-only, not attached to every stderr line;
- the Admin panel renders partial and legacy data safely.

## Checklist

- [x] Automatic hardware fallback is generic across supported backends.
- [x] GPU encode remains available when only hardware decode fails.
- [x] Full software remains the final compatibility path.
- [x] Cache lifetime and size are bounded.
- [x] Local, remote, Jellyfin, and reconstructed playback are covered.
- [x] Throttling and segment retention bound forward/backward work.
- [x] Explicit administrator opt-outs are preserved.
- [x] FFmpeg diagnostics are correlated with Activity sessions.
- [x] Admin settings explain and strongly recommend resource protection.
- [x] Backend, frontend, static, formatting, and hardware checks were performed.

## AI disclosure

- Harness: Codex desktop app
- Tooling: Codex <code>exec_command</code> and <code>apply_patch</code>
- Model family: GPT-5 Codex
- Involvement: AI-assisted implementation, tests, review, and PR documentation
- Adversarial review: examined fallback boundaries, startup process lifecycle, cache isolation/concurrency, device selection, tone-map exclusions, reconstruction parity, throttle defaults/hysteresis, segment retention, logging volume, session correlation, and Admin rendering fallbacks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic transcoding now retries safer hardware and software paths when playback startup fails, including improved GPU fallback handling.
  * Added detailed FFmpeg and transcoding diagnostics to Admin Activity, including the exact command, video/audio settings, HDR processing, caching, and throttling status.
  * Playback sessions now preserve transcoding resolution and resource-management settings across stream tokens and remote nodes.

* **Improvements**
  * Added clearer Playback settings guidance for throttling, buffer limits, hardware acceleration fallback, and segment cleanup.
  * Improved transcoding throttling stability to reduce unnecessary pause/resume cycling.
  * Updated default playback segment retention to 120 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->