### PR TITLE
fix(sections): deduplicate items within home rows

### DIFF
--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -1255,6 +1255,8 @@ type sectionItemImageURLs struct {
 // already-validated library scope of library-scoped endpoints (nil for the
 // home/profile surfaces) so play-target resolution stays scoped to it.
 func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sections.SectionWithItems, libraryID *int) homeSectionsResponse {
+	deduplicateSectionItems(r.Context(), withItems)
+
 	overlaySummaries := make(map[string]*models.OverlaySummary)
 	contentIDs := make([]string, 0)
 	seen := make(map[string]struct{})
@@ -1361,6 +1363,58 @@ func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sect
 		})
 	}
 	return resp
+}
+
+// deduplicateSectionItems enforces the wire-level invariant that a non-empty
+// content ID appears at most once within one section. Invalid cards are dropped
+// because downstream enrichment and keyed client layouts require a usable
+// content ID. The first occurrence wins so query ordering and per-card fields
+// such as PlayContentID stay intact. Each section has its own seen set because
+// overlap between different rows is controlled separately by
+// applyDiversityFilter.
+func deduplicateSectionItems(ctx context.Context, withItems []sections.SectionWithItems) {
+	for i := range withItems {
+		if len(withItems[i].Items) == 0 {
+			continue
+		}
+
+		originalCount := len(withItems[i].Items)
+		seen := make(map[string]struct{}, len(withItems[i].Items))
+		kept := withItems[i].Items[:0]
+		duplicateCount := 0
+		invalidCount := 0
+		for _, item := range withItems[i].Items {
+			if item == nil || item.ContentID == "" {
+				invalidCount++
+				continue
+			}
+			if _, duplicate := seen[item.ContentID]; duplicate {
+				duplicateCount++
+				continue
+			}
+			seen[item.ContentID] = struct{}{}
+			kept = append(kept, item)
+		}
+		if duplicateCount == 0 && invalidCount == 0 {
+			continue
+		}
+
+		withItems[i].Items = kept
+		// A total no larger than the rendered slice is a rendered-count total
+		// and can be repaired exactly. A larger total describes the full source,
+		// which this limited slice cannot safely recompute; its producer owns the
+		// unique full-count invariant.
+		if withItems[i].TotalCount <= originalCount {
+			withItems[i].TotalCount = len(kept)
+		}
+		slog.WarnContext(ctx, "removed invalid or duplicate section items",
+			"component", "api",
+			"section_id", withItems[i].ID,
+			"type", withItems[i].SectionType,
+			"duplicate_count", duplicateCount,
+			"invalid_count", invalidCount,
+		)
+	}
 }
 
 // sectionProgressStore resolves the acting profile's store so play-target

--- a/internal/api/handlers/sections_test.go
+++ b/internal/api/handlers/sections_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -294,34 +295,59 @@ func TestBuildSectionsResponseScopesPlayTargetsToLibraryAndProgress(t *testing.T
 	}
 }
 
-// Recently-added TV keeps one card per scan-run event, so a series hit by two
-// multi-episode runs appears twice with different anchors. Each card must
-// resolve its own target: keying the resolver's answers by content ID alone
-// silently gave both cards the first card's episode.
-func TestBuildSectionsResponseResolvesRepeatedSeriesEventsIndependently(t *testing.T) {
+// Section responses keep the first occurrence of a content ID within each row.
+// A later row may still contain the same item because cross-section overlap is
+// a separate, recipe-controlled behavior.
+func TestBuildSectionsResponseDeduplicatesItemsWithinEachSection(t *testing.T) {
 	resolver := &stubSectionPlayableTargetResolver{targets: map[string]string{
-		playTargetKey("series", "series-1", "episode-s01e01"): "episode-s01e01",
 		playTargetKey("series", "series-1", "episode-s02e05"): "episode-s02e05",
 	}}
 	h := &SectionHandler{playableTargets: resolver}
-	withItems := []sections.SectionWithItems{{
-		ResolvedSection: sections.ResolvedSection{ID: "recent", SectionType: sections.SectionRecentlyAdded, Title: "Recently Added"},
-		Items: []*models.MediaItem{
-			{ContentID: "series-1", Type: "series", Title: "Long Runner", Status: "matched", PlayContentID: "episode-s02e05"},
-			{ContentID: "series-1", Type: "series", Title: "Long Runner", Status: "matched", PlayContentID: "episode-s01e01"},
+	withItems := []sections.SectionWithItems{
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "recent", SectionType: sections.SectionRecentlyAdded, Title: "Recently Added", ItemLimit: 3},
+			Items: []*models.MediaItem{
+				nil,
+				{ContentID: "series-1", Type: "series", Title: "Long Runner", Status: "matched", PlayContentID: "episode-s02e05"},
+				{ContentID: "", Type: "movie", Title: "Invalid", Status: "matched"},
+				{ContentID: "movie-2", Type: "movie", Title: "Second", Status: "matched"},
+				{ContentID: "series-1", Type: "series", Title: "Long Runner", Status: "matched", PlayContentID: "episode-s01e01"},
+				{ContentID: "movie-3", Type: "movie", Title: "Third", Status: "matched"},
+			},
+			TotalCount: 6,
 		},
-	}}
+		{
+			ResolvedSection: sections.ResolvedSection{ID: "featured", SectionType: sections.SectionRecentlyReleased, Title: "Featured"},
+			Items: []*models.MediaItem{
+				{ContentID: "series-1", Type: "series", Title: "Long Runner", Status: "matched", PlayContentID: "episode-s02e05"},
+				{ContentID: "series-1", Type: "series", Title: "Long Runner", Status: "matched", PlayContentID: "episode-s01e01"},
+			},
+			TotalCount: 10,
+		},
+	}
 
 	resp := h.buildSectionsResponse(httptest.NewRequest(http.MethodGet, "/sections", nil), withItems, nil)
+	if len(resp.Sections) != 2 {
+		t.Fatalf("sections = %d, want 2", len(resp.Sections))
+	}
 	items := resp.Sections[0].Items
-	if len(items) != 2 {
-		t.Fatalf("items = %d, want 2", len(items))
+	if len(items) != 3 {
+		t.Fatalf("first section items = %d, want 3", len(items))
+	}
+	if got := []string{items[0].ContentID, items[1].ContentID, items[2].ContentID}; !reflect.DeepEqual(got, []string{"series-1", "movie-2", "movie-3"}) {
+		t.Fatalf("first section IDs = %v, want [series-1 movie-2 movie-3]", got)
 	}
 	if items[0].PlayContentID != "episode-s02e05" {
-		t.Fatalf("newer event play content id = %q, want episode-s02e05", items[0].PlayContentID)
+		t.Fatalf("first occurrence play content id = %q, want episode-s02e05", items[0].PlayContentID)
 	}
-	if items[1].PlayContentID != "episode-s01e01" {
-		t.Fatalf("older event play content id = %q, want episode-s01e01", items[1].PlayContentID)
+	if resp.Sections[0].TotalCount != 3 {
+		t.Fatalf("first section total count = %d, want 3", resp.Sections[0].TotalCount)
+	}
+	if got := resp.Sections[1].Items; len(got) != 1 || got[0].ContentID != "series-1" {
+		t.Fatalf("second section items = %#v, want cross-section series-1", got)
+	}
+	if resp.Sections[1].TotalCount != 10 {
+		t.Fatalf("second section full total count = %d, want 10", resp.Sections[1].TotalCount)
 	}
 }
 

--- a/internal/catalog/recent_tv.go
+++ b/internal/catalog/recent_tv.go
@@ -15,8 +15,9 @@ const (
 	recentTVTypeSeries  = "series"
 )
 
-// RecentTVTarget is one card-producing TV availability event. Separate scan
-// runs remain separate even when two multi-episode runs target the same show.
+// RecentTVTarget is one card-producing TV availability event. By default,
+// separate scan runs remain separate even when two multi-episode runs target
+// the same show; RecentTVQuery.UniqueTargets can collapse them for keyed rows.
 type RecentTVTarget struct {
 	ContentID string
 	Type      string
@@ -35,13 +36,14 @@ type RecentTVTarget struct {
 
 // RecentTVQuery describes one page of Plex-style recently-added TV events.
 type RecentTVQuery struct {
-	LibraryIDs []int
-	Access     AccessFilter
-	NamePrefix string
-	SnapshotAt *time.Time
-	Limit      int
-	Offset     int
-	SkipTotal  bool
+	LibraryIDs    []int
+	Access        AccessFilter
+	NamePrefix    string
+	SnapshotAt    *time.Time
+	Limit         int
+	Offset        int
+	SkipTotal     bool
+	UniqueTargets bool // collapse repeated target content IDs, keeping the newest event
 }
 
 // RecentTVRepository resolves scan-batched episode availability into episode
@@ -150,7 +152,9 @@ func ResolveRecentTVLibraryIDs(
 	return sortedUniqueInts(ids), true, nil
 }
 
-// List returns one page after event grouping and per-event target de-duplication.
+// List returns one page after event grouping. UniqueTargets collapses repeated
+// target content IDs before counting and pagination; otherwise each scan event
+// remains independently addressable.
 func (r *RecentTVRepository) List(ctx context.Context, q RecentTVQuery) ([]RecentTVTarget, int, bool, error) {
 	if r == nil || r.pool == nil || len(q.LibraryIDs) == 0 {
 		return []RecentTVTarget{}, 0, false, nil
@@ -246,14 +250,33 @@ func (r *RecentTVRepository) List(ctx context.Context, q RecentTVQuery) ([]Recen
 	// aggregation, so that path keeps the single-pass shape.
 	var sqlText string
 	if strings.TrimSpace(q.NamePrefix) == "" {
-		totalsCTE := `,
+		if q.UniqueTargets {
+			totalsCTE := `,
+			totals AS (
+				SELECT COUNT(*)::int AS total_count FROM unique_target_keys
+			)`
+			if q.SkipTotal {
+				totalsCTE = ""
+			}
+			sqlText = buildUniqueRecentTVNoPrefixQuery(
+				strings.Join(episodeRowConditions, " AND "),
+				eventWhere,
+				strings.Join(seriesConditions, " AND "),
+				limitIdx,
+				offsetIdx,
+				totalsCTE,
+				totalColumn,
+				fromClause,
+			)
+		} else {
+			totalsCTE := `,
 		totals AS (
 			SELECT ((SELECT COUNT(*) FROM event_keys) + (SELECT COUNT(*) FROM series_without_episode_events))::int AS total_count
 		)`
-		if q.SkipTotal {
-			totalsCTE = ""
-		}
-		sqlText = fmt.Sprintf(`
+			if q.SkipTotal {
+				totalsCTE = ""
+			}
+			sqlText = fmt.Sprintf(`
 		WITH raw_event_keys AS MATERIALIZED (
 			-- Narrow first pass: one row per (series, scan run) availability
 			-- event carrying only its added_at. It deliberately applies only
@@ -342,36 +365,9 @@ func (r *RecentTVRepository) List(ctx context.Context, q RecentTVQuery) ([]Recen
 			ORDER BY added_at DESC, target_type ASC, target_id ASC, event_id ASC
 			LIMIT $%[4]d OFFSET $%[5]d
 		)
-		SELECT page.target_id, page.target_type, page.added_at,
-		       COALESCE(page.single_episode_id, play_target.content_id) AS play_content_id%[7]s
-		%[8]s
-		-- Anchor hint only: profile-independent by design, so this page can be
-		-- shared through the process-global resolved-list cache. Playback
-		-- quality is enforced later by PlayableTargetResolver, which re-checks
-		-- this hint before using it (see RecentTVTarget.PlayContentID).
-		LEFT JOIN LATERAL (
-			SELECT e_play.content_id
-			FROM episodes e_play
-			WHERE page.target_type = 'series'
-			  AND e_play.series_id = page.series_id
-			  AND e_play.season_number = page.anchor_season_number
-			  AND EXISTS (
-				SELECT 1
-				FROM episode_libraries el_play
-				WHERE el_play.episode_id = e_play.content_id
-				  AND el_play.media_folder_id = ANY($1)
-				  AND EXISTS (
-					SELECT 1 FROM media_files mf_play
-					WHERE mf_play.episode_id = el_play.episode_id
-					  AND mf_play.media_folder_id = el_play.media_folder_id
-					  AND mf_play.missing_since IS NULL
-				  )
-			  )
-			ORDER BY e_play.episode_number ASC, e_play.content_id ASC
-			LIMIT 1
-		) play_target ON true
-		ORDER BY page.added_at DESC, page.target_type ASC, page.target_id ASC, page.event_id ASC
-	`, strings.Join(episodeRowConditions, " AND "), eventWhere, strings.Join(seriesConditions, " AND "), limitIdx, offsetIdx, totalsCTE, totalColumn, fromClause)
+			`, strings.Join(episodeRowConditions, " AND "), eventWhere, strings.Join(seriesConditions, " AND "), limitIdx, offsetIdx, totalsCTE)
+			sqlText += buildRecentTVResultQuery(totalColumn, fromClause)
+		}
 	} else {
 		totalsCTE := `,
 		totals AS (
@@ -379,6 +375,14 @@ func (r *RecentTVRepository) List(ctx context.Context, q RecentTVQuery) ([]Recen
 		)`
 		if q.SkipTotal {
 			totalsCTE = ""
+		}
+		filteredSQL := `SELECT target_id, target_type, added_at, event_id, series_id, anchor_season_number, single_episode_id
+			FROM all_events`
+		if q.UniqueTargets {
+			filteredSQL = `SELECT DISTINCT ON (target_id)
+				target_id, target_type, added_at, event_id, series_id, anchor_season_number, single_episode_id
+			FROM all_events
+			ORDER BY target_id, added_at DESC, target_type ASC, event_id ASC`
 		}
 		sqlText = fmt.Sprintf(`
 		WITH available_episode_rows AS MATERIALIZED (
@@ -443,15 +447,8 @@ func (r *RecentTVRepository) List(ctx context.Context, q RecentTVQuery) ([]Recen
 			SELECT series_id, 'series'::text, added_at, ''::text, series_id, NULL::integer, NULL::text
 			FROM series_without_episode_events
 		),
-		-- No de-duplication pass: (target_id, target_type, event_id) is already
-		-- unique. episode_events groups by (series_id, first_seen_scan_run_id)
-		-- and an episode belongs to exactly one series, and
-		-- series_without_episode_events is disjoint from it by construction —
-		-- it only emits series with no present episode file, which every
-		-- episode_events row requires.
 		filtered AS (
-			SELECT target_id, target_type, added_at, event_id, series_id, anchor_season_number, single_episode_id
-			FROM all_events
+			%s
 		)%s,
 		page AS (
 			SELECT target_id, target_type, added_at, event_id, series_id, anchor_season_number, single_episode_id
@@ -459,36 +456,8 @@ func (r *RecentTVRepository) List(ctx context.Context, q RecentTVQuery) ([]Recen
 			ORDER BY added_at DESC, target_type ASC, target_id ASC, event_id ASC
 			LIMIT $%d OFFSET $%d
 		)
-		SELECT page.target_id, page.target_type, page.added_at,
-		       COALESCE(page.single_episode_id, play_target.content_id) AS play_content_id%s
-		%s
-		-- Anchor hint only: profile-independent by design, so this page can be
-		-- shared through the process-global resolved-list cache. Playback
-		-- quality is enforced later by PlayableTargetResolver, which re-checks
-		-- this hint before using it (see RecentTVTarget.PlayContentID).
-		LEFT JOIN LATERAL (
-			SELECT e_play.content_id
-			FROM episodes e_play
-			WHERE page.target_type = 'series'
-			  AND e_play.series_id = page.series_id
-			  AND e_play.season_number = page.anchor_season_number
-			  AND EXISTS (
-				SELECT 1
-				FROM episode_libraries el_play
-				WHERE el_play.episode_id = e_play.content_id
-				  AND el_play.media_folder_id = ANY($1)
-				  AND EXISTS (
-					SELECT 1 FROM media_files mf_play
-					WHERE mf_play.episode_id = el_play.episode_id
-					  AND mf_play.media_folder_id = el_play.media_folder_id
-					  AND mf_play.missing_since IS NULL
-				  )
-			  )
-			ORDER BY e_play.episode_number ASC, e_play.content_id ASC
-			LIMIT 1
-		) play_target ON true
-		ORDER BY page.added_at DESC, page.target_type ASC, page.target_id ASC, page.event_id ASC
-	`, strings.Join(episodeRowConditions, " AND "), eventWhere, strings.Join(seriesConditions, " AND "), totalsCTE, limitIdx, offsetIdx, totalColumn, fromClause)
+		`, strings.Join(episodeRowConditions, " AND "), eventWhere, strings.Join(seriesConditions, " AND "), filteredSQL, totalsCTE, limitIdx, offsetIdx)
+		sqlText += buildRecentTVResultQuery(totalColumn, fromClause)
 	}
 
 	rows, err := r.pool.Query(ctx, sqlText, args...)
@@ -528,6 +497,136 @@ func (r *RecentTVRepository) List(ctx context.Context, q RecentTVQuery) ([]Recen
 		return targets, 0, hasMore, nil
 	}
 	return targets, total, q.Offset+len(targets) < total, nil
+}
+
+// buildUniqueRecentTVNoPrefixQuery keeps the no-prefix path's expensive anchor
+// aggregation page-bounded while selecting and counting unique card targets.
+// MIN/MAX is enough to distinguish a one-episode scan event from a multi-
+// episode event even when one episode has availability rows in several folders.
+func buildUniqueRecentTVNoPrefixQuery(
+	episodeConditions string,
+	eventConditions string,
+	seriesConditions string,
+	limitIdx int,
+	offsetIdx int,
+	totalsCTE string,
+	totalColumn string,
+	fromClause string,
+) string {
+	return fmt.Sprintf(`
+	WITH raw_event_keys AS MATERIALIZED (
+		-- Keep this first pass narrow: target identity needs only scalar
+		-- aggregates. Episode counts and playback anchors remain page-bound.
+		SELECT e.series_id,
+		       el.first_seen_scan_run_id AS scan_run_id,
+		       MAX(el.first_seen_at) AS added_at,
+		       MIN(el.episode_id) AS min_episode_id,
+		       MAX(el.episode_id) AS max_episode_id
+		FROM episode_libraries el
+		JOIN episodes e ON e.content_id = el.episode_id
+		WHERE %[1]s
+		GROUP BY e.series_id, el.first_seen_scan_run_id
+	),
+	series_without_episode_events AS MATERIALIZED (
+		SELECT mi.content_id AS series_id,
+		       MAX(mil.first_seen_at) AS added_at
+		FROM media_item_libraries mil
+		JOIN media_items mi ON mi.content_id = mil.content_id
+		WHERE %[3]s
+		  AND NOT EXISTS (
+			SELECT 1 FROM raw_event_keys rek WHERE rek.series_id = mi.content_id
+		  )
+		GROUP BY mi.content_id
+	),
+	target_keys AS (
+		SELECT CASE
+		         WHEN rek.scan_run_id IS NOT NULL AND rek.min_episode_id = rek.max_episode_id THEN rek.min_episode_id
+		         ELSE rek.series_id
+		       END AS target_id,
+		       CASE
+		         WHEN rek.scan_run_id IS NOT NULL AND rek.min_episode_id = rek.max_episode_id THEN 'episode'::text
+		         ELSE 'series'::text
+		       END AS target_type,
+		       rek.added_at,
+		       COALESCE(rek.scan_run_id, '') AS event_id,
+		       rek.series_id,
+		       rek.scan_run_id
+		FROM raw_event_keys rek
+		JOIN media_items si ON si.content_id = rek.series_id
+		WHERE %[2]s
+		UNION ALL
+		SELECT series_id, 'series'::text, added_at, ''::text, series_id, NULL::text
+		FROM series_without_episode_events
+	),
+	unique_target_keys AS MATERIALIZED (
+		SELECT DISTINCT ON (target_id)
+		       target_id, target_type, added_at, event_id, series_id, scan_run_id
+		FROM target_keys
+		ORDER BY target_id, added_at DESC, target_type ASC, event_id ASC
+	)%[6]s,
+	page_keys AS MATERIALIZED (
+		SELECT target_id, target_type, added_at, event_id, series_id, scan_run_id
+		FROM unique_target_keys
+		ORDER BY added_at DESC, target_type ASC, target_id ASC, event_id ASC
+		LIMIT $%[4]d OFFSET $%[5]d
+	),
+	page AS (
+		SELECT pk.target_id,
+		       pk.target_type,
+		       pk.added_at,
+		       pk.event_id,
+		       pk.series_id,
+		       anchor.anchor_season_number,
+		       CASE WHEN pk.target_type = 'episode' THEN pk.target_id END AS single_episode_id
+		FROM page_keys pk
+		LEFT JOIN LATERAL (
+			SELECT (array_agg(e.season_number ORDER BY el.first_seen_at DESC, e.season_number DESC, e.episode_number DESC, el.episode_id ASC))[1] AS anchor_season_number
+			FROM episodes e
+			JOIN episode_libraries el
+			  ON el.episode_id = e.content_id
+			 AND el.first_seen_scan_run_id IS NOT DISTINCT FROM pk.scan_run_id
+			WHERE pk.target_type = 'series'
+			  AND e.series_id = pk.series_id
+			  AND %[1]s
+		) anchor ON true
+	)
+	`, episodeConditions, eventConditions, seriesConditions, limitIdx, offsetIdx, totalsCTE) + buildRecentTVResultQuery(totalColumn, fromClause)
+}
+
+// buildRecentTVResultQuery renders the common result projection after each
+// query shape has produced the same page columns.
+func buildRecentTVResultQuery(totalColumn, fromClause string) string {
+	return fmt.Sprintf(`
+	SELECT page.target_id, page.target_type, page.added_at,
+	       COALESCE(page.single_episode_id, play_target.content_id) AS play_content_id%s
+	%s
+	-- Anchor hint only: profile-independent by design, so this page can be
+	-- shared through the process-global resolved-list cache. Playback quality
+	-- is enforced later by PlayableTargetResolver, which re-checks this hint
+	-- before using it (see RecentTVTarget.PlayContentID).
+	LEFT JOIN LATERAL (
+		SELECT e_play.content_id
+		FROM episodes e_play
+		WHERE page.target_type = 'series'
+		  AND e_play.series_id = page.series_id
+		  AND e_play.season_number = page.anchor_season_number
+		  AND EXISTS (
+			SELECT 1
+			FROM episode_libraries el_play
+			WHERE el_play.episode_id = e_play.content_id
+			  AND el_play.media_folder_id = ANY($1)
+			  AND EXISTS (
+				SELECT 1 FROM media_files mf_play
+				WHERE mf_play.episode_id = el_play.episode_id
+				  AND mf_play.media_folder_id = el_play.media_folder_id
+				  AND mf_play.missing_since IS NULL
+			  )
+		  )
+		ORDER BY e_play.episode_number ASC, e_play.content_id ASC
+		LIMIT 1
+	) play_target ON true
+	ORDER BY page.added_at DESC, page.target_type ASC, page.target_id ASC, page.event_id ASC
+	`, totalColumn, fromClause)
 }
 
 func appendAllowedContentCondition(column string, allowed []string, conditions *[]string, args *[]any, argIdx *int) {

--- a/internal/catalog/recent_tv_db_test.go
+++ b/internal/catalog/recent_tv_db_test.go
@@ -130,6 +130,54 @@ func TestRecentTVRepositoryGroupsScanBatchesAndPaginates(t *testing.T) {
 	if err != nil || previewTotal != 0 || !previewHasMore || !equalRecentTVTargets(preview, want[1:3]) {
 		t.Fatalf("count-free page = %#v, total %d, hasMore %v, err %v", preview, previewTotal, previewHasMore, err)
 	}
+
+	uniqueWant := []RecentTVTarget{
+		{ContentID: epA2, Type: "episode", AddedAt: base.Add(10 * time.Minute), PlayContentID: epA2},
+		{ContentID: seriesB, Type: "series", AddedAt: base.Add(9 * time.Minute), PlayContentID: epB3},
+		{ContentID: epA1, Type: "episode", AddedAt: base.Add(5 * time.Minute), PlayContentID: epA1},
+		{ContentID: seriesD, Type: "series", AddedAt: base.Add(3 * time.Minute)},
+		{ContentID: seriesC, Type: "series", AddedAt: base.Add(2 * time.Minute), PlayContentID: epC1},
+	}
+	unique, uniqueTotal, uniqueHasMore, err := repo.List(ctx, RecentTVQuery{
+		LibraryIDs:    []int{tvFolderID},
+		Limit:         20,
+		UniqueTargets: true,
+	})
+	if err != nil || uniqueTotal != len(uniqueWant) || uniqueHasMore || !equalRecentTVTargets(unique, uniqueWant) {
+		t.Fatalf("unique targets = %#v, total %d, hasMore %v, err %v; want %#v", unique, uniqueTotal, uniqueHasMore, err, uniqueWant)
+	}
+
+	uniquePage, uniquePageTotal, uniquePageHasMore, err := repo.List(ctx, RecentTVQuery{
+		LibraryIDs:    []int{tvFolderID},
+		Limit:         2,
+		Offset:        1,
+		UniqueTargets: true,
+	})
+	if err != nil || uniquePageTotal != len(uniqueWant) || !uniquePageHasMore || !equalRecentTVTargets(uniquePage, uniqueWant[1:3]) {
+		t.Fatalf("unique page = %#v, total %d, hasMore %v, err %v; want %#v", uniquePage, uniquePageTotal, uniquePageHasMore, err, uniqueWant[1:3])
+	}
+
+	uniquePreview, uniquePreviewTotal, uniquePreviewHasMore, err := repo.List(ctx, RecentTVQuery{
+		LibraryIDs:    []int{tvFolderID},
+		Limit:         2,
+		Offset:        1,
+		SkipTotal:     true,
+		UniqueTargets: true,
+	})
+	if err != nil || uniquePreviewTotal != 0 || !uniquePreviewHasMore || !equalRecentTVTargets(uniquePreview, uniqueWant[1:3]) {
+		t.Fatalf("count-free unique page = %#v, total %d, hasMore %v, err %v; want %#v", uniquePreview, uniquePreviewTotal, uniquePreviewHasMore, err, uniqueWant[1:3])
+	}
+
+	uniqueNamed, uniqueNamedTotal, uniqueNamedHasMore, err := repo.List(ctx, RecentTVQuery{
+		LibraryIDs:    []int{tvFolderID},
+		NamePrefix:    "Beta",
+		Limit:         20,
+		UniqueTargets: true,
+	})
+	if err != nil || uniqueNamedTotal != 1 || uniqueNamedHasMore || !equalRecentTVTargets(uniqueNamed, []RecentTVTarget{uniqueWant[1]}) {
+		t.Fatalf("named unique targets = %#v, total %d, hasMore %v, err %v; want newest Beta event", uniqueNamed, uniqueNamedTotal, uniqueNamedHasMore, err)
+	}
+
 	empty, emptyTotal, emptyHasMore, err := repo.List(ctx, RecentTVQuery{LibraryIDs: []int{tvFolderID}, Limit: 2, Offset: 99})
 	if err != nil || emptyTotal != len(want) || emptyHasMore || len(empty) != 0 {
 		t.Fatalf("past-end page = %#v, total %d, hasMore %v, err %v", empty, emptyTotal, emptyHasMore, err)

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -2378,9 +2378,10 @@ func (f *Fetcher) fetchTVRecentlyAdded(
 	}
 
 	targets, total, _, err := catalog.NewRecentTVRepository(f.pool).List(ctx, catalog.RecentTVQuery{
-		LibraryIDs: effectiveLibraryIDs,
-		Access:     filter,
-		Limit:      s.ItemLimit,
+		LibraryIDs:    effectiveLibraryIDs,
+		Access:        filter,
+		Limit:         s.ItemLimit,
+		UniqueTargets: true,
 	})
 	if err != nil {
 		return nil, 0, true, err


### PR DESCRIPTION
## Problem

Related issue: #927

Home section responses must not contain the same non-empty `content_id` more than once within one row. Current `main` can violate that invariant in Recently Added TV: the repository emits one card-producing event per scan run, so two multi-episode scan batches for the same series produce the same series card twice. Those duplicates can crash clients that use `content_id` as a keyed-list identity.

The production report did not capture the affected section type. This change therefore fixes the deterministic current-source producer and adds a final response guard for every native section path.

## Approach

- Add an opt-in unique-target mode to the recent-TV repository. It selects the newest event for each target before total calculation, `LIMIT`, or `OFFSET`, so duplicates do not consume page slots and the retained card keeps the newest playback anchor.
- Enable unique-target mode only for native Recently Added section fetching. The catalog section browser keeps its existing event-per-scan behavior, and jellycompat keeps its existing distinct-series compatibility path.
- Enforce stable first-occurrence uniqueness in the shared section response builder used by both aggregate and per-section endpoints. The guard drops nil or empty-ID cards, allows overlap between different rows, repairs rendered-count totals when exact, and logs only the section identity and duplicate/invalid counts.
- Keep the hot no-prefix query's expensive anchor aggregation page-bounded. A pre-commit complexity review also consolidated the common result projection and removed a redundant page-local CTE chain.

## Validation

The new regressions were confirmed failing before the implementation: the repository returned six events instead of five unique targets, and the response builder retained four keyed items instead of three.

Passed on the final diff:

```text
SILO_TEST_DATABASE_URL='postgres://silo:silo@127.0.0.1:55433/silo?sslmode=disable' go test -race ./internal/catalog -run '^TestRecentTVRepositoryGroupsScanBatchesAndPaginates$' -count=1 -v
PASS
ok github.com/Silo-Server/silo-server/internal/catalog

go test -race ./internal/api/handlers -run '^TestBuildSectionsResponseDeduplicatesItemsWithinEachSection$' -count=1 -v
PASS
ok github.com/Silo-Server/silo-server/internal/api/handlers

make test-go
PASS

go build ./...
PASS

go vet ./...
PASS

go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --new-from-merge-base=origin/main ./...
0 issues.

gofmt -l .
(no output)

git diff --check
PASS

make verify-local-paths
PASS

make verify-playback-fixtures
playback fixtures are current

make verify-settings-bindings
settings bindings are current
```

Additional validation notes:

- A database-enabled run of all three affected packages reached an unrelated assertion in untouched `TestEpisodeSearchPostgresAndDocumentSource`: PostgreSQL returned the `silo_recommendations` vector key with a nil value where the test expected no key. The focused PostgreSQL regression above and the normal full Go suite pass.
- `make verify-settings-bindings-all` verified the server binding, then could not run the unchanged web binding's formatting check because `prettier` is not installed in this worktree. The server-only verification above passes.
- Web lint, build, and tests were not run because this change has no web code or generated web-contract changes. Screenshots are not applicable to this backend response fix.

## Risks

- The exact section type in the original production response remains unknown. The final response guard enforces the invariant for all section types and logs enough sanitized context to identify any additional producer.
- Unique-target selection adds scalar aggregation and deduplication to native Recently Added TV. Playback-anchor aggregation remains limited to the requested page.
- There is no migration or API shape change. Catalog browsing, cross-section overlap, and jellycompat behavior remain unchanged.

If the response guard logs another producer, follow-up work should fix that producer so duplicates cannot consume its item limit before serialization.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop app
- Tool(s): OpenAI Codex with multi-agent collaboration
- Model(s): primary runtime model identifier not exposed (`n/a`); independent review subagents used `gpt-5.6-sol` with high reasoning effort
- Involvement: AI-assisted
- Adversarial review: Five independent `gpt-5.6-sol` high-reasoning subagent workstreams covered producer diagnosis, regression design, catalog/jellycompat/client compatibility, SQL and response-boundary correctness, and over-engineering. The complexity review identified a redundant page-local CTE chain, repeated SQL result projection, a one-use CTE, and an unnecessary slice return; all were removed or consolidated, cutting 76 net lines before the final test pass. The final staged-diff reviews found no unresolved correctness or complexity findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recent TV results now avoid repeated content targets, retaining the newest occurrence while preserving distinct episodes.
  - Pagination and result counts reflect deduplicated content.
  - Duplicate items are removed within sections, while the same item may still appear across different sections.
- **Bug Fixes**
  - Empty, invalid, and repeated section items are excluded from rendered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->