### PR TITLE
perf(sections): make Continue Watching stop re-reading watch history

### DIFF
--- a/internal/catalog/continue_watching_progress.go
+++ b/internal/catalog/continue_watching_progress.go
@@ -58,6 +58,16 @@ const supersededProgressMaxPages = 5
 // own progress. Those entries are stale — the viewer already moved past them.
 // Non-episode entries never match.
 func (f *ContinueWatchingProgressFilter) SupersededEpisodeProgressIDs(ctx context.Context, store ProgressLister, profileID string, entries []userstore.WatchProgress) (map[string]struct{}, error) {
+	return f.SupersededEpisodeProgressIDsCached(ctx, store, profileID, entries, nil)
+}
+
+// SupersededEpisodeProgressIDsCached is SupersededEpisodeProgressIDs with a
+// caller-supplied completed-history cache. Callers that ask more than once
+// within a single request — Continue Watching walks its in-progress rows a page
+// at a time — pass one cache across all the calls so the completed side is read
+// once instead of once per page. A nil cache reads it fresh, which is what a
+// one-shot caller wants.
+func (f *ContinueWatchingProgressFilter) SupersededEpisodeProgressIDsCached(ctx context.Context, store ProgressLister, profileID string, entries []userstore.WatchProgress, cache *CompletedProgressCache) (map[string]struct{}, error) {
 	if f == nil || f.pool == nil {
 		return map[string]struct{}{}, nil
 	}
@@ -82,7 +92,7 @@ func (f *ContinueWatchingProgressFilter) SupersededEpisodeProgressIDs(ctx contex
 		}
 	}
 
-	completed, err := CompletedProgressSnapshots(ctx, store, profileID, oldestInProgress)
+	completed, err := cache.snapshots(ctx, store, profileID, oldestInProgress)
 	if err != nil {
 		return nil, err
 	}
@@ -113,6 +123,104 @@ func (f *ContinueWatchingProgressFilter) SupersededEpisodeProgressIDs(ctx contex
 	return superseded, nil
 }
 
+// CompletedProgressCache holds one request's walk of a profile's completed
+// progress rows so repeated superseded-episode checks share it.
+//
+// Continue Watching pages its in-progress rows (up to continueProgressMaxScanned
+// / continueProgressPageSize pages) and asks for the superseded set once per
+// page. Each ask needs the completed rows newer than that page's oldest
+// in-progress entry. Because in-progress pages come back updated_at DESC, later
+// pages ask for older cutoffs, so the walks are nested rather than disjoint:
+// without a cache every page re-reads everything the previous page already read,
+// which on a full run is supersededProgressMaxPages reads repeated for each
+// in-progress page.
+//
+// The cache reads strictly forward. It keeps the rows it has seen plus the
+// updated_at it has scanned down to, and only reads more pages when a caller
+// asks for a cutoff older than that. A row is never read twice, and the answer
+// for any cutoff is identical to a fresh walk.
+//
+// Not safe for concurrent use: scope one to a single request.
+type CompletedProgressCache struct {
+	profileID string
+	snaps     []ProgressSnapshot
+	seen      map[string]struct{}
+	pagesRead int
+	// scannedTo is the updated_at of the last row read. Every unread row is at
+	// or before it. Meaningful only once pagesRead > 0.
+	scannedTo time.Time
+	// done means the source is exhausted or the page cap stopped the walk;
+	// either way there is nothing further to read.
+	done   bool
+	capped bool
+}
+
+// NewCompletedProgressCache returns a cache for one request.
+func NewCompletedProgressCache() *CompletedProgressCache {
+	return &CompletedProgressCache{seen: make(map[string]struct{})}
+}
+
+// snapshots returns the deduplicated completed snapshots updated after
+// notBefore, reading only the pages the cache has not already read. A nil
+// receiver, or a cache already bound to a different profile, falls back to a
+// fresh uncached walk.
+func (c *CompletedProgressCache) snapshots(ctx context.Context, store ProgressLister, profileID string, notBefore time.Time) ([]ProgressSnapshot, error) {
+	if c == nil || (c.profileID != "" && c.profileID != profileID) {
+		return CompletedProgressSnapshots(ctx, store, profileID, notBefore)
+	}
+	if c.seen == nil {
+		c.seen = make(map[string]struct{})
+	}
+	c.profileID = profileID
+
+	// Read forward until the unread remainder is entirely at or before the
+	// cutoff, at which point it cannot contain anything this caller wants.
+	for !c.done && (c.pagesRead == 0 || c.scannedTo.After(notBefore)) {
+		if c.pagesRead >= supersededProgressMaxPages {
+			c.done = true
+			c.capped = true
+			// Fell out with a full final page: the cap halted the walk before
+			// the cutoff, so completed rows past the scanned window were
+			// skipped. Log it so a real profile that trips this backstop is
+			// visible rather than silently mis-filtered.
+			slog.WarnContext(ctx, "continue-watching: superseded-episode walk hit page cap; completed-history tail left unscanned",
+				"profile_id", profileID,
+				"pages_scanned", supersededProgressMaxPages,
+				"rows_scanned", len(c.snaps))
+			break
+		}
+		offset := c.pagesRead * supersededProgressPageSize
+		entries, err := store.ListProgress(ctx, profileID, "completed", supersededProgressPageSize, offset)
+		if err != nil {
+			return nil, fmt.Errorf("listing completed progress for superseded episodes: %w", err)
+		}
+		c.pagesRead++
+
+		for _, snapshot := range ProgressSnapshots(entries) {
+			c.scannedTo = snapshot.UpdatedAt
+			if _, ok := c.seen[snapshot.ContentID]; ok {
+				continue
+			}
+			c.seen[snapshot.ContentID] = struct{}{}
+			c.snaps = append(c.snaps, snapshot)
+		}
+
+		if len(entries) < supersededProgressPageSize {
+			c.done = true
+		}
+	}
+
+	// c.snaps is updated_at DESC, so the wanted rows are a prefix of it.
+	result := make([]ProgressSnapshot, 0, len(c.snaps))
+	for _, snapshot := range c.snaps {
+		if !snapshot.UpdatedAt.After(notBefore) {
+			break
+		}
+		result = append(result, snapshot)
+	}
+	return result, nil
+}
+
 // CompletedProgressSnapshots pages through the profile's completed progress
 // rows and returns deduplicated snapshots updated after notBefore. The
 // completed listing is ordered updated_at DESC (newest first), so once a row at
@@ -120,45 +228,13 @@ func (f *ContinueWatchingProgressFilter) SupersededEpisodeProgressIDs(ctx contex
 // stops — callers only care about completed episodes finished more recently
 // than an in-progress entry, so older rows are irrelevant. Pass a zero
 // notBefore to walk the whole history.
+//
+// This is the one-shot form. A caller that asks repeatedly within one request
+// should hold a CompletedProgressCache instead and pass it to
+// SupersededEpisodeProgressIDsCached.
 func CompletedProgressSnapshots(ctx context.Context, store ProgressLister, profileID string, notBefore time.Time) ([]ProgressSnapshot, error) {
-	seen := make(map[string]struct{})
-	snapshots := make([]ProgressSnapshot, 0)
-
-	for page := 0; page < supersededProgressMaxPages; page++ {
-		offset := page * supersededProgressPageSize
-		entries, err := store.ListProgress(ctx, profileID, "completed", supersededProgressPageSize, offset)
-		if err != nil {
-			return nil, fmt.Errorf("listing completed progress for superseded episodes: %w", err)
-		}
-
-		reachedCutoff := false
-		for _, snapshot := range ProgressSnapshots(entries) {
-			if !snapshot.UpdatedAt.After(notBefore) {
-				reachedCutoff = true
-				break
-			}
-			contentID := snapshot.ContentID
-			if _, ok := seen[contentID]; ok {
-				continue
-			}
-			seen[contentID] = struct{}{}
-			snapshots = append(snapshots, snapshot)
-		}
-
-		if reachedCutoff || len(entries) < supersededProgressPageSize {
-			return snapshots, nil
-		}
-	}
-
-	// Fell out of the loop with a full final page: the page cap halted the walk
-	// before the cutoff, so completed rows past the scanned window were skipped.
-	// Log it so a real profile that trips this backstop is visible rather than
-	// silently under-filtered.
-	slog.Warn("continue-watching: superseded-episode walk hit page cap; completed-history tail left unscanned",
-		"profile_id", profileID,
-		"pages_scanned", supersededProgressMaxPages,
-		"rows_scanned", len(snapshots))
-	return snapshots, nil
+	fresh := &CompletedProgressCache{seen: make(map[string]struct{}), profileID: profileID}
+	return fresh.snapshots(ctx, store, profileID, notBefore)
 }
 
 // ProgressSnapshots converts progress rows to snapshots, dropping rows with a

--- a/internal/catalog/continue_watching_progress_test.go
+++ b/internal/catalog/continue_watching_progress_test.go
@@ -245,3 +245,141 @@ func (s *stubProgressLister) ListProgress(_ context.Context, profileID, status s
 	}
 	return s.entries[offset:end], nil
 }
+
+// completedWalkFixture builds n completed rows ordered updated_at DESC, the
+// order ListProgress("completed") returns them in.
+func completedWalkFixture(n int) []userstore.WatchProgress {
+	entries := make([]userstore.WatchProgress, n)
+	for i := range entries {
+		entries[i] = userstore.WatchProgress{
+			MediaItemID: "done-" + strconv.Itoa(i),
+			UpdatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Add(time.Duration(n-i) * time.Minute).Format(time.RFC3339),
+		}
+	}
+	return entries
+}
+
+func TestCompletedProgressCacheMatchesFreshWalkForNestedCutoffs(t *testing.T) {
+	t.Parallel()
+
+	entries := completedWalkFixture(supersededProgressPageSize*2 + 40)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Continue Watching pages in-progress rows updated_at DESC, so each page
+	// asks for an older cutoff than the last. Walk from newest to oldest.
+	cutoffs := []time.Time{
+		base.Add(1000 * time.Minute),
+		base.Add(600 * time.Minute),
+		base.Add(200 * time.Minute),
+		base.Add(30 * time.Minute),
+		{},
+	}
+
+	cached := NewCompletedProgressCache()
+	cachedStore := &stubProgressLister{entries: entries}
+
+	for _, cutoff := range cutoffs {
+		freshStore := &stubProgressLister{entries: entries}
+		want, err := CompletedProgressSnapshots(context.Background(), freshStore, "p1", cutoff)
+		if err != nil {
+			t.Fatalf("fresh walk at %v: %v", cutoff, err)
+		}
+		got, err := cached.snapshots(context.Background(), cachedStore, "p1", cutoff)
+		if err != nil {
+			t.Fatalf("cached walk at %v: %v", cutoff, err)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("cutoff %v: cached returned %d snapshots, fresh returned %d", cutoff, len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("cutoff %v: snapshot %d = %+v, want %+v", cutoff, i, got[i], want[i])
+			}
+		}
+	}
+
+	// The whole fixture is three pages. A fresh walk per cutoff would have read
+	// far more; the cache must never read a page twice.
+	wantPages := 3
+	if len(cachedStore.calls) != wantPages {
+		t.Fatalf("cached ListProgress calls = %d (%+v), want %d — each page read exactly once", len(cachedStore.calls), cachedStore.calls, wantPages)
+	}
+	for i, call := range cachedStore.calls {
+		if call.offset != i*supersededProgressPageSize {
+			t.Fatalf("call %d offset = %d, want %d — the walk must read strictly forward", i, call.offset, i*supersededProgressPageSize)
+		}
+	}
+}
+
+func TestCompletedProgressCacheStopsEarlyWhenCutoffIsSatisfied(t *testing.T) {
+	t.Parallel()
+
+	entries := completedWalkFixture(supersededProgressPageSize * 3)
+	store := &stubProgressLister{entries: entries}
+	cache := NewCompletedProgressCache()
+
+	// A cutoff inside the first page must not drag in later pages.
+	cutoff, err := time.Parse(time.RFC3339, entries[10].UpdatedAt)
+	if err != nil {
+		t.Fatalf("parsing fixture cutoff: %v", err)
+	}
+	cutoff = cutoff.UTC()
+	got, err := cache.snapshots(context.Background(), store, "p1", cutoff)
+	if err != nil {
+		t.Fatalf("cached walk: %v", err)
+	}
+	if len(got) != 10 {
+		t.Fatalf("snapshots = %d, want 10 rows newer than the cutoff", len(got))
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("ListProgress calls = %d, want 1 — a satisfied cutoff must not page further", len(store.calls))
+	}
+}
+
+func TestCompletedProgressCacheHonoursPageCap(t *testing.T) {
+	t.Parallel()
+
+	entries := completedWalkFixture(supersededProgressPageSize * (supersededProgressMaxPages + 3))
+	store := &stubProgressLister{entries: entries}
+	cache := NewCompletedProgressCache()
+
+	got, err := cache.snapshots(context.Background(), store, "p1", time.Time{})
+	if err != nil {
+		t.Fatalf("cached walk: %v", err)
+	}
+	if len(store.calls) != supersededProgressMaxPages {
+		t.Fatalf("ListProgress calls = %d, want the %d-page cap", len(store.calls), supersededProgressMaxPages)
+	}
+	if len(got) != supersededProgressPageSize*supersededProgressMaxPages {
+		t.Fatalf("snapshots = %d, want the capped window", len(got))
+	}
+	// Once capped the cache is done: a further ask must not resume paging.
+	if _, err := cache.snapshots(context.Background(), store, "p1", time.Time{}); err != nil {
+		t.Fatalf("second cached walk: %v", err)
+	}
+	if len(store.calls) != supersededProgressMaxPages {
+		t.Fatalf("ListProgress calls after second ask = %d, want no further paging", len(store.calls))
+	}
+}
+
+func TestCompletedProgressCacheFallsBackForADifferentProfile(t *testing.T) {
+	t.Parallel()
+
+	entries := completedWalkFixture(10)
+	store := &stubProgressLister{entries: entries}
+	cache := NewCompletedProgressCache()
+
+	if _, err := cache.snapshots(context.Background(), store, "p1", time.Time{}); err != nil {
+		t.Fatalf("first profile: %v", err)
+	}
+	got, err := cache.snapshots(context.Background(), store, "p2", time.Time{})
+	if err != nil {
+		t.Fatalf("second profile: %v", err)
+	}
+	if len(got) != len(entries) {
+		t.Fatalf("snapshots for p2 = %d, want %d from an uncached walk", len(got), len(entries))
+	}
+	last := store.calls[len(store.calls)-1]
+	if last.profileID != "p2" || last.offset != 0 {
+		t.Fatalf("last call = %+v, want a fresh offset-0 read for p2", last)
+	}
+}

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -423,11 +423,17 @@ func (f *Fetcher) fetchContinueWatchingSection(ctx context.Context, resolved Res
 	orderedItems := make([]*models.MediaItem, 0, limit)
 	itemMeta := make(map[string]SectionItemMeta)
 
+	// One completed-history walk shared by every in-progress page below. The
+	// pages ask for progressively older cutoffs, so the walks nest; the cache
+	// reads each completed row once for the whole request instead of once per
+	// page.
+	completedCache := catalog.NewCompletedProgressCache()
+
 	// Ebook resume points live in ebook_reader_progress rather than the
 	// watch-progress store, so reading sections pull from that table and skip
 	// the next-up handling below.
 	if continueType == ContinueTypeReading {
-		orderedItems, err = f.collectContinueProgressItems(ctx, store, profileID, dismissals, continueType, effectiveLibID, effectiveLibraryIDs, filter, limit, orderedItems, itemMeta,
+		orderedItems, err = f.collectContinueProgressItems(ctx, store, profileID, dismissals, continueType, effectiveLibID, effectiveLibraryIDs, filter, limit, orderedItems, itemMeta, completedCache,
 			func(pageLimit, offset int) ([]userstore.WatchProgress, error) {
 				entries, err := f.listEbookContinueWatchingProgress(ctx, userID, profileID, pageLimit, offset)
 				if err != nil {
@@ -454,7 +460,7 @@ func (f *Fetcher) fetchContinueWatchingSection(ctx context.Context, resolved Res
 		}, nil
 	}
 
-	orderedItems, err = f.collectContinueProgressItems(ctx, store, profileID, dismissals, continueType, effectiveLibID, effectiveLibraryIDs, filter, limit, orderedItems, itemMeta,
+	orderedItems, err = f.collectContinueProgressItems(ctx, store, profileID, dismissals, continueType, effectiveLibID, effectiveLibraryIDs, filter, limit, orderedItems, itemMeta, completedCache,
 		func(pageLimit, offset int) ([]userstore.WatchProgress, error) {
 			entries, err := store.ListProgress(ctx, profileID, "in_progress", pageLimit, offset)
 			if err != nil {
@@ -523,6 +529,7 @@ func (f *Fetcher) collectContinueProgressItems(
 	limit int,
 	orderedItems []*models.MediaItem,
 	itemMeta map[string]SectionItemMeta,
+	completedCache *catalog.CompletedProgressCache,
 	listPage func(pageLimit, offset int) ([]userstore.WatchProgress, error),
 ) ([]*models.MediaItem, error) {
 	// LIMIT/OFFSET pages over a live, updated_at-ordered source: a progress
@@ -548,7 +555,7 @@ func (f *Fetcher) collectContinueProgressItems(
 		rawProgressCount := len(progressEntries)
 		progressEntries = dismissals.FilterProgress(progressEntries)
 
-		pageItems, pageMeta, err := f.fetchContinueProgressItems(ctx, store, profileID, progressEntries, continueType, libraryID, libraryIDs, filter)
+		pageItems, pageMeta, err := f.fetchContinueProgressItems(ctx, store, profileID, progressEntries, continueType, libraryID, libraryIDs, filter, completedCache)
 		if err != nil {
 			return nil, err
 		}
@@ -640,7 +647,7 @@ const (
 	continueProgressMaxScanned = 1000
 )
 
-func (f *Fetcher) fetchContinueProgressItems(ctx context.Context, store userstore.UserStore, profileID string, entries []userstore.WatchProgress, continueType ContinueType, libraryID *int, libraryIDs []int, filter catalog.AccessFilter) ([]*models.MediaItem, map[string]SectionItemMeta, error) {
+func (f *Fetcher) fetchContinueProgressItems(ctx context.Context, store userstore.UserStore, profileID string, entries []userstore.WatchProgress, continueType ContinueType, libraryID *int, libraryIDs []int, filter catalog.AccessFilter, completedCache *catalog.CompletedProgressCache) ([]*models.MediaItem, map[string]SectionItemMeta, error) {
 	if len(entries) == 0 {
 		return nil, map[string]SectionItemMeta{}, nil
 	}
@@ -681,7 +688,7 @@ func (f *Fetcher) fetchContinueProgressItems(ctx context.Context, store userstor
 		matchingEntries = append(matchingEntries, entry)
 	}
 	if ContinueTypeAllowsNextUp(continueType) && hasEpisodeEntries {
-		supersededEpisodeProgress, err := f.progressFilter.SupersededEpisodeProgressIDs(ctx, store, profileID, matchingEntries)
+		supersededEpisodeProgress, err := f.progressFilter.SupersededEpisodeProgressIDsCached(ctx, store, profileID, matchingEntries, completedCache)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/migrations/sql/20260904144457_continue_watching_planner_stats.sql
+++ b/migrations/sql/20260904144457_continue_watching_planner_stats.sql
@@ -1,0 +1,59 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- user_id and profile_id are functionally dependent: a profile belongs to
+-- exactly one user, so (user_id = $1 AND profile_id = $2) selects the same rows
+-- profile_id alone would. The planner does not know that. It multiplies the two
+-- selectivities as if they were independent -- roughly (1/1300) * (1/1300) over
+-- a few million rows -- and estimates one row where the real answer is
+-- thousands.
+--
+-- Continue Watching pays for that estimate. Believing the outer side yields a
+-- single row, the planner reads a rescan of the profile's whole hidden-history
+-- slice as free, so it declines to push media_item_id into the inner index
+-- condition and picks a nested-loop anti join against
+-- user_history_hidden_items. It also scans idx_user_watch_progress_profile and
+-- filters for completed, rather than reading the partial index that already
+-- holds only completed rows. Measured on production data for one profile with
+-- 3384 completed rows and 189 hidden rows: 639576 rows discarded by the join
+-- filter, 372553 buffers, 251ms.
+--
+-- Extended statistics teach the planner the dependency. The same query then
+-- plans as a hash anti join over idx_uwp_profile_completed_cursor: 26 rows
+-- discarded, 1986 buffers, 4.0ms -- 62.7x faster, 188x fewer buffers. The top-N
+-- sort stays; the win is the join method and the index, not the ordering.
+--
+-- Verified across ten production profiles, best of three passes, using the
+-- column list ListProgress actually selects. The completed-history walk
+-- improves on nine of the ten, 1.1x to 62.7x. Three of the twenty queries
+-- measured get slower, all of them fast in absolute terms and all reproducible
+-- across passes: on one profile the walk goes 0.43ms to 6.30ms and its resume
+-- page 0.23ms to 1.49ms, because correct estimates make the planner hash all
+-- 5635 completed rows and top-N sort instead of walking the ordered index and
+-- stopping at 500; on another the resume page goes 0.43ms to 7.48ms. Continue
+-- Watching as a whole is still faster on every profile measured -- the
+-- request-scoped cache in the following commit removes far more work than these
+-- plans add -- so the two commits belong together and should not be split.
+--
+-- These objects cover user_id and profile_id by name. Postgres drops an
+-- extended statistics object silently, with no error, when a column it covers
+-- is dropped -- so a later migration that drops either column takes the query
+-- back to the nested loop with nothing failing to announce it. Renames and type
+-- changes are safe: the object follows a RENAME and survives an ALTER TYPE
+-- (its sampled data resets and the next ANALYZE refills it).
+CREATE STATISTICS IF NOT EXISTS uwp_user_profile (dependencies, ndistinct)
+    ON user_id, profile_id FROM public.user_watch_progress;
+
+CREATE STATISTICS IF NOT EXISTS uhhi_user_profile (dependencies, ndistinct)
+    ON user_id, profile_id FROM public.user_history_hidden_items;
+
+-- A statistics object is inert until a sample exists for it. Without this the
+-- fix lands whenever autoanalyze next happens to visit the table, which on a
+-- table this size can be hours. Both ANALYZE runs sample rather than scan and
+-- take well under a second each on a multi-million-row table.
+ANALYZE public.user_watch_progress;
+ANALYZE public.user_history_hidden_items;
+
+-- +goose Down
+DROP STATISTICS IF EXISTS uhhi_user_profile;
+DROP STATISTICS IF EXISTS uwp_user_profile;

--- a/migrations/sql/20260904144457_continue_watching_planner_stats.sql
+++ b/migrations/sql/20260904144457_continue_watching_planner_stats.sql
@@ -1,5 +1,3 @@
--- +goose NO TRANSACTION
-
 -- +goose Up
 -- user_id and profile_id are functionally dependent: a profile belongs to
 -- exactly one user, so (user_id = $1 AND profile_id = $2) selects the same rows


### PR DESCRIPTION
Two commits: a Postgres planner fix and a request-scoped cache. They measure separately but ship together — see Risk.

## Problem

**Continue Watching was the slowest row on the home screen, and it got worse the more you had watched.** For households with a long viewing history, building that single row cost between a quarter-second and a full second of database time before anything reached the client. The people with the most watch history had the worst experience, which is exactly backwards.

Two independent causes, neither visible from outside the server:

- **The database was guessing wrong about who owns a profile.** Every lookup of a profile's finished episodes filters on both the account and the profile. Postgres treated those as two unrelated conditions and concluded each lookup would return about *one* row, when the true answer was thousands. Working from that guess it chose a strategy that read hundreds of thousands of rows and threw almost all of them away. Across ten real profiles the guess was between 52x and 3839x too low, and never once right.
- **The row kept asking the same question over and over.** Continue Watching is assembled in pages, and each page re-asked "what has this profile already finished?" starting again from the top of history. Because pages arrive newest-first, each page reached further back than the one before, so every page re-read everything its predecessors had already read. A full row build issued up to fifty history reads where five would have done.

## Solution

### perf(db): teach the planner that a profile belongs to one user

`user_id` and `profile_id` are functionally dependent — a profile belongs to exactly one user — so `WHERE user_id = $1 AND profile_id = $2` selects the same rows `profile_id` alone would. The planner does not know that and multiplies the two selectivities as if independent.

`migrations/sql/20260904144457_continue_watching_planner_stats.sql` creates `CREATE STATISTICS ... (dependencies, ndistinct)` on both `user_watch_progress` and `user_history_hidden_items`, then runs `ANALYZE` on each. No query and no application code changes. The `ANALYZE` is deliberate: a statistics object is inert until a sample exists, and without it the fix would land whenever autoanalyze next happened to reach a multi-million-row table.

Chosen over the alternative of dropping the redundant `user_id` predicate from the queries, because the statistics fix helps every query with this shape — including `ListProgressByMediaItems`, reworked independently in #946 — instead of the handful we happened to edit.

The migration comment records a trap worth knowing: Postgres drops an extended statistics object **silently** when a column it covers is dropped. A future migration that drops `user_id` or `profile_id` puts these queries straight back on the slow plan with nothing failing to announce it.

### perf(sections): read the completed-history walk once per request, not per page

`CompletedProgressCache` (`internal/catalog/continue_watching_progress.go`) holds one request's walk. It reads strictly forward, keeping the rows seen so far plus the `updated_at` it has scanned down to, and pages further only when a caller asks for a cutoff older than that. A row is never read twice, and the answer for any cutoff is byte-identical to a fresh walk.

`CompletedProgressSnapshots` keeps its signature and now runs through a single-use cache, so there is one implementation of the walk rather than two that can drift. `internal/sections/fetcher.go:*` builds the cache once per request. The jellycompat Resume caller already asked once per request and is unchanged.

## Measurements

Replayed against the production database in the exact query sequence `internal/sections/fetcher.go` issues. Best of three measured passes after a warmup pass; the "after" phase runs inside a transaction that is rolled back. Ten profiles, anonymised — each letter is one real household profile.

**One full Continue Watching load, `main` → this branch:**

| Profile | Before | After | Speedup | Queries |
|---|---:|---:|---:|---:|
| A | 962.6 ms | 36.5 ms | 26.4x | 9 → 9 |
| C | 539.3 ms | 83.6 ms | 6.5x | 18 → 13 |
| K | 587.0 ms | 112.6 ms | 5.2x | 45 → 25 |
| L | 507.3 ms | 107.0 ms | 4.7x | 54 → 29 |
| M | 430.3 ms | 123.8 ms | 3.5x | 63 → 33 |
| H | 278.1 ms | 82.8 ms | 3.4x | 9 → 9 |
| I | 282.3 ms | 191.4 ms | 1.5x | 90 → 45 |

**Split by commit:**

| Profile | main | + planner stats | + hoisted walk |
|---|---:|---:|---:|
| A | 962.6 | 36.9 | 36.5 |
| C | 539.3 | 136.5 | 83.6 |
| K | 587.0 | 208.9 | 112.6 |
| L | 507.3 | 166.2 | 107.0 |
| M | 430.3 | 259.3 | 123.8 |
| H | 278.1 | 78.0 | 82.8 |
| I | 282.3 | 344.2 | 191.4 |

**Completed-history walk on its own** (`EXPLAIN (ANALYZE, BUFFERS)`, production column list):

| Profile | Before | After | Speedup |
|---|---:|---:|---:|
| A | 251.6 ms | 4.0 ms | 62.7x |
| B | 57.9 ms | 1.3 ms | 43.0x |
| C | 30.2 ms | 1.8 ms | 17.2x |
| D | 25.9 ms | 1.8 ms | 14.6x |
| E | 16.3 ms | 1.9 ms | 8.4x |
| F | 59.8 ms | 7.5 ms | 8.0x |
| G | 7.2 ms | 1.2 ms | 5.8x |
| H | 38.2 ms | 7.1 ms | 5.4x |
| J | 1.70 ms | 1.61 ms | 1.1x |
| I | 0.43 ms | 6.30 ms | **0.07x — slower** |

On profile A the plan goes from a nested-loop anti join discarding 639,576 rows over 372,553 buffers, to a hash anti join over `idx_uwp_profile_completed_cursor` discarding 26 rows over 1,986 buffers: 188x fewer buffers.

## Risk / follow-ups

- **Three of the twenty measured queries get slower, and the two commits must not be split.** On profile I the walk goes 0.43 ms → 6.30 ms and its resume page 0.23 ms → 1.49 ms; on profile H the resume page goes 0.43 ms → 7.48 ms. Correct estimates make the planner hash all of a profile's completed rows and top-N sort, instead of walking the ordered index and stopping at 500. Reproducible across every pass, not noise. The planner commit alone makes profile I's full load 22% slower (282 → 344 ms); the caching commit takes it to 191 ms. Landing the first without the second is a regression for that shape.
- Postgres silently drops an extended statistics object when a covered column is dropped. A future migration touching `user_id` or `profile_id` on either table reverts this fix with no error. Renames and type changes are safe.
- Profiles whose in-progress list fits on one page get nothing from the second commit by construction (A and H above, 9 queries either way).
- The migration runs `ANALYZE` outside a transaction on two multi-million-row tables. Both sample rather than scan and finished well under a second each on production-sized data, but it is worth watching on first deploy.
- Not a client-visible change: no API shape, auth, playback, session, library, or metadata behaviour changes, so no `silo-apple` / `silo-android` follow-up, no jellycompat parity work, and no `docs/*-api.md` update. jellycompat's Resume path benefits automatically — it shares the walk and already called it once per request.

## Verification

- `go build ./...` — clean. `gofmt -l internal/catalog internal/sections` — clean.
- `go vet ./internal/catalog/... ./internal/sections/...` — clean.
- `go test ./internal/catalog/... ./internal/sections/... ./internal/userstore/...` — all pass.
- `golangci-lint run --new-from-merge-base=origin/main ./internal/catalog/... ./internal/sections/...` — 0 issues.
- `make verify-local-paths` — clean.
- New test in `internal/catalog/continue_watching_progress_test.go` runs the cached walk and a fresh walk side by side and asserts identical results for every cutoff, which is the correctness argument for the cache.
- Production replay: 8 passes, 3,608 statements for the end-to-end run plus 160 `EXPLAIN (ANALYZE, BUFFERS)` runs for the query-level table. Zero errors; the statistics were created inside a transaction and rolled back, so the production database is unchanged and still has no extended statistics.
- Rebased onto `origin/main` at 3131494e with no conflicts, and re-verified after the rebase.

Related issue: N/A — no prior coordination needed; found and fixed while profiling the home screen.

## AI-use disclosure

Written with Claude Code (agent harness) using model `claude-opus-5[1m]`. The planner diagnosis, the cache design, the migration, and all measurement harnesses were produced with AI assistance and reviewed against production `EXPLAIN` output. No other AI tooling was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Continue Watching loading by reusing completed-watch history during a single request.
  * Reduced repeated progress lookups when browsing multiple pages of Continue Watching content.
  * Added database optimizations to support faster Continue Watching queries.

* **Reliability**
  * Preserved consistent completed-progress handling across nested and paginated Continue Watching results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->