### PR TITLE
fix(historyimport): request the Emby UserData fields the importer reads

### DIFF
--- a/internal/historyimport/emby_client.go
+++ b/internal/historyimport/emby_client.go
@@ -207,11 +207,17 @@ func (c *EmbyClient) FetchFavoriteItems(ctx context.Context, auth embyLocalAuth)
 	return c.fetchItems(ctx, auth, "IsFavorite", "Movie,Series")
 }
 
+// embyItemFields are the item fields the importer reads. EnableUserData alone
+// returns only the base UserData block: Emby omits LastPlayedDate and PlayCount
+// unless UserDataLastPlayedDate and UserDataPlayCount are requested by name, and
+// normalizeEmbyItem reads both.
+const embyItemFields = "ProviderIds,UserDataLastPlayedDate,UserDataPlayCount"
+
 func (c *EmbyClient) fetchItems(ctx context.Context, auth embyLocalAuth, filter, includeItemTypes string) ([]embyItem, error) {
 	query := url.Values{}
 	query.Set("Recursive", "true")
 	query.Set("EnableUserData", "true")
-	query.Set("Fields", "ProviderIds")
+	query.Set("Fields", embyItemFields)
 	query.Set("IncludeItemTypes", includeItemTypes)
 	query.Set("Filters", filter)
 	path := fmt.Sprintf("%s/Users/%s/Items?%s", auth.BaseURL, url.PathEscape(auth.UserID), query.Encode())

--- a/internal/historyimport/emby_client_test.go
+++ b/internal/historyimport/emby_client_test.go
@@ -1,0 +1,116 @@
+package historyimport
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Emby returns the base UserData block for EnableUserData=true but omits
+// LastPlayedDate and PlayCount unless they are named in Fields. normalizeEmbyItem
+// reads both, so a request without them silently yields records with no watch
+// timestamp, and the importer then creates no history rows.
+func TestEmbyFetchItems_RequestsUserDataFieldsTheImporterReads(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		fetch func(*EmbyClient, embyLocalAuth) error
+	}{
+		{
+			name: "FetchItems",
+			fetch: func(c *EmbyClient, auth embyLocalAuth) error {
+				_, err := c.FetchItems(context.Background(), auth, "IsPlayed")
+				return err
+			},
+		},
+		{
+			name: "FetchFavoriteItems",
+			fetch: func(c *EmbyClient, auth embyLocalAuth) error {
+				_, err := c.FetchFavoriteItems(context.Background(), auth)
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotFields string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotFields = r.URL.Query().Get("Fields")
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(embyItemsResponse{}); err != nil {
+					t.Errorf("encode response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			auth := embyLocalAuth{BaseURL: server.URL, UserID: "user-1", AccessToken: "token-1"}
+			if err := tc.fetch(NewEmbyClient(), auth); err != nil {
+				t.Fatalf("fetch returned error: %v", err)
+			}
+
+			fields := strings.Split(gotFields, ",")
+			for _, want := range []string{"ProviderIds", "UserDataLastPlayedDate", "UserDataPlayCount"} {
+				if !containsField(fields, want) {
+					t.Errorf("Fields = %q, missing %q", gotFields, want)
+				}
+			}
+		})
+	}
+}
+
+// A played item carrying LastPlayedDate must reach the record as the watch
+// timestamp: addImportedHistoryIfMissing drops the record when it is nil, which
+// is what leaves imported history empty.
+func TestNormalizeEmbyItem_CarriesLastPlayedDateAndPlayCount(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{"Items":[{
+		"Id":"item-1","Name":"Arrival","Type":"Movie","ProductionYear":2016,
+		"UserData":{"Played":true,"PlayCount":3,"LastPlayedDate":"2026-01-22T22:03:35Z"}
+	}],"TotalRecordCount":1}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(payload)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	auth := embyLocalAuth{BaseURL: server.URL, UserID: "user-1", AccessToken: "token-1"}
+	items, err := NewEmbyClient().FetchItems(context.Background(), auth, "IsPlayed")
+	if err != nil {
+		t.Fatalf("FetchItems returned error: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+
+	record := normalizeEmbyItem(items[0], embyItem{})
+	if record.LastPlayedAt == nil {
+		t.Fatal("record.LastPlayedAt is nil, want the item's LastPlayedDate")
+	}
+	if got := record.LastPlayedAt.UTC().Format("2006-01-02T15:04:05Z"); got != "2026-01-22T22:03:35Z" {
+		t.Errorf("record.LastPlayedAt = %s, want 2026-01-22T22:03:35Z", got)
+	}
+	if record.PlayCount != 3 {
+		t.Errorf("record.PlayCount = %d, want 3", record.PlayCount)
+	}
+	if record.UpdatedAt.IsZero() {
+		t.Error("record.UpdatedAt is zero, want the last-played time")
+	}
+}
+
+func containsField(fields []string, want string) bool {
+	for _, field := range fields {
+		if strings.TrimSpace(field) == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/historyimport/emby_client_test.go
+++ b/internal/historyimport/emby_client_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -38,9 +40,14 @@ func TestEmbyFetchItems_RequestsUserDataFieldsTheImporterReads(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// The handler runs on the server's goroutine; guard the capture so
+			// reading it back here has a happens-before edge.
+			var mu sync.Mutex
 			var gotFields string
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
 				gotFields = r.URL.Query().Get("Fields")
+				mu.Unlock()
 				w.Header().Set("Content-Type", "application/json")
 				if err := json.NewEncoder(w).Encode(embyItemsResponse{}); err != nil {
 					t.Errorf("encode response: %v", err)
@@ -53,10 +60,17 @@ func TestEmbyFetchItems_RequestsUserDataFieldsTheImporterReads(t *testing.T) {
 				t.Fatalf("fetch returned error: %v", err)
 			}
 
-			fields := strings.Split(gotFields, ",")
+			mu.Lock()
+			captured := gotFields
+			mu.Unlock()
+
+			fields := strings.Split(captured, ",")
+			for i, field := range fields {
+				fields[i] = strings.TrimSpace(field)
+			}
 			for _, want := range []string{"ProviderIds", "UserDataLastPlayedDate", "UserDataPlayCount"} {
-				if !containsField(fields, want) {
-					t.Errorf("Fields = %q, missing %q", gotFields, want)
+				if !slices.Contains(fields, want) {
+					t.Errorf("Fields = %q, missing %q", captured, want)
 				}
 			}
 		})
@@ -104,13 +118,4 @@ func TestNormalizeEmbyItem_CarriesLastPlayedDateAndPlayCount(t *testing.T) {
 	if record.UpdatedAt.IsZero() {
 		t.Error("record.UpdatedAt is zero, want the last-played time")
 	}
-}
-
-func containsField(fields []string, want string) bool {
-	for _, field := range fields {
-		if strings.TrimSpace(field) == want {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Emby history imports never create history rows. Every run finishes as `completed`
and reports `history_created=0`, while progress rows are written normally. The
failure is silent: nothing errors, and the run summary looks healthy.

Observed on a production deployment, two Emby servers, 56 mapped users:

```
 status    | runs | fetched | matched | unmatched | progress | history
-----------+------+---------+---------+-----------+----------+---------
 completed |  114 |  117978 |  117840 |       138 |    73678 |       0
```

`user_watch_history` gained no rows from the import. The only rows present came
from other sources that predate it:

```
  source  | count
----------+-------
 playback |     7
 simkl    |  3678
 trakt    |   111
```

The cause is the item query. `fetchItems` sends `EnableUserData=true` and
`Fields=ProviderIds`. That returns the base `UserData` block, but Emby omits
`LastPlayedDate` and `PlayCount` unless they are named in `Fields`.
`normalizeEmbyItem` reads both, so `record.LastPlayedAt` is always nil, and
`addImportedHistoryIfMissingWithSource` (`internal/watchstate/service.go`)
returns before inserting when the timestamp is nil.

Reproduced directly against Emby 4.9.5.0, same user and filter, varying only
`Fields` (API key redacted, user id redacted):

```
Fields=ProviderIds                                     LastPlayedDate=False PlayCount=0
Fields=ProviderIds,UserDataLastPlayedDate              LastPlayedDate=True  PlayCount=0
Fields=ProviderIds,UserDataPlayCount                   LastPlayedDate=False PlayCount=3
Fields=ProviderIds,UserDataLastPlayedDate,UserDataPlayCount  LastPlayedDate=True  PlayCount=3
```

Each field independently gates its own value. A single item fetched through
`/Users/{id}/Items/{itemId}`, which does not take `Fields`, shows the data is
present all along:

```json
{"PlaybackPositionTicks": 0, "PlayCount": 3, "IsFavorite": false,
 "LastPlayedDate": "2026-01-22T22:03:35.0000000Z", "Played": true}
```

## Approach

Request the two fields the importer already reads:

```go
const embyItemFields = "ProviderIds,UserDataLastPlayedDate,UserDataPlayCount"
```

`fetchItems` backs both `FetchItems` and `FetchFavoriteItems`, so one change
covers both callers.

`FetchItemsByIDs` is deliberately left alone. It resolves series for title,
year, and provider ids (`getSeriesMap`); it reads no `UserData`, so widening its
field list would fetch data nothing consumes.

`PlayCount` is included because `normalizeEmbyItem` assigns it to
`Record.PlayCount` and `mergeRecords` compares it. It is the same defect as the
timestamp — the query does not ask for a field the code reads — so it is fixed
here rather than left as a known-wrong value. The importer's write path does not
branch on `PlayCount` today, so this part changes no behavior on its own.

Alternative considered: defaulting `LastPlayedAt` to the run time when Emby
returns none. Rejected — it fabricates watch dates, and the real timestamps are
available.

`internal/historyimport/jellyfin_client.go` builds its `Fields` list the same
way and may have the same defect. I have no Jellyfin deployment to reproduce
against, so it is not touched here and not claimed as a bug.

## Validation

Run from the repository root, Go 1.26.4 in a container. Commands are quoted
exactly.

The new query test fails before the fix and passes after. Before (fix reverted,
test kept):

```
=== NAME  TestEmbyFetchItems_RequestsUserDataFieldsTheImporterReads/FetchItems
    emby_client_test.go:59: Fields = "ProviderIds", missing "UserDataLastPlayedDate"
    emby_client_test.go:59: Fields = "ProviderIds", missing "UserDataPlayCount"
--- FAIL: TestEmbyFetchItems_RequestsUserDataFieldsTheImporterReads (0.00s)
    --- FAIL: .../FetchItems (0.00s)
    --- FAIL: .../FetchFavoriteItems (0.00s)
FAIL	github.com/Silo-Server/silo-server/internal/historyimport	0.016s
```

After:

```
--- PASS: TestNormalizeEmbyItem_CarriesLastPlayedDateAndPlayCount (0.00s)
--- PASS: TestEmbyFetchItems_RequestsUserDataFieldsTheImporterReads (0.00s)
    --- PASS: .../FetchItems (0.00s)
    --- PASS: .../FetchFavoriteItems (0.00s)
ok  	github.com/Silo-Server/silo-server/internal/historyimport	0.012s
```

`TestNormalizeEmbyItem_CarriesLastPlayedDateAndPlayCount` passes both before and
after — it feeds the payload directly and so bypasses the query. It is a
regression guard on the field mapping, not a reproduction of the bug.

```
go build ./...                     exit 0, no output
gofmt -l .                         no output
go vet ./internal/historyimport/... exit 0, no output
go test ./internal/historyimport/... ok  github.com/Silo-Server/silo-server/internal/historyimport  3.017s
golangci-lint run --new-from-merge-base="origin/main" ./internal/historyimport/...
                                   0 issues.
make verify-local-paths            exit 0
make verify-playback-fixtures      exit 0
make test-go                       exit 0 — 136 packages ok, 0 failed
```

`golangci-lint` is v2.12.2, the version pinned in `.github/workflows/ci.yml`.
A package-scoped run without `--new-from-merge-base` reports 25 pre-existing
findings in `internal/historyimport`, 3 of them in `emby_client.go` at lines 79,
270, and 312. None fall on lines this branch changes, and none are added by it.

**Not run:**

- `make verify-settings-bindings-all` — the Go half printed `settings bindings
  are current`; the web half needs `pnpm`, which was not available in my
  container. This branch changes no settings bindings.
- The entire web gate (`pnpm install`, `pnpm run lint`, `pnpm run format:check`,
  `pnpm run build`, `make test-web`) — no `pnpm` available. This branch touches
  no files under `web/`.

**Manual verification:** the deployment above is mid-migration from Emby and
cannot take a patched server build yet, so I have not observed history rows
appear end to end after the fix. What is verified end to end is the failure: the
114-run table above, `history_created=0` throughout, and the isolated `Fields`
reproduction showing the data Emby will return once asked. Worth an independent
check on a deployment that can run a patched build before merge.

## Risks

Low. The change adds two field names to one outbound query string.

- Emby returns the extra fields on 4.9.5.0 (verified above). `Fields` values
  Emby does not recognise are ignored rather than rejected, so an older server
  degrades to today's behavior rather than erroring.
- Re-running an import after this lands backfills history onto existing progress
  without duplicating: `AddHistoryIfMissing` existence-checks
  `(user_id, profile_id, media_item_id, watched_at)` and `SetProgressAt` is an
  upsert.
- No schema, API, or client-visible contract change. No migration.

## Follow-up

`internal/historyimport/jellyfin_client.go` may need the same treatment; it
needs someone with a Jellyfin deployment to confirm before changing.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code (CLI)
- Tool(s): Claude Code
- Model(s): `claude-opus-5`
- Involvement: Fully AI-generated, human verified
- Adversarial review: Self-review against the live deployment rather than a
  second model. Scope: whether the diagnosis was the real cause and whether the
  fix was the minimal one. Method and findings: (1) An earlier draft of this
  analysis cited `Repository.InsertHistoryIfMissing` as the insert path; grepping
  the whole repository showed it has no callers and the live path is
  `watchstate.addImportedHistoryIfMissingWithSource` → `AddHistoryIfMissing`.
  The conclusion held but the cited evidence was wrong, and the corrected path is
  what this description uses. (2) The first fix widened `Fields` on both
  `fetchItems` and `FetchItemsByIDs`; reading `getSeriesMap` showed the latter
  consumes no `UserData`, so it was reverted to keep the diff minimal.
  (3) Each `Fields` value was then tested in isolation against a real server
  rather than assumed together, which is what established that `PlayCount` was
  separately affected. Unresolved: no independent reviewer has checked this, and
  the post-fix behavior is not observed on a running server (see Validation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Emby history imports now preserve each item’s last-played date and play count.
  * Imported playback history includes additional activity details for more complete and accurate library history.

* **Tests**
  * Added coverage to verify playback activity details are requested and retained during Emby imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->