### PR TITLE
chore(apiv2): satisfy goconst on the apiv2 push lint

### DIFF
--- a/internal/apiv2/gates.go
+++ b/internal/apiv2/gates.go
@@ -14,6 +14,14 @@ import (
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 )
 
+// Legacy v1 error codes the gates translate that have no v2 problem type of
+// their own (the others reuse the matching ProblemType's ID).
+const (
+	legacyForbiddenCode      = "forbidden"
+	legacyDemoRestrictedCode = "demo_restricted"
+	legacyBadRequestCode     = "bad_request"
+)
+
 // classGate composes the existing chi-style gates onto a Huma operation from
 // the class it declared. It runs first among the API middlewares so nothing
 // about an operation (media type, parameters, body) is judged before the
@@ -183,9 +191,9 @@ func (d *denialWriter) problem() *Problem {
 		// keeps a type of its own rather than collapsing into permission_denied.
 		p = NewProblem(TypeProfileVerificationRequired,
 			"The declared profile is locked; verify it and retry with X-Profile-Token.")
-	case "forbidden", "demo_restricted":
+	case legacyForbiddenCode, legacyDemoRestrictedCode:
 		p = NewProblem(TypePermissionDenied, safeDetail(legacy.Message, "The caller is not permitted to perform this operation."))
-	case "not_found":
+	case TypeNotFound.ID:
 		p = NewProblem(TypeNotFound, safeDetail(legacy.Message, "The requested resource does not exist."))
 	case "rate_limit_exceeded":
 		p = NewProblem(TypeRateLimited, "Too many requests; retry after the Retry-After delay.")
@@ -194,9 +202,9 @@ func (d *denialWriter) problem() *Problem {
 		} else {
 			p = p.WithRetryAfter(1)
 		}
-	case "bad_request":
+	case legacyBadRequestCode:
 		p = badRequestProblem(d.reason)
-	case "internal_error":
+	case TypeInternalError.ID:
 		p = NewProblem(TypeInternalError, "An unexpected error occurred.")
 	default:
 		if d.status >= 500 || d.status == 0 {

--- a/internal/apiv2/pilot_fakes_test.go
+++ b/internal/apiv2/pilot_fakes_test.go
@@ -213,7 +213,7 @@ func (f *fakeProfiles) DeleteProfile(_ context.Context, cmd handlers.ProfileDele
 		return &handlers.APIError{Status: http.StatusConflict, Code: "primary_profile_protected", Message: "The primary profile cannot be deleted. Delete the user account instead."}
 	}
 	if cmd.ProfileID != f.view.ID {
-		return &handlers.APIError{Status: http.StatusNotFound, Code: "not_found", Message: "Profile not found"}
+		return &handlers.APIError{Status: http.StatusNotFound, Code: TypeNotFound.ID, Message: "Profile not found"}
 	}
 	return nil
 }
@@ -232,7 +232,7 @@ func (f *fakeProfiles) VerifyPIN(_ context.Context, cmd handlers.ProfileVerifyPI
 		return handlers.ProfileVerification{}, f.err
 	}
 	if cmd.ProfileID != f.view.ID {
-		return handlers.ProfileVerification{}, &handlers.APIError{Status: http.StatusNotFound, Code: "not_found", Message: "Profile not found or has no PIN"}
+		return handlers.ProfileVerification{}, &handlers.APIError{Status: http.StatusNotFound, Code: TypeNotFound.ID, Message: "Profile not found or has no PIN"}
 	}
 	if cmd.PIN != "1234" {
 		return handlers.ProfileVerification{Valid: false}, nil
@@ -250,7 +250,7 @@ func (f *fakeProfiles) UploadAvatar(_ context.Context, up handlers.ProfileAvatar
 		return handlers.ProfileView{}, &handlers.APIError{Status: http.StatusServiceUnavailable, Code: "unavailable", Message: "Avatar upload storage is not configured"}
 	}
 	if up.ProfileID != f.view.ID {
-		return handlers.ProfileView{}, &handlers.APIError{Status: http.StatusNotFound, Code: "not_found", Message: "Profile not found"}
+		return handlers.ProfileView{}, &handlers.APIError{Status: http.StatusNotFound, Code: TypeNotFound.ID, Message: "Profile not found"}
 	}
 	if len(data) > 10<<20 {
 		return handlers.ProfileView{}, &handlers.APIError{Status: http.StatusRequestEntityTooLarge, Code: "too_large", Message: "Avatar must be under 10 MB"}
@@ -269,7 +269,7 @@ func (f *fakeProfiles) DeleteAvatar(_ context.Context, _ int, profileID string) 
 		return handlers.ProfileView{}, f.err
 	}
 	if profileID != f.view.ID {
-		return handlers.ProfileView{}, &handlers.APIError{Status: http.StatusNotFound, Code: "not_found", Message: "Profile not found"}
+		return handlers.ProfileView{}, &handlers.APIError{Status: http.StatusNotFound, Code: TypeNotFound.ID, Message: "Profile not found"}
 	}
 	return f.view, nil
 }

--- a/internal/apiv2/profile_sections_test.go
+++ b/internal/apiv2/profile_sections_test.go
@@ -204,7 +204,7 @@ func TestReplaceProfileSectionOverridesDecisions(t *testing.T) {
 		{&handlers.APIError{Status: http.StatusBadRequest, Code: "invalid_config", Message: "library_ids: at least one"}, TypeValidationFailed, locationOverrides},
 		// An admin-only recipe on a server that does not allow custom sections.
 		{&handlers.APIError{Status: http.StatusForbidden, Code: "custom_disabled", Message: "this server does not allow profiles to build custom sections"}, TypePermissionDenied, ""},
-		{&handlers.APIError{Status: http.StatusInternalServerError, Code: "internal_error", Message: "Failed to save overrides"}, TypeInternalError, ""},
+		{&handlers.APIError{Status: http.StatusInternalServerError, Code: TypeInternalError.ID, Message: "Failed to save overrides"}, TypeInternalError, ""},
 	} {
 		h := newTestHandler(t, sectionDeps(&fakeProfileSections{err: tc.err}))
 		p := requireProblem(t, do(t, h, http.MethodPut, "/api/v2/profile/sections", body, auth), tc.want)

--- a/internal/apiv2/profiles.go
+++ b/internal/apiv2/profiles.go
@@ -95,8 +95,11 @@ const (
 
 // profileUpdateNullable names the members whose null is a clearing value;
 // null on any other member is a type failure.
+// memberAvatar is the profile member the avatar operations address.
+const memberAvatar = "avatar"
+
 var profileUpdateNullable = map[string]bool{
-	"avatar": true, "pin": true, "max_content_rating": true, "language": true,
+	memberAvatar: true, "pin": true, "max_content_rating": true, "language": true,
 	"preferred_metadata_language": true, "subtitle_language": true, fieldMaxPlaybackQuality: true,
 }
 

--- a/internal/apiv2/profiles_test.go
+++ b/internal/apiv2/profiles_test.go
@@ -452,7 +452,7 @@ func TestListHouseholdSessions(t *testing.T) {
 		want ProblemType
 	}{
 		{&handlers.APIError{Status: http.StatusForbidden, Code: "forbidden", Message: "Profile management requires the primary profile or admin access"}, TypePermissionDenied},
-		{&handlers.APIError{Status: http.StatusInternalServerError, Code: "internal_error", Message: "Playback sessions are not configured"}, TypeInternalError},
+		{&handlers.APIError{Status: http.StatusInternalServerError, Code: TypeInternalError.ID, Message: "Playback sessions are not configured"}, TypeInternalError},
 	} {
 		h := newTestHandler(t, pilotDeps(nil, &fakeProfiles{err: tc.err}))
 		requireProblem(t, do(t, h, http.MethodGet, "/api/v2/profiles/household/sessions", "", bearer(memberToken)), tc.want)


### PR DESCRIPTION
## Problem

CI lints `apiv2` pushes with `--new-from-merge-base` against `main`, so string literals the merged sections added tipped goconst over its threshold (`forbidden`, `not_found`, `bad_request`, `internal_error`, `avatar`) and the `apiv2` push run has been red since the profiles merge.

## Solution

Name the legacy v1 error codes the gates translate (`legacyForbiddenCode`, `legacyDemoRestrictedCode`, `legacyBadRequestCode`), reuse the matching `ProblemType.ID` where one exists, name the `avatar` profile member, and use the problem IDs in the test fakes. No behaviour change.

## Validation

```
golangci-lint run --new-from-merge-base=origin/main ./...   0 issues
go test ./internal/apiv2/                                    ok
```

Related issue: N/A — narrow fix

## AI Disclosure

- Harness: Claude Code
- Model: claude-fable-5-1[1m]
- Involvement: Fully AI-generated under the maintainer's standing instruction for overnight apiv2 work; maintainer review pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)