### PR TITLE
fix(sections): keep cached rows available after scans

### DIFF
--- a/internal/sections/resolvedlistcache.go
+++ b/internal/sections/resolvedlistcache.go
@@ -106,11 +106,11 @@ var (
 	}
 )
 
-// InvalidateResolvedListCache advances the cache namespace and releases the
-// entries the bump supersedes. In-flight refreshes remain under the old
-// generation and therefore cannot repopulate reads after a catalog scan
-// completes. Scan-complete bursts are coalesced so large batches advance the
-// namespace at most once per 30 seconds.
+// InvalidateResolvedListCache marks Recently Added rows for refresh after a
+// scan. Unexpired membership remains usable while one background rebuild picks
+// up the changes; profile-specific overlays are still resolved on every request.
+// The generation fences off older builds without making a warm page cold.
+// Scan-complete bursts advance the generation at most once per 30 seconds.
 func InvalidateResolvedListCache() {
 	resolvedListInvalidationMu.Lock()
 	defer resolvedListInvalidationMu.Unlock()
@@ -131,7 +131,7 @@ func InvalidateResolvedListCache() {
 				resolvedListInvalidationPending = false
 				resolvedListInvalidationCancel = nil
 				resolvedListLastInvalidation = deadline
-				dropSupersededResolvedListEntries(resolvedListGeneration.Add(1))
+				advanceResolvedListGeneration(resolvedListNow())
 			})
 		}
 		return
@@ -143,47 +143,32 @@ func InvalidateResolvedListCache() {
 	}
 	resolvedListInvalidationPending = false
 	resolvedListLastInvalidation = now
-	dropSupersededResolvedListEntries(resolvedListGeneration.Add(1))
+	advanceResolvedListGeneration(now)
 }
 
-// dropSupersededResolvedListEntries releases the cache entries a generation bump
-// leaves behind. Advancing the generation only changes FUTURE keys, so without
-// this every obsolete (library × access-scope) recently-added entry would stay
-// resident until its 15-minute expiry and be swept only opportunistically by
-// pruneExpiredResolvedListEntriesLocked. A long multi-library rescan bumps the
-// generation every 30s, which would otherwise keep up to 30 generations of every
-// entry — each holding an ItemLimit-sized item slice — alive at once.
-//
-// Entries with an in-flight background refresh are left in place so a refresh
-// that started under the old generation can still finish writing to its own old
-// key (it can never repopulate the active key, whose generation differs). Those
-// keys are superseded too, so the next bump releases them.
-//
-// Concurrency: the caller holds resolvedListInvalidationMu. This takes
-// resolvedListRefreshMu and resolvedListCacheMu one after the other and never
-// nests them, and no cache path ever acquires resolvedListInvalidationMu, so the
-// immediate and trailing-edge invalidation paths cannot deadlock.
-func dropSupersededResolvedListEntries(generation uint64) {
-	current := resolvedListGenerationKeyPrefix(generation)
-
-	resolvedListRefreshMu.Lock()
-	refreshing := make(map[string]struct{}, len(resolvedListRefreshing))
-	for key := range resolvedListRefreshing {
-		refreshing[key] = struct{}{}
-	}
-	resolvedListRefreshMu.Unlock()
-
+// advanceResolvedListGeneration carries only the previous generation's usable
+// entries into the new namespace and makes them due for refresh. Keep their
+// original hard expiry: repeated scans or failed refreshes must not extend it.
+// The cache lock makes the generation change atomic with both migration and
+// writes, so a late old-generation build cannot overwrite or outlive this state.
+// The caller holds resolvedListInvalidationMu.
+func advanceResolvedListGeneration(now time.Time) {
 	resolvedListCacheMu.Lock()
-	for key := range resolvedListCache {
-		if !strings.HasPrefix(key, resolvedListGenerationPrefix) || strings.HasPrefix(key, current) {
+	defer resolvedListCacheMu.Unlock()
+	previous := resolvedListGenerationKeyPrefix(resolvedListGeneration.Load())
+	current := resolvedListGenerationKeyPrefix(resolvedListGeneration.Add(1))
+	next := make(map[string]resolvedListEntry, len(resolvedListCache))
+	for key, entry := range resolvedListCache {
+		if !strings.HasPrefix(key, resolvedListGenerationPrefix) {
+			next[key] = entry
 			continue
 		}
-		if _, inflight := refreshing[key]; inflight {
-			continue
+		if suffix, ok := strings.CutPrefix(key, previous); ok && now.Before(entry.expiresAt) {
+			entry.refreshAfter = now
+			next[current+suffix] = entry
 		}
-		delete(resolvedListCache, key)
 	}
-	resolvedListCacheMu.Unlock()
+	resolvedListCache = next
 }
 
 // getOrRefresh returns the shared item list for key, implementing serve /
@@ -304,6 +289,11 @@ func resolvedListGet(key string) (resolvedListEntry, bool) {
 
 func resolvedListSet(key string, items []*models.MediaItem, total int, now time.Time) {
 	resolvedListCacheMu.Lock()
+	defer resolvedListCacheMu.Unlock()
+	if strings.HasPrefix(key, resolvedListGenerationPrefix) &&
+		!strings.HasPrefix(key, resolvedListGenerationKeyPrefix(resolvedListGeneration.Load())) {
+		return
+	}
 	pruneExpiredResolvedListEntriesLocked(now)
 	resolvedListCache[key] = resolvedListEntry{
 		items:        cloneMediaItems(items),
@@ -312,7 +302,6 @@ func resolvedListSet(key string, items []*models.MediaItem, total int, now time.
 		refreshAfter: now.Add(resolvedListRefreshAfter),
 		expiresAt:    now.Add(resolvedListTTL),
 	}
-	resolvedListCacheMu.Unlock()
 }
 
 // pruneExpiredResolvedListEntriesLocked sweeps expired entries at most once per

--- a/internal/sections/resolvedlistcache_test.go
+++ b/internal/sections/resolvedlistcache_test.go
@@ -97,14 +97,15 @@ func TestResolvedListCacheScopeIsolation(t *testing.T) {
 	}
 }
 
-func TestResolvedListCacheInvalidationAdvancesGeneration(t *testing.T) {
+func TestResolvedListCacheInvalidationDropsExpiredGeneration(t *testing.T) {
 	resetResolvedListCacheForTest()
 	defer resetResolvedListCacheForTest()
 
 	resolved := ResolvedSection{SectionType: SectionRecentlyAdded, ItemLimit: 20}
 	oldKey := resolvedListCacheKey(resolved, nil, []int{7}, catalog.AccessFilter{})
 	now := time.Unix(1_700_000_000, 0)
-	if _, _, err := getOrRefresh(context.Background(), oldKey, now, staticLoader(mediaItems("stale"), nil)); err != nil {
+	resolvedListNow = func() time.Time { return now.Add(resolvedListTTL) }
+	if _, _, err := getOrRefresh(t.Context(), oldKey, now, staticLoader(mediaItems("stale"), nil)); err != nil {
 		t.Fatalf("prime old generation: %v", err)
 	}
 
@@ -130,11 +131,8 @@ func TestResolvedListCacheInvalidationAdvancesGeneration(t *testing.T) {
 	}
 }
 
-// TestResolvedListCacheInvalidationReleasesSupersededEntries verifies a
-// generation bump actually frees the entries it obsoletes — a long rescan bumps
-// the generation every 30s, well inside the 15-minute TTL, so leaving them for
-// the expiry sweep would keep many generations of every (library × scope) entry
-// resident at once. Generation-independent entries must survive.
+// A scan keeps one usable entry per scope, without accumulating generations
+// or extending the hard expiry. Other section types are unaffected.
 func TestResolvedListCacheInvalidationReleasesSupersededEntries(t *testing.T) {
 	resetResolvedListCacheForTest()
 	defer resetResolvedListCacheForTest()
@@ -181,7 +179,6 @@ func TestResolvedListCacheInvalidationReleasesSupersededEntries(t *testing.T) {
 
 	// The new generation caches normally and is itself released by the next bump.
 	newKey := resolvedListCacheKey(recent, nil, []int{1}, catalog.AccessFilter{})
-	prime(newKey)
 	clock = clock.Add(resolvedListInvalidationInterval)
 	InvalidateResolvedListCache()
 	if _, ok := resolvedListGet(newKey); ok {
@@ -193,8 +190,17 @@ func TestResolvedListCacheInvalidationReleasesSupersededEntries(t *testing.T) {
 	resolvedListCacheMu.RLock()
 	size := len(resolvedListCache)
 	resolvedListCacheMu.RUnlock()
+	if size != 4 {
+		t.Fatalf("cache holds %d entries after two bumps, want one per scope plus genre", size)
+	}
+	// Scans must not renew the last successful load's hard expiry.
+	clock = clock.Add(resolvedListTTL)
+	InvalidateResolvedListCache()
+	resolvedListCacheMu.RLock()
+	size = len(resolvedListCache)
+	resolvedListCacheMu.RUnlock()
 	if size != 1 {
-		t.Fatalf("cache holds %d entries after two bumps, want 1 (the generation-independent rail)", size)
+		t.Fatalf("expired recently-added rows survived repeated scans: %d entries", size)
 	}
 }
 
@@ -288,6 +294,7 @@ func TestResolvedListCacheInvalidationIsolatesInflightRefresh(t *testing.T) {
 
 	resolved := ResolvedSection{SectionType: SectionRecentlyAdded, ItemLimit: 20}
 	base := time.Unix(1_700_000_000, 0)
+	resolvedListNow = func() time.Time { return base.Add(6 * time.Minute) }
 	oldKey := resolvedListCacheKey(resolved, nil, []int{7}, catalog.AccessFilter{})
 	if _, _, err := getOrRefresh(context.Background(), oldKey, base, staticLoader(mediaItems("old"), nil)); err != nil {
 		t.Fatalf("prime old generation: %v", err)
@@ -314,12 +321,15 @@ func TestResolvedListCacheInvalidationIsolatesInflightRefresh(t *testing.T) {
 	}
 	close(releaseRefresh)
 	<-refreshDone
-
 	if !waitFor(2*time.Second, func() bool {
-		entry, ok := resolvedListGet(oldKey)
-		return ok && len(entry.items) == 1 && entry.items[0].ContentID == "late-stale"
+		resolvedListRefreshMu.Lock()
+		defer resolvedListRefreshMu.Unlock()
+		return len(resolvedListRefreshing) == 0
 	}) {
-		t.Fatal("old generation refresh did not finish")
+		t.Fatal("refreshes did not finish")
+	}
+	if _, ok := resolvedListGet(oldKey); ok {
+		t.Fatal("late refresh retained an obsolete generation")
 	}
 	active, _, err := getOrRefresh(context.Background(), newKey, base.Add(6*time.Minute), func(context.Context) ([]*models.MediaItem, int, error) {
 		t.Fatal("late old-generation refresh repopulated the active key")

--- a/internal/sections/scan_refresh_test.go
+++ b/internal/sections/scan_refresh_test.go
@@ -1,0 +1,80 @@
+package sections
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestScanRefreshServesCachedRowWhileRebuilding(t *testing.T) {
+	resetResolvedListCacheForTest()
+	defer resetResolvedListCacheForTest()
+	now := time.Now()
+	resolved := ResolvedSection{SectionType: SectionRecentlyAdded, ItemLimit: 20}
+	scope := catalog.AccessFilter{AllowedLibraryIDs: []int{7}, MaxContentRating: "PG"}
+	key := resolvedListCacheKey(resolved, nil, []int{7}, scope)
+	resolvedListSet(key, mediaItems("cached"), 1, now)
+	InvalidateResolvedListCache()
+	key = resolvedListCacheKey(resolved, nil, []int{7}, scope)
+	started, release := make(chan struct{}), make(chan struct{})
+	var calls atomic.Int32
+	loader := func(context.Context) ([]*models.MediaItem, int, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return mediaItems("fresh"), 1, nil
+	}
+	type result struct {
+		items []*models.MediaItem
+		err   error
+	}
+	returned := make(chan result, 1)
+	go func() {
+		items, _, err := getOrRefresh(t.Context(), key, time.Now(), loader)
+		returned <- result{items, err}
+	}()
+	// Always release and join the refresh, including when the old blocking
+	// behavior makes the foreground request miss its deadline.
+	defer func() {
+		close(release)
+		if !waitFor(2*time.Second, func() bool {
+			entry, ok := resolvedListGet(key)
+			resolvedListRefreshMu.Lock()
+			idle := len(resolvedListRefreshing) == 0
+			resolvedListRefreshMu.Unlock()
+			return idle && ok && len(entry.items) == 1 && entry.items[0].ContentID == "fresh"
+		}) {
+			t.Error("completed refresh did not replace the cached row")
+		}
+	}()
+	<-started
+	select {
+	case got := <-returned:
+		if got.err != nil || len(got.items) != 1 || got.items[0].ContentID != "cached" {
+			t.Fatalf("got %v, %v; want cached row during refresh", itemIDs(got.items), got.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("page request is blocked on the post-scan row rebuild")
+	}
+	// Concurrent page requests keep using the row and join one refresh.
+	for range 10 {
+		items, _, err := getOrRefresh(t.Context(), key, time.Now(), loader)
+		if err != nil || len(items) != 1 || items[0].ContentID != "cached" {
+			t.Fatalf("refresh waiter got %v, %v", itemIDs(items), err)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("started %d refreshes; want 1", calls.Load())
+	}
+	// A different access scope must still perform its own read.
+	otherKey := resolvedListCacheKey(resolved, nil, []int{7}, catalog.AccessFilter{AllowedLibraryIDs: []int{7}, MaxContentRating: "G"})
+	items, _, err := getOrRefresh(t.Context(), otherKey, time.Now(), staticLoader(mediaItems("restricted"), nil))
+	if err != nil || len(items) != 1 || items[0].ContentID != "restricted" {
+		t.Fatalf("new access scope received migrated membership: %v, %v", itemIDs(items), err)
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Home and library Recommended pages intermittently wait several seconds for the server after catalog scans. In a tvOS simulator investigation, the Series library response took 12.35 seconds on the server and 12.43 seconds in URLSession. Home took 8.28 seconds on the server and 8.89 seconds in the client. Movies took 4.40 seconds on the server.

Recently Added row builds accounted for roughly 6–9 seconds of several slow responses. Scan-complete events, including scans reporting no changes, discard those cached rows through a generation bump. The existing 30-second debounce limits invalidations but still repeatedly turns usable rows into blocking cache misses. A read-only query plan confirmed the TV aggregate processes hundreds of thousands of episode memberships on this catalog.

## Approach

Carry unexpired Recently Added membership into the next generation and mark it due for the existing background refresh. A request after a scan can use that row while the rebuild picks up catalog changes. Preserve the original hard expiry and keep only one cached generation per scope. Reject writes from obsolete generations so a late refresh cannot resurrect discarded entries.

Library and access-filter keys remain separate; per-profile overlays are resolved on every response. The v1 response contract is unchanged, so Apple and Android require no coordinated edits. Jellyfin section consumers use the same cache; no protocol change is needed. No migration or new dependency is required.

## Validation

- Regression reproduced before the fix: `TestScanRefreshServesCachedRowWhileRebuilding` failed because the page remained blocked on the post-scan rebuild. With this change it receives cached content before the blocked loader is released, subsequent reads share one refresh, and a different access scope reads its own membership.
- `go test -race ./internal/sections/...` — passed.
- `go test -race ./internal/sections -run 'TestScanRefresh|TestResolvedListCacheInvalidation|TestResolvedListCacheScopeIsolation' -count=20` — passed. Coverage includes hard expiry, bounded retained generations, and late in-flight refreshes.
- `make embed-stub`, `go build ./...`, `gofmt -l .`, `go vet ./...` — passed; gofmt produced no output.
- `golangci-lint run --allow-parallel-runners --new-from-merge-base=origin/main ./...` with an isolated lint cache — 0 issues.
- `GOMAXPROCS=4 GOFLAGS=-p=2 make test-go` — final complete run passed. Earlier runs under concurrent validation hit 25 ms policy evaluation deadlines and a Jellyfin transcode test failure; both packages passed on rerun without source changes.
- `pnpm install --frozen-lockfile`, `pnpm run lint`, `pnpm run format:check`, `pnpm run build` — passed. Build emitted existing asset/chunk warnings.
- Web suite with the Makefile's existing four exclusions and `--maxWorkers=4` — 361 files / 3,102 tests passed. Initial `make test-web` hit one AdminUserDetail test timeout; its focused rerun and the full bounded-worker rerun passed without source changes.
- `make verify-settings-bindings-all`, `make verify-playback-fixtures`, `make verify-local-paths` — passed.
- Built, installed, and launched the Apple client in tvOS and iOS simulators, retaining their saved server configuration. XCTest navigated Home, Movies, Series, and For You repeatedly. Six warm tvOS transitions completed in 1.26–1.34 seconds; seven iOS transitions completed in 3.03–3.42 seconds. These figures include XCTest input and idle-wait overhead and are not isolated rendering measurements. iOS startup requests measured 2.38 seconds for Home and 3.48 seconds for recommendations; a >5-second iOS stall was not reproduced.
- Ponytail review completed: no behavior-preserving simplifications found.

The simulator measurements and recording use the existing server deployment. This branch has not been deployed there; the before/after proof for the changed behavior is the blocked-loader regression test, not a claimed live latency improvement.

## Risks

Recently Added membership can briefly lag a scan while its background refresh completes. Repeated scans and failed refreshes retain the original 15-minute hard expiry. Truly cold or expired entries still wait for the initial query; optimizing that query remains separate follow-up work. This change addresses scan-induced cache misses and does not guarantee every page request finishes below a fixed threshold.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Codex desktop
- Tool(s): Codex shell and patch tools, XcodeBuildMCP, XCTest/XCUIRemote, Silo runtime helper, Unified Computer Use, GitHub CLI
- Model(s): gpt-6-astra
- Involvement: AI-assisted; investigation, implementation, tests, and PR prepared by Codex at the maintainer's request. Human review pending.
- Adversarial review: self-review of cache generation races, hard expiry, access-scope separation, and late writes; blocked-loader regression exercised against the original and changed implementation; repeated race tests passed. Ponytail review found no safe simplifications. No independent agent review was requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolved-list cache invalidation so outdated entries are no longer retained or restored by delayed refreshes.
  * Preserved valid cached results during refreshes, while ensuring completed refreshes replace outdated data.
  * Prevented repeated invalidation scans from extending existing expiration times.
  * Maintained isolation between different access scopes during concurrent refreshes.

* **Tests**
  * Added coverage for cache invalidation, expiration handling, concurrent refresh sharing, and stale refresh prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->