### PR TITLE
fix(userstore): keep repeated watch-progress lookups fast

### DIFF
--- a/internal/userstore/pgstore/progress.go
+++ b/internal/userstore/pgstore/progress.go
@@ -850,19 +850,14 @@ func (s *PostgresUserStore) ListProgressByMediaItems(ctx context.Context, profil
 		return result, nil
 	}
 
-	placeholders := make([]string, len(mediaItemIDs))
-	args := make([]any, 0, len(mediaItemIDs)+2)
-	args = append(args, s.userID, profileID)
-	for i, mediaItemID := range mediaItemIDs {
-		placeholders[i] = fmt.Sprintf("$%d", i+3)
-		args = append(args, mediaItemID)
-	}
-
+	// Keep one statement shape for every batch size. Expanding IDs into IN
+	// parameters can make a reused plan scan all profile progress and compare
+	// each row against thousands of parameters instead of using the item index.
 	rows, err := s.pool.Query(ctx, `
 		SELECT profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at,
 		       last_file_id, last_resolution, last_hdr, last_codec_video, last_edition_key
 		FROM user_watch_progress
-		WHERE user_id = $1 AND profile_id = $2 AND media_item_id IN (`+strings.Join(placeholders, ",")+`)
+		WHERE user_id = $1 AND profile_id = $2 AND media_item_id = ANY($3::text[])
 		  AND NOT EXISTS (
 			SELECT 1
 			FROM user_history_hidden_items hhi
@@ -871,7 +866,7 @@ func (s *PostgresUserStore) ListProgressByMediaItems(ctx context.Context, profil
 			  AND hhi.media_item_id = user_watch_progress.media_item_id
 			  AND user_watch_progress.updated_at <= hhi.hidden_before
 		  )`,
-		args...,
+		s.userID, profileID, mediaItemIDs,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing progress by media items: %w", err)

--- a/internal/userstore/pgstore/progress_test.go
+++ b/internal/userstore/pgstore/progress_test.go
@@ -1,6 +1,15 @@
 package pgstore
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
 
 func TestCompactMediaItemIDsReturnsEmptySliceForNilInput(t *testing.T) {
 	ids := compactMediaItemIDs(nil)
@@ -9,5 +18,82 @@ func TestCompactMediaItemIDsReturnsEmptySliceForNilInput(t *testing.T) {
 	}
 	if len(ids) != 0 {
 		t.Fatalf("len = %d, want 0", len(ids))
+	}
+}
+
+func TestListProgressByMediaItemsReusedPlan(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exercise the plan used after repeated browse requests, including when
+	// the same prepared statement receives a different number of item IDs.
+	config.ConnConfig.RuntimeParams["plan_cache_mode"] = "force_generic_plan"
+	config.MaxConns = 1
+	ctx := t.Context()
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	userIDs := make([]int, 0, 2)
+	t.Cleanup(func() {
+		_, err := pool.Exec(context.WithoutCancel(ctx), `DELETE FROM users WHERE id = ANY($1)`, userIDs)
+		if err != nil {
+			t.Errorf("clean up users: %v", err)
+		}
+	})
+	for i := range 2 {
+		var id int
+		if err := pool.QueryRow(ctx, `INSERT INTO users (username, role) VALUES ($1, 'user') RETURNING id`,
+			fmt.Sprintf("progress-array-%d-%d", time.Now().UnixNano(), i)).Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		userIDs = append(userIDs, id)
+	}
+	const quotedID = "episode-'quoted'\\path"
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO user_watch_progress
+			(user_id, profile_id, media_item_id, position_seconds, duration_seconds, completed, updated_at)
+		VALUES ($1, 'a', $3, 30, 120, FALSE, $4),
+		       ($1, 'a', 'hidden', 40, 120, FALSE, $4),
+		       ($1, 'a', 'newer', 120, 120, TRUE, $4),
+		       ($1, 'a', 'unrequested', 50, 120, FALSE, $4),
+		       ($1, 'b', 'profile-only', 60, 120, FALSE, $4),
+		       ($2, 'a', 'account-only', 70, 120, FALSE, $4)
+	`, userIDs[0], userIDs[1], quotedID, at); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO user_history_hidden_items (user_id, profile_id, media_item_id, hidden_before)
+		VALUES ($1, 'a', 'hidden', $2), ($1, 'a', 'newer', $3)
+	`, userIDs[0], at, at.Add(-time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	store := newStore(pool, userIDs[0])
+	ids := []string{quotedID, quotedID, "hidden", "newer", "profile-only", "account-only", "missing"}
+	largeIDs := slices.Clone(ids)
+	for i := range 5000 {
+		largeIDs = append(largeIDs, fmt.Sprintf("missing-%d", i))
+	}
+	for _, batch := range [][]string{ids, largeIDs, ids, nil, {}} {
+		got, err := store.ListProgressByMediaItems(ctx, "a", batch)
+		if err != nil {
+			t.Fatalf("batch size %d: %v", len(batch), err)
+		}
+		if len(batch) == 0 {
+			if len(got) != 0 {
+				t.Fatalf("empty batch returned %d items", len(got))
+			}
+			continue
+		}
+		if len(got) != 2 || got[quotedID].PositionSeconds != 30 || !got["newer"].Completed {
+			t.Fatalf("batch size %d: unexpected progress: %+v", len(batch), got)
+		}
 	}
 }


### PR DESCRIPTION
Library and Home responses can become slower after repeated visits because playable-target lookups expand thousands of episode IDs into individual SQL parameters. Once PostgreSQL chooses a generic plan, it can scan all watch-progress rows for a profile and compare each row against every requested ID.

Pass the IDs as one `text[]` parameter with `ANY($3::text[])`. This keeps the query shape stable and allows the measured generic plan to use the existing primary-key index. Account/profile scoping, hidden-history filtering, returned fields, and empty-input behavior remain unchanged. No cache lifetime changes or database migration are required.

Related issue: N/A — narrow server query fix. The separate Apple progressive-loading follow-up is Silo-Server/silo-apple#254. This branch does not include the cache changes in #944.

**Performance evidence**

A read-only database comparison used the same 2,334 episode IDs for both query forms. Both statements returned 74 progress rows and switched from five custom plans to three generic plans.

| Execution | Expanded `IN` | Array `ANY` |
| --- | ---: | ---: |
| First five, custom plans | 3.147–5.943 ms | 3.037–6.333 ms |
| Sixth, generic plan | 926.508 ms | 1.140 ms |
| Seventh, generic plan | 928.342 ms | 0.882 ms |
| Eighth, generic plan | 937.956 ms | 0.861 ms |

Deployment validation compared 40 requests before the change with 80 afterward using the same test conditions. All measured requests returned HTTP 200 and were correlated with server logs. A preliminary run affected by authentication rate limiting was excluded; both comparison runs reused a single authenticated session.

| API response | Before median | After median | Reduction |
| --- | ---: | ---: | ---: |
| Library A: recently released row | 1,385 ms | 548 ms | 60% |
| Library B: trending row | 1,353 ms | 560 ms | 59% |
| Library A: combined sections | 3,238 ms | 2,527 ms | 22% |
| Library B: combined sections | 2,456 ms | 1,709 ms | 30% |
| Home: combined sections | 1,297 ms | 876 ms | 33% |

These are total HTTP response times, including transfer. The first request to each surface after restart is included. Item counts remained consistent, and the checked 20-card row retained identical content IDs, playable targets, and user-state values. Browser smoke tests passed for Home and both library recommended pages with no recorded console errors. Health and readiness checks passed.

**Validation**

- Go build, formatting, vet, changed-line lint, and the full Go suite passed.
- Database-backed userstore and sections race tests passed. Focused playable-target, Recently Added TV, and array-query tests passed with the race detector; the main focused cases passed three repeated runs.
- The new test covers reused generic plans, changing batch sizes, 5,007 IDs, duplicate/missing/quoted IDs, empty inputs, account/profile isolation, and hidden-history cutoffs.
- The broader database-backed catalog suite encountered the existing `TestEpisodeSearchPostgresAndDocumentSource` nil-vector failure, which reproduced without this patch. Relevant catalog database tests passed.
- Web install, lint, formatting, and build passed. All 3,102 web tests passed across 361 files, preserving the four existing exclusions.
- Settings bindings, playback fixtures, local-path checks, and Ponytail review passed.
- CI Go, Web, Docs hygiene, and CodeRabbit checks passed on this commit in the previous PR.

Some combined responses still exceeded three seconds. Cold Recently Added TV aggregation and Apple's wait-for-every-row behavior remain separate sources of latency. API contracts are unchanged, so no coordinated client changes are needed for this query optimization.

AI disclosure: implemented, investigated, and validated with `gpt-6-astra` in the Codex desktop agent harness. Modern Go Guidelines CLI and Ponytail review were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress lookups for batches of media items, including quoted, duplicate, large, missing, and empty ID lists.
  * Preserved visibility and account-specific filtering when retrieving progress records.
  * Improved reliability when queries are reused across different batch sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->