### PR TITLE
perf(scanner): cache classified subtitle candidates

### DIFF
--- a/internal/scanner/subtitles.go
+++ b/internal/scanner/subtitles.go
@@ -25,8 +25,14 @@ type externalSubtitleDirCache struct {
 }
 
 type externalSubtitleDirListing struct {
-	entries []os.DirEntry
-	err     error
+	candidates []externalSubtitleCandidate
+	err        error
+}
+
+type externalSubtitleCandidate struct {
+	name string
+	base string
+	ext  string
 }
 
 func newExternalSubtitleDirCache() *externalSubtitleDirCache {
@@ -46,7 +52,7 @@ func (c *externalSubtitleDirCache) Detect(mediaFilePath string) ([]ExternalSubti
 	c.mu.Unlock()
 	if !ok {
 		entries, err := os.ReadDir(dir)
-		listing = externalSubtitleDirListing{entries: entries, err: err}
+		listing = externalSubtitleDirListing{candidates: externalSubtitleCandidates(entries), err: err}
 		c.mu.Lock()
 		if existing, found := c.dirs[dir]; found {
 			listing = existing
@@ -59,7 +65,7 @@ func (c *externalSubtitleDirCache) Detect(mediaFilePath string) ([]ExternalSubti
 		return nil, fmt.Errorf("subtitles: read dir %s: %w", dir, listing.err)
 	}
 
-	return externalSubtitlesFromEntries(mediaFilePath, listing.entries), nil
+	return externalSubtitlesFromCandidates(mediaFilePath, listing.candidates), nil
 }
 
 // DetectExternalSubtitles scans the directory containing the media file for
@@ -84,10 +90,11 @@ func DetectExternalSubtitles(mediaFilePath string) ([]ExternalSubtitleInfo, erro
 }
 
 func externalSubtitlesFromEntries(mediaFilePath string, entries []os.DirEntry) []ExternalSubtitleInfo {
-	dir := filepath.Dir(mediaFilePath)
-	mediaBase := stripExtension(filepath.Base(mediaFilePath))
-	var results []ExternalSubtitleInfo
+	return externalSubtitlesFromCandidates(mediaFilePath, externalSubtitleCandidates(entries))
+}
 
+func externalSubtitleCandidates(entries []os.DirEntry) []externalSubtitleCandidate {
+	var candidates []externalSubtitleCandidate
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -98,10 +105,24 @@ func externalSubtitlesFromEntries(mediaFilePath string, entries []os.DirEntry) [
 		if !subtitleExtensions[ext] {
 			continue
 		}
+		candidates = append(candidates, externalSubtitleCandidate{
+			name: name,
+			base: name[:len(name)-len(ext)],
+			ext:  ext,
+		})
+	}
+	return candidates
+}
 
+func externalSubtitlesFromCandidates(mediaFilePath string, candidates []externalSubtitleCandidate) []ExternalSubtitleInfo {
+	dir := filepath.Dir(mediaFilePath)
+	mediaBase := stripExtension(filepath.Base(mediaFilePath))
+	var results []ExternalSubtitleInfo
+
+	for _, candidate := range candidates {
 		// Check that the subtitle file starts with the media basename
 		// followed by either a dot separator or nothing (exact match).
-		nameWithoutExt := name[:len(name)-len(ext)]
+		nameWithoutExt := candidate.base
 		if !strings.HasPrefix(nameWithoutExt, mediaBase) {
 			continue
 		}
@@ -114,9 +135,9 @@ func externalSubtitlesFromEntries(mediaFilePath string, entries []os.DirEntry) [
 		}
 
 		info := ExternalSubtitleInfo{
-			Path:   filepath.Join(dir, name),
-			Format: strings.TrimPrefix(ext, "."),
-			Title:  name,
+			Path:   filepath.Join(dir, candidate.name),
+			Format: strings.TrimPrefix(candidate.ext, "."),
+			Title:  candidate.name,
 		}
 
 		parseSuffix(suffix, &info)

--- a/internal/scanner/subtitles_bench_test.go
+++ b/internal/scanner/subtitles_bench_test.go
@@ -1,0 +1,53 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkExternalSubtitleDirCache(b *testing.B) {
+	benchmarkExternalSubtitleDirCache(b, false)
+}
+
+func BenchmarkExternalSubtitleDirCacheCold(b *testing.B) {
+	benchmarkExternalSubtitleDirCache(b, true)
+}
+
+func benchmarkExternalSubtitleDirCache(b *testing.B, cold bool) {
+	for _, count := range []int{1000, 10000} {
+		for _, density := range []string{"empty", "sparse", "dense"} {
+			b.Run(fmt.Sprintf("%d/%s", count, density), func(b *testing.B) {
+				dir := b.TempDir()
+				paths := make([]string, count)
+				for i := range count {
+					paths[i] = filepath.Join(dir, fmt.Sprintf("Movie%05d.mkv", i))
+					if err := os.WriteFile(paths[i], nil, 0600); err != nil {
+						b.Fatal(err)
+					}
+					if density == "dense" || density == "sparse" && i%100 == 0 {
+						if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("Movie%05d.en.srt", i)), nil, 0600); err != nil {
+							b.Fatal(err)
+						}
+					}
+				}
+				cache := newExternalSubtitleDirCache()
+				if _, err := cache.Detect(paths[0]); err != nil {
+					b.Fatal(err)
+				}
+				b.ReportAllocs()
+				i := 0
+				for b.Loop() {
+					if cold {
+						cache = newExternalSubtitleDirCache()
+					}
+					if _, err := cache.Detect(paths[i%count]); err != nil {
+						b.Fatal(err)
+					}
+					i++
+				}
+			})
+		}
+	}
+}

--- a/internal/scanner/subtitles_test.go
+++ b/internal/scanner/subtitles_test.go
@@ -1,0 +1,67 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestExternalSubtitleDirCacheMatchesSidecars(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Movie.mkv", "Movie.srt", "Movie.en.forced.SRT", "MovieExtra.srt", "Movie.jpg", "Movie.part2.mkv", "Movie.part2.fr.ass", "Other.vtt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "Movie.de.srt"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	cache := newExternalSubtitleDirCache()
+	for _, test := range []struct {
+		media  string
+		titles []string
+	}{
+		{"Movie.mkv", []string{"Movie.en.forced.SRT", "Movie.part2.fr.ass", "Movie.srt"}},
+		{"Movie.part2.mkv", []string{"Movie.part2.fr.ass"}},
+		{"Missing.mkv", nil},
+	} {
+		got, err := cache.Detect(filepath.Join(dir, test.media))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var titles []string
+		for _, subtitle := range got {
+			titles = append(titles, subtitle.Title)
+		}
+		if !reflect.DeepEqual(titles, test.titles) {
+			t.Fatalf("%s titles = %v, want %v", test.media, titles, test.titles)
+		}
+		want, err := DetectExternalSubtitles(filepath.Join(dir, test.media))
+		if err != nil || !reflect.DeepEqual(got, want) {
+			t.Fatalf("cached = %#v, uncached = %#v, error = %v", got, want, err)
+		}
+		if test.media == "Movie.mkv" && (!got[0].Forced || got[0].Language != "en" || got[0].Format != "srt") {
+			t.Fatalf("uppercase forced sidecar = %#v", got[0])
+		}
+	}
+}
+
+func TestExternalSubtitleDirCacheConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Movie.en.srt"), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	cache := newExternalSubtitleDirCache()
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			got, err := cache.Detect(filepath.Join(dir, "Movie.mkv"))
+			if err != nil || len(got) != 1 {
+				t.Errorf("Detect = %#v, %v", got, err)
+			}
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

Related issue: #965

Every media lookup reclassifies all filenames in a directory even after its listing is cached. Large directories repeat that work for each media file.

## Approach

Cache subtitle candidates with their basename and normalized extension when reading a directory. Keep existing prefix rules, language/forced flags, directory order, directory exclusion, and concurrent cache behavior.

## Validation

| Directory workload | Before median | After median |
|---|---|---|
| Warm / 1,000 media, sparse sidecars | 12.747 µs | 0.213 µs |
| Warm / 10,000 media, sparse sidecars | 126.532 µs | 0.415 µs |
| Warm / 10,000 media, dense sidecars | 268.057 µs | 26.667 µs |
| Cold / 10,000 media, no sidecars; control | 4.905 ms | 4.911 ms |

Warm results use three samples; the cold empty-directory control uses five repeats. Sparse means one sidecar per 100 media files, dense one per file.

Focused cached/uncached equivalence and concurrent-access tests passed. `go test -race ./internal/scanner -run TestExternalSubtitleDirCache` passed.

Branch validation passed: `go test ./internal/scanner/...` and `golangci-lint run --new-from-merge-base=origin/main --timeout=10m ./internal/scanner/...` (0 issues).

## Risks

Dense 10,000-file cold construction allocates about 3.25 → 5.58 MB/op; warm allocations stay unchanged. This is allocated bytes, not retained heap. Directory reuse determines the gain. No full-scan duration, network-filesystem latency, or scanner-wide peak-memory improvement is claimed.

No public API changes; Apple and Android need no client updates. Shared behavior remains compatible with Jellyfin clients, which were not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
