### PR TITLE
test: deflake the capability refresh and ABS telemetry tests

### DIFF
--- a/internal/api/handlers/playback_v3_capability_retry_test.go
+++ b/internal/api/handlers/playback_v3_capability_retry_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -84,8 +85,22 @@ func TestLookupRemoteCapabilitiesFetchesOnceWhenNothingInvalidates(t *testing.T)
 func TestRefreshNodeCapabilitiesKeepsTheLearnedProbeBudget(t *testing.T) {
 	handler := NewPlaybackHandler(nil)
 
+	// The invalidation under test also starts a background re-probe, and a
+	// local node answers it in well under a millisecond. Left free, that probe
+	// refills the cache between the invalidation and the check that it was
+	// emptied whenever the test goroutine is descheduled in between — which a
+	// loaded package run does routinely. The node holds the second read until
+	// the assertions have run, so the cache state they inspect is the
+	// invalidation's, not the scheduler's.
+	var fetches atomic.Int32
+	reprobeStarted := make(chan struct{})
+	releaseReprobe := make(chan struct{})
 	advertised := 136_000
 	node := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if fetches.Add(1) == 2 {
+			close(reprobeStarted)
+			<-releaseReprobe
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"resolved":                 "qsv",
@@ -93,6 +108,11 @@ func TestRefreshNodeCapabilitiesKeepsTheLearnedProbeBudget(t *testing.T) {
 		})
 	}))
 	t.Cleanup(node.Close)
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseReprobe) }) }
+	// Registered after node.Close so it runs first: Close waits for the held
+	// request, and a failed assertion must not turn into a hang.
+	t.Cleanup(release)
 
 	if _, err := handler.lookupRemoteCapabilitiesV3(context.Background(), node.URL, false); err != nil {
 		t.Fatalf("lookupRemoteCapabilitiesV3: %v", err)
@@ -103,16 +123,28 @@ func TestRefreshNodeCapabilitiesKeepsTheLearnedProbeBudget(t *testing.T) {
 	}
 
 	handler.RefreshNodeCapabilitiesV3(node.URL)
+	select {
+	case <-reprobeStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("invalidation did not start the background re-probe it owes")
+	}
 
 	if got := handler.remoteToneMapProbeTimeoutV3(node.URL); got != learned {
 		t.Fatalf("budget after invalidation = %v, want the learned %v — the refresh it triggers is sized from this",
 			got, learned)
 	}
-	// The inventory itself is still discarded; only the budget survives.
+	// The inventory itself is still discarded; only the budget survives. With
+	// the re-probe held at the node, an entry here can only be the one the
+	// invalidation should have removed.
 	handler.v3NodeCapabilitiesMu.Lock()
 	_, cached := handler.v3NodeCapabilities[node.URL]
 	handler.v3NodeCapabilitiesMu.Unlock()
 	if cached {
 		t.Fatal("invalidation left the inventory cached")
 	}
+
+	// Let the re-probe finish and refill the cache before the node goes away,
+	// so the background goroutine does not outlive the test that started it.
+	release()
+	waitForCachedNodeCapabilitiesV3(t, handler, node.URL)
 }

--- a/internal/audiobooks/abs/streamtelemetry_test.go
+++ b/internal/audiobooks/abs/streamtelemetry_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -70,17 +71,53 @@ func telemetryRegistry(t testing.TB, families ...streamtelemetry.Family) *stream
 // all — behind a real socket. Handler-level tests bypass the middleware under
 // test, which is how this project once shipped a feature that was a no-op for
 // weeks.
-func absTelemetryServer(t testing.TB, registry *streamtelemetry.Registry, deps Dependencies) *httptest.Server {
+func absTelemetryServer(t testing.TB, registry *streamtelemetry.Registry, deps Dependencies) *absServer {
 	t.Helper()
 	handler := New(deps)
 	handler.SetStreamTelemetry(registry)
+	server := &absServer{registry: registry}
 	router := chi.NewRouter()
+	// Outermost on purpose: it returns only after every inner handler,
+	// including the telemetry observer's deferred release, has run.
+	router.Use(server.trackInFlight)
 	router.Use(middleware.Recoverer)
 	router.Use(httpstream.CompressExcept(5, SkipMediaCompression))
 	handler.Mount(router)
-	server := httptest.NewServer(router)
+	server.Server = httptest.NewServer(router)
 	t.Cleanup(server.Close)
 	return server
+}
+
+// absServer is the mounted router plus a count of requests its handlers have
+// not finished. The client sees the last body byte before the handler's
+// deferred telemetry release has run, so a Sweep taken straight after client.Do
+// can fold an observation whose bytes and outcome are not recorded yet.
+type absServer struct {
+	*httptest.Server
+	registry *streamtelemetry.Registry
+	inFlight atomic.Int64
+}
+
+func (s *absServer) trackInFlight(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.inFlight.Add(1)
+		defer s.inFlight.Add(-1)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// settledSweep sweeps the registry once the server has finished every request
+// the test sent — the only point at which the totals are final.
+func (s *absServer) settledSweep(t testing.TB) streamtelemetry.Snapshot {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for s.inFlight.Load() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("%d request(s) still in flight after 10s", s.inFlight.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return s.registry.Sweep()
 }
 
 func absPublicTrackDeps(t testing.TB, sid, contentID, userID string, body []byte) Dependencies {
@@ -145,7 +182,7 @@ func TestMountedABSRouterAttributesPublicTrack(t *testing.T) {
 
 	// Byte totals come from Sweep, not Snapshot: SessionView.BytesAccepted is
 	// lastSweptBytes and only the sweep folds live observations into it.
-	snapshot := registry.Sweep()
+	snapshot := server.settledSweep(t)
 	if len(snapshot.Sessions) != 1 {
 		t.Fatalf("sessions = %+v", snapshot.Sessions)
 	}
@@ -191,7 +228,7 @@ func TestMountedABSRouterPublicTrackEdgeCases(t *testing.T) {
 		if got.status != http.StatusOK || len(got.body) != 0 {
 			t.Fatalf("HEAD = %d, %d bytes", got.status, len(got.body))
 		}
-		snapshot := registry.Sweep()
+		snapshot := server.settledSweep(t)
 		if len(snapshot.Sessions) != 1 {
 			t.Fatalf("sessions = %+v", snapshot.Sessions)
 		}
@@ -218,7 +255,7 @@ func TestMountedABSRouterPublicTrackEdgeCases(t *testing.T) {
 		if !bytes.Equal(got.body, large[1000:3000]) {
 			t.Fatalf("range body mismatch: %d bytes", len(got.body))
 		}
-		if snapshot := registry.Sweep(); len(snapshot.Sessions) != 1 || snapshot.Sessions[0].BytesAccepted != 2000 {
+		if snapshot := server.settledSweep(t); len(snapshot.Sessions) != 1 || snapshot.Sessions[0].BytesAccepted != 2000 {
 			t.Fatalf("range accounting = %+v", snapshot.Sessions)
 		}
 	})
@@ -251,7 +288,7 @@ func TestMountedABSRouterPublicTrackEdgeCases(t *testing.T) {
 			if got.status != test.wantStatus {
 				t.Fatalf("status = %d, want %d", got.status, test.wantStatus)
 			}
-			snapshot := registry.Sweep()
+			snapshot := server.settledSweep(t)
 			if len(snapshot.Sessions) != 0 || len(snapshot.Transfers) != 0 {
 				t.Fatalf("rejected request created logical activity: %+v %+v", snapshot.Sessions, snapshot.Transfers)
 			}
@@ -314,7 +351,7 @@ func TestMountedABSRouterFeedFileResolvesOwner(t *testing.T) {
 	if got.status != http.StatusOK || !bytes.Equal(got.body, body) {
 		t.Fatalf("GET = %d, %d bytes", got.status, len(got.body))
 	}
-	snapshot := registry.Sweep()
+	snapshot := server.settledSweep(t)
 	if len(snapshot.Sessions) != 0 {
 		t.Fatalf("feed file created a logical session: %+v", snapshot.Sessions)
 	}
@@ -340,7 +377,7 @@ func TestMountedABSRouterFamilyGate(t *testing.T) {
 	if got.status != http.StatusOK || len(got.body) == 0 {
 		t.Fatalf("gated-out family broke serving: %d, %d bytes", got.status, len(got.body))
 	}
-	snapshot := registry.Sweep()
+	snapshot := server.settledSweep(t)
 	if len(snapshot.Sessions) != 0 || snapshot.UnattributedObservations != 0 {
 		t.Fatalf("gated-out family still observed: %+v", snapshot)
 	}


### PR DESCRIPTION
## Problem

Two Go tests fail intermittently on CI and have blocked unrelated `apiv2` section pull requests seven times today:

- `TestRefreshNodeCapabilitiesKeepsTheLearnedProbeBudget` (`internal/api/handlers`): `invalidation left the inventory cached`.
- `TestMountedABSRouterPublicTrackEdgeCases` / `TestMountedABSRouterFeedFileResolvesOwner` (`internal/audiobooks/abs`): a stream-telemetry record with a partial byte total.

## Solution

Both are test races, not production defects.

- The capability refresh deletes the cache entry and starts a background re-probe. Against the local test node the probe completes in under a millisecond, so the cache could be refilled before the "cache is empty" assertion ran. The test now holds the node's second response until the assertions have run, then releases it and waits for the refilled entry, so the goroutine does not outlive the server.
- The client sees the last body byte before the telemetry observer's per-slice accounting and deferred release finish, so an immediate sweep could fold a partial total. The test router now counts in-flight requests in its outermost middleware and every sweep waits for that count to reach zero.

Neither test relies on a sleep; both wait on observable state, per CLAUDE.md.

## Validation

```
go build ./...                                             ok
gofmt -l internal                                          (empty)
go test -count=20 -race -run 'TestRefreshNodeCapabilities|TestMountedABSRouter' ./internal/api/handlers/ ./internal/audiobooks/abs/   ok
go test -count=100 -cpu 1,2,8 -race -run TestRefreshNodeCapabilities ./internal/api/handlers/   ok (a 20 ms sleep after the invalidation reproduced the failure 3/3 before the fix)
go test -count=150 -cpu 1,2,8 -race -run TestMountedABSRouter ./internal/audiobooks/abs/       ok (1/50 failed before the fix)
go test -count=1 ./internal/api/handlers/... ./internal/audiobooks/...   ok
golangci-lint run --new-from-merge-base=origin/apiv2 ./...   0 issues
```

Related issue: N/A — narrow fix (unblocks the #135 section PRs)

## AI Disclosure

- Harness: Claude Code (orchestrating session with an implementer subagent)
- Model: claude-fable-5-1[1m]
- Involvement: Fully AI-generated under the maintainer's standing instruction for overnight apiv2 work; maintainer review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
