### PR TITLE
perf(imageutil): reuse equivalent artwork encodes

### DIFF
--- a/internal/imageutil/imageutil.go
+++ b/internal/imageutil/imageutil.go
@@ -10,6 +10,7 @@ import (
 	"image/color"
 	_ "image/jpeg"
 	_ "image/png"
+	"slices"
 	"sort"
 
 	"github.com/h2non/bimg"
@@ -69,12 +70,13 @@ func GenerateVariants(data []byte, widths []int) (*VariantResult, error) {
 	variants = append(variants, Variant{Key: "original", Data: original})
 
 	// Sort widths descending (largest first).
-	sorted := make([]int, len(widths))
-	copy(sorted, widths)
-	sort.Sort(sort.Reverse(sort.IntSlice(sorted)))
+	sorted := slices.Clone(widths)
+	slices.Sort(sorted)
+	slices.Reverse(sorted)
 
+	previousWidth, previousHeight := originalOptions.Width, originalOptions.Height
+	previousOutput := original
 	for _, w := range sorted {
-		size, _ := bimg.NewImage(data).Size()
 		opts := bimg.Options{
 			Type:          bimg.WEBP,
 			Quality:       webpQuality,
@@ -83,10 +85,18 @@ func GenerateVariants(data []byte, widths []int) (*VariantResult, error) {
 		if size.Width > w {
 			opts.Width = w
 		}
-		out, err := bimg.NewImage(data).Process(opts)
-		if err != nil {
-			return nil, fmt.Errorf("imageutil: resize to w%d: %w", w, err)
+		var out []byte
+		if opts.Width == previousWidth && opts.Height == previousHeight {
+			// Equivalent encodes share the work, while each variant retains its
+			// own buffer. Compare both dimensions: tall originals may be capped.
+			out = bytes.Clone(previousOutput)
+		} else {
+			out, err = bimg.NewImage(data).Process(opts)
+			if err != nil {
+				return nil, fmt.Errorf("imageutil: resize to w%d: %w", w, err)
+			}
 		}
+		previousWidth, previousHeight, previousOutput = opts.Width, opts.Height, out
 		variants = append(variants, Variant{Key: fmt.Sprintf("w%d", w), Data: out})
 	}
 

--- a/internal/imageutil/variants_bench_test.go
+++ b/internal/imageutil/variants_bench_test.go
@@ -1,0 +1,26 @@
+package imageutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/artworkkey"
+)
+
+func BenchmarkGenerateVariants(b *testing.B) {
+	for _, size := range [][2]int{{320, 180}, {500, 750}, {1920, 1080}} {
+		b.Run(fmt.Sprintf("%dx%d", size[0], size[1]), func(b *testing.B) {
+			data := largeTestJPEG(b, size[0], size[1])
+			widths := artworkkey.VariantWidths(artworkkey.ImagePoster)
+			if size[0] == 1920 {
+				widths = artworkkey.VariantWidths(artworkkey.ImageBackdrop)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := GenerateVariants(data, widths); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/imageutil/variants_test.go
+++ b/internal/imageutil/variants_test.go
@@ -1,0 +1,53 @@
+package imageutil
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/h2non/bimg"
+)
+
+func TestGenerateVariantsPreservesEncodes(t *testing.T) {
+	for _, size := range [][2]int{{320, 180}, {500, 750}, {1920, 1080}, {500, 2400}, {2400, 1600}} {
+		t.Run(fmt.Sprintf("%dx%d", size[0], size[1]), func(t *testing.T) {
+			data := largeTestJPEG(t, size[0], size[1])
+			widths := []int{300, 1920, 500, 780, 500}
+			got, err := GenerateVariants(data, widths)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(widths, []int{300, 1920, 500, 780, 500}) {
+				t.Fatal("mutated requested widths")
+			}
+			if got.Ext != ".webp" || len(got.Variants) != 6 {
+				t.Fatalf("unexpected result: %#v", got)
+			}
+			for i, width := range []int{0, 1920, 780, 500, 500, 300} {
+				opts := bimg.Options{Type: bimg.WEBP, Quality: webpQuality, StripMetadata: true}
+				key := "original"
+				if i == 0 {
+					fitWithin(&opts, bimg.ImageSize{Width: size[0], Height: size[1]}, MaxCachedOriginalDimension)
+				} else {
+					key = fmt.Sprintf("w%d", width)
+					if size[0] > width {
+						opts.Width = width
+					}
+				}
+				want, err := bimg.NewImage(data).Process(opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got.Variants[i].Key != key || !bytes.Equal(got.Variants[i].Data, want) {
+					t.Fatalf("variant %d (%s) differs from independent encode", i, key)
+				}
+			}
+			before := bytes.Clone(got.Variants[4].Data)
+			got.Variants[3].Data[0] ^= 0xff
+			if !bytes.Equal(got.Variants[4].Data, before) {
+				t.Fatal("duplicate variants share mutable buffers")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: #965

Artwork ingestion re-encodes identical outputs when an image is smaller than several requested rungs or a width is repeated.

## Approach

Read dimensions once and reuse an equivalent output when the requested width and height match. Each returned variant still owns its buffer, and distinct resizes still start from the original bytes. Comparing both dimensions preserves the tall-original cap.

## Validation

| Input / ladder | Before median | After median | Go allocations/op |
|---|---|---|---|
| 320×180 / poster | 11.990 ms | 5.987 ms | 40 → 24 |
| 500×750 / poster | 48.473 ms | 21.621 ms | 40 → 24 |
| 1920×1080 / backdrop | 178.443 ms | 111.857 ms | 43 → 30 |

Three samples per source version on Apple M4 Max, Go 1.26.5, using the existing image ladders.

Byte-for-byte equivalence tests passed for independent encodes, duplicate widths, tall and oversized inputs, unchanged width arguments, and independent output buffers.

Branch validation passed: `go test ./internal/imageutil/...` and `golangci-lint run --new-from-merge-base=origin/main --timeout=10m ./internal/imageutil/...` (0 issues).

## Risks

Measurements cover local encoding only. Provider downloads, S3 requests/uploads, total ingestion throughput, and libvips native memory are outside this benchmark. Image names, ladder selection, and output ownership remain unchanged.

No public API changes; Apple and Android need no client updates. Shared behavior remains compatible with Jellyfin clients, which were not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
