### PR TITLE
ci: run the gate on pushes to the apiv2 integration branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+      # Integration branch for the API v2 program (#135). Stacked PRs merge
+      # here first; the merge commits need the same gate as main.
+      - apiv2
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem

The API v2 program (#135) merges its stacked PRs into the `apiv2` integration branch before `main`, so `latest` keeps serving v1-only builds until the bridge release is ready. CI ran only on pull requests and pushes to `main`, so a merge commit on `apiv2` was untested until the next PR opened against it.

## Solution

Add `apiv2` to the `push` trigger in `.github/workflows/ci.yml`. Push-triggered workflows read the workflow file on the pushed ref, so this targets `apiv2` and reaches `main` when the integration branch merges. `docker.yml` and `discord-commits.yml` stay `main`-only on purpose: nothing on `apiv2` publishes an image or announces a commit.

## Validation

- `actionlint .github/workflows/ci.yml`: no findings.
- The change is a two-line trigger edit; the first push to `apiv2` after merge is the live check.

## Risks and follow-up

- None to the release path. `apiv2` has no branch protection yet; that is a repo settings change, not part of this PR.

Related issue: #135

## AI Disclosure

- Harness: Claude Code
- Model: claude-fable-5-1[1m]
- Involvement: AI-authored on maintainer instruction; the maintainer created the `apiv2` branch decision and reviewed the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
