### PR TITLE
style(routeinventory): name the repeated trait and middleware literals

### DIFF
--- a/internal/routeinventory/classify.go
+++ b/internal/routeinventory/classify.go
@@ -58,6 +58,10 @@ const (
 	traitAuthenticated = "authenticated"
 	traitActingAdmin   = "acting_admin"
 	traitRateLimited   = "rate_limited"
+	traitViewerAccess  = "viewer_access"
+	traitProfileReq    = "profile_required"
+	traitOptionalView  = "optional_viewer_access"
+	mwRequestID        = "middleware.RequestID"
 )
 
 // Middleware markers for router.go sites that register through a spread
@@ -429,8 +433,8 @@ var authRules = []authRule{
 	{marker: "markerEditAccess", class: authPermissionGated, trait: "marker_edit", rank: 50},
 	{marker: "metadataItemAccess", class: authPermissionGated, trait: "metadata_curation", rank: 50},
 	{marker: "metadataCurationAccess", class: authPermissionGated, trait: "metadata_curation", rank: 50},
-	{marker: "RequireViewerAccess", class: authProfileScoped, trait: "viewer_access", rank: 40},
-	{marker: "RequireProfile", class: authProfileScoped, trait: "profile_required", rank: 40},
+	{marker: "RequireViewerAccess", class: authProfileScoped, trait: traitViewerAccess, rank: 40},
+	{marker: "RequireProfile", class: authProfileScoped, trait: traitProfileReq, rank: 40},
 	// The Apple push display gate (internal/api/middleware/apple_push_display.go)
 	// requires auth on both credential paths and resolves a profile: ordinary
 	// tokens fall back to RequireAuth + viewer access + RequireProfile, and a
@@ -438,8 +442,8 @@ var authRules = []authRule{
 	// session and written to X-Profile-Id. router.go registers it through the
 	// spread slice `displayMiddlewares`, which is the identifier the analyzer
 	// prints, so both spellings carry the same rules.
-	{marker: markerApplePushDisplayAuth, class: authProfileScoped, trait: "profile_required", rank: 40},
-	{marker: markerDisplayMiddlewares, class: authProfileScoped, trait: "profile_required", rank: 40},
+	{marker: markerApplePushDisplayAuth, class: authProfileScoped, trait: traitProfileReq, rank: 40},
+	{marker: markerDisplayMiddlewares, class: authProfileScoped, trait: traitProfileReq, rank: 40},
 	{marker: "RequireAuth", class: authAuthenticated, trait: traitAuthenticated, rank: 30},
 	{marker: "requireBearer", class: authNodeBearer, trait: "node_bearer", rank: 30},
 	{marker: "OptionalAuth", class: authOptional, trait: "optional_auth", rank: 20},
@@ -453,29 +457,29 @@ var traitOnlyRules = []authRule{
 	{marker: "demoGuard", trait: "demo_guarded"},
 	{marker: "meterEgress", trait: "egress_metered"},
 	{marker: "cors.Handler", trait: "cors"},
-	{marker: "optionalProfileViewerAccess", trait: "optional_viewer_access"},
+	{marker: "optionalProfileViewerAccess", trait: traitOptionalView},
 	// router.go builds `passwordChangeMiddlewares` for POST
 	// /api/v1/auth/account/password: optionalProfileViewerAccess plus, when a
 	// limiter is configured, RateLimitMW.AuthEndpointHandler("password_change").
 	// RequireAuth is applied separately by the enclosing group. Conditional
 	// limiters are recorded as present, matching the RateLimitMW rules above.
-	{marker: markerPasswordChange, trait: "optional_viewer_access"},
+	{marker: markerPasswordChange, trait: traitOptionalView},
 	{marker: markerPasswordChange, trait: traitRateLimited},
 	// The Apple push display gate always ends in RequireAuth-equivalent
 	// authentication, viewer access, and RequireProfile; `displayMiddlewares`
 	// also prepends RateLimitMW.Handler when a limiter is configured. See the
 	// matching authRules entries for the class.
 	{marker: markerApplePushDisplayAuth, trait: traitAuthenticated},
-	{marker: markerApplePushDisplayAuth, trait: "viewer_access"},
+	{marker: markerApplePushDisplayAuth, trait: traitViewerAccess},
 	{marker: markerDisplayMiddlewares, trait: traitAuthenticated},
-	{marker: markerDisplayMiddlewares, trait: "viewer_access"},
+	{marker: markerDisplayMiddlewares, trait: traitViewerAccess},
 	{marker: markerDisplayMiddlewares, trait: traitRateLimited},
 }
 
 // infrastructureMiddleware is the base stack every request passes through. It
 // is listed so a genuinely new middleware stands out as unclassified.
 var infrastructureMiddleware = []string{
-	"apimw.RequestID", "middleware.RequestID", "middleware.Recoverer", "apimw.RequestLogger", "apimw.Metrics",
+	"apimw.RequestID", mwRequestID, "middleware.Recoverer", "apimw.RequestLogger", "apimw.Metrics",
 	"httpstream.CompressExcept", "clientip.Middleware", "activitylog.NewMiddleware",
 }
 


### PR DESCRIPTION
## Problem

CI lints pushes to `apiv2` with `--new-from-merge-base=origin/main`, so the route-inventory classification rules that landed in #948 fail goconst on every `apiv2` push even though the PR gate (against `apiv2`) was clean.

## Solution

Hoist the four repeated literals (`viewer_access`, `profile_required`, `optional_viewer_access`, `middleware.RequestID`) into constants next to the existing trait constants. No behavior change; the route inventory is byte-identical.

## Validation

```
go test ./internal/routeinventory/                                    ok
golangci-lint run --new-from-merge-base=origin/main ./internal/routeinventory/...   0 issues
make verify-route-inventory                                            current
```

Related issue: #135

## AI Disclosure

- Harness: Claude Code; Model: claude-fable-5-1[1m]; AI-authored under the maintainer's overnight instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)