### PR TITLE
fix(jellycompat): reserve static plays and preserve recovery identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,20 @@ jobs:
   go:
     name: Go
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: silo_test
+          POSTGRES_PASSWORD: silo_test
+          POSTGRES_DB: silo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U silo_test -d silo_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -45,7 +59,7 @@ jobs:
       - name: Install libvips
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libvips-dev
+          sudo apt-get install -y --no-install-recommends libvips-dev postgresql-client
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -113,6 +127,20 @@ jobs:
       # defaults. Without this job those tests exist but never run.
       - name: Test
         run: make test-go
+
+      - name: Test static playback reservations and recovery across API instances
+        env:
+          PGPASSWORD: silo_test
+          SILO_TEST_DATABASE_URL: postgres://silo_test:silo_test@localhost:5432/silo_test?sslmode=disable
+        run: |
+          sed '/^-- +goose Down/,$d' migrations/sql/20260618053223_add_jellycompat_playback_sessions.sql | psql -h localhost -U silo_test -d silo_test -v ON_ERROR_STOP=1
+          psql -h localhost -U silo_test -d silo_test -v ON_ERROR_STOP=1 -c 'CREATE TABLE playback_sessions_sync (session_id text PRIMARY KEY, media_file_id integer)'
+          go test -race ./internal/jellycompat -run 'TestDurableCompatPlaybackStoreStaticReservation|TestDurableStaticAttachment|TestDurableLegacyStaticDuplicates|TestLegacyStaticDuplicates|TestDevicePlaybackAlias|TestHandlePlaybackReport_DeviceAlias|TestCreateStaticPlaySessionConcurrent|TestStaticPlayback|TestPlaybackSessionStoreStaticReservation|TestHandleVideoStream.*Static' -count=1 -v
+
+      - name: Benchmark static reservation reuse
+        env:
+          SILO_TEST_DATABASE_URL: postgres://silo_test:silo_test@localhost:5432/silo_test?sslmode=disable
+        run: go test ./internal/jellycompat -run '^$' -bench 'Benchmark(StaticPlayback|DurableStatic)ReservationReuse$' -benchmem -benchtime=250ms -count=5
 
   web:
     name: Web

--- a/internal/jellycompat/playback_report_liveness_test.go
+++ b/internal/jellycompat/playback_report_liveness_test.go
@@ -3,6 +3,7 @@ package jellycompat
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -117,6 +118,41 @@ func TestHandlePlaybackReport_DeviceAliasIgnoresUnresolvedLegacyRecords(t *testi
 				}
 			}
 		})
+	}
+}
+
+func TestHandlePlaybackReport_DeviceAliasRejectsUnscopedLegacySession(t *testing.T) {
+	for _, stop := range []bool{false, true} {
+		for _, storedDevice := range []string{"", "other-device"} {
+			for _, playID := range []string{"client-play", "unknown-play", "play-1"} {
+				t.Run(fmt.Sprintf("stop_%t/device_%s/play_%s", stop, storedDevice, playID), func(t *testing.T) {
+					handler, mgr, routeID, sourceID := newReportLivenessHandler("legacy-native", true)
+					if err := handler.playbackStore.Update("play-1", func(s *PlaybackSession) error {
+						s.ClientPlaySessionID, s.ClientDeviceID = "client-play", storedDevice
+						return nil
+					}); err != nil {
+						t.Fatal(err)
+					}
+					req := httptest.NewRequest(http.MethodPost, "/Sessions/Playing/Progress", strings.NewReader(`{"PlaySessionId":"`+playID+`","ItemId":"`+routeID+`","MediaSourceId":"`+sourceID+`","PositionTicks":600000000}`))
+					req.Header.Set("X-Emby-Authorization", `MediaBrowser DeviceId="current-device"`)
+					req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, &Session{Token: "token-1", StreamAppUserID: 1, ProfileID: "profile-1"}))
+					rec := httptest.NewRecorder()
+					handler.handlePlaybackReport(rec, req, stop)
+					if rec.Code != http.StatusNoContent {
+						t.Fatalf("status = %d", rec.Code)
+					}
+					// An exact caller-owned server ID remains sufficient for a
+					// legacy record; an alias/route must match the explicit device.
+					allow := playID == "play-1" && storedDevice == ""
+					if !allow && (len(mgr.progressUpdates) != 0 || len(mgr.stopCalls) != 0) {
+						t.Fatal("explicit-device report mutated an unscoped or other-device session")
+					}
+					if allow && ((stop && len(mgr.stopCalls) != 1) || (!stop && len(mgr.progressUpdates) != 1)) {
+						t.Fatal("exact caller-owned legacy session ID stopped working")
+					}
+				})
+			}
+		}
 	}
 }
 

--- a/internal/jellycompat/playback_report_liveness_test.go
+++ b/internal/jellycompat/playback_report_liveness_test.go
@@ -76,6 +76,76 @@ func postProgressReport(handler *PlaybackHandler, body string) *httptest.Respons
 	return rec
 }
 
+func TestHandlePlaybackReport_DeviceAliasIgnoresUnresolvedLegacyRecords(t *testing.T) {
+	for _, stop := range []bool{false, true} {
+		t.Run(map[bool]string{false: "progress", true: "stop"}[stop], func(t *testing.T) {
+			handler, mgr, routeID, sourceID := newReportLivenessHandler("current-native", true)
+			if err := handler.playbackStore.Update("play-1", func(s *PlaybackSession) error {
+				s.ClientPlaySessionID, s.ClientDeviceID, s.StaticPlaybackKey = "client-play", "current-device", "reservation"
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			first, second := legacyStaticPair("token-1", time.Now())
+			for _, old := range []PlaybackSession{first, second} {
+				old.ClientDeviceID, old.RouteItemID = "", routeID
+				old.MediaSources = []PlaybackMediaSource{{ID: sourceID, FileID: 42}, {ID: "another-edition", FileID: 43}}
+				handler.playbackStore.Put(old)
+			}
+			reportSourceID := sourceID
+			if !stop {
+				reportSourceID = routeID // Jellyfin's item-as-source convention.
+			}
+			req := httptest.NewRequest(http.MethodPost, "/Sessions/Playing/Progress", strings.NewReader(`{"PlaySessionId":"client-play","ItemId":"`+routeID+`","MediaSourceId":"`+reportSourceID+`","PositionTicks":600000000}`))
+			req.Header.Set("X-Emby-Authorization", `MediaBrowser DeviceId="current-device"`)
+			req = req.WithContext(context.WithValue(req.Context(), compatSessionKey, &Session{Token: "token-1", StreamAppUserID: 1, ProfileID: "profile-1"}))
+			rec := httptest.NewRecorder()
+			handler.handlePlaybackReport(rec, req, stop)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d", rec.Code)
+			}
+			if stop {
+				if len(mgr.stopCalls) != 1 || mgr.stopCalls[0] != "current-native" {
+					t.Fatal("stop did not resolve the exact device playback")
+				}
+			} else if len(mgr.progressUpdates) != 1 || mgr.progressUpdates[0].sessionID != "current-native" {
+				t.Fatal("unresolved historical aliases blocked current progress")
+			}
+			for _, old := range []PlaybackSession{first, second} {
+				if _, ok := handler.playbackStore.Get(old.ID); !ok {
+					t.Fatal("unproven historical record was modified")
+				}
+			}
+		})
+	}
+}
+
+func TestHandlePlaybackReport_ReviveSelectedEdition(t *testing.T) {
+	for _, selected := range []int{43, 99} {
+		handler, mgr, routeID, _ := newReportLivenessHandler("expired-native", false)
+		if err := handler.playbackStore.Update("play-1", func(s *PlaybackSession) error {
+			second := s.MediaSources[0]
+			second.ID, second.FileID, second.Version.FileID = "second-edition", 43, 43
+			s.MediaSources = append(s.MediaSources, second)
+			s.SelectedMediaFileID = selected
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		rec := postProgressReport(handler, `{"PlaySessionId":"play-1","ItemId":"`+routeID+`","MediaSourceId":"`+routeID+`","PositionTicks":600000000}`)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		if selected == 43 {
+			if got := mgr.sessions["upstream-started"]; got == nil || got.MediaFileID != 43 {
+				t.Fatal("recovery substituted the first edition")
+			}
+		} else if mgr.startCalls != 0 {
+			t.Fatal("missing selected edition was replaced by another file")
+		}
+	}
+}
+
 // TestHandlePlaybackReport_ClientPlaySessionIDFallsBackToItemRoute proves a
 // progress report whose PlaySessionId is unknown to the server (the client
 // generated it because Static=true direct play skipped PlaybackInfo) still

--- a/internal/jellycompat/playback_sessions.go
+++ b/internal/jellycompat/playback_sessions.go
@@ -33,7 +33,11 @@ type PlaybackSession struct {
 	// when it differs from ours (Static=true direct play skips PlaybackInfo,
 	// so the client never learns the server id). Playback reports carrying
 	// that id resolve to this session directly instead of by ambiguous route.
-	ClientPlaySessionID        string
+	ClientPlaySessionID string
+	// StaticPlaybackKey identifies one caller/device/play/item/source tuple.
+	// It is a hash, not a credential or a client-visible session identifier.
+	StaticPlaybackKey          string
+	SelectedMediaFileID        int
 	UserID                     string
 	InitialSeekSeconds         float64
 	MediaSources               []PlaybackMediaSource
@@ -45,7 +49,10 @@ type PlaybackSession struct {
 	// Terminal hides a play session from stream and progress routing after
 	// ActiveEncodings cleanup while retaining the authenticated mapping long
 	// enough for a later Stopped report to publish its authoritative position.
-	Terminal              bool
+	Terminal bool
+	// SupersededBy retains a legacy duplicate's canonical mapping without
+	// inventing a playback-stop event or allowing the duplicate to revive.
+	SupersededBy          string
 	TerminalAuthoritative bool
 	TerminalFallbackSent  bool
 	TerminalClaimUntil    time.Time
@@ -112,6 +119,9 @@ type CompatPlaybackStore interface {
 	// PutNegotiated stores a PlaybackInfo negotiation and atomically replaces
 	// older, still-unstarted negotiations for the same client device and item.
 	PutNegotiated(session PlaybackSession)
+	// GetOrCreateStatic atomically reserves one live session for a static play.
+	// Persistence failure must not create an uncoordinated local session.
+	GetOrCreateStatic(ctx context.Context, session PlaybackSession) (*PlaybackSession, error)
 	// Get returns a session when it exists and is not expired.
 	Get(id string) (*PlaybackSession, bool)
 	// Delete removes a session.
@@ -203,6 +213,27 @@ func (s *PlaybackSessionStore) Put(session PlaybackSession) {
 // publishing a stale pause.
 func (s *PlaybackSessionStore) PutNegotiated(session PlaybackSession) {
 	s.putNegotiatedNormalized(session)
+}
+
+func (s *PlaybackSessionStore) GetOrCreateStatic(ctx context.Context, session PlaybackSession) (*PlaybackSession, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if session.CompatToken == "" || session.StaticPlaybackKey == "" {
+		return nil, ErrSessionNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, existing := range s.sessions {
+		if existing.CompatToken == session.CompatToken && existing.StaticPlaybackKey == session.StaticPlaybackKey &&
+			!existing.Terminal && existing.ExpiresAt.After(s.now()) {
+			return &existing, nil
+		}
+	}
+	stored := s.normalizeSession(session)
+	s.sessions[stored.ID] = stored
+	return &stored, nil
 }
 
 // putNormalized stores or replaces a compat playback session and returns the
@@ -366,7 +397,7 @@ func (s *PlaybackSessionStore) StageTerminal(
 	defer s.mu.Unlock()
 
 	session, ok := s.sessions[id]
-	if !ok || session.CompatToken != compatToken {
+	if !ok || session.CompatToken != compatToken || session.SupersededBy != "" {
 		return nil, ErrSessionNotFound
 	}
 	if !session.ExpiresAt.After(s.now()) {
@@ -510,7 +541,7 @@ func (s *PlaybackSessionStore) GetFinalizable(id, compatToken string) (*Playback
 	defer s.mu.Unlock()
 
 	session, ok := s.sessions[id]
-	if !ok || session.CompatToken != compatToken {
+	if !ok || session.CompatToken != compatToken || session.SupersededBy != "" {
 		return nil, false
 	}
 	if !session.ExpiresAt.After(s.now()) {
@@ -548,6 +579,7 @@ func (s *PlaybackSessionStore) Update(id string, fn func(*PlaybackSession) error
 // PlaySessionId across plays makes the alias ambiguous, and the caller should
 // fall back to route matching instead of binding an arbitrary session.
 func (s *PlaybackSessionStore) FindByClientPlaySessionID(compatToken, clientPlaySessionID string) (*PlaybackSession, bool) {
+	s.reconcileLegacyStaticDuplicates(compatToken, clientPlaySessionID)
 	return s.findByClientPlaySessionID(compatToken, clientPlaySessionID, "", "", false)
 }
 
@@ -557,6 +589,7 @@ func (s *PlaybackSessionStore) FindByClientPlaySessionID(compatToken, clientPlay
 func (s *PlaybackSessionStore) FindFinalizableByClientPlaySessionID(
 	compatToken, clientPlaySessionID, routeItemID, mediaSourceID string,
 ) (*PlaybackSession, bool) {
+	s.reconcileLegacyStaticDuplicates(compatToken, clientPlaySessionID)
 	return s.findByClientPlaySessionID(
 		compatToken, clientPlaySessionID, routeItemID, mediaSourceID, true,
 	)
@@ -569,6 +602,13 @@ func (s *PlaybackSessionStore) findByClientPlaySessionID(
 	mediaSourceID string,
 	includeTerminal bool,
 ) (*PlaybackSession, bool) {
+	return s.findDeviceClientPlaySessionID(compatToken, clientPlaySessionID, "", routeItemID, mediaSourceID, includeTerminal)
+}
+
+func (s *PlaybackSessionStore) findDeviceClientPlaySessionID(
+	compatToken, clientPlaySessionID, deviceID, routeItemID, mediaSourceID string,
+	includeTerminal bool,
+) (*PlaybackSession, bool) {
 	if clientPlaySessionID == "" {
 		return nil, false
 	}
@@ -578,10 +618,13 @@ func (s *PlaybackSessionStore) findByClientPlaySessionID(
 	now := s.now()
 	var match *PlaybackSession
 	for _, session := range s.sessions {
-		if !session.ExpiresAt.After(now) || (!includeTerminal && session.Terminal) {
+		if !session.ExpiresAt.After(now) || session.SupersededBy != "" || (!includeTerminal && session.Terminal) {
 			continue
 		}
 		if session.CompatToken != compatToken {
+			continue
+		}
+		if deviceID != "" && session.ClientDeviceID != deviceID {
 			continue
 		}
 		if routeItemID != "" && !mediaSourceIDsEqual(session.RouteItemID, routeItemID) {
@@ -622,7 +665,7 @@ func (s *PlaybackSessionStore) FindByUpstreamSessionID(upstreamSessionID string)
 
 // FindByRoute resolves a route item/media-source identifier to a compat playback session.
 func (s *PlaybackSessionStore) FindByRoute(compatToken, routeID string) (*PlaybackSession, *PlaybackMediaSource, bool) {
-	return s.findByRoute(compatToken, routeID, false, false)
+	return s.findByRoute(compatToken, routeID, false, true)
 }
 
 // FindFinalizableByRoute includes terminal sessions retained for a stopped
@@ -644,7 +687,7 @@ func (s *PlaybackSessionStore) findByRoute(
 	var matchedSession *PlaybackSession
 	var matchedSource *PlaybackMediaSource
 	for _, session := range s.sessions {
-		if !session.ExpiresAt.After(now) || (!includeTerminal && session.Terminal) {
+		if !session.ExpiresAt.After(now) || session.SupersededBy != "" || (!includeTerminal && session.Terminal) {
 			continue
 		}
 		if compatToken != "" && session.CompatToken != compatToken {

--- a/internal/jellycompat/playback_sessions_postgres.go
+++ b/internal/jellycompat/playback_sessions_postgres.go
@@ -859,7 +859,9 @@ func (d *DurableCompatPlaybackStore) Update(id string, fn func(*PlaybackSession)
 		// reflects any concurrent writer's fields that fn merged on top of.
 		d.mem.Put(*committed)
 		d.markIDValidated(committed.ID)
-		if len(pending) > 0 {
+		// On a rejected CAS this is the authoritative pre-transaction row,
+		// not a commit of the pending mutations. Keep those mutations for retry.
+		if err == nil && len(pending) > 0 {
 			d.consumePendingUpdates(id, pending[len(pending)-1].sequence)
 		}
 	}

--- a/internal/jellycompat/playback_sessions_postgres.go
+++ b/internal/jellycompat/playback_sessions_postgres.go
@@ -3,6 +3,8 @@ package jellycompat
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -283,6 +285,81 @@ func negotiatedPlaybackScope(compatToken, clientDeviceID, routeItemID string) st
 	)
 }
 
+// GetOrCreateStatic serializes the initial lookup and insert across API nodes.
+// The existing token index bounds the lookup to this caller's playback rows.
+func (d *DurableCompatPlaybackStore) GetOrCreateStatic(ctx context.Context, session PlaybackSession) (*PlaybackSession, error) {
+	if d.pool == nil {
+		return d.mem.GetOrCreateStatic(ctx, session)
+	}
+	if session.CompatToken == "" || session.StaticPlaybackKey == "" {
+		return nil, ErrSessionNotFound
+	}
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	// Domain-separate static reservations from PlaybackInfo negotiation locks.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock($1::bigint)`, staticPlaybackReservationLockKey(session.CompatToken, session.StaticPlaybackKey)); err != nil {
+		return nil, err
+	}
+	var data []byte
+	err = tx.QueryRow(ctx, `
+		SELECT data FROM jellycompat_playback_sessions
+		WHERE compat_token = $1 AND data->>'StaticPlaybackKey' = $2
+			AND expires_at > $3
+			AND COALESCE((data->>'Terminal')::boolean, false) = false
+		ORDER BY created_at, id LIMIT 1 FOR UPDATE
+	`, session.CompatToken, session.StaticPlaybackKey, d.now()).Scan(&data)
+	if errors.Is(err, pgx.ErrNoRows) {
+		session = d.mem.normalizeSession(session)
+		data, err = marshalPlaybackSession(session)
+		if err == nil {
+			_, err = tx.Exec(ctx, `
+				INSERT INTO jellycompat_playback_sessions (id, compat_token, user_id, data, expires_at)
+				VALUES ($1, $2, $3, $4, $5)
+			`, session.ID, session.CompatToken, session.UserID, data, session.ExpiresAt)
+		}
+	} else if err == nil {
+		err = json.Unmarshal(data, &session)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	// Reload through the normal generation-aware cache path. Applying the
+	// transaction's snapshot directly could overwrite a concurrent upstream
+	// attachment, progress update, or terminal marker after the commit.
+	d.invalidateValidation(session.ID, session.CompatToken)
+	stored, ok := d.Get(session.ID)
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	return stored, nil
+}
+
+// staticPlaybackReservationLockKey retains the deployed reservation lock's
+// framing and domain without changing PlaybackInfo negotiation locking. The
+// static marker separates these reservations from ordinary negotiated scopes.
+// A truncated-hash collision can only serialize unrelated callers: the row
+// lookup still checks the full token and reservation key.
+func staticPlaybackReservationLockKey(token, key string) int64 {
+	const domain = "silo:jellycompat:negotiated-session:v1"
+	const marker = "static-playback-reservation"
+	framed := make([]byte, 0, len(domain)+3*8+len(token)+len(marker)+len(key))
+	framed = append(framed, domain...)
+	for _, value := range [...]string{token, marker, key} {
+		framed = binary.BigEndian.AppendUint64(framed, uint64(len(value)))
+		framed = append(framed, value...)
+	}
+	digest := sha256.Sum256(framed)
+	return int64(binary.BigEndian.Uint64(digest[:8]))
+}
+
 // Get periodically revalidates the durable row before returning an active
 // session. Query failures preserve a still-valid cache entry: a temporary DB
 // outage must not interrupt an already-playing stream.
@@ -493,6 +570,9 @@ func (d *DurableCompatPlaybackStore) stageTerminalDB(
 	var session PlaybackSession
 	if err := json.Unmarshal(raw, &session); err != nil {
 		return nil, err
+	}
+	if session.SupersededBy != "" {
+		return nil, ErrSessionNotFound
 	}
 	if !session.TerminalAuthoritative || authoritative {
 		eventCopy := event
@@ -784,6 +864,12 @@ func (d *DurableCompatPlaybackStore) Update(id string, fn func(*PlaybackSession)
 		}
 	}
 	if err != nil {
+		if errors.Is(err, errUpstreamReplaced) {
+			// A rejected compare-and-set is not a retryable persistence failure.
+			// The authoritative winner above replaces the speculative cache write;
+			// queuing the losing closure could later attach an obsolete session.
+			return err
+		}
 		d.appendPendingUpdate(id, d.mem.compatTokenForID(id), fn)
 		// The in-memory mutation stands (live state is correct), but the durable
 		// row was NOT updated: surface the failure so durability-sensitive callers
@@ -841,6 +927,15 @@ func (d *DurableCompatPlaybackStore) updateDB(id string, fn func(*PlaybackSessio
 		return nil, err
 	}
 	if err := fn(&session); err != nil {
+		if errors.Is(err, errUpstreamReplaced) {
+			// Pending closures may have mutated the decoded copy before the CAS
+			// rejected it. Reload the original locked row for the caller's cache.
+			var authoritative PlaybackSession
+			if decodeErr := json.Unmarshal(raw, &authoritative); decodeErr != nil {
+				return nil, decodeErr
+			}
+			return &authoritative, err
+		}
 		// The mutation itself rejected the authoritative row; the cache mutation
 		// (already applied) stands. This is a fn/data condition, not an
 		// infrastructure failure, so it is not surfaced as a durability error.
@@ -910,15 +1005,8 @@ func (d *DurableCompatPlaybackStore) FindFinalizableByRoute(
 // rows from Postgres into the cache (same bounded fallback as FindByRoute; the
 // alias uniqueness check runs against the repopulated cache).
 func (d *DurableCompatPlaybackStore) FindByClientPlaySessionID(compatToken, clientPlaySessionID string) (*PlaybackSession, bool) {
-	if compatToken == "" {
-		return d.mem.FindByClientPlaySessionID(compatToken, clientPlaySessionID)
-	}
-	cached, cachedOK := d.mem.FindByClientPlaySessionID(compatToken, clientPlaySessionID)
-	if cachedOK && !d.shouldRevalidateToken(compatToken) {
-		return cached, true
-	}
-	_ = d.loadByCompatToken(compatToken)
-	return d.mem.FindByClientPlaySessionID(compatToken, clientPlaySessionID)
+	session, err := d.ResolveClientPlaySessionID(compatToken, clientPlaySessionID)
+	return session, err == nil
 }
 
 // FindFinalizableByClientPlaySessionID is the terminal-aware alias lookup used
@@ -926,20 +1014,21 @@ func (d *DurableCompatPlaybackStore) FindByClientPlaySessionID(compatToken, clie
 func (d *DurableCompatPlaybackStore) FindFinalizableByClientPlaySessionID(
 	compatToken, clientPlaySessionID, routeItemID, mediaSourceID string,
 ) (*PlaybackSession, bool) {
-	if compatToken == "" {
+	if compatToken == "" || d.pool == nil {
 		return d.mem.FindFinalizableByClientPlaySessionID(
 			compatToken, clientPlaySessionID, routeItemID, mediaSourceID,
 		)
 	}
-	cached, cachedOK := d.mem.FindFinalizableByClientPlaySessionID(
-		compatToken, clientPlaySessionID, routeItemID, mediaSourceID,
+	_, _ = d.ResolveClientPlaySessionID(compatToken, clientPlaySessionID)
+	cached, cachedOK := d.mem.findByClientPlaySessionID(
+		compatToken, clientPlaySessionID, routeItemID, mediaSourceID, true,
 	)
 	if cachedOK && !d.shouldRevalidateToken(compatToken) {
 		return cached, true
 	}
 	_ = d.loadByCompatToken(compatToken)
-	return d.mem.FindFinalizableByClientPlaySessionID(
-		compatToken, clientPlaySessionID, routeItemID, mediaSourceID,
+	return d.mem.findByClientPlaySessionID(
+		compatToken, clientPlaySessionID, routeItemID, mediaSourceID, true,
 	)
 }
 

--- a/internal/jellycompat/playback_sessions_postgres_test.go
+++ b/internal/jellycompat/playback_sessions_postgres_test.go
@@ -3,6 +3,7 @@ package jellycompat
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -51,7 +52,7 @@ func TestNegotiatedPlaybackScopeIsPostgresSafeAndUnambiguous(t *testing.T) {
 	}
 }
 
-func newCompatTestPool(t *testing.T) *pgxpool.Pool {
+func newCompatTestPool(t testing.TB) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
@@ -71,6 +72,277 @@ func newCompatTestPool(t *testing.T) *pgxpool.Pool {
 		t.Skip("test database has not applied jellycompat playback sessions migration")
 	}
 	return pool
+}
+
+func TestStaticPlaybackReservationLockKey(t *testing.T) {
+	const want int64 = -530545320499500074
+	if got := staticPlaybackReservationLockKey("example-token", "example-key"); got != want {
+		t.Fatalf("reservation lock key = %d, want deployed framing %d", got, want)
+	}
+	seen := make(map[int64]bool)
+	for _, scope := range [][2]string{{"a", "b"}, {"ab", ""}, {"", "ab"}, {"a\x00", "b"}, {"a", "\x00b"}} {
+		key := staticPlaybackReservationLockKey(scope[0], scope[1])
+		if seen[key] {
+			t.Fatal("distinct test scopes shared a lock key")
+		}
+		seen[key] = true
+	}
+}
+
+func TestDurableStaticAttachmentRejectsStaleWriter(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	id := fmt.Sprintf("static-attachment-test-%d", time.Now().UnixNano())
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM jellycompat_playback_sessions WHERE id = $1`, id) })
+	first := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	second := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	first.Put(PlaybackSession{ID: id, CompatToken: "example-token"})
+	if _, ok := second.Get(id); !ok {
+		t.Fatal("second API instance did not cache the unbound reservation")
+	}
+	attach := func(upstream string) func(*PlaybackSession) error {
+		return func(session *PlaybackSession) error {
+			if session.UpstreamSessionID != "" {
+				return errUpstreamReplaced
+			}
+			session.UpstreamSessionID = upstream
+			return nil
+		}
+	}
+	if err := first.Update(id, attach("winner")); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Update(id, attach("loser")); !errors.Is(err, errUpstreamReplaced) {
+		t.Fatalf("stale attachment = %v, want rejected compare-and-set", err)
+	}
+	if second.hasPendingUpdates(id) {
+		t.Fatal("losing attachment was queued to retry later")
+	}
+	for _, store := range []*DurableCompatPlaybackStore{first, second, NewDurableCompatPlaybackStore(pool, time.Hour, nil)} {
+		got, ok := store.Get(id)
+		if !ok || got.UpstreamSessionID != "winner" {
+			t.Fatal("cache or durable row did not retain the winning attachment")
+		}
+	}
+}
+
+// BenchmarkDurableStaticReservationReuse measures the reservation transaction,
+// not native playback startup or media delivery. Run only on a test database.
+func BenchmarkDurableStaticReservationReuse(b *testing.B) {
+	pool := newCompatTestPool(b)
+	ctx := context.Background()
+	id := fmt.Sprintf("static-benchmark-%d", time.Now().UnixNano())
+	b.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM jellycompat_playback_sessions WHERE id = $1`, id) })
+	store := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	input := PlaybackSession{ID: id, CompatToken: id, StaticPlaybackKey: "example-key"}
+	if _, err := store.GetOrCreateStatic(ctx, input); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := store.GetOrCreateStatic(ctx, input); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestDurableCompatPlaybackStoreStaticReservationAcrossInstances(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	token := fmt.Sprintf("static-reservation-test-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		if _, err := pool.Exec(ctx, `DELETE FROM jellycompat_playback_sessions WHERE compat_token = $1`, token); err != nil {
+			t.Errorf("clean static reservation fixtures: %v", err)
+		}
+	})
+	const requests = 12
+	type result struct {
+		session *PlaybackSession
+		err     error
+	}
+	results := make(chan result, requests)
+	start := make(chan struct{})
+	for i := range requests {
+		go func() {
+			store := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+			<-start
+			session, err := store.GetOrCreateStatic(ctx, PlaybackSession{
+				ID: fmt.Sprintf("%s-%d", token, i), CompatToken: token, StaticPlaybackKey: "same-play",
+			})
+			results <- result{session, err}
+		}()
+	}
+	close(start)
+	var firstID string
+	for range requests {
+		got := <-results
+		if got.err != nil {
+			t.Errorf("reserve across instances: %v", got.err)
+			continue
+		}
+		if firstID == "" {
+			firstID = got.session.ID
+		}
+		if got.session.ID != firstID {
+			t.Error("different API instances reserved different sessions for one play")
+		}
+	}
+	var count int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM jellycompat_playback_sessions WHERE compat_token = $1`, token).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("durable rows = %d, want 1", count)
+	}
+	store := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	if err := store.Update(firstID, func(session *PlaybackSession) error {
+		session.UpstreamSessionID = "attached-upstream"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	candidate := PlaybackSession{ID: token + "-retry", CompatToken: token, StaticPlaybackKey: "same-play"}
+	got, err := NewDurableCompatPlaybackStore(pool, time.Hour, nil).GetOrCreateStatic(ctx, candidate)
+	if err != nil || got.ID != firstID || got.UpstreamSessionID != "attached-upstream" {
+		t.Fatalf("retry did not preserve the live session: %v", err)
+	}
+	if err := store.Update(firstID, func(session *PlaybackSession) error {
+		session.Terminal = true
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err = store.GetOrCreateStatic(ctx, candidate)
+	if err != nil || got.ID != candidate.ID {
+		t.Fatalf("terminal session was reused: %v", err)
+	}
+}
+
+func TestDurableLegacyStaticDuplicatesAcrossInstances(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	token := fmt.Sprintf("legacy-static-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM jellycompat_playback_sessions WHERE compat_token=$1`, token)
+	})
+	first, second := legacyStaticPair(token, time.Now())
+	// Both negotiations offered two editions; the active native sessions
+	// prove that both actually selected the second one.
+	first.UpstreamSessionID, second.UpstreamSessionID = token+"-native-first", token+"-native-second"
+	first.MediaSources = append(first.MediaSources, PlaybackMediaSource{ID: "second-edition", FileID: 43})
+	second.MediaSources = append(second.MediaSources, PlaybackMediaSource{ID: "second-edition", FileID: 43})
+	if _, err := pool.Exec(ctx, `INSERT INTO playback_sessions_sync(session_id,media_file_id) VALUES($1,43),($2,43)`, first.UpstreamSessionID, second.UpstreamSessionID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM playback_sessions_sync WHERE session_id=ANY($1::text[])`, []string{first.UpstreamSessionID, second.UpstreamSessionID})
+	})
+	seed := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	seed.Put(first)
+	seed.Put(second)
+	const requests = 12
+	results := make(chan error, requests)
+	start := make(chan struct{})
+	for range requests {
+		go func() {
+			<-start
+			store := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+			got, err := store.ResolveClientPlaySessionID(token, "client-play")
+			if err == nil && (got == nil || got.ID != first.ID || got.UpstreamSessionID != first.UpstreamSessionID) {
+				err = errors.New("wrong canonical playback")
+			}
+			results <- err
+		}()
+	}
+	close(start)
+	for range requests {
+		if err := <-results; err != nil {
+			t.Error(err)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+	var total, active int
+	if err := pool.QueryRow(ctx, `SELECT count(*),count(*) FILTER(WHERE COALESCE((data->>'Terminal')::boolean,false)=false) FROM jellycompat_playback_sessions WHERE compat_token=$1`, token).Scan(&total, &active); err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || active != 1 {
+		t.Fatalf("records total=%d active=%d, want 2 and 1", total, active)
+	}
+	fresh := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	if _, ok := fresh.Get(second.ID); ok {
+		t.Fatal("fresh instance revived the duplicate")
+	}
+	if _, ok := fresh.GetFinalizable(second.ID, token); ok {
+		t.Fatal("duplicate became finalizable after restart")
+	}
+	fresh.Delete(first.ID)
+	fresh = NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	if _, err := fresh.ResolveClientPlaySessionID(token, "client-play"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("duplicate revived after canonical stop: %v", err)
+	}
+}
+
+func TestDurableLegacyStaticDuplicatesFailureDoesNotChangeCache(t *testing.T) {
+	pool := newCompatTestPool(t)
+	pool.Close()
+	store := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	first, second := legacyStaticPair("offline-legacy", time.Now())
+	store.mem.Put(first)
+	store.mem.Put(second)
+	if _, err := store.ResolveClientPlaySessionID(first.CompatToken, first.ClientPlaySessionID); err == nil {
+		t.Fatal("storage failure was not returned")
+	}
+	if _, ok := store.mem.Get(second.ID); !ok {
+		t.Fatal("failed durable repair changed the local routing map")
+	}
+}
+
+func TestDurableLegacyStaticDuplicatesDeviceRecoveryWithoutNativeSnapshot(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	token := fmt.Sprintf("device-recovery-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM jellycompat_playback_sessions WHERE compat_token=$1`, token)
+	})
+	first, second := legacyStaticPair(token, time.Now())
+	first.ClientDeviceID, second.ClientDeviceID = "", ""
+	first.MediaSources = append(first.MediaSources, PlaybackMediaSource{ID: "other", FileID: 43})
+	second.MediaSources = append(second.MediaSources, PlaybackMediaSource{ID: "other", FileID: 43})
+	current := first
+	current.ID, current.ClientDeviceID, current.StaticPlaybackKey = token+"-current", "current-device", "reservation"
+	seed := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	for _, session := range []PlaybackSession{first, second, current} {
+		seed.Put(session)
+	}
+	fresh := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	got, err := fresh.ResolveDeviceClientPlaySessionID(token, "client-play", "current-device", "route", "source", false)
+	if err != nil || got == nil || got.ID != current.ID {
+		t.Fatalf("device recovery failed: %v", err)
+	}
+	var active int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM jellycompat_playback_sessions WHERE compat_token=$1 AND COALESCE((data->>'Terminal')::boolean,false)=false`, token).Scan(&active); err != nil {
+		t.Fatal(err)
+	}
+	if active != 3 {
+		t.Fatal("unproven historical records were modified")
+	}
+}
+
+func TestDurableCompatPlaybackStoreStaticReservationFailureLeavesNoLocalRow(t *testing.T) {
+	pool := newCompatTestPool(t)
+	pool.Close()
+	store := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	_, err := store.GetOrCreateStatic(context.Background(), PlaybackSession{
+		ID: "failed-static", CompatToken: "token", StaticPlaybackKey: "play",
+	})
+	if err == nil {
+		t.Fatal("closed database unexpectedly accepted a reservation")
+	}
+	if _, ok := store.mem.Get("failed-static"); ok {
+		t.Fatal("persistence failure left an uncoordinated local session")
+	}
 }
 
 // A session written by one store instance must be reloadable by a fresh instance

--- a/internal/jellycompat/playback_sessions_postgres_test.go
+++ b/internal/jellycompat/playback_sessions_postgres_test.go
@@ -126,6 +126,49 @@ func TestDurableStaticAttachmentRejectsStaleWriter(t *testing.T) {
 	}
 }
 
+func TestDurableStaticAttachmentPreservesUncommittedPendingUpdate(t *testing.T) {
+	pool := newCompatTestPool(t)
+	ctx := context.Background()
+	id := fmt.Sprintf("static-pending-attachment-%d", time.Now().UnixNano())
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, `DELETE FROM jellycompat_playback_sessions WHERE id = $1`, id) })
+	first := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	second := NewDurableCompatPlaybackStore(pool, time.Hour, nil)
+	first.Put(PlaybackSession{ID: id, CompatToken: "example-token"})
+	if _, ok := second.Get(id); !ok {
+		t.Fatal("second API instance did not cache the reservation")
+	}
+	second.appendPendingUpdate(id, "example-token", func(session *PlaybackSession) error {
+		session.InitialSeekSeconds = 37
+		return nil
+	})
+	if err := first.Update(id, func(session *PlaybackSession) error {
+		session.UpstreamSessionID = "winner"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	err := second.Update(id, func(session *PlaybackSession) error {
+		if session.UpstreamSessionID != "" {
+			return errUpstreamReplaced
+		}
+		session.UpstreamSessionID = "loser"
+		return nil
+	})
+	if !errors.Is(err, errUpstreamReplaced) {
+		t.Fatalf("attachment = %v, want rejected compare-and-set", err)
+	}
+	if len(second.pendingUpdatesSnapshot(id)) != 1 {
+		t.Fatal("rollback discarded the unrelated pending update or queued the losing attachment")
+	}
+	if err := second.Update(id, func(*PlaybackSession) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := NewDurableCompatPlaybackStore(pool, time.Hour, nil).Get(id)
+	if !ok || got.UpstreamSessionID != "winner" || got.InitialSeekSeconds != 37 || second.hasPendingUpdates(id) {
+		t.Fatal("pending update was not committed without replacing the winning attachment")
+	}
+}
+
 // BenchmarkDurableStaticReservationReuse measures the reservation transaction,
 // not native playback startup or media delivery. Run only on a test database.
 func BenchmarkDurableStaticReservationReuse(b *testing.B) {

--- a/internal/jellycompat/playback_static_directplay_test.go
+++ b/internal/jellycompat/playback_static_directplay_test.go
@@ -330,6 +330,33 @@ func TestCreateStaticPlaySessionConcurrentRequestsShareReservation(t *testing.T)
 	}
 }
 
+func TestStaticPlaybackReservationPreservesSelectedSourceBeforeAttachment(t *testing.T) {
+	handler, routeID, _ := newStaticDirectPlayHandler(t)
+	detail := handler.content.(*stubContentService).detail
+	second := detail.Versions[0]
+	second.FileID = 43
+	detail.Versions = append(detail.Versions, second)
+	sourceID := handler.codec.EncodeIntID(EncodedIDMediaSource, int64(second.FileID))
+	caller := &Session{Token: "token-1", ProfileID: "profile-1"}
+	reserved, _, err := handler.createStaticPlaySession(context.Background(), caller, routeID, sourceID, "client-play", "device")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reserved.UpstreamSessionID != "" {
+		t.Fatal("test must resolve the reservation before native attachment")
+	}
+	for _, sourceParam := range []string{"", routeID} {
+		r := httptest.NewRequest("GET", "/Videos/stream?Static=true&DeviceId=device&PlaySessionId=client-play", nil)
+		got, source, err := handler.resolvePlaybackRoute(r, caller, routeID, sourceParam)
+		if err != nil || got == nil || source == nil || got.ID != reserved.ID || source.FileID != second.FileID {
+			t.Fatalf("pre-attachment request lost the selected edition: %v", err)
+		}
+	}
+	if got := len(handler.playbackStore.(*PlaybackSessionStore).sessions); got != 1 {
+		t.Fatalf("reserved %d sessions, want one selected-edition reservation", got)
+	}
+}
+
 func legacyStaticPair(token string, now time.Time) (PlaybackSession, PlaybackSession) {
 	first := PlaybackSession{
 		ID: token + "-first", CompatToken: token, UserID: "profile-user", ClientDeviceID: "device",

--- a/internal/jellycompat/playback_static_directplay_test.go
+++ b/internal/jellycompat/playback_static_directplay_test.go
@@ -2,6 +2,8 @@ package jellycompat
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -258,6 +260,291 @@ func TestHandleVideoStream_StaticDirectPlayReusesSessionAcrossRequests(t *testin
 
 	if mgr.startCalls != 1 {
 		t.Fatalf("StartSession ran %d times across 3 Static requests with the same PlaySessionId; want 1 (sessions must be reused, not leaked)", mgr.startCalls)
+	}
+}
+
+// BenchmarkStaticPlaybackReservationReuse includes the in-memory lookup scan
+// at several active-store sizes; it does not measure client startup latency.
+func BenchmarkStaticPlaybackReservationReuse(b *testing.B) {
+	for _, size := range []int{1, 100, 1000} {
+		b.Run(fmt.Sprintf("sessions_%d", size), func(b *testing.B) {
+			store := NewPlaybackSessionStore(time.Hour, nil)
+			for i := range size {
+				store.Put(PlaybackSession{ID: fmt.Sprint(i), CompatToken: "example-token", StaticPlaybackKey: fmt.Sprint(i)})
+			}
+			input := PlaybackSession{ID: "unused", CompatToken: "example-token", StaticPlaybackKey: "0"}
+			b.ReportAllocs()
+			for b.Loop() {
+				got, err := store.GetOrCreateStatic(context.Background(), input)
+				if err != nil || got.ID != "0" {
+					b.Fatal("existing reservation was not reused")
+				}
+			}
+		})
+	}
+}
+
+func TestCreateStaticPlaySessionConcurrentRequestsShareReservation(t *testing.T) {
+	handler, routeID, _ := newStaticDirectPlayHandler(t)
+	caller := &Session{Token: "static-test-token", ProfileID: "profile"}
+	const requests = 16
+	start := make(chan struct{})
+	type result struct {
+		session *PlaybackSession
+		err     error
+	}
+	results := make(chan result, requests)
+	for range requests {
+		go func() {
+			<-start
+			session, _, err := handler.createStaticPlaySession(context.Background(), caller, routeID, "", "client-play", "device")
+			results <- result{session, err}
+		}()
+	}
+	close(start)
+	var sessionID string
+	for range requests {
+		got := <-results
+		if got.err != nil {
+			t.Fatalf("reserve static playback: %v", got.err)
+		}
+		if sessionID == "" {
+			sessionID = got.session.ID
+		}
+		if got.session.ID != sessionID {
+			t.Fatalf("simultaneous requests created different sessions")
+		}
+	}
+	if got := len(handler.playbackStore.(*PlaybackSessionStore).sessions); got != 1 {
+		t.Fatalf("stored %d sessions for one static play, want 1", got)
+	}
+	if err := handler.playbackStore.Update(sessionID, func(session *PlaybackSession) error {
+		session.UpstreamSessionID = "active-upstream"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := handler.createStaticPlaySession(context.Background(), caller, routeID, "", "client-play", "device")
+	if err != nil || got.UpstreamSessionID != "active-upstream" {
+		t.Fatalf("reservation overwrote the active upstream attachment: %v", err)
+	}
+}
+
+func legacyStaticPair(token string, now time.Time) (PlaybackSession, PlaybackSession) {
+	first := PlaybackSession{
+		ID: token + "-first", CompatToken: token, UserID: "profile-user", ClientDeviceID: "device",
+		ClientPlaySessionID: "client-play", ItemID: "item", RouteItemID: "route",
+		UpstreamSessionID: "native-first", UpstreamPlayMethod: "direct",
+		CreatedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Hour),
+		MediaSources: []PlaybackMediaSource{{ID: "source", FileID: 42}},
+	}
+	second := first
+	second.ID, second.UpstreamSessionID = token+"-second", "native-second"
+	second.CreatedAt = first.CreatedAt.Add(4 * time.Millisecond)
+	return first, second
+}
+
+func TestLegacyStaticDuplicatesResolveToOneStableSession(t *testing.T) {
+	now := time.Now()
+	first, second := legacyStaticPair("token", now)
+	store := NewPlaybackSessionStore(time.Hour, func() time.Time { return now })
+	store.Put(first)
+	store.Put(second)
+	results := make(chan *PlaybackSession, 16)
+	for range 16 {
+		go func() { session, _ := store.ResolveClientPlaySessionID("token", "client-play"); results <- session }()
+	}
+	for range 16 {
+		got := <-results
+		if got == nil || got.ID != first.ID || got.UpstreamSessionID != first.UpstreamSessionID {
+			t.Fatal("the canonical playback changed under concurrent lookup")
+		}
+	}
+	if _, ok := store.Get(second.ID); ok {
+		t.Fatal("duplicate remained routable")
+	}
+	if _, ok := store.GetFinalizable(second.ID, "token"); ok {
+		t.Fatal("duplicate remained finalizable")
+	}
+	if got, ok := store.FindFinalizableByClientPlaySessionID("token", "client-play", "route", "source"); !ok || got.ID != first.ID {
+		t.Fatal("a final report could not identify the canonical playback")
+	}
+	store.Delete(first.ID)
+	if _, err := store.ResolveClientPlaySessionID("token", "client-play"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatal("old duplicate revived after canonical stop")
+	}
+	if _, _, ok := store.FindByRoute("token", "route"); ok {
+		t.Fatal("route fallback revived a duplicate")
+	}
+	if len(store.sessions) != 1 || store.sessions[second.ID].SupersededBy != first.ID {
+		t.Fatal("the superseded record should be retained, not deleted")
+	}
+}
+
+func TestLegacyStaticDuplicatesDoNotMergeDistinctPlays(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(*PlaybackSession)
+	}{
+		{"device", func(s *PlaybackSession) { s.ClientDeviceID = "other-device" }},
+		{"profile", func(s *PlaybackSession) { s.UserID = "other-profile" }},
+		{"token", func(s *PlaybackSession) { s.CompatToken = "other-token" }},
+		{"client-play", func(s *PlaybackSession) { s.ClientPlaySessionID = "other-play" }},
+		{"later-play", func(s *PlaybackSession) { s.CreatedAt = s.CreatedAt.Add(time.Minute) }},
+		{"multiple-sources", func(s *PlaybackSession) {
+			s.MediaSources = append(s.MediaSources, PlaybackMediaSource{ID: "other", FileID: 43})
+		}},
+		{"new-reservation", func(s *PlaybackSession) { s.StaticPlaybackKey = "reserved" }},
+		{"transcode", func(s *PlaybackSession) { s.UpstreamPlayMethod = "transcode" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			first, second := legacyStaticPair("token", time.Now())
+			tc.change(&second)
+			if _, ids := legacyStaticDuplicateGroup([]PlaybackSession{first, second}); len(ids) != 0 {
+				t.Fatal("independent playback was classified as a legacy duplicate")
+			}
+		})
+	}
+}
+
+func TestLegacyStaticDuplicatesRequireSameSelectedEdition(t *testing.T) {
+	for _, selected := range []int{0, 42, 43, 99} {
+		t.Run(fmt.Sprintf("second-selected-%d", selected), func(t *testing.T) {
+			first, second := legacyStaticPair("token", time.Now())
+			first.MediaSources = append(first.MediaSources, PlaybackMediaSource{ID: "edition", FileID: 43})
+			second.MediaSources = append(second.MediaSources, PlaybackMediaSource{ID: "edition", FileID: 43})
+			first.SelectedMediaFileID, second.SelectedMediaFileID = 43, selected
+			winner, ids := legacyStaticDuplicateGroup([]PlaybackSession{second, first})
+			if selected == 43 {
+				if winner != first.ID || len(ids) != 1 || ids[0] != second.ID {
+					t.Fatal("proven duplicate of the selected edition was not reconciled")
+				}
+			} else if len(ids) != 0 {
+				t.Fatal("unknown or different selected edition was merged")
+			}
+		})
+	}
+}
+
+func TestDevicePlaybackAliasRequiresExactUniqueIdentity(t *testing.T) {
+	store := NewPlaybackSessionStore(time.Hour, nil)
+	first, second := legacyStaticPair("token", time.Now())
+	first.ClientDeviceID, second.ClientDeviceID = "first-device", "second-device"
+	store.Put(first)
+	store.Put(second)
+	if _, err := store.ResolveDeviceClientPlaySessionID("token", "client-play", "", "route", "source", false); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatal("absent device guessed a playback")
+	}
+	if _, err := store.ResolveDeviceClientPlaySessionID("other-token", "client-play", "first-device", "route", "source", false); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatal("foreign token matched")
+	}
+	if _, err := store.ResolveDeviceClientPlaySessionID("token", "client-play", "first-device", "route", "other-source", false); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatal("different source matched")
+	}
+	if got, err := store.ResolveDeviceClientPlaySessionID("token", "client-play", "second-device", "route", "source", false); err != nil || got.ID != second.ID {
+		t.Fatal("exact device did not resolve")
+	}
+	second.ClientDeviceID = first.ClientDeviceID
+	store.Put(second)
+	if _, err := store.ResolveDeviceClientPlaySessionID("token", "client-play", "first-device", "route", "source", false); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatal("ambiguous device guessed a playback")
+	}
+}
+
+func TestStaticPlaybackKeySeparatesPlaybackIdentities(t *testing.T) {
+	baseline := staticPlaybackKey(&Session{Token: "token", ProfileID: "profile"}, "device", "play", "item", "source")
+	variants := []struct{ token, profile, device, play, item, source string }{
+		{"other-token", "profile", "device", "play", "item", "source"},
+		{"token", "other-profile", "device", "play", "item", "source"},
+		{"token", "profile", "other-device", "play", "item", "source"},
+		{"token", "profile", "device", "other-play", "item", "source"},
+		{"token", "profile", "device", "play", "other-item", "source"},
+		{"token", "profile", "device", "play", "item", "other-source"},
+	}
+	store := NewPlaybackSessionStore(time.Hour, nil)
+	for i, variant := range variants {
+		key := staticPlaybackKey(&Session{Token: variant.token, ProfileID: variant.profile}, variant.device, variant.play, variant.item, variant.source)
+		if key == baseline {
+			t.Fatalf("identity field %d did not affect the reservation key", i)
+		}
+		candidate := PlaybackSession{ID: fmt.Sprintf("distinct-%d", i), CompatToken: variant.token, StaticPlaybackKey: key}
+		got, err := store.GetOrCreateStatic(context.Background(), candidate)
+		if err != nil || got.ID != candidate.ID {
+			t.Fatalf("distinct playback %d was merged: %v", i, err)
+		}
+	}
+	if left, right := staticPlaybackKey(&Session{Token: "ab"}, "c", "", "", ""), staticPlaybackKey(&Session{Token: "a"}, "bc", "", "", ""); left == right {
+		t.Fatal("reservation keys lost field boundaries")
+	}
+}
+
+func TestPlaybackSessionStoreStaticReservationSkipsTerminalAndExpired(t *testing.T) {
+	now := time.Now()
+	store := NewPlaybackSessionStore(time.Minute, func() time.Time { return now })
+	first := PlaybackSession{ID: "first", CompatToken: "token", StaticPlaybackKey: "scope"}
+	if _, err := store.GetOrCreateStatic(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.HideFromRouting(first.ID, first.CompatToken); err != nil {
+		t.Fatal(err)
+	}
+	second := first
+	second.ID = "second"
+	got, err := store.GetOrCreateStatic(context.Background(), second)
+	if err != nil || got.ID != second.ID {
+		t.Fatalf("terminal reservation was reused: %v", err)
+	}
+	now = now.Add(2 * time.Minute)
+	third := first
+	third.ID = "third"
+	got, err = store.GetOrCreateStatic(context.Background(), third)
+	if err != nil || got.ID != third.ID {
+		t.Fatalf("expired reservation was reused: %v", err)
+	}
+}
+
+func TestHandleVideoStreamStaticKeepsDistinctClientPlays(t *testing.T) {
+	handler, routeID, _ := newStaticDirectPlayHandler(t)
+	for _, playID := range []string{"play-a", "play-b", "play-a", "play-b"} {
+		if response := serveStaticStream(handler, routeID, "Static=true&PlaySessionId="+playID); response.Code != 200 {
+			t.Fatalf("static play failed: %d", response.Code)
+		}
+	}
+	if got := handler.sessionMgr.(*testCompatSessionManager).startCalls; got != 2 {
+		t.Fatalf("started %d upstream sessions for two distinct plays, want 2", got)
+	}
+	if got := len(handler.playbackStore.(*PlaybackSessionStore).sessions); got != 2 {
+		t.Fatalf("stored %d sessions, want 2", got)
+	}
+}
+
+func TestHandleVideoStreamStaticKeepsDistinctDevicesWithoutClientPlayID(t *testing.T) {
+	handler, routeID, _ := newStaticDirectPlayHandler(t)
+	for _, deviceID := range []string{"device-a", "device-b", "device-a", "device-b"} {
+		if response := serveStaticStream(handler, routeID, "static=true&DeviceId="+deviceID); response.Code != 200 {
+			t.Fatalf("static play failed: %d", response.Code)
+		}
+	}
+	if got := handler.sessionMgr.(*testCompatSessionManager).startCalls; got != 2 {
+		t.Fatalf("started %d upstream sessions for two devices, want 2", got)
+	}
+}
+
+type failingStaticReservationStore struct{ CompatPlaybackStore }
+
+func (s failingStaticReservationStore) GetOrCreateStatic(context.Context, PlaybackSession) (*PlaybackSession, error) {
+	return nil, errors.New("reservation unavailable")
+}
+
+func TestHandleVideoStreamStaticReservationFailureDoesNotStartPlayback(t *testing.T) {
+	handler, routeID, _ := newStaticDirectPlayHandler(t)
+	handler.playbackStore = failingStaticReservationStore{handler.playbackStore}
+	response := serveStaticStream(handler, routeID, "Static=true&PlaySessionId=play")
+	if response.Code != 503 {
+		t.Fatalf("response = %d, want retryable 503", response.Code)
+	}
+	if handler.sessionMgr.(*testCompatSessionManager).startCalls != 0 {
+		t.Fatal("persistence failure started an uncoordinated playback session")
 	}
 }
 

--- a/internal/jellycompat/playback_static_duplicates.go
+++ b/internal/jellycompat/playback_static_duplicates.go
@@ -1,0 +1,289 @@
+package jellycompat
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/playback"
+)
+
+// ResolveDeviceClientPlaySessionID uses the request's explicit device identity
+// to disambiguate a current play from older records that never stored a device.
+// It does not merge or delete those records, or guess when identity is absent.
+func (s *PlaybackSessionStore) ResolveDeviceClientPlaySessionID(token, playID, deviceID, routeID, sourceID string, includeTerminal bool) (*PlaybackSession, error) {
+	if deviceID != "" {
+		if session, ok := s.findDeviceClientPlaySessionID(token, playID, deviceID, routeID, sourceID, includeTerminal); ok {
+			return session, nil
+		}
+	}
+	return nil, ErrSessionNotFound
+}
+
+func (d *DurableCompatPlaybackStore) ResolveDeviceClientPlaySessionID(token, playID, deviceID, routeID, sourceID string, includeTerminal bool) (*PlaybackSession, error) {
+	if d.pool == nil {
+		return d.mem.ResolveDeviceClientPlaySessionID(token, playID, deviceID, routeID, sourceID, includeTerminal)
+	}
+	if token == "" || playID == "" || deviceID == "" {
+		return nil, ErrSessionNotFound
+	}
+	cached, cachedOK := d.mem.findDeviceClientPlaySessionID(token, playID, deviceID, routeID, sourceID, includeTerminal)
+	if cachedOK && !d.shouldRevalidateToken(token) {
+		return cached, nil
+	}
+	if err := d.loadByCompatToken(token); err != nil {
+		if cachedOK {
+			return cached, nil
+		}
+		return nil, err
+	}
+	return d.mem.ResolveDeviceClientPlaySessionID(token, playID, deviceID, routeID, sourceID, includeTerminal)
+}
+
+// ResolveClientPlaySessionID preserves a storage failure for callers that may
+// otherwise create a new static reservation after an ambiguous lookup.
+func (s *PlaybackSessionStore) ResolveClientPlaySessionID(token, clientPlayID string) (*PlaybackSession, error) {
+	s.reconcileLegacyStaticDuplicates(token, clientPlayID)
+	if session, ok := s.findByClientPlaySessionID(token, clientPlayID, "", "", false); ok {
+		return session, nil
+	}
+	return nil, ErrSessionNotFound
+}
+
+func (d *DurableCompatPlaybackStore) ResolveClientPlaySessionID(token, clientPlayID string) (*PlaybackSession, error) {
+	if d.pool == nil {
+		return d.mem.ResolveClientPlaySessionID(token, clientPlayID)
+	}
+	if token == "" || clientPlayID == "" {
+		return nil, ErrSessionNotFound
+	}
+	cached, cachedOK := d.mem.findByClientPlaySessionID(token, clientPlayID, "", "", false)
+	if cachedOK && !d.shouldRevalidateToken(token) {
+		return cached, nil
+	}
+	if err := d.loadByCompatToken(token); err != nil {
+		if cachedOK {
+			return cached, nil
+		}
+		return nil, err
+	}
+	if err := d.reconcileLegacyStaticDuplicates(token, clientPlayID); err != nil {
+		return nil, err
+	}
+	if session, ok := d.mem.findByClientPlaySessionID(token, clientPlayID, "", "", false); ok {
+		return session, nil
+	}
+	return nil, ErrSessionNotFound
+}
+
+// legacyStaticDuplicateGroup recognizes only the old parallel Static=true
+// creation race. A shared title/route alone is never evidence of one play.
+// Restrict repair to direct plays of the same selected file, with the same nonempty client
+// play ID and identity, created within one second. New reservations use their
+// own atomic key and are not candidates for this legacy repair.
+func legacyStaticDuplicateGroup(sessions []PlaybackSession) (string, []string) {
+	if len(sessions) < 2 || len(sessions) > 32 {
+		return "", nil
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		if sessions[i].CreatedAt.Equal(sessions[j].CreatedAt) {
+			return sessions[i].ID < sessions[j].ID
+		}
+		return sessions[i].CreatedAt.Before(sessions[j].CreatedAt)
+	})
+	first := sessions[0]
+	if first.CompatToken == "" || first.UserID == "" || first.ItemID == "" || first.RouteItemID == "" || first.CreatedAt.IsZero() {
+		return "", nil
+	}
+	selectedFile := legacyStaticSelectedFile(first)
+	if selectedFile <= 0 {
+		return "", nil
+	}
+	for _, s := range sessions {
+		if s.Terminal || s.SupersededBy != "" || s.StaticPlaybackKey != "" || s.Recipe != nil || s.TranscodeStarted ||
+			s.UpstreamPlayMethod != string(playback.PlayDirect) || s.UpstreamSessionID == "" ||
+			s.ClientPlaySessionID == "" || s.ClientPlaySessionID == s.ID ||
+			s.CompatToken != first.CompatToken || s.UserID != first.UserID || s.ClientDeviceID != first.ClientDeviceID ||
+			s.ClientPlaySessionID != first.ClientPlaySessionID || s.ItemID != first.ItemID ||
+			!mediaSourceIDsEqual(s.RouteItemID, first.RouteItemID) || s.CreatedAt.Sub(first.CreatedAt) > time.Second {
+			return "", nil
+		}
+		if legacyStaticSelectedFile(s) != selectedFile {
+			return "", nil
+		}
+	}
+	ids := make([]string, 0, len(sessions)-1)
+	for _, s := range sessions[1:] {
+		ids = append(ids, s.ID)
+	}
+	return first.ID, ids
+}
+
+func legacyStaticSelectedFile(s PlaybackSession) int {
+	if s.SelectedMediaFileID > 0 {
+		for _, source := range s.MediaSources {
+			if source.FileID == s.SelectedMediaFileID {
+				return source.FileID
+			}
+		}
+		return 0
+	}
+	if len(s.MediaSources) == 1 {
+		return s.MediaSources[0].FileID
+	}
+	return 0
+}
+
+func (s *PlaybackSessionStore) legacyStaticCandidates(token, clientPlayID string) []PlaybackSession {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var candidates []PlaybackSession
+	for _, session := range s.sessions {
+		if session.CompatToken == token && session.ClientPlaySessionID == clientPlayID &&
+			!session.Terminal && session.ExpiresAt.After(s.now()) {
+			candidates = append(candidates, session)
+		}
+	}
+	return candidates
+}
+
+func (s *PlaybackSessionStore) supersedeStaticSessions(token, winner string, ids []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range ids {
+		if session, ok := s.sessions[id]; ok && session.CompatToken == token {
+			session.Terminal = true
+			session.SupersededBy = winner
+			session.UpdatedAt = s.now()
+			s.sessions[id] = session
+		}
+	}
+}
+
+func (s *PlaybackSessionStore) reconcileLegacyStaticDuplicates(token, clientPlayID string) {
+	// Recheck under the mutation lock: a stop or a recipe update between the
+	// candidate read and repair must not be overwritten.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var candidates []PlaybackSession
+	for _, session := range s.sessions {
+		if session.CompatToken == token && session.ClientPlaySessionID == clientPlayID &&
+			!session.Terminal && session.ExpiresAt.After(s.now()) {
+			candidates = append(candidates, session)
+		}
+	}
+	winner, ids := legacyStaticDuplicateGroup(candidates)
+	for _, id := range ids {
+		session := s.sessions[id]
+		session.Terminal, session.SupersededBy = true, winner
+		session.UpdatedAt = s.now()
+		s.sessions[id] = session
+	}
+}
+
+func (d *DurableCompatPlaybackStore) reconcileLegacyStaticDuplicates(token, clientPlayID string) error {
+	if d.pool == nil {
+		d.mem.reconcileLegacyStaticDuplicates(token, clientPlayID)
+		return nil
+	}
+	if len(d.mem.legacyStaticCandidates(token, clientPlayID)) < 2 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	rows, err := tx.Query(ctx, `SELECT data FROM jellycompat_playback_sessions
+		WHERE compat_token = $1 AND data->>'ClientPlaySessionID' = $2
+		AND expires_at > $3 AND COALESCE((data->>'Terminal')::boolean, false) = false
+		ORDER BY id LIMIT 33 FOR UPDATE`, token, clientPlayID, d.now())
+	if err != nil {
+		return err
+	}
+	var candidates []PlaybackSession
+	for rows.Next() {
+		var data []byte
+		var session PlaybackSession
+		if err = rows.Scan(&data); err == nil {
+			err = json.Unmarshal(data, &session)
+		}
+		if err != nil {
+			rows.Close()
+			return err
+		}
+		candidates = append(candidates, session)
+	}
+	err = rows.Err()
+	rows.Close()
+	if err != nil {
+		return err
+	}
+	// Legacy multi-version negotiations did not store the selected source.
+	// Use the native session snapshot as evidence, never the first edition.
+	var upstreamIDs []string
+	for _, candidate := range candidates {
+		if legacyStaticSelectedFile(candidate) == 0 && candidate.UpstreamSessionID != "" {
+			upstreamIDs = append(upstreamIDs, candidate.UpstreamSessionID)
+		}
+	}
+	if len(upstreamIDs) > 0 {
+		selectedRows, queryErr := tx.Query(ctx, `SELECT session_id, media_file_id FROM playback_sessions_sync WHERE session_id = ANY($1::text[])`, upstreamIDs)
+		if queryErr != nil {
+			return queryErr
+		}
+		selectedFiles := make(map[string]int)
+		for selectedRows.Next() {
+			var id string
+			var fileID int
+			if err = selectedRows.Scan(&id, &fileID); err != nil {
+				selectedRows.Close()
+				return err
+			}
+			selectedFiles[id] = fileID
+		}
+		err = selectedRows.Err()
+		selectedRows.Close()
+		if err != nil {
+			return err
+		}
+		for i := range candidates {
+			if candidates[i].SelectedMediaFileID == 0 {
+				candidates[i].SelectedMediaFileID = selectedFiles[candidates[i].UpstreamSessionID]
+			}
+		}
+	}
+	winner, ids := legacyStaticDuplicateGroup(candidates)
+	if len(ids) == 0 {
+		// Another node may have committed the same repair while this request
+		// waited for row locks. Refresh its tombstones before resolving again.
+		_ = tx.Rollback(ctx)
+		return d.loadByCompatToken(token)
+	}
+	// Preserve the records and their unknown JSON fields. Superseded rows
+	// cannot be reconstructed or selected by a later Stopped report, even
+	// after the canonical session ends. No artificial scrobble is emitted.
+	_, err = tx.Exec(ctx, `UPDATE jellycompat_playback_sessions
+		SET data = jsonb_set(jsonb_set(data, '{Terminal}', 'true'::jsonb, true),
+		'{SupersededBy}', to_jsonb($3::text), true)
+		WHERE compat_token = $1 AND id = ANY($2::text[])`, token, ids, winner)
+	if err != nil {
+		return err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return err
+	}
+	d.cacheMutationMu.RLock()
+	defer d.cacheMutationMu.RUnlock()
+	d.mem.supersedeStaticSessions(token, winner, ids)
+	for _, id := range ids {
+		d.clearPendingUpdates(id)
+		d.clearUnpersisted(id)
+		d.invalidateValidation(id, token)
+		d.bumpCacheGenerations(id, token)
+	}
+	return nil
+}

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -2008,6 +2008,7 @@ func (h *PlaybackHandler) handlePlaybackReport(w http.ResponseWriter, r *http.Re
 			playSession, ok = nil, false
 		}
 	}
+	matchedServerPlayID := ok
 	if !ok {
 		// Static=true direct play (Infuse, SenPlayer) skips PlaybackInfo, so the
 		// client reports progress under its own generated PlaySessionId. The
@@ -2047,7 +2048,11 @@ func (h *PlaybackHandler) handlePlaybackReport(w http.ResponseWriter, r *http.Re
 		}
 	}
 	deviceID := staticPlaybackClientDeviceID(r)
-	if ok && deviceID != "" && playSession.ClientDeviceID != "" && playSession.ClientDeviceID != deviceID {
+	// An explicit device must match aliases and route fallbacks, including
+	// legacy records with no device. A precise caller-owned server ID remains
+	// sufficient for those legacy records, but never for another known device.
+	if ok && deviceID != "" && playSession.ClientDeviceID != deviceID &&
+		(!matchedServerPlayID || playSession.ClientDeviceID != "") {
 		ok = false
 	}
 	if !ok || playSession.UpstreamSessionID == "" {
@@ -3110,6 +3115,9 @@ func (h *PlaybackHandler) createStaticPlaySession(ctx context.Context, session *
 	if matched == nil {
 		return nil, nil, ErrSessionNotFound
 	}
+	// Preserve the selected edition in the reservation itself: another range
+	// request can resolve this alias before native playback is attached.
+	ps.SelectedMediaFileID = matched.FileID
 	ps.StaticPlaybackKey = staticPlaybackKey(session, clientDeviceID, clientPlaySessionID, detail.ContentID, matched.ID)
 	stored, err := h.playbackStore.GetOrCreateStatic(ctx, *ps)
 	if err != nil {

--- a/internal/jellycompat/streams.go
+++ b/internal/jellycompat/streams.go
@@ -3,6 +3,7 @@ package jellycompat
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -37,6 +38,8 @@ const (
 	compatRoutingPolicyUnsatisfiedCode = "RoutingPolicyUnsatisfied"
 	compatRouteCapacityUnavailableCode = "RouteCapacityUnavailable"
 	compatPlaybackRouteUnboundCode     = "PlaybackRouteUnbound"
+	compatDeviceIDParameter            = "DeviceId"
+	compatPlaySessionIDParameter       = "PlaySessionId"
 )
 
 // compatRouteOutcomeCode maps an unselected route outcome onto the Jellyfin
@@ -421,16 +424,20 @@ func (h *PlaybackHandler) HandleVideoStream(w http.ResponseWriter, r *http.Reque
 	mediaSourceID := firstNonEmpty(r.URL.Query().Get("mediaSourceId"), r.URL.Query().Get("MediaSourceId"))
 	staticRequest := strings.EqualFold(newCaseInsensitiveQuery(r.URL.Query()).Get("Static"), "true")
 	playSession, source, err := h.resolvePlaybackRoute(r, session, routeID, mediaSourceID)
-	if err != nil && staticRequest {
+	if errors.Is(err, ErrSessionNotFound) && staticRequest {
 		// Infuse uses Static=true for direct play without calling PlaybackInfo first.
 		// Create an on-the-fly play session so the stream can proceed. The key
 		// lookup must be case-insensitive: SenPlayer sends "static=true"
 		// (lowercase) and a case-sensitive Get("Static") would miss it, dropping
 		// the client to a 404 "Playback session not found" on every direct play.
 		clientPlaySessionID := newCaseInsensitiveQuery(r.URL.Query()).Get("PlaySessionId")
-		playSession, source, err = h.createStaticPlaySession(r.Context(), session, routeID, mediaSourceID, clientPlaySessionID)
+		playSession, source, err = h.createStaticPlaySession(r.Context(), session, routeID, mediaSourceID, clientPlaySessionID, staticPlaybackClientDeviceID(r))
 	}
 	if err != nil {
+		if !errors.Is(err, ErrSessionNotFound) {
+			writeError(w, http.StatusServiceUnavailable, "ServiceUnavailable", "Playback session could not be reserved")
+			return
+		}
 		writeError(w, http.StatusNotFound, "NotFound", "Playback session not found")
 		return
 	}
@@ -2009,11 +2016,18 @@ func (h *PlaybackHandler) handlePlaybackReport(w http.ResponseWriter, r *http.Re
 		// route-scoped lookup the stream path uses (see resolvePlaybackRoute).
 		// Without either, these reports silently no-op, the admin activity view
 		// position freezes, and stale cleanup drops the still-active session.
-		if stop {
+		var resolveErr error
+		playSession, resolveErr = h.resolveDevicePlaybackAlias(r, session.Token, req.PlaySessionID, req.ItemID, req.MediaSourceID, stop)
+		if resolveErr != nil && !errors.Is(resolveErr, ErrSessionNotFound) {
+			writeError(w, http.StatusServiceUnavailable, "ServiceUnavailable", "Playback session could not be resolved")
+			return
+		}
+		ok = resolveErr == nil
+		if !ok && stop {
 			playSession, ok = h.playbackStore.FindFinalizableByClientPlaySessionID(
 				session.Token, req.PlaySessionID, req.ItemID, req.MediaSourceID,
 			)
-		} else {
+		} else if !ok {
 			playSession, ok = h.playbackStore.FindByClientPlaySessionID(session.Token, req.PlaySessionID)
 		}
 		if ok && !reportMatchesPlaySession(playSession, req) {
@@ -2031,6 +2045,10 @@ func (h *PlaybackHandler) handlePlaybackReport(w http.ResponseWriter, r *http.Re
 			}
 			playSession, ok = nil, false
 		}
+	}
+	deviceID := staticPlaybackClientDeviceID(r)
+	if ok && deviceID != "" && playSession.ClientDeviceID != "" && playSession.ClientDeviceID != deviceID {
+		ok = false
 	}
 	if !ok || playSession.UpstreamSessionID == "" {
 		w.WriteHeader(http.StatusNoContent)
@@ -2183,7 +2201,7 @@ func reportMatchesPlaySession(playSession *PlaybackSession, req sessionReportReq
 	if req.ItemID != "" && !mediaSourceIDsEqual(playSession.RouteItemID, req.ItemID) {
 		return false
 	}
-	if req.MediaSourceID != "" && findMediaSource(playSession, req.MediaSourceID) == nil {
+	if req.MediaSourceID != "" && !mediaSourceIDsEqual(req.MediaSourceID, playSession.RouteItemID) && findMediaSource(playSession, req.MediaSourceID) == nil {
 		return false
 	}
 	return true
@@ -2197,8 +2215,8 @@ func (h *PlaybackHandler) reviveUpstreamForReport(ctx context.Context, session *
 		return nil
 	}
 	source := findMediaSource(playSession, mediaSourceID)
-	if source == nil {
-		source = firstMediaSource(playSession)
+	if source == nil && (mediaSourceID == "" || mediaSourceIDsEqual(mediaSourceID, playSession.RouteItemID)) {
+		source = defaultPlaybackMediaSource(playSession)
 	}
 	if source == nil {
 		return nil
@@ -2351,6 +2369,7 @@ func (h *PlaybackHandler) ensureUpstreamPlayback(ctx context.Context, compatSess
 			return errUpstreamReplaced
 		}
 		current.UpstreamSessionID = session.ID
+		current.SelectedMediaFileID = source.FileID
 		current.UpstreamPlayMethod = method
 		current.TranscodeStarted = false
 		// A new upstream session has no committed HLS route yet. Retaining the
@@ -3053,7 +3072,7 @@ func (h *PlaybackHandler) compatSegmentDuration() int {
 // Static=true direct play requests that skip PlaybackInfo. clientPlaySessionID
 // is the client's own PlaySessionId (if it sent one) so later playback reports
 // carrying it can resolve this session directly.
-func (h *PlaybackHandler) createStaticPlaySession(ctx context.Context, session *Session, routeID, mediaSourceID, clientPlaySessionID string) (*PlaybackSession, *PlaybackMediaSource, error) {
+func (h *PlaybackHandler) createStaticPlaySession(ctx context.Context, session *Session, routeID, mediaSourceID, clientPlaySessionID, clientDeviceID string) (*PlaybackSession, *PlaybackMediaSource, error) {
 	contentID, err := decodeContentID(h.codec, routeID)
 	if err != nil {
 		return nil, nil, ErrSessionNotFound
@@ -3077,11 +3096,10 @@ func (h *PlaybackHandler) createStaticPlaySession(ctx context.Context, session *
 		ItemID:              detail.ContentID,
 		RouteItemID:         routeID,
 		ClientPlaySessionID: clientPlaySessionID,
+		ClientDeviceID:      clientDeviceID,
 		UserID:              session.PseudoUserID.String(),
 		MediaSources:        sources,
 	}
-	h.playbackStore.Put(*ps)
-
 	var matched *PlaybackMediaSource
 	if mediaSourceID != "" {
 		matched = findMediaSource(ps, mediaSourceID)
@@ -3089,7 +3107,58 @@ func (h *PlaybackHandler) createStaticPlaySession(ctx context.Context, session *
 	if matched == nil {
 		matched = firstMediaSource(ps)
 	}
-	return ps, matched, nil
+	if matched == nil {
+		return nil, nil, ErrSessionNotFound
+	}
+	ps.StaticPlaybackKey = staticPlaybackKey(session, clientDeviceID, clientPlaySessionID, detail.ContentID, matched.ID)
+	stored, err := h.playbackStore.GetOrCreateStatic(ctx, *ps)
+	if err != nil {
+		return nil, nil, err
+	}
+	return stored, findMediaSource(stored, matched.ID), nil
+}
+
+func staticPlaybackClientDeviceID(r *http.Request) string {
+	return stripCompatNUL(firstNonEmpty(
+		firstMediaBrowserAuthorizationValue(r, compatDeviceIDParameter),
+		newCaseInsensitiveQuery(r.URL.Query()).Get(compatDeviceIDParameter),
+	))
+}
+
+func (h *PlaybackHandler) resolveDevicePlaybackAlias(r *http.Request, token, playID, routeID, sourceID string, includeTerminal bool) (*PlaybackSession, error) {
+	if sourceID != "" && mediaSourceIDsEqual(sourceID, routeID) {
+		sourceID = "" // Jellyfin's MediaSource.Id == Item.Id convention.
+	}
+	deviceID := staticPlaybackClientDeviceID(r)
+	if deviceID != "" {
+		if resolver, ok := h.playbackStore.(interface {
+			ResolveDeviceClientPlaySessionID(string, string, string, string, string, bool) (*PlaybackSession, error)
+		}); ok {
+			return resolver.ResolveDeviceClientPlaySessionID(token, playID, deviceID, routeID, sourceID, includeTerminal)
+		}
+	}
+	return nil, ErrSessionNotFound
+}
+
+func staticPlaybackKey(session *Session, deviceID, clientPlayID, contentID, sourceID string) string {
+	// JSON framing preserves field boundaries even when client IDs contain
+	// separators. Content/source IDs come from the catalog, not URL spelling.
+	data, _ := json.Marshal([]string{"static-playback-v1", session.Token, session.ProfileID, deviceID, clientPlayID, contentID, sourceID})
+	return fmt.Sprintf("%x", sha256.Sum256(data))
+}
+
+func staticPlaybackRouteMatches(r *http.Request, caller *Session, session *PlaybackSession, source *PlaybackMediaSource) bool {
+	if session.StaticPlaybackKey == "" {
+		return true
+	}
+	if source == nil {
+		return false
+	}
+	clientPlayID := newCaseInsensitiveQuery(r.URL.Query()).Get(compatPlaySessionIDParameter)
+	if clientPlayID == session.ID {
+		clientPlayID = session.ClientPlaySessionID
+	}
+	return session.StaticPlaybackKey == staticPlaybackKey(caller, staticPlaybackClientDeviceID(r), clientPlayID, session.ItemID, source.ID)
 }
 
 func (h *PlaybackHandler) resolvePlaybackRoute(r *http.Request, compatSession *Session, routeID, mediaSourceID string) (*PlaybackSession, *PlaybackMediaSource, error) {
@@ -3107,7 +3176,39 @@ func (h *PlaybackHandler) resolvePlaybackRoute(r *http.Request, compatSession *S
 			// empty or item-id mediaSourceId.
 			source := findMediaSource(playSession, mediaSourceID)
 			if source == nil && (mediaSourceID == "" || mediaSourceIDsEqual(mediaSourceID, routeID)) {
-				source = firstMediaSource(playSession)
+				source = defaultPlaybackMediaSource(playSession)
+			}
+			if !staticPlaybackRouteMatches(r, compatSession, playSession, source) {
+				return nil, nil, ErrSessionNotFound
+			}
+			return playSession, source, nil
+		}
+		// Static clients use their own ID on subsequent range requests. Resolve
+		// it before route fallback so concurrent plays of one item stay distinct.
+		playSession, resolveErr := h.resolveDevicePlaybackAlias(r, compatSession.Token, clientPlaySessionID, routeID, mediaSourceID, false)
+		if resolveErr != nil && !errors.Is(resolveErr, ErrSessionNotFound) {
+			return nil, nil, resolveErr
+		}
+		ok := resolveErr == nil
+		if resolver, supported := h.playbackStore.(interface {
+			ResolveClientPlaySessionID(string, string) (*PlaybackSession, error)
+		}); !ok && supported {
+			playSession, resolveErr = resolver.ResolveClientPlaySessionID(compatSession.Token, clientPlaySessionID)
+			if resolveErr != nil && !errors.Is(resolveErr, ErrSessionNotFound) {
+				return nil, nil, resolveErr
+			}
+			ok = resolveErr == nil
+		} else if !ok {
+			playSession, ok = h.playbackStore.FindByClientPlaySessionID(compatSession.Token, clientPlaySessionID)
+		}
+		if ok &&
+			mediaSourceIDsEqual(playSession.RouteItemID, routeID) {
+			source := findMediaSource(playSession, mediaSourceID)
+			if source == nil && (mediaSourceID == "" || mediaSourceIDsEqual(mediaSourceID, routeID)) {
+				source = defaultPlaybackMediaSource(playSession)
+			}
+			if !staticPlaybackRouteMatches(r, compatSession, playSession, source) {
+				return nil, nil, ErrSessionNotFound
 			}
 			return playSession, source, nil
 		}
@@ -3125,6 +3226,15 @@ func (h *PlaybackHandler) resolvePlaybackRoute(r *http.Request, compatSession *S
 	if !ok {
 		return nil, nil, ErrSessionNotFound
 	}
+	if source == nil && mediaSourceID != "" {
+		source = findMediaSource(playSession, mediaSourceID)
+	}
+	if source == nil {
+		source = defaultPlaybackMediaSource(playSession)
+	}
+	if !staticPlaybackRouteMatches(r, compatSession, playSession, source) {
+		return nil, nil, ErrSessionNotFound
+	}
 	if clientPlaySessionID != "" && playSession.ClientPlaySessionID != clientPlaySessionID {
 		// Remember the client's own PlaySessionId so playback reports carrying
 		// it resolve to this session directly instead of by ambiguous route.
@@ -3135,12 +3245,6 @@ func (h *PlaybackHandler) resolvePlaybackRoute(r *http.Request, compatSession *S
 			playSession.ClientPlaySessionID = clientPlaySessionID
 		}
 	}
-	if source == nil && mediaSourceID != "" {
-		source = findMediaSource(playSession, mediaSourceID)
-	}
-	if source == nil {
-		source = firstMediaSource(playSession)
-	}
 	return playSession, source, nil
 }
 
@@ -3150,6 +3254,20 @@ func firstMediaSource(session *PlaybackSession) *PlaybackMediaSource {
 	}
 	source := session.MediaSources[0]
 	return &source
+}
+
+// A resumed play keeps its selected edition when the client omits a source or
+// uses Jellyfin's item-as-source alias. Never substitute another known edition.
+func defaultPlaybackMediaSource(session *PlaybackSession) *PlaybackMediaSource {
+	if session != nil && session.SelectedMediaFileID > 0 {
+		for _, source := range session.MediaSources {
+			if source.FileID == session.SelectedMediaFileID {
+				return &source
+			}
+		}
+		return nil
+	}
+	return firstMediaSource(session)
 }
 
 func findMediaSource(session *PlaybackSession, mediaSourceID string) *PlaybackMediaSource {


### PR DESCRIPTION
## Problem

Related issue: #922. Companion reporting PR: [#924](https://github.com/Silo-Server/silo-server/pull/924).

During live playback verification, I saw duplicate Activity rows for what appeared to be one Jellyfin-compatible client play. Matching titles alone were not enough to merge them: they could have represented separate devices, plays, profiles, or media editions.

The static path had a concrete creation race. Parallel `Static=true` requests could both miss the session lookup and create different compatibility records before either attached its native playback session. Subsequent progress/recovery lookups could then be ambiguous. A separate recovery risk was selecting the first media source after the originally selected edition had been lost from the lookup context.

## Solution

### Reserve one static playback identity atomically

A static reservation is keyed by the authenticated compatibility token, profile, explicit device identity, client play ID, content item, and selected source. The fields are framed before hashing; a title or route by itself is never the deduplication key.

```text
Authenticated Static=true request
    → resolve and validate item + selected source
    → reserve exact token/profile/device/play/item/source tuple
         memory store: lookup + insert under one mutex
         durable store: transaction-scoped lock + exact-row lookup/insert
    → attach native playback session with compare-and-set
         winner: retain attachment
         losing writer: adopt authoritative state, reject stale attachment
    → later range requests / progress resolve the same caller-owned play
```

- `GetOrCreateStatic` is implemented by both stores.
- The durable path uses a bounded, transaction-scoped PostgreSQL advisory lock. Its exact token/key predicate remains authoritative; a truncated lock-hash collision would only serialize unrelated requests.
- The lock framing matches the already-deployed static reservation format. It does not port or change ordinary PlaybackInfo negotiation locking from the separate #852 contribution.
- Committing a reservation reloads through the existing generation-aware cache path; it does not overwrite a concurrent attachment with an earlier transaction snapshot.
- Terminal or expired reservations are not reused.
- A database failure is not treated as a clean lookup miss, and cannot create a new local-only reservation. The static request returns a service error instead.
- Different devices, profiles, play IDs, and selected sources remain distinct.

[PostgreSQL's advisory-lock documentation](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS) describes why a transaction-scoped lock fits this reservation: release follows transaction completion, including rollback, rather than depending on a later application unlock.

### Preserve the winning native-session attachment across API instances

The existing native attachment path already checks which upstream session it observed before creating a replacement. The durable update layer could swallow that closure's `errUpstreamReplaced` rejection after another API instance won, leaving the stale writer believing its speculative attachment succeeded.

I now return that specific rejection with the authoritative locked row, replace the speculative cached state with the winner, and do not queue the losing closure for a later persistence retry. Unrelated pending updates survive a rejected attachment transaction and are consumed only after a successful commit. The caller can follow its existing losing-attachment cleanup/adoption path. Other update-error behavior is unchanged.

This is covered by a real-PostgreSQL regression using two independent durable stores with stale cached state, followed by a fresh third store. All must retain the same winner, and the losing store must have no queued attachment retry.

### Resolve recovery by device and selected edition

- Capture explicit device identity from the established header/query paths.
- Prefer a unique caller-owned device/client-play match, with route and source checks.
- Reject ambiguity rather than choosing the first matching route.
- Persist `SelectedMediaFileID` in the reservation before native attachment. A concurrent range request with an omitted source or item-as-source alias therefore retains the selected edition even during that attachment window.
- If a known selected edition is no longer present, fail resolution rather than silently play the first edition.
- Preserve the legacy fallback only where no selected-file identity was ever stored.
- Keep an item-as-source alias compatible without letting it change the selected media file.
- Progress and delayed stop aliases/route fallbacks require an exact device match when the request supplies one; an empty-device legacy record is not enough. A precise caller-owned server play ID remains valid for a legacy record without device metadata, but cannot override a known different device.

### Reconcile only provable legacy duplicates

Legacy repair is deliberately narrower than new reservation:

- same authenticated identity, client play, device, item and route;
- direct sessions, no active transcode recipe, no newer static reservation key;
- creation within one second, with a bounded group of at most 32 rows;
- the same selected file proven by stored source identity, or by the native session snapshot when the old negotiation offered multiple editions.

The oldest record is the stable canonical mapping. The other records are retained with a terminal/superseded marker; unknown JSON fields are preserved. Superseded records cannot return through stream lookup, terminal finalization, or restart recovery. Repair does not manufacture a stop/scrobble event or manually delete playback history.

If source identity is missing, contradictory, or unavailable, historical rows remain untouched. Explicit device identity can still resolve the current play without guessing what those older records meant. This was important in the live case: unproven old records were not merged to make the dashboard count look better.

## Scope and rollout

This is the Jellyfin-compatible static-session lifecycle contribution, not the dashboard vocabulary change. It needs no new schema migration; the added fields live in the existing compatibility-session JSON. Reporting/output-format changes are isolated in [#924](https://github.com/Silo-Server/silo-server/pull/924).

Native Android/Apple decoder advertisement, V3 planning, transcoding policy, and the successful Original HTTP playback path are unchanged. This does not require a new native client build. No deployment configuration or unrelated production-fork changes are included.

Reservation prevention requires the participating API instances to run the new static path. An older instance can still create an unreserved row during a mixed-version rollout; the conservative legacy rules are not a promise to identify every such historical duplicate.

The equivalent static reservation/device/edition behavior was tested on the deployed fork. The cross-instance stale-attachment correction and the pre-attachment edition/device-fallback edge-case fixes added during upstream review are new to this contribution, not claimed as a new production deployment. The working production server was not changed while preparing these PRs.

## Validation

Latest follow-up: `a6dfa3924a5c013103939a53dcfc30cb316bdd43`. The new edition-reservation and device-fallback regressions failed before their fixes and now pass with the nearby targeted tests. [The full upstream CI rerun for this head](https://github.com/Silo-Server/silo-server/actions/runs/33712660911) is pending; the previously completed gate is recorded below.

[Full upstream repository CI passed](https://github.com/Silo-Server/silo-server/actions/runs/33711562014) on `437a56b13e3a2f9030d9a397e387d49a2af6fb5a`:

- Go build, gofmt, vet, changed-line golangci-lint, and `make test-go`.
- Web lint, format check, production build, and `make test-web`: **358 test files, 3,062 tests passed**.
- Generated settings/playback fixtures and docs hygiene checks.
- A disposable PostgreSQL 17 job applying the existing compatibility-session migration and running the targeted cross-instance/reservation/recovery suite with `go test -race`. This is additional coverage beyond the normal suite, whose database-dependent tests otherwise skip without a test DSN.

Actual database regression output:

```text
--- PASS: TestDurableStaticAttachmentRejectsStaleWriter (0.02s)
--- PASS: TestDurableStaticAttachmentPreservesUncommittedPendingUpdate (0.02s)
--- PASS: TestDurableCompatPlaybackStoreStaticReservationAcrossInstances (0.05s)
--- PASS: TestDurableLegacyStaticDuplicatesAcrossInstances (0.07s)
--- PASS: TestDurableLegacyStaticDuplicatesFailureDoesNotChangeCache (0.01s)
--- PASS: TestDurableLegacyStaticDuplicatesDeviceRecoveryWithoutNativeSnapshot (0.02s)
--- PASS: TestDurableCompatPlaybackStoreStaticReservationFailureLeavesNoLocalRow (0.01s)
ok  	github.com/Silo-Server/silo-server/internal/jellycompat	1.646s
```

The focused in-memory/static/report tests also passed locally; heavy builds and the full gate ran on GitHub-hosted runners, not the Mac or production server. No production database was used for the tests or benchmarks.

The targeted regressions cover:

- 16 simultaneous in-memory static creation calls returning one reservation.
- 12 independent durable-store callers returning one row, preserving its attached upstream session, and creating a new reservation after terminal state.
- Rejection of a stale cross-instance attachment, authoritative cache refresh, and no queued losing closure.
- 12 concurrent legacy-recovery callers selecting the same canonical record.
- Selected-edition proof, source resolution before native attachment, device-specific recovery without a native snapshot, and preservation of unproven records.
- Progress/stop checks across client aliases, unknown play IDs and exact server IDs, with empty-device and other-device records; precise caller-owned legacy server IDs remain compatible.
- Distinct device/play/source identities, terminal/expired records, delayed reports, database failure, and post-restart non-revival.

These concurrency assertions test identity correctness; they are not measurements of client playback startup.

The final review additionally found that a rejected attachment could incorrectly consume unrelated pending updates. A new regression checks rollback retention and a later successful retry. The follow-up correction at `437a56b1` passed the full upstream CI gate, including the new rollback-retention test. The benchmark below retains its exact original measured commit; it is not relabeled as a later measurement.

### Reservation microbenchmarks

Measured on the exact contribution commit `c9a34f3152b6f3dbd053cb1401cab8ffb6f7ee1b` by [GitHub Actions / Go](https://github.com/blurbery/silo-server/actions/runs/33710552795/job/100508897392): Go 1.26.4, Linux/amd64, AMD EPYC 7763 host CPU, benchmark suffix `-4`, PostgreSQL 17 in a disposable local service container. Five 250 ms benchmark samples per case, not five playback attempts.

```sh
go test ./internal/jellycompat -run '^$' \
  -bench 'Benchmark(StaticPlayback|DurableStatic)ReservationReuse$' \
  -benchmem -benchtime=250ms -count=5
```

| Reservation reuse path | Median µs/op | Range µs/op | B/op | Allocs/op |
| --- | ---: | ---: | ---: | ---: |
| PostgreSQL: one reservation | 1196.017 | 1134.004–1333.930 | 23378–23392 | 294 |
| Memory: 1 session | 0.303 | 0.301–0.310 | 384 | 1 |
| Memory: 100 sessions | 1.343 | 1.290–1.390 | 384 | 1 |
| Memory: 1000 sessions | 11.925 | 11.469–11.957 | 384 | 1 |

In-memory lookup scaling (one block ≈ 0.5 µs/op; same 0–12 µs scale):

```text
   1 session    ▌                         0.303 µs/op
 100 sessions   ███                       1.343 µs/op
1000 sessions   ████████████████████████ 11.925 µs/op
```

The durable median is 1.196 ms/op for reservation reuse, including the transaction, lock, exact lookup, decoding and cache revalidation. It is not FFmpeg startup or client first frame. The memory cases measure a scan in a populated store; the durable case has one reservation and is not a thousand-row database/load test. These are measurements of the new correctness path, **not a claimed speedup over the previous non-atomic path**.

<details>
<summary>Actual CI benchmark output (all samples)</summary>

```text
BenchmarkDurableStaticReservationReuse-4    	     254	   1161875 ns/op	   23384 B/op	     294 allocs/op
BenchmarkDurableStaticReservationReuse-4    	     272	   1134004 ns/op	   23378 B/op	     294 allocs/op
BenchmarkDurableStaticReservationReuse-4    	     201	   1333930 ns/op	   23392 B/op	     294 allocs/op
BenchmarkDurableStaticReservationReuse-4    	     252	   1196017 ns/op	   23383 B/op	     294 allocs/op
BenchmarkDurableStaticReservationReuse-4    	     246	   1227225 ns/op	   23385 B/op	     294 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1-4         	  998550	       300.8 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1-4         	  974982	       301.0 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1-4         	  970812	       307.1 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1-4         	 1000000	       309.6 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1-4         	 1000000	       303.2 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_100-4       	  219052	      1390 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_100-4       	  233424	      1297 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_100-4       	  227758	      1353 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_100-4       	  237352	      1343 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_100-4       	  241996	      1290 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1000-4      	   25512	     11736 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1000-4      	   25166	     11949 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1000-4      	   25124	     11957 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1000-4      	   25264	     11925 ns/op	     384 B/op	       1 allocs/op
BenchmarkStaticPlaybackReservationReuse/sessions_1000-4      	   26295	     11469 ns/op	     384 B/op	       1 allocs/op
```

</details>

## Wider playback work and startup evidence

The linked reporting PR contains the complete sanitized pipeline history, timing table, and references to merged Android #250, #262, #268, #275, #282, #284 and related server work. Those changes are present in the published Android build 16 release; this compatibility-session fix does not claim authorship of other contributors' work or make Android decoding depend on Jellyfin-compatible session reservations.

The live viewer's approximately five-second-to-one–two-second improvement and no-buffering feedback remains an attributed observation. The same-file retained build 16 sample records 3,917 ms for client plan installation to first frame and 21 ms for server session/transport commit. Those are different timer scopes. This PR makes no one–two second startup performance claim.

## Review, risks and limits

The adversarial review traced reservation through storage, native attachment, cached state, progress/stop resolution, source selection, and restart handling. It found the swallowed cross-instance attachment rejection; this PR fixes it and adds the regression described above. I checked token/profile/device/source separation, lock framing, expiry/terminal state, missing metadata, failure behavior, and legacy records that must not be guessed away. The repository's automatic CodeRabbit review also identified the pre-attachment selected-source gap and unscoped legacy-device fallback. I verified both with failing regressions before applying the focused fixes; review suggestions were not accepted without checking the actual paths.

The in-memory reservation lookup remains linear in the active store size. The durable query is bounded by the existing token index, not a new global scan or migration. Benchmark results characterize those paths; they do not establish production throughput, cross-region database latency, or end-to-end playback speed.

Ambiguous historical records may remain visible until normal lifecycle expiry. That is safer than merging distinct plays or choosing a different edition. No account names, IP addresses, media titles, real session/device IDs, paths, credentials, or private logs are included.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex local command execution (`exec_command`), `apply_patch`, GitHub CLI, and Codex web search.
- Model(s): `gpt-5.6-sol`, reasoning effort `ultra` (Sol Ultra).
- Involvement: AI-assisted. I researched the playback behavior, designed the intended behavior and scope, directed Codex through the investigation and implementation, and performed the live test confirmations. Codex assisted with code, regression tests, reference checks, CI analysis, and this write-up.
- Adversarial review: Same-agent source/diff review plus targeted regressions, disposable-PostgreSQL cross-instance tests under the race detector, and the repository CI gate. I also used the repository's automatic CodeRabbit review comments after independently checking them against the code and reproducing the issues. CodeRabbit's underlying model was not exposed, so I do not claim a model identity for it. No separately delegated Codex agent was used. Findings and limitations are recorded above.
