### PR TITLE
feat(notifications): mint a long-lived display token for Apple push enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ defines each tag and the SemVer contract.
 
 - [Documentation index](docs/wiki/index.md) — user and operator guides
 - [Development guide](DEVELOPMENT.md) — source setup, builds, tests, migrations
-- [Settings API](docs/settings-api.md) and [Downloads API](docs/downloads-api.md) — client contracts
+- [Settings API](docs/settings-api.md), [Downloads API](docs/downloads-api.md), and [Apple Push Display Token](docs/notifications-push-api.md) — client contracts
 
 ## Community and contributions
 

--- a/docs/notifications-push-api.md
+++ b/docs/notifications-push-api.md
@@ -92,7 +92,7 @@ Authentication rules for this route only:
 
 | Credential | Behavior |
 |---|---|
-| Display token in `Authorization` header | Accepted. The profile comes from the token's claims; `X-Profile-Id` and `X-Profile-Token` are ignored. PIN verification is skipped because the token was issued to an already verified profile session. The login session must still be valid. |
+| Display token in `Authorization` header | Accepted. The profile comes from the token's claims; `X-Profile-Id` and `X-Profile-Token` are ignored. PIN verification is skipped because the token was issued to an already verified profile session. The login session must still be valid, and the profile must still exist and belong to the user (a deleted profile's token returns `404`). |
 | Display token in `?token=` query | Rejected with `401`. Long-lived credentials must not appear in URLs. |
 | Access token | Accepted through the normal chain: `X-Profile-Id` is required and PIN-protected profiles need `X-Profile-Token`, as before. |
 | Refresh token or API key | `401` / normal API key handling; neither is a display credential. |

--- a/docs/notifications-push-api.md
+++ b/docs/notifications-push-api.md
@@ -98,5 +98,5 @@ Authentication rules for this route only:
 | Refresh token or API key | `401` / normal API key handling; neither is a display credential. |
 
 `404 not_found` is returned when the delivery does not belong to the
-authenticated profile. The route is rate limited like other authenticated
+authenticated profile. The route is rate-limited like other authenticated
 routes.

--- a/docs/notifications-push-api.md
+++ b/docs/notifications-push-api.md
@@ -1,0 +1,102 @@
+# Apple Push Display Token (client integration guide)
+
+The iOS Notification Service extension turns a generic APNs alert into the
+real notification text by fetching compact display metadata from the server.
+The extension runs in its own process and cannot refresh the app's short-lived
+access token, so the server issues it a separate long-lived credential at
+push registration.
+
+> All endpoints are under `/api/v1`. Android is unaffected: it fetches
+> `GET /notifications/{id}` through the app's normal auth path, which refreshes
+> on `401`.
+
+## Discovery
+
+```
+GET /notifications/capability
+```
+
+```json
+{
+  "apple_push": {
+    "available": true,
+    "provider": "silo_relay",
+    "supported_modes": ["private_push", "in_app_only"],
+    "display_token": true
+  }
+}
+```
+
+`apple_push.display_token` is `true` when Apple push registration returns a
+display token. It is omitted (false) on servers without JWT auth or older
+servers. `android_push` never carries the field.
+
+## Registration
+
+```
+POST /devices/push/apple
+Authorization: Bearer <access token>
+X-Profile-Id: <profile>
+```
+
+The request body is unchanged. When the server can mint one, the response
+gains two additive fields:
+
+```json
+{
+  "id": "01M...",
+  "server_device_id": "...",
+  "enabled": true,
+  "push_mode": "private_push",
+  "display_token": "<jwt>",
+  "display_token_expires_at": "2026-10-03T00:00:00Z"
+}
+```
+
+- `display_token` is a JWT with `token_type: "apple_push_display"`, bound to
+  the registering user, login session, and profile.
+- Its lifetime follows the server's refresh-token expiry (30 days by
+  default). Re-register before `display_token_expires_at` to renew it; the
+  Apple client re-registers a week ahead.
+- Both fields are omitted when the server cannot mint a token. Clients must
+  fall back to the access token in that case.
+- Registration with an API key (`sa_` prefix) never returns a token: there is
+  no login session to bind.
+
+Store the token where the extension can read it (the Apple client uses the
+shared Keychain access group) and clear it on sign-out, server removal, or
+profile change. The server revokes it implicitly when the login session is
+revoked or expires.
+
+## Display fetch
+
+```
+GET /notifications/push/apple/display/{delivery_id}
+Authorization: Bearer <display token or access token>
+```
+
+Returns the same compact `NotificationDisplay` payload as before:
+
+```json
+{
+  "delivery_id": "01M...",
+  "title": "The latest episode of Severance S02E01 just dropped!",
+  "body": "Hello, Ms. Cobel",
+  "thread_id": "series:series-1",
+  "category": "episode_available",
+  "url": "/item/episode-1"
+}
+```
+
+Authentication rules for this route only:
+
+| Credential | Behavior |
+|---|---|
+| Display token in `Authorization` header | Accepted. The profile comes from the token's claims; `X-Profile-Id` and `X-Profile-Token` are ignored. PIN verification is skipped because the token was issued to an already verified profile session. The login session must still be valid. |
+| Display token in `?token=` query | Rejected with `401`. Long-lived credentials must not appear in URLs. |
+| Access token | Accepted through the normal chain: `X-Profile-Id` is required and PIN-protected profiles need `X-Profile-Token`, as before. |
+| Refresh token or API key | `401` / normal API key handling; neither is a display credential. |
+
+`404 not_found` is returned when the delivery does not belong to the
+authenticated profile. The route is rate limited like other authenticated
+routes.

--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -356,6 +356,10 @@ type capabilityPush struct {
 	Available      bool     `json:"available"`
 	Provider       string   `json:"provider"`
 	SupportedModes []string `json:"supported_modes"`
+	// DisplayToken is true when Apple push registration returns a
+	// long-lived display token for the Notification Service extension.
+	// Additive; Android registration never carries one.
+	DisplayToken bool `json:"display_token,omitempty"`
 }
 
 type capabilityWebhooks struct {
@@ -420,6 +424,7 @@ func (h *NotificationsHandler) HandleCapability(w http.ResponseWriter, r *http.R
 				Available:      true,
 				Provider:       notifications.PushProviderSiloRelay,
 				SupportedModes: []string{notifications.PushModePrivatePush, notifications.PushModeInAppOnly},
+				DisplayToken:   h.displayTokens != nil,
 			}
 		}
 		if h.system.Settings.AndroidPushDeliveryEnabled(r.Context()) {

--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"time"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
 	evt "github.com/Silo-Server/silo-server/internal/events"
 	"github.com/Silo-Server/silo-server/internal/notifications"
 	"github.com/go-chi/chi/v5"
@@ -23,6 +25,26 @@ const (
 type NotificationsHandler struct {
 	system *notifications.System
 	hub    *evt.Hub
+	// displayTokens mints the long-lived display token returned from Apple
+	// push registration. Nil when JWT auth is not configured; registration
+	// then omits the token and the extension falls back to the access token.
+	displayTokens ApplePushDisplayTokenIssuer
+}
+
+// ApplePushDisplayTokenIssuer mints the profile-scoped token the iOS
+// Notification Service extension presents to the display endpoint.
+type ApplePushDisplayTokenIssuer interface {
+	GenerateApplePushDisplayToken(userID int, role, sessionID, profileID string) (string, time.Time, error)
+}
+
+// SetApplePushDisplayTokenIssuer wires the token issuer used by
+// HandleRegisterApplePushDevice. A nil *auth.JWTService is treated as unset.
+func (h *NotificationsHandler) SetApplePushDisplayTokenIssuer(issuer ApplePushDisplayTokenIssuer) {
+	if jwt, ok := issuer.(*auth.JWTService); ok && jwt == nil {
+		h.displayTokens = nil
+		return
+	}
+	h.displayTokens = issuer
 }
 
 // NewNotificationsHandler creates a NotificationsHandler.

--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -34,7 +34,7 @@ type NotificationsHandler struct {
 // ApplePushDisplayTokenIssuer mints the profile-scoped token the iOS
 // Notification Service extension presents to the display endpoint.
 type ApplePushDisplayTokenIssuer interface {
-	GenerateApplePushDisplayToken(userID int, role, sessionID, profileID string) (string, time.Time, error)
+	GenerateApplePushDisplayToken(userID int, role, sessionID, profileID string, impersonatorUserID *int) (string, time.Time, error)
 }
 
 // SetApplePushDisplayTokenIssuer wires the token issuer used by

--- a/internal/api/handlers/notifications_push_devices.go
+++ b/internal/api/handlers/notifications_push_devices.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/notifications"
@@ -23,6 +24,13 @@ type applePushRegisterResponse struct {
 	ServerDeviceID string `json:"server_device_id"`
 	Enabled        bool   `json:"enabled"`
 	PushMode       string `json:"push_mode"`
+	// DisplayToken is a long-lived, profile-scoped credential the iOS
+	// Notification Service extension presents to the display endpoint. The
+	// extension cannot refresh the short-lived access token, so without this
+	// every push arriving after access expiry rendered as generic text.
+	// Omitted when the server cannot mint one (no JWT auth or session).
+	DisplayToken          string `json:"display_token,omitempty"`
+	DisplayTokenExpiresAt string `json:"display_token_expires_at,omitempty"`
 }
 
 func (h *NotificationsHandler) pushDevices() *notifications.PushDeviceService {
@@ -67,12 +75,24 @@ func (h *NotificationsHandler) HandleRegisterApplePushDevice(w http.ResponseWrit
 		return
 	}
 
-	writeJSON(w, http.StatusOK, applePushRegisterResponse{
+	response := applePushRegisterResponse{
 		ID:             device.ID,
 		ServerDeviceID: device.ServerDeviceID,
 		Enabled:        device.Enabled,
 		PushMode:       device.PushMode,
-	})
+	}
+	if claims := apimw.GetClaims(r.Context()); claims != nil && h.displayTokens != nil && claims.SessionID != "" {
+		token, expiresAt, err := h.displayTokens.GenerateApplePushDisplayToken(
+			claims.UserID, claims.Role, claims.SessionID, apimw.GetProfileID(r.Context()),
+		)
+		if err == nil {
+			response.DisplayToken = token
+			response.DisplayTokenExpiresAt = expiresAt.UTC().Format(time.RFC3339)
+		}
+		// A minting failure is not a registration failure: the device is
+		// registered and the extension keeps its access-token fallback.
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 type pushDeviceRegisterRequest struct {
@@ -122,12 +142,24 @@ func (h *NotificationsHandler) HandleRegisterPushDevice(w http.ResponseWriter, r
 		return
 	}
 
-	writeJSON(w, http.StatusOK, applePushRegisterResponse{
+	response := applePushRegisterResponse{
 		ID:             device.ID,
 		ServerDeviceID: device.ServerDeviceID,
 		Enabled:        device.Enabled,
 		PushMode:       device.PushMode,
-	})
+	}
+	if claims := apimw.GetClaims(r.Context()); claims != nil && h.displayTokens != nil && claims.SessionID != "" {
+		token, expiresAt, err := h.displayTokens.GenerateApplePushDisplayToken(
+			claims.UserID, claims.Role, claims.SessionID, apimw.GetProfileID(r.Context()),
+		)
+		if err == nil {
+			response.DisplayToken = token
+			response.DisplayTokenExpiresAt = expiresAt.UTC().Format(time.RFC3339)
+		}
+		// A minting failure is not a registration failure: the device is
+		// registered and the extension keeps its access-token fallback.
+	}
+	writeJSON(w, http.StatusOK, response)
 }
 
 // HandleUnregisterPushDevice handles DELETE /notifications/push/devices/{device_id}.

--- a/internal/api/handlers/notifications_push_devices.go
+++ b/internal/api/handlers/notifications_push_devices.go
@@ -83,7 +83,7 @@ func (h *NotificationsHandler) HandleRegisterApplePushDevice(w http.ResponseWrit
 	}
 	if claims := apimw.GetClaims(r.Context()); claims != nil && h.displayTokens != nil && claims.SessionID != "" {
 		token, expiresAt, err := h.displayTokens.GenerateApplePushDisplayToken(
-			claims.UserID, claims.Role, claims.SessionID, apimw.GetProfileID(r.Context()),
+			claims.UserID, claims.Role, claims.SessionID, apimw.GetProfileID(r.Context()), claims.ImpersonatorUserID,
 		)
 		if err == nil {
 			response.DisplayToken = token

--- a/internal/api/handlers/notifications_push_devices.go
+++ b/internal/api/handlers/notifications_push_devices.go
@@ -142,24 +142,12 @@ func (h *NotificationsHandler) HandleRegisterPushDevice(w http.ResponseWriter, r
 		return
 	}
 
-	response := applePushRegisterResponse{
+	writeJSON(w, http.StatusOK, applePushRegisterResponse{
 		ID:             device.ID,
 		ServerDeviceID: device.ServerDeviceID,
 		Enabled:        device.Enabled,
 		PushMode:       device.PushMode,
-	}
-	if claims := apimw.GetClaims(r.Context()); claims != nil && h.displayTokens != nil && claims.SessionID != "" {
-		token, expiresAt, err := h.displayTokens.GenerateApplePushDisplayToken(
-			claims.UserID, claims.Role, claims.SessionID, apimw.GetProfileID(r.Context()),
-		)
-		if err == nil {
-			response.DisplayToken = token
-			response.DisplayTokenExpiresAt = expiresAt.UTC().Format(time.RFC3339)
-		}
-		// A minting failure is not a registration failure: the device is
-		// registered and the extension keeps its access-token fallback.
-	}
-	writeJSON(w, http.StatusOK, response)
+	})
 }
 
 // HandleUnregisterPushDevice handles DELETE /notifications/push/devices/{device_id}.

--- a/internal/api/handlers/notifications_push_devices_test.go
+++ b/internal/api/handlers/notifications_push_devices_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
@@ -74,7 +75,7 @@ func handlerPushCipher(t *testing.T) *secret.Cipher {
 
 func newApplePushRequest(body string) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/devices/push/apple", strings.NewReader(body))
-	ctx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 42, Role: "user", TokenType: auth.TokenTypeAccess})
+	ctx := apimw.SetClaims(req.Context(), &auth.Claims{UserID: 42, Role: "user", SessionID: "sess-1", TokenType: auth.TokenTypeAccess})
 	ctx = apimw.SetProfileID(ctx, "profile-1")
 	return req.WithContext(ctx)
 }
@@ -110,6 +111,65 @@ func TestHandleRegisterApplePushDevice(t *testing.T) {
 	}
 	if store.got.UserID != 42 || store.got.ProfileID != "profile-1" || store.got.DeviceID != "local-device" {
 		t.Fatalf("unexpected stored registration: %+v", store.got)
+	}
+	if response.DisplayToken != "" || response.DisplayTokenExpiresAt != "" {
+		t.Fatalf("display token must be omitted without an issuer: %+v", response)
+	}
+}
+
+func TestHandleRegisterApplePushDeviceMintsDisplayToken(t *testing.T) {
+	store := &handlerPushStore{}
+	handler := NewNotificationsHandler(&notifications.System{
+		PushDevices: notifications.NewPushDeviceService(store, handlerPushCipher(t)),
+	}, nil)
+	jwt := auth.NewJWTService("test-secret", 15*time.Minute, 7*24*time.Hour)
+	handler.SetApplePushDisplayTokenIssuer(jwt)
+
+	body := `{
+		"device_id":"local-device",
+		"apns_token":"` + strings.Repeat("a", 64) + `",
+		"apns_environment":"production",
+		"apns_topic":"org.siloserver.silo",
+		"push_mode":"private_push"
+	}`
+	rr := httptest.NewRecorder()
+	handler.HandleRegisterApplePushDevice(rr, newApplePushRequest(body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var response applePushRegisterResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.DisplayToken == "" {
+		t.Fatalf("expected display token: %+v", response)
+	}
+	claims, err := jwt.ValidateToken(response.DisplayToken)
+	if err != nil {
+		t.Fatalf("validate display token: %v", err)
+	}
+	if claims.TokenType != auth.TokenTypeApplePushDisplay || claims.UserID != 42 ||
+		claims.SessionID != "sess-1" || claims.ProfileID != "profile-1" {
+		t.Fatalf("claims = %+v", claims)
+	}
+	if _, err := time.Parse(time.RFC3339, response.DisplayTokenExpiresAt); err != nil {
+		t.Fatalf("display_token_expires_at = %q: %v", response.DisplayTokenExpiresAt, err)
+	}
+
+	// A typed-nil JWT service must behave as "no issuer", not panic.
+	var nilJWT *auth.JWTService
+	handler.SetApplePushDisplayTokenIssuer(nilJWT)
+	rr = httptest.NewRecorder()
+	handler.HandleRegisterApplePushDevice(rr, newApplePushRequest(body))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	response = applePushRegisterResponse{}
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.DisplayToken != "" {
+		t.Fatalf("display token should be omitted with nil issuer")
 	}
 }
 

--- a/internal/api/handlers/notifications_push_devices_test.go
+++ b/internal/api/handlers/notifications_push_devices_test.go
@@ -185,6 +185,9 @@ func TestHandleRegisterPushDeviceAndroid(t *testing.T) {
 	handler := NewNotificationsHandler(&notifications.System{
 		PushDevices: notifications.NewPushDeviceService(store, handlerPushCipher(t)),
 	}, nil)
+	// The Apple display token is Apple-only: Android registration must never
+	// receive one even when an issuer is configured.
+	handler.SetApplePushDisplayTokenIssuer(auth.NewJWTService("test-secret", 15*time.Minute, 7*24*time.Hour))
 
 	token := strings.Repeat("F", 140)
 	body := `{

--- a/internal/api/middleware/apple_push_display.go
+++ b/internal/api/middleware/apple_push_display.go
@@ -22,7 +22,7 @@ func (am *AuthMiddleware) RequireApplePushDisplayAuth(fallback func(http.Handler
 	return func(next http.Handler) http.Handler {
 		standard := fallback(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Header only. extractBearerToken also honours ?token= for media
+			// Header only. extractBearerToken also accepts ?token= for media
 			// elements, but a credential that lives as long as a refresh
 			// token must not end up in proxy and access logs via the URL.
 			token, ok := headerBearerToken(r)

--- a/internal/api/middleware/apple_push_display.go
+++ b/internal/api/middleware/apple_push_display.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Silo-Server/silo-server/internal/activitylog"
 	"github.com/Silo-Server/silo-server/internal/auth"
 )
 
@@ -55,6 +56,13 @@ func (am *AuthMiddleware) RequireApplePushDisplayAuth(
 			if err != nil || !valid {
 				writeUnauthorized(w, "Session is no longer valid")
 				return
+			}
+			// Same attribution RequireAuth performs, so display fetches are
+			// not anonymous in the activity and request logs.
+			if lc := activitylog.GetLogContext(r.Context()); lc != nil {
+				uid := claims.UserID
+				lc.UserID = &uid
+				lc.SessionID = claims.SessionID
 			}
 			ctx := SetClaims(r.Context(), claims)
 			ctx = SetProfileID(ctx, claims.ProfileID)

--- a/internal/api/middleware/apple_push_display.go
+++ b/internal/api/middleware/apple_push_display.go
@@ -11,16 +11,26 @@ import (
 // endpoint. It accepts the long-lived, profile-scoped display token minted at
 // Apple push registration; any other bearer credential is handed to
 // `fallback`, which should be the ordinary access-token chain (RequireAuth,
-// viewer access, RequireProfile) so normal sessions keep working unchanged.
+// rate limiting, viewer access, RequireProfile) so normal sessions keep
+// working unchanged. `afterAuth` runs on the display-token path once claims
+// are set, so the same rate limiter can sit after authentication on both
+// paths (it needs claims to apply per-key budgets). Pass nil to skip it.
 //
 // The display token path deliberately bypasses viewer-access PIN checks: the
 // token was issued to an already-verified profile session, carries that
 // profile in its claims, and only unlocks compact notification text. The
 // profile in the claims is authoritative; the X-Profile-Id header is ignored
 // so a token cannot be replayed against another profile's inbox.
-func (am *AuthMiddleware) RequireApplePushDisplayAuth(fallback func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+func (am *AuthMiddleware) RequireApplePushDisplayAuth(
+	fallback func(http.Handler) http.Handler,
+	afterAuth func(http.Handler) http.Handler,
+) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		standard := fallback(next)
+		display := next
+		if afterAuth != nil {
+			display = afterAuth(next)
+		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Header only. extractBearerToken also accepts ?token= for media
 			// elements, but a credential that lives as long as a refresh
@@ -48,7 +58,7 @@ func (am *AuthMiddleware) RequireApplePushDisplayAuth(fallback func(http.Handler
 			}
 			ctx := SetClaims(r.Context(), claims)
 			ctx = SetProfileID(ctx, claims.ProfileID)
-			next.ServeHTTP(w, r.WithContext(ctx))
+			display.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/internal/api/middleware/apple_push_display.go
+++ b/internal/api/middleware/apple_push_display.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+// RequireApplePushDisplayAuth authenticates the Apple notification display
+// endpoint. It accepts the long-lived, profile-scoped display token minted at
+// Apple push registration; any other bearer credential is handed to
+// `fallback`, which should be the ordinary access-token chain (RequireAuth,
+// viewer access, RequireProfile) so normal sessions keep working unchanged.
+//
+// The display token path deliberately bypasses viewer-access PIN checks: the
+// token was issued to an already-verified profile session, carries that
+// profile in its claims, and only unlocks compact notification text. The
+// profile in the claims is authoritative; the X-Profile-Id header is ignored
+// so a token cannot be replayed against another profile's inbox.
+func (am *AuthMiddleware) RequireApplePushDisplayAuth(fallback func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		standard := fallback(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token, ok := extractBearerToken(r)
+			if !ok || strings.HasPrefix(token, "sa_") {
+				standard.ServeHTTP(w, r)
+				return
+			}
+			claims, err := am.tokenValidator.ValidateToken(token)
+			if err != nil || claims.TokenType != auth.TokenTypeApplePushDisplay {
+				// Not a display token (or an expired one): let the standard
+				// chain produce its usual 401 or succeed on an access token.
+				standard.ServeHTTP(w, r)
+				return
+			}
+			if claims.ProfileID == "" {
+				writeUnauthorized(w, "Invalid or expired token")
+				return
+			}
+			valid, err := am.checkSession(r.Context(), claims.SessionID)
+			if err != nil || !valid {
+				writeUnauthorized(w, "Session is no longer valid")
+				return
+			}
+			ctx := SetClaims(r.Context(), claims)
+			ctx = SetProfileID(ctx, claims.ProfileID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/api/middleware/apple_push_display.go
+++ b/internal/api/middleware/apple_push_display.go
@@ -12,16 +12,16 @@ import (
 // endpoint. It accepts the long-lived, profile-scoped display token minted at
 // Apple push registration; any other bearer credential is handed to
 // `fallback`, which should be the ordinary access-token chain (RequireAuth,
-// rate limiting, viewer access, RequireProfile) so normal sessions keep
-// working unchanged. `afterAuth` runs on the display-token path once claims
-// are set, so the same rate limiter can sit after authentication on both
-// paths (it needs claims to apply per-key budgets). Pass nil to skip it.
+// viewer access, RequireProfile) so normal sessions keep working unchanged.
 //
-// The display token path deliberately bypasses viewer-access PIN checks: the
-// token was issued to an already-verified profile session, carries that
-// profile in its claims, and only unlocks compact notification text. The
-// profile in the claims is authoritative; the X-Profile-Id header is ignored
-// so a token cannot be replayed against another profile's inbox.
+// On the display-token path the middleware validates the token and its
+// login session, sets the claims, and rewrites X-Profile-Id to the profile
+// in the claims before running `afterAuth`. That should be the same viewer
+// access + RequireProfile chain as the fallback: viewer access re-checks the
+// profile still exists and belongs to the user (a deleted profile's token
+// must stop working) while skipping the PIN proof, which the token already
+// represents. The header rewrite means a token cannot be replayed against
+// another profile's inbox.
 func (am *AuthMiddleware) RequireApplePushDisplayAuth(
 	fallback func(http.Handler) http.Handler,
 	afterAuth func(http.Handler) http.Handler,
@@ -67,7 +67,10 @@ func (am *AuthMiddleware) RequireApplePushDisplayAuth(
 			}
 			ctx := SetClaims(r.Context(), claims)
 			ctx = SetProfileID(ctx, claims.ProfileID)
-			display.ServeHTTP(w, r.WithContext(ctx))
+			r = r.WithContext(ctx)
+			r.Header.Set("X-Profile-Id", claims.ProfileID)
+			r.Header.Del("X-Profile-Token")
+			display.ServeHTTP(w, r)
 		})
 	}
 }

--- a/internal/api/middleware/apple_push_display.go
+++ b/internal/api/middleware/apple_push_display.go
@@ -62,6 +62,7 @@ func (am *AuthMiddleware) RequireApplePushDisplayAuth(
 			if lc := activitylog.GetLogContext(r.Context()); lc != nil {
 				uid := claims.UserID
 				lc.UserID = &uid
+				lc.ImpersonatorUserID = claims.ImpersonatorUserID
 				lc.SessionID = claims.SessionID
 			}
 			ctx := SetClaims(r.Context(), claims)

--- a/internal/api/middleware/apple_push_display.go
+++ b/internal/api/middleware/apple_push_display.go
@@ -22,7 +22,10 @@ func (am *AuthMiddleware) RequireApplePushDisplayAuth(fallback func(http.Handler
 	return func(next http.Handler) http.Handler {
 		standard := fallback(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			token, ok := extractBearerToken(r)
+			// Header only. extractBearerToken also honours ?token= for media
+			// elements, but a credential that lives as long as a refresh
+			// token must not end up in proxy and access logs via the URL.
+			token, ok := headerBearerToken(r)
 			if !ok || strings.HasPrefix(token, "sa_") {
 				standard.ServeHTTP(w, r)
 				return
@@ -48,4 +51,15 @@ func (am *AuthMiddleware) RequireApplePushDisplayAuth(fallback func(http.Handler
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// headerBearerToken reads only the Authorization header, ignoring the
+// ?token= query fallback that extractBearerToken allows.
+func headerBearerToken(r *http.Request) (string, bool) {
+	parts := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "bearer") {
+		return "", false
+	}
+	token := strings.TrimSpace(parts[1])
+	return token, token != ""
 }

--- a/internal/api/middleware/apple_push_display_test.go
+++ b/internal/api/middleware/apple_push_display_test.go
@@ -24,8 +24,19 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 
 	var gotProfile string
 	var gotClaims *auth.Claims
-	fallback := func(next http.Handler) http.Handler { return am.RequireAuth(RequireProfile(next)) }
-	handler := am.RequireApplePushDisplayAuth(fallback)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// afterAuth stands in for the rate limiter: it must observe claims on
+	// both the display-token path and the access-token fallback.
+	var afterAuthSawClaims int
+	afterAuth := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if GetClaims(r.Context()) != nil {
+				afterAuthSawClaims++
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+	fallback := func(next http.Handler) http.Handler { return am.RequireAuth(afterAuth(RequireProfile(next))) }
+	handler := am.RequireApplePushDisplayAuth(fallback, afterAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotProfile = GetProfileID(r.Context())
 		gotClaims = GetClaims(r.Context())
 		w.WriteHeader(http.StatusNoContent)
@@ -66,7 +77,7 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotProfile, gotClaims = "", nil
+			gotProfile, gotClaims, afterAuthSawClaims = "", nil, 0
 			target := "/api/v1/notifications/push/apple/display/d1"
 			if strings.HasPrefix(tt.token, "?") {
 				target += "?token=" + strings.TrimPrefix(tt.token, "?")
@@ -88,6 +99,9 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 			}
 			if tt.wantStatus == http.StatusNoContent && (gotClaims == nil || gotClaims.UserID != 42) {
 				t.Fatalf("claims = %+v", gotClaims)
+			}
+			if tt.wantStatus == http.StatusNoContent && afterAuthSawClaims != 1 {
+				t.Fatalf("afterAuth saw claims %d times, want exactly 1", afterAuthSawClaims)
 			}
 		})
 	}

--- a/internal/api/middleware/apple_push_display_test.go
+++ b/internal/api/middleware/apple_push_display_test.go
@@ -1,0 +1,88 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/auth"
+)
+
+type fakeSessionValidator struct{ valid map[string]bool }
+
+func (f *fakeSessionValidator) IsValid(_ context.Context, id string) (bool, error) {
+	return f.valid[id], nil
+}
+
+func TestRequireApplePushDisplayAuth(t *testing.T) {
+	jwt := auth.NewJWTService("test-secret", 15*time.Minute, 7*24*time.Hour)
+	sessions := &fakeSessionValidator{valid: map[string]bool{"sess-live": true}}
+	am := NewAuthMiddleware(jwt, sessions, nil, nil)
+
+	var gotProfile string
+	var gotClaims *auth.Claims
+	fallback := func(next http.Handler) http.Handler { return am.RequireAuth(RequireProfile(next)) }
+	handler := am.RequireApplePushDisplayAuth(fallback)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotProfile = GetProfileID(r.Context())
+		gotClaims = GetClaims(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	display, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-live", "profile-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	revoked, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-dead", "profile-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	access, err := jwt.GenerateAccessToken(42, "user", "sess-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	refresh, err := jwt.GenerateRefreshToken(42, "user", "sess-live")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		token       string
+		profileHdr  string
+		wantStatus  int
+		wantProfile string
+	}{
+		{"display token binds profile from claims", display, "profile-other", http.StatusNoContent, "profile-1"},
+		{"display token with revoked session", revoked, "", http.StatusUnauthorized, ""},
+		{"access token still works through fallback chain", access, "profile-2", http.StatusNoContent, "profile-2"},
+		{"access token without profile header hits fallback 400", access, "", http.StatusBadRequest, ""},
+		{"refresh token rejected", refresh, "", http.StatusUnauthorized, ""},
+		{"missing token", "", "", http.StatusUnauthorized, ""},
+		{"garbage token", "not-a-jwt", "", http.StatusUnauthorized, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProfile, gotClaims = "", nil
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications/push/apple/display/d1", nil)
+			if tt.token != "" {
+				req.Header.Set("Authorization", "Bearer "+tt.token)
+			}
+			if tt.profileHdr != "" {
+				req.Header.Set("X-Profile-Id", tt.profileHdr)
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body %s)", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+			if gotProfile != tt.wantProfile {
+				t.Fatalf("profile = %q, want %q", gotProfile, tt.wantProfile)
+			}
+			if tt.wantStatus == http.StatusNoContent && (gotClaims == nil || gotClaims.UserID != 42) {
+				t.Fatalf("claims = %+v", gotClaims)
+			}
+		})
+	}
+}

--- a/internal/api/middleware/apple_push_display_test.go
+++ b/internal/api/middleware/apple_push_display_test.go
@@ -49,11 +49,12 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 		inner.ServeHTTP(w, r.WithContext(activitylog.SetLogContext(r.Context(), lastLog)))
 	})
 
-	display, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-live", "profile-1")
+	admin := 7
+	display, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-live", "profile-1", &admin)
 	if err != nil {
 		t.Fatal(err)
 	}
-	revoked, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-dead", "profile-1")
+	revoked, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-dead", "profile-1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,6 +113,9 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 			}
 			if tt.wantStatus == http.StatusNoContent && (lastLog.UserID == nil || *lastLog.UserID != 42 || lastLog.SessionID != "sess-live") {
 				t.Fatalf("activity log context not attributed: %+v", lastLog)
+			}
+			if tt.token == display && (lastLog.ImpersonatorUserID == nil || *lastLog.ImpersonatorUserID != 7) {
+				t.Fatalf("impersonator not carried through display token: %+v", lastLog)
 			}
 		})
 	}

--- a/internal/api/middleware/apple_push_display_test.go
+++ b/internal/api/middleware/apple_push_display_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/activitylog"
 	"github.com/Silo-Server/silo-server/internal/auth"
 )
@@ -37,8 +38,17 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 			next.ServeHTTP(w, r)
 		})
 	}
-	fallback := func(next http.Handler) http.Handler { return am.RequireAuth(afterAuth(RequireProfile(next))) }
-	inner := am.RequireApplePushDisplayAuth(fallback, afterAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Viewer access on both paths: the display token skips the PIN proof but
+	// the profile must still resolve as owned by the user.
+	viewer := NewViewerAccessMiddleware(&fakeViewerResolver{
+		profiles: map[string]int{"profile-1": 42, "profile-2": 42, "profile-pin": 42},
+		pinned:   map[string]bool{"profile-pin": true},
+	})
+	postAuth := func(next http.Handler) http.Handler {
+		return afterAuth(viewer.RequireViewerAccess(RequireProfile(next)))
+	}
+	fallback := func(next http.Handler) http.Handler { return am.RequireAuth(postAuth(next)) }
+	inner := am.RequireApplePushDisplayAuth(fallback, postAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotProfile = GetProfileID(r.Context())
 		gotClaims = GetClaims(r.Context())
 		w.WriteHeader(http.StatusNoContent)
@@ -55,6 +65,14 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	revoked, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-dead", "profile-1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deletedProfile, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-live", "profile-gone", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pinnedProfile, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-live", "profile-pin", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,6 +94,9 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 	}{
 		{"display token binds profile from claims", display, "profile-other", http.StatusNoContent, "profile-1"},
 		{"display token with revoked session", revoked, "", http.StatusUnauthorized, ""},
+		{"display token for a deleted profile", deletedProfile, "", http.StatusNotFound, ""},
+		{"display token skips the PIN proof", pinnedProfile, "", http.StatusNoContent, "profile-pin"},
+		{"access token for a PIN profile still needs proof", access, "profile-pin", http.StatusForbidden, ""},
 		{"access token still works through fallback chain", access, "profile-2", http.StatusNoContent, "profile-2"},
 		{"access token without profile header hits fallback 400", access, "", http.StatusBadRequest, ""},
 		{"refresh token rejected", refresh, "", http.StatusUnauthorized, ""},
@@ -119,4 +140,25 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeViewerResolver approximates access.Resolver: unknown profiles are not
+// found, PIN-protected profiles need SkipPINVerification or a profile token.
+type fakeViewerResolver struct {
+	profiles map[string]int
+	pinned   map[string]bool
+}
+
+func (f *fakeViewerResolver) Resolve(_ context.Context, in access.ResolveInput) (access.Scope, error) {
+	if in.ProfileID == "" {
+		return access.Scope{UserID: in.UserID}, nil
+	}
+	owner, ok := f.profiles[in.ProfileID]
+	if !ok || owner != in.UserID {
+		return access.Scope{}, access.ErrProfileNotFound
+	}
+	if f.pinned[in.ProfileID] && !in.SkipPINVerification && in.ProfileToken == "" {
+		return access.Scope{}, access.ErrProfileUnverified
+	}
+	return access.Scope{UserID: in.UserID, ProfileID: in.ProfileID}, nil
 }

--- a/internal/api/middleware/apple_push_display_test.go
+++ b/internal/api/middleware/apple_push_display_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Silo-Server/silo-server/internal/activitylog"
 	"github.com/Silo-Server/silo-server/internal/auth"
 )
 
@@ -19,6 +20,7 @@ func (f *fakeSessionValidator) IsValid(_ context.Context, id string) (bool, erro
 
 func TestRequireApplePushDisplayAuth(t *testing.T) {
 	jwt := auth.NewJWTService("test-secret", 15*time.Minute, 7*24*time.Hour)
+	var lastLog *activitylog.LogContext
 	sessions := &fakeSessionValidator{valid: map[string]bool{"sess-live": true}}
 	am := NewAuthMiddleware(jwt, sessions, nil, nil)
 
@@ -36,11 +38,16 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 		})
 	}
 	fallback := func(next http.Handler) http.Handler { return am.RequireAuth(afterAuth(RequireProfile(next))) }
-	handler := am.RequireApplePushDisplayAuth(fallback, afterAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	inner := am.RequireApplePushDisplayAuth(fallback, afterAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotProfile = GetProfileID(r.Context())
 		gotClaims = GetClaims(r.Context())
 		w.WriteHeader(http.StatusNoContent)
 	}))
+	// Stand in for the activitylog middleware so attribution can be checked.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastLog = &activitylog.LogContext{}
+		inner.ServeHTTP(w, r.WithContext(activitylog.SetLogContext(r.Context(), lastLog)))
+	})
 
 	display, _, err := jwt.GenerateApplePushDisplayToken(42, "user", "sess-live", "profile-1")
 	if err != nil {
@@ -102,6 +109,9 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 			}
 			if tt.wantStatus == http.StatusNoContent && afterAuthSawClaims != 1 {
 				t.Fatalf("afterAuth saw claims %d times, want exactly 1", afterAuthSawClaims)
+			}
+			if tt.wantStatus == http.StatusNoContent && (lastLog.UserID == nil || *lastLog.UserID != 42 || lastLog.SessionID != "sess-live") {
+				t.Fatalf("activity log context not attributed: %+v", lastLog)
 			}
 		})
 	}

--- a/internal/api/middleware/apple_push_display_test.go
+++ b/internal/api/middleware/apple_push_display_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -60,13 +61,18 @@ func TestRequireApplePushDisplayAuth(t *testing.T) {
 		{"access token without profile header hits fallback 400", access, "", http.StatusBadRequest, ""},
 		{"refresh token rejected", refresh, "", http.StatusUnauthorized, ""},
 		{"missing token", "", "", http.StatusUnauthorized, ""},
+		{"display token in query string is rejected", "?" + display, "", http.StatusUnauthorized, ""},
 		{"garbage token", "not-a-jwt", "", http.StatusUnauthorized, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotProfile, gotClaims = "", nil
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/notifications/push/apple/display/d1", nil)
-			if tt.token != "" {
+			target := "/api/v1/notifications/push/apple/display/d1"
+			if strings.HasPrefix(tt.token, "?") {
+				target += "?token=" + strings.TrimPrefix(tt.token, "?")
+			}
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			if tt.token != "" && !strings.HasPrefix(tt.token, "?") {
 				req.Header.Set("Authorization", "Bearer "+tt.token)
 			}
 			if tt.profileHdr != "" {

--- a/internal/api/middleware/viewer_access.go
+++ b/internal/api/middleware/viewer_access.go
@@ -36,11 +36,16 @@ func (m *ViewerAccessMiddleware) RequireViewerAccess(next http.Handler) http.Han
 
 		profileID := r.Header.Get("X-Profile-Id")
 		input := access.ResolveInput{
-			UserID:              claims.UserID,
-			SessionID:           claims.SessionID,
-			ProfileID:           profileID,
-			ProfileToken:        r.Header.Get("X-Profile-Token"),
-			SkipPINVerification: claims.TokenType == auth.TokenTypeAPIKey,
+			UserID:       claims.UserID,
+			SessionID:    claims.SessionID,
+			ProfileID:    profileID,
+			ProfileToken: r.Header.Get("X-Profile-Token"),
+			// API keys have no PIN proof by design. A display token was
+			// issued to an already verified profile session and carries the
+			// profile in its claims; the profile still has to exist and be
+			// owned by the user, which Resolve checks.
+			SkipPINVerification: claims.TokenType == auth.TokenTypeAPIKey ||
+				claims.TokenType == auth.TokenTypeApplePushDisplay,
 		}
 
 		scope, err := m.resolver.Resolve(r.Context(), input)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2147,7 +2147,15 @@ func NewRouter(deps Dependencies) chi.Router {
 				}
 				return authMiddleware.RequireAuth(chain)
 			}
-			r.With(authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth)).Get(
+			displayMiddlewares := []func(http.Handler) http.Handler{
+				authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth),
+			}
+			if deps.RateLimitMW != nil {
+				// Same limiter the authenticated group applies; the route
+				// only left that group to accept the display token type.
+				displayMiddlewares = append(displayMiddlewares, deps.RateLimitMW.Handler)
+			}
+			r.With(displayMiddlewares...).Get(
 				"/notifications/push/apple/display/{delivery_id}",
 				handlers.NewNotificationsHandler(deps.Notifications, deps.EventsHub).HandleApplePushDisplay,
 			)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2140,22 +2140,25 @@ func NewRouter(deps Dependencies) chi.Router {
 		// display token is not an access token; RequireApplePushDisplayAuth
 		// still validates the session and binds the profile from the claims.
 		if authMiddleware != nil && deps.Notifications != nil {
+			// Same order as the authenticated group: auth, then the limiter
+			// (it needs claims for per-API-key budgets), then viewer access
+			// so rejected profile or PIN resolutions still consume budget.
+			// The route only left that group to accept the display token.
+			var limiter func(http.Handler) http.Handler
+			if deps.RateLimitMW != nil {
+				limiter = deps.RateLimitMW.Handler
+			}
 			standardDisplayAuth := func(next http.Handler) http.Handler {
 				chain := apimw.RequireProfile(next)
 				if viewerAccessMiddleware != nil {
 					chain = viewerAccessMiddleware.RequireViewerAccess(chain)
 				}
+				if limiter != nil {
+					chain = limiter(chain)
+				}
 				return authMiddleware.RequireAuth(chain)
 			}
-			// Limiter first, as in the authenticated group, so rejected
-			// profile or PIN resolutions still consume budget. The route
-			// only left that group to accept the display token type.
-			var displayMiddlewares []func(http.Handler) http.Handler
-			if deps.RateLimitMW != nil {
-				displayMiddlewares = append(displayMiddlewares, deps.RateLimitMW.Handler)
-			}
-			displayMiddlewares = append(displayMiddlewares, authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth))
-			r.With(displayMiddlewares...).Get(
+			r.With(authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth, limiter)).Get(
 				"/notifications/push/apple/display/{delivery_id}",
 				handlers.NewNotificationsHandler(deps.Notifications, deps.EventsHub).HandleApplePushDisplay,
 			)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2140,15 +2140,19 @@ func NewRouter(deps Dependencies) chi.Router {
 		// display token is not an access token; RequireApplePushDisplayAuth
 		// still validates the session and binds the profile from the claims.
 		if authMiddleware != nil && deps.Notifications != nil {
-			// Same order as the authenticated group: auth, then the limiter
-			// (it needs claims for per-API-key budgets), then viewer access
-			// so rejected profile or PIN resolutions still consume budget.
-			// The route only left that group to accept the display token.
+			// The route only left the authenticated group to accept the
+			// display token. Both credential paths share the same
+			// post-auth chain: the limiter (per-API-key budgets need
+			// claims), then viewer access so a deleted or foreign profile
+			// is rejected and rejected resolutions still consume budget.
+			// The limiter also runs once before auth: a display token lives
+			// as long as a refresh token, so its session lookup must not be
+			// reachable outside the global and per-IP budgets.
 			var limiter func(http.Handler) http.Handler
 			if deps.RateLimitMW != nil {
 				limiter = deps.RateLimitMW.Handler
 			}
-			standardDisplayAuth := func(next http.Handler) http.Handler {
+			postAuth := func(next http.Handler) http.Handler {
 				chain := apimw.RequireProfile(next)
 				if viewerAccessMiddleware != nil {
 					chain = viewerAccessMiddleware.RequireViewerAccess(chain)
@@ -2156,9 +2160,18 @@ func NewRouter(deps Dependencies) chi.Router {
 				if limiter != nil {
 					chain = limiter(chain)
 				}
-				return authMiddleware.RequireAuth(chain)
+				return chain
 			}
-			r.With(authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth, limiter)).Get(
+			standardDisplayAuth := func(next http.Handler) http.Handler {
+				return authMiddleware.RequireAuth(postAuth(next))
+			}
+			displayMiddlewares := []func(http.Handler) http.Handler{}
+			if limiter != nil {
+				displayMiddlewares = append(displayMiddlewares, limiter)
+			}
+			displayMiddlewares = append(displayMiddlewares,
+				authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth, postAuth))
+			r.With(displayMiddlewares...).Get(
 				"/notifications/push/apple/display/{delivery_id}",
 				handlers.NewNotificationsHandler(deps.Notifications, deps.EventsHub).HandleApplePushDisplay,
 			)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2134,6 +2134,25 @@ func NewRouter(deps Dependencies) chi.Router {
 			})
 		}
 
+		// Apple notification display metadata: authenticated by either the
+		// normal access token or the long-lived display token minted at Apple
+		// push registration. Sits outside the RequireAuth group because the
+		// display token is not an access token; RequireApplePushDisplayAuth
+		// still validates the session and binds the profile from the claims.
+		if authMiddleware != nil && deps.Notifications != nil {
+			standardDisplayAuth := func(next http.Handler) http.Handler {
+				chain := apimw.RequireProfile(next)
+				if viewerAccessMiddleware != nil {
+					chain = viewerAccessMiddleware.RequireViewerAccess(chain)
+				}
+				return authMiddleware.RequireAuth(chain)
+			}
+			r.With(authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth)).Get(
+				"/notifications/push/apple/display/{delivery_id}",
+				handlers.NewNotificationsHandler(deps.Notifications, deps.EventsHub).HandleApplePushDisplay,
+			)
+		}
+
 		// All remaining routes require auth.
 		if authMiddleware != nil {
 			r.Group(func(r chi.Router) {
@@ -2178,6 +2197,7 @@ func NewRouter(deps Dependencies) chi.Router {
 						deps.Notifications.SetImageResolver(detailSvc)
 					}
 					notificationsHandler := handlers.NewNotificationsHandler(deps.Notifications, deps.EventsHub)
+					notificationsHandler.SetApplePushDisplayTokenIssuer(jwtService)
 					r.With(apimw.RequireProfile).Post("/events/ws-ticket", notificationsHandler.HandleMintWSTicket)
 					r.With(apimw.RequireProfile).Post("/devices/push/apple", notificationsHandler.HandleRegisterApplePushDevice)
 					// Discord DM channel: the linked identity and mode hang off
@@ -2198,7 +2218,6 @@ func NewRouter(deps Dependencies) chi.Router {
 						r.Get("/capability", notificationsHandler.HandleCapability)
 						r.Get("/preferences", notificationsHandler.HandleGetPreferences)
 						r.Put("/preferences", notificationsHandler.HandleUpdatePreferences)
-						r.Get("/push/apple/display/{delivery_id}", notificationsHandler.HandleApplePushDisplay)
 						// Platform-generic registration used by the Android
 						// client; Apple keeps its dedicated route above.
 						r.Post("/push/devices", notificationsHandler.HandleRegisterPushDevice)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2147,14 +2147,14 @@ func NewRouter(deps Dependencies) chi.Router {
 				}
 				return authMiddleware.RequireAuth(chain)
 			}
-			displayMiddlewares := []func(http.Handler) http.Handler{
-				authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth),
-			}
+			// Limiter first, as in the authenticated group, so rejected
+			// profile or PIN resolutions still consume budget. The route
+			// only left that group to accept the display token type.
+			var displayMiddlewares []func(http.Handler) http.Handler
 			if deps.RateLimitMW != nil {
-				// Same limiter the authenticated group applies; the route
-				// only left that group to accept the display token type.
 				displayMiddlewares = append(displayMiddlewares, deps.RateLimitMW.Handler)
 			}
+			displayMiddlewares = append(displayMiddlewares, authMiddleware.RequireApplePushDisplayAuth(standardDisplayAuth))
 			r.With(displayMiddlewares...).Get(
 				"/notifications/push/apple/display/{delivery_id}",
 				handlers.NewNotificationsHandler(deps.Notifications, deps.EventsHub).HandleApplePushDisplay,

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -37,6 +37,12 @@ const (
 	TokenTypeRefresh      = "refresh"
 	TokenTypeAPIKey       = "api_key"
 	TokenTypePluginAccess = "plugin_access"
+	// TokenTypeApplePushDisplay is a long-lived, profile-scoped credential
+	// issued at Apple push registration. It is only accepted by the
+	// notification display endpoint the iOS Notification Service extension
+	// calls, so an expired short-lived access token no longer degrades every
+	// push to generic text.
+	TokenTypeApplePushDisplay = "apple_push_display"
 )
 
 const PluginAccessCookieName = "silo_plugin_access"
@@ -107,6 +113,35 @@ func (j *JWTService) GeneratePluginAccessToken(
 		SessionID: sessionID,
 		ProfileID: profileID,
 	}, TokenTypePluginAccess, ttl)
+}
+
+// GenerateApplePushDisplayToken creates a signed token scoped to one
+// profile that the notification display endpoint accepts. Its lifetime
+// follows the refresh token: the session must still be valid at use time,
+// so revoking the session revokes the display token too.
+func (j *JWTService) GenerateApplePushDisplayToken(
+	userID int, role, sessionID, profileID string,
+) (string, time.Time, error) {
+	if sessionID == "" {
+		return "", time.Time{}, fmt.Errorf("%w: session is required", ErrInvalidToken)
+	}
+	if profileID == "" {
+		return "", time.Time{}, fmt.Errorf("%w: profile is required", ErrInvalidToken)
+	}
+	ttl := j.RefreshExpiry()
+	if ttl <= 0 {
+		ttl = 30 * 24 * time.Hour
+	}
+	token, err := j.generateToken(Claims{
+		UserID:    userID,
+		Role:      role,
+		SessionID: sessionID,
+		ProfileID: profileID,
+	}, TokenTypeApplePushDisplay, ttl)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return token, time.Now().Add(ttl), nil
 }
 
 func (j *JWTService) generateAccessToken(claims Claims) (string, error) {

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -119,8 +119,10 @@ func (j *JWTService) GeneratePluginAccessToken(
 // profile that the notification display endpoint accepts. Its lifetime
 // follows the refresh token: the session must still be valid at use time,
 // so revoking the session revokes the display token too.
+// impersonatorUserID is carried so display fetches made under an
+// impersonated session stay attributed to the acting admin.
 func (j *JWTService) GenerateApplePushDisplayToken(
-	userID int, role, sessionID, profileID string,
+	userID int, role, sessionID, profileID string, impersonatorUserID *int,
 ) (string, time.Time, error) {
 	if sessionID == "" {
 		return "", time.Time{}, fmt.Errorf("%w: session is required", ErrInvalidToken)
@@ -133,10 +135,11 @@ func (j *JWTService) GenerateApplePushDisplayToken(
 		ttl = 30 * 24 * time.Hour
 	}
 	token, err := j.generateToken(Claims{
-		UserID:    userID,
-		Role:      role,
-		SessionID: sessionID,
-		ProfileID: profileID,
+		UserID:             userID,
+		Role:               role,
+		SessionID:          sessionID,
+		ProfileID:          profileID,
+		ImpersonatorUserID: impersonatorUserID,
 	}, TokenTypeApplePushDisplay, ttl)
 	if err != nil {
 		return "", time.Time{}, err

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -291,3 +291,32 @@ func TestJWT_DifferentUsersGetDifferentTokens(t *testing.T) {
 		t.Error("tokens for different users should be different")
 	}
 }
+
+func TestJWT_ApplePushDisplayTokenIsProfileScopedAndLongLived(t *testing.T) {
+	svc := newTestJWTService()
+
+	token, expiresAt, err := svc.GenerateApplePushDisplayToken(42, "user", "sess-1", "profile-1")
+	if err != nil {
+		t.Fatalf("GenerateApplePushDisplayToken() error: %v", err)
+	}
+	claims, err := svc.ValidateToken(token)
+	if err != nil {
+		t.Fatalf("ValidateToken() error: %v", err)
+	}
+	if claims.TokenType != auth.TokenTypeApplePushDisplay {
+		t.Fatalf("token_type = %q, want %q", claims.TokenType, auth.TokenTypeApplePushDisplay)
+	}
+	if claims.UserID != 42 || claims.SessionID != "sess-1" || claims.ProfileID != "profile-1" {
+		t.Fatalf("claims = %+v", claims)
+	}
+	// Follows the refresh expiry (7d in the test service), not the 15m access expiry.
+	if remaining := time.Until(expiresAt); remaining < 6*24*time.Hour {
+		t.Fatalf("expiry too short: %v", remaining)
+	}
+	if _, _, err := svc.GenerateApplePushDisplayToken(42, "user", "", "profile-1"); err == nil {
+		t.Fatal("expected error without session")
+	}
+	if _, _, err := svc.GenerateApplePushDisplayToken(42, "user", "sess-1", ""); err == nil {
+		t.Fatal("expected error without profile")
+	}
+}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -295,7 +295,8 @@ func TestJWT_DifferentUsersGetDifferentTokens(t *testing.T) {
 func TestJWT_ApplePushDisplayTokenIsProfileScopedAndLongLived(t *testing.T) {
 	svc := newTestJWTService()
 
-	token, expiresAt, err := svc.GenerateApplePushDisplayToken(42, "user", "sess-1", "profile-1")
+	admin := 7
+	token, expiresAt, err := svc.GenerateApplePushDisplayToken(42, "user", "sess-1", "profile-1", &admin)
 	if err != nil {
 		t.Fatalf("GenerateApplePushDisplayToken() error: %v", err)
 	}
@@ -306,17 +307,18 @@ func TestJWT_ApplePushDisplayTokenIsProfileScopedAndLongLived(t *testing.T) {
 	if claims.TokenType != auth.TokenTypeApplePushDisplay {
 		t.Fatalf("token_type = %q, want %q", claims.TokenType, auth.TokenTypeApplePushDisplay)
 	}
-	if claims.UserID != 42 || claims.SessionID != "sess-1" || claims.ProfileID != "profile-1" {
+	if claims.UserID != 42 || claims.SessionID != "sess-1" || claims.ProfileID != "profile-1" ||
+		claims.ImpersonatorUserID == nil || *claims.ImpersonatorUserID != 7 {
 		t.Fatalf("claims = %+v", claims)
 	}
 	// Follows the refresh expiry (7d in the test service), not the 15m access expiry.
 	if remaining := time.Until(expiresAt); remaining < 6*24*time.Hour {
 		t.Fatalf("expiry too short: %v", remaining)
 	}
-	if _, _, err := svc.GenerateApplePushDisplayToken(42, "user", "", "profile-1"); err == nil {
+	if _, _, err := svc.GenerateApplePushDisplayToken(42, "user", "", "profile-1", nil); err == nil {
 		t.Fatal("expected error without session")
 	}
-	if _, _, err := svc.GenerateApplePushDisplayToken(42, "user", "sess-1", ""); err == nil {
+	if _, _, err := svc.GenerateApplePushDisplayToken(42, "user", "sess-1", "", nil); err == nil {
 		t.Fatal("expected error without profile")
 	}
 }


### PR DESCRIPTION
## Problem

iOS notifications from production show the generic "New notification available" body instead of the episode text. Push delivery itself is fine: every Apple push in the last 3 days was accepted by the relay.

The Notification Service extension fetches the text from `GET /api/v1/notifications/push/apple/display/{delivery_id}` using the app's mirrored access token. The extension cannot refresh that token, and access tokens expire after 8 hours by default. Most pushes arrive while the phone is idle, so the fetch returns 401 and the extension keeps the generic fallback. Production logs for the 01:52 UTC batch on 2026-09-04 show 3 of 4 display fetches returning 401, followed by the main app itself refreshing on a 401.

## Solution

- Add a new token type, `apple_push_display`, minted by `JWTService.GenerateApplePushDisplayToken`. It is scoped to one user, session, and profile, and its lifetime follows the refresh-token expiry.
- `POST /api/v1/devices/push/apple` now returns `display_token` and `display_token_expires_at` alongside the existing fields. Both are omitted when JWT auth is not configured, so older clients and tests are unaffected.
- The display route moves out of the `RequireAuth` group and is guarded by `RequireApplePushDisplayAuth`. A display token is validated, its session checked for revocation, and `X-Profile-Id` rewritten to the profile in its claims. Both credential paths then run the same rate limiter, viewer access, and `RequireProfile` chain, so a deleted or foreign profile is rejected. Viewer access skips only the PIN proof for this token type. The limiter also runs once before authentication so a replayed token's session lookup is budgeted.
- Refresh tokens and API keys are not accepted as display tokens.
- `GET /api/v1/notifications/capability` reports `apple_push.display_token: true` when the server can mint one, so clients can discover support without registering. Android registration never returns the token.
- The relocated route keeps the same `RateLimitMW.Handler` the authenticated group applies, ahead of auth so rejected profile resolutions still consume budget.
- Display-token requests are attributed in the activity log like access-token requests.
- The display token is accepted only from the `Authorization` header. A display token in `?token=` returns 401.
- Contract documented in `docs/notifications-push-api.md` and linked from the README.

Companion client change: Silo-Server/silo-apple#240. Android fetches through the shared Ktor client, which already refreshes on 401, so no Android change is needed.

## Validation

- `go build ./...`, `go vet ./internal/api/... ./internal/auth/...`
- `go test ./internal/auth/... ./internal/api/... ./internal/notifications/...` passes.
- New tests: `TestJWT_ApplePushDisplayTokenIsProfileScopedAndLongLived`, `TestRequireApplePushDisplayAuth` (display token binds profile, revoked session rejected, refresh token rejected, access token still works through the fallback chain), `TestHandleRegisterApplePushDeviceMintsDisplayToken` (including typed-nil issuer). `TestHandleRegisterPushDeviceAndroid` now sets an issuer and proves Android gets no token.

## Risks

- The display token is long-lived. It only unlocks compact notification text for its own profile, and revoking the session revokes it. It is stored in the shared iOS Keychain slot alongside the existing mirrored access token.
- Servers that deploy this before clients update are unaffected: the extension still sends the access token, which the fallback chain accepts.

## AI disclosure

Written with Claude Code using model `claude-fable-5-1`. The author reviewed the change and ran the validation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
