### PR TITLE
perf(metadata): batch completed episode debt deletion

### DIFF
--- a/internal/metadata/episode_refresh_debt_db_test.go
+++ b/internal/metadata/episode_refresh_debt_db_test.go
@@ -2,12 +2,14 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/models"
@@ -34,7 +36,8 @@ func episodeRefreshDebtTestPool(t *testing.T) (*pgxpool.Pool, *seasonEpisodeQuer
 	t.Cleanup(pool.Close)
 	// A session-local table isolates these assertions from the database's
 	// catalog and avoids requiring an entire migrated Silo deployment.
-	_, err = pool.Exec(ctx, `CREATE TEMP TABLE metadata_refresh_debt (
+	_, err = pool.Exec(ctx, `CREATE TEMP TABLE episodes (content_id TEXT PRIMARY KEY, series_id TEXT NOT NULL);
+	CREATE TEMP TABLE metadata_refresh_debt (
 		target_type TEXT NOT NULL, content_id TEXT NOT NULL,
 		priority INTEGER NOT NULL DEFAULT 0, reason_mask BIGINT NOT NULL DEFAULT 0,
 		next_refresh_at TIMESTAMPTZ NOT NULL, claimed_at TIMESTAMPTZ,
@@ -54,7 +57,7 @@ func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
 	for _, count := range []int{1, 100, 1000} {
 		for _, mixed := range []bool{false, true} {
 			t.Run(fmt.Sprintf("episodes=%d/mixed=%t", count, mixed), func(t *testing.T) {
-				if _, err := pool.Exec(ctx, `TRUNCATE metadata_refresh_debt`); err != nil {
+				if _, err := pool.Exec(ctx, `TRUNCATE metadata_refresh_debt, episodes`); err != nil {
 					t.Fatal(err)
 				}
 				now := time.Now().UTC().Truncate(time.Microsecond)
@@ -64,6 +67,9 @@ func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
 				for i := range count {
 					id := fmt.Sprintf("episode-%d", i)
 					episodes.episodes[id] = &models.Episode{ContentID: id, SeriesID: "series", Title: "Complete", TmdbID: "123"}
+				}
+				if _, err := pool.Exec(ctx, `INSERT INTO episodes SELECT 'episode-' || n, 'series' FROM generate_series(0, $1::int - 1) n`, count); err != nil {
+					t.Fatal(err)
 				}
 				if mixed {
 					episodes.episodes["incomplete"] = &models.Episode{ContentID: "incomplete", SeriesID: "series", Title: "TBA"}
@@ -84,7 +90,7 @@ func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
 				service.refreshSeriesEpisodeMetadataState(ctx, "series", now)
 				queries := tracer.count()
 				t.Logf("complete=%d mixed=%t queries=%d elapsed=%s", count, mixed, queries, time.Since(started))
-				wantQueries := 1
+				wantQueries := 2
 				if mixed {
 					wantQueries += 2
 				}
@@ -151,6 +157,9 @@ func TestRefreshSeriesEpisodeMetadataStateRetainsFailureDuringIncompleteSync(t *
 		RefreshDebtReasonEpisodeIncomplete, now, 1, "old failure"); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := pool.Exec(ctx, `INSERT INTO episodes VALUES ('complete', 'series'), ('incomplete', 'series')`); err != nil {
+		t.Fatal(err)
+	}
 	items := newFakeItemRepo()
 	items.items["series"] = &models.MediaItem{ContentID: "series"}
 	episodes := &orderedDebtEpisodeRepo{episodes: []*models.Episode{
@@ -177,5 +186,207 @@ func TestRefreshSeriesEpisodeMetadataStateRetainsFailureDuringIncompleteSync(t *
 	}
 	if debt.AttemptCount != 2 || debt.LastError != "newer provider failure" || !debt.NextRefreshAt.Equal(debts.retryAt) {
 		t.Fatalf("newer retry = %#v", debt)
+	}
+}
+
+type failureDuringEpisodeListRepo struct {
+	*orderedDebtEpisodeRepo
+	recordFailure func(context.Context) error
+}
+
+func (r *failureDuringEpisodeListRepo) ListBySeries(ctx context.Context, seriesID string) ([]*models.Episode, error) {
+	episodes, err := r.orderedDebtEpisodeRepo.ListBySeries(ctx, seriesID)
+	if err != nil {
+		return nil, err
+	}
+	// The completeness snapshot is already read when another refresh finishes.
+	if err := r.recordFailure(ctx); err != nil {
+		return nil, err
+	}
+	return episodes, nil
+}
+
+func TestRefreshSeriesEpisodeMetadataStateRetainsFailureAfterEpisodeSnapshot(t *testing.T) {
+	for _, existing := range []bool{false, true} {
+		t.Run(fmt.Sprintf("existing=%t", existing), func(t *testing.T) {
+			pool, _ := episodeRefreshDebtTestPool(t)
+			ctx := t.Context()
+			debts := NewRefreshDebtRepository(pool)
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			if _, err := pool.Exec(ctx, `INSERT INTO episodes VALUES ('complete', 'series'), ('unchanged', 'series')`); err != nil {
+				t.Fatal(err)
+			}
+			if err := debts.MarkTargetFailure(ctx, RefreshTargetEpisode, "unchanged", 300,
+				RefreshDebtReasonEpisodeIncomplete, now, 1, "old failure"); err != nil {
+				t.Fatal(err)
+			}
+			if existing {
+				if err := debts.MarkTargetFailure(ctx, RefreshTargetEpisode, "complete", 300,
+					RefreshDebtReasonEpisodeIncomplete, now, 1, "old failure"); err != nil {
+					t.Fatal(err)
+				}
+			}
+			items := newFakeItemRepo()
+			items.items["series"] = &models.MediaItem{ContentID: "series"}
+			episodes := &failureDuringEpisodeListRepo{
+				orderedDebtEpisodeRepo: &orderedDebtEpisodeRepo{episodes: []*models.Episode{
+					{ContentID: "complete", SeriesID: "series", Title: "Complete", TmdbID: "123"},
+					{ContentID: "unchanged", SeriesID: "series", Title: "Complete", TmdbID: "456"},
+				}},
+				recordFailure: func(ctx context.Context) error {
+					return debts.MarkTargetFailure(ctx, RefreshTargetEpisode, "complete", 300,
+						RefreshDebtReasonEpisodeIncomplete, now.Add(time.Hour), 2, "newer provider failure")
+				},
+			}
+			service := &MetadataService{itemRepo: items, episodeRepo: episodes, refreshDebtRepo: debts}
+			service.refreshSeriesEpisodeMetadataState(ctx, "series", now)
+			debt, err := debts.GetTarget(ctx, RefreshTargetEpisode, "complete")
+			if err != nil {
+				t.Fatalf("newer retry was lost: %v", err)
+			}
+			if debt.AttemptCount != 2 || debt.LastError != "newer provider failure" || !debt.NextRefreshAt.Equal(now.Add(time.Hour)) {
+				t.Fatalf("newer retry = %#v", debt)
+			}
+			if _, err := debts.GetTarget(ctx, RefreshTargetEpisode, "unchanged"); !errors.Is(err, ErrRefreshDebtNotFound) {
+				t.Fatalf("unchanged complete debt error = %v, want ErrRefreshDebtNotFound", err)
+			}
+		})
+	}
+}
+
+func TestDeleteEpisodeDebtsRetainsSameTransactionRewrite(t *testing.T) {
+	pool, _ := episodeRefreshDebtTestPool(t)
+	ctx := t.Context()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `INSERT INTO metadata_refresh_debt (target_type, content_id, next_refresh_at)
+		VALUES ('episode', 'complete', NOW())`); err != nil {
+		t.Fatal(err)
+	}
+	// Both writes have the same xmin and NOW(). Only the tuple location changes.
+	var version string
+	if err := tx.QueryRow(ctx, `SELECT xmin::text || ':' || ctid::text FROM metadata_refresh_debt
+		WHERE target_type = 'episode' AND content_id = 'complete'`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE metadata_refresh_debt SET last_error = 'newer provider failure',
+		updated_at = NOW() WHERE target_type = 'episode' AND content_id = 'complete'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	debts := NewRefreshDebtRepository(pool)
+	if err := debts.DeleteEpisodeDebts(ctx, []string{"complete"}, map[string]string{"complete": version}); err != nil {
+		t.Fatal(err)
+	}
+	debt, err := debts.GetTarget(ctx, RefreshTargetEpisode, "complete")
+	if err != nil || debt.LastError != "newer provider failure" {
+		t.Fatalf("rewritten debt = %#v, error = %v", debt, err)
+	}
+}
+
+func TestDeleteEpisodeDebtsRetainsConcurrentUpdateWhileDeleteWaits(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A private schema lets the updater, deleter and lock observer use separate
+	// connections without touching deployment data. This test needs migrations.
+	schema := fmt.Sprintf("episode_debt_wait_%d", time.Now().UnixNano())
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+	config.MaxConns = 2
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	quotedSchema := pgx.Identifier{schema}.Sanitize()
+	if _, err := pool.Exec(ctx, "CREATE SCHEMA "+quotedSchema); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		if _, err := pool.Exec(cleanupCtx, "DROP SCHEMA "+quotedSchema+" CASCADE"); err != nil {
+			t.Errorf("cleaning up test schema: %v", err)
+		}
+	})
+	if _, err := pool.Exec(ctx, `CREATE TABLE metadata_refresh_debt (LIKE public.metadata_refresh_debt INCLUDING ALL);
+		CREATE TABLE episodes (content_id TEXT PRIMARY KEY, series_id TEXT NOT NULL);
+		INSERT INTO episodes VALUES ('complete', 'series')`); err != nil {
+		t.Fatal(err)
+	}
+	debts := NewRefreshDebtRepository(pool)
+	if err := debts.MarkTargetFailure(ctx, RefreshTargetEpisode, "complete", 300,
+		RefreshDebtReasonEpisodeIncomplete, time.Now(), 1, "old failure"); err != nil {
+		t.Fatal(err)
+	}
+	versions, err := debts.SnapshotEpisodeDebts(ctx, "series")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleterConfig := config.Copy()
+	deleterConfig.MaxConns = 1
+	deleterPool, err := pgxpool.NewWithConfig(ctx, deleterConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(deleterPool.Close)
+	var deleterPID int
+	if err := deleterPool.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&deleterPID); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	updaterPID := tx.Conn().PgConn().PID()
+	if _, err := tx.Exec(ctx, `UPDATE metadata_refresh_debt SET last_error = 'newer provider failure',
+		attempt_count = 2 WHERE target_type = 'episode' AND content_id = 'complete'`); err != nil {
+		t.Fatal(err)
+	}
+	deleted := make(chan error, 1)
+	go func() {
+		deleted <- NewRefreshDebtRepository(deleterPool).DeleteEpisodeDebts(ctx, []string{"complete"}, versions)
+	}()
+	for {
+		select {
+		case err := <-deleted:
+			t.Fatalf("DELETE finished before waiting for the updater: %v", err)
+		default:
+		}
+		var waiting bool
+		if err := pool.QueryRow(ctx, `SELECT $1::int = ANY(pg_blocking_pids($2::int))`, updaterPID, deleterPID).Scan(&waiting); err != nil {
+			t.Fatal(err)
+		}
+		if waiting {
+			break
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-deleted:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	debt, err := debts.GetTarget(ctx, RefreshTargetEpisode, "complete")
+	if err != nil || debt.LastError != "newer provider failure" || debt.AttemptCount != 2 {
+		t.Fatalf("concurrent retry = %#v, error = %v", debt, err)
 	}
 }

--- a/internal/metadata/episode_refresh_debt_db_test.go
+++ b/internal/metadata/episode_refresh_debt_db_test.go
@@ -1,8 +1,10 @@
 package metadata
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +13,8 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
-func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
+func episodeRefreshDebtTestPool(t *testing.T) (*pgxpool.Pool, *seasonEpisodeQueryTracer) {
+	t.Helper()
 	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
 	if dsn == "" {
 		t.Skip("SILO_TEST_DATABASE_URL is not set")
@@ -42,6 +45,12 @@ func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return pool, tracer
+}
+
+func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
+	pool, tracer := episodeRefreshDebtTestPool(t)
+	ctx := t.Context()
 	for _, count := range []int{1, 100, 1000} {
 		for _, mixed := range []bool{false, true} {
 			t.Run(fmt.Sprintf("episodes=%d/mixed=%t", count, mixed), func(t *testing.T) {
@@ -99,5 +108,74 @@ func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// Keep the complete episode first so this interleaving also preserves the
+// behavior of the original per-episode cleanup loop.
+type orderedDebtEpisodeRepo struct {
+	metadataEpisodeRepo
+	episodes []*models.Episode
+}
+
+func (r *orderedDebtEpisodeRepo) ListBySeries(context.Context, string) ([]*models.Episode, error) {
+	return r.episodes, nil
+}
+
+type failureDuringEpisodeSyncRepo struct {
+	*RefreshDebtRepository
+	retryAt time.Time
+}
+
+func (r *failureDuringEpisodeSyncRepo) GetTarget(ctx context.Context, targetType, contentID string) (*models.MetadataRefreshDebt, error) {
+	if targetType == RefreshTargetEpisode && contentID == "incomplete" {
+		// Another refresh records a failure after ListBySeries returned a
+		// complete snapshot, while this refresh is syncing another episode.
+		if err := r.MarkTargetFailure(ctx, RefreshTargetEpisode, "complete", 300,
+			RefreshDebtReasonEpisodeIncomplete, r.retryAt, 2, "newer provider failure"); err != nil {
+			return nil, err
+		}
+	}
+	return r.RefreshDebtRepository.GetTarget(ctx, targetType, contentID)
+}
+
+func TestRefreshSeriesEpisodeMetadataStateRetainsFailureDuringIncompleteSync(t *testing.T) {
+	pool, tracer := episodeRefreshDebtTestPool(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	debts := &failureDuringEpisodeSyncRepo{
+		RefreshDebtRepository: NewRefreshDebtRepository(pool),
+		retryAt:               now.Add(time.Hour),
+	}
+	if err := debts.MarkTargetFailure(ctx, RefreshTargetEpisode, "complete", 300,
+		RefreshDebtReasonEpisodeIncomplete, now, 1, "old failure"); err != nil {
+		t.Fatal(err)
+	}
+	items := newFakeItemRepo()
+	items.items["series"] = &models.MediaItem{ContentID: "series"}
+	episodes := &orderedDebtEpisodeRepo{episodes: []*models.Episode{
+		{ContentID: "complete", SeriesID: "series", Title: "Complete", TmdbID: "123"},
+		{ContentID: "incomplete", SeriesID: "series", Title: "TBA"},
+	}}
+	service := &MetadataService{itemRepo: items, episodeRepo: episodes, refreshDebtRepo: debts}
+	tracer.reset()
+	service.refreshSeriesEpisodeMetadataState(ctx, "series", now)
+	tracer.mu.Lock()
+	deletes := 0
+	for _, query := range tracer.queries {
+		if strings.HasPrefix(strings.TrimSpace(query), "DELETE FROM metadata_refresh_debt") {
+			deletes++
+		}
+	}
+	tracer.mu.Unlock()
+	if deletes != 1 {
+		t.Fatalf("debt DELETE statements = %d, want 1", deletes)
+	}
+	debt, err := debts.GetTarget(ctx, RefreshTargetEpisode, "complete")
+	if err != nil {
+		t.Fatalf("newer retry was lost: %v", err)
+	}
+	if debt.AttemptCount != 2 || debt.LastError != "newer provider failure" || !debt.NextRefreshAt.Equal(debts.retryAt) {
+		t.Fatalf("newer retry = %#v", debt)
 	}
 }

--- a/internal/metadata/episode_refresh_debt_db_test.go
+++ b/internal/metadata/episode_refresh_debt_db_test.go
@@ -1,0 +1,103 @@
+package metadata
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestRefreshSeriesEpisodeMetadataStateDebtQueries(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := t.Context()
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracer := &seasonEpisodeQueryTracer{}
+	config.ConnConfig.Tracer = tracer
+	config.MaxConns = 1
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	// A session-local table isolates these assertions from the database's
+	// catalog and avoids requiring an entire migrated Silo deployment.
+	_, err = pool.Exec(ctx, `CREATE TEMP TABLE metadata_refresh_debt (
+		target_type TEXT NOT NULL, content_id TEXT NOT NULL,
+		priority INTEGER NOT NULL DEFAULT 0, reason_mask BIGINT NOT NULL DEFAULT 0,
+		next_refresh_at TIMESTAMPTZ NOT NULL, claimed_at TIMESTAMPTZ,
+		lease_expires_at TIMESTAMPTZ, last_attempt_at TIMESTAMPTZ, last_success_at TIMESTAMPTZ,
+		attempt_count INTEGER NOT NULL DEFAULT 0, last_error TEXT NOT NULL DEFAULT '',
+		updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), PRIMARY KEY (target_type, content_id)
+	)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, count := range []int{1, 100, 1000} {
+		for _, mixed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("episodes=%d/mixed=%t", count, mixed), func(t *testing.T) {
+				if _, err := pool.Exec(ctx, `TRUNCATE metadata_refresh_debt`); err != nil {
+					t.Fatal(err)
+				}
+				now := time.Now().UTC().Truncate(time.Microsecond)
+				episodes := newFakeEpisodeRepo()
+				items := newFakeItemRepo()
+				items.items["series"] = &models.MediaItem{ContentID: "series"}
+				for i := range count {
+					id := fmt.Sprintf("episode-%d", i)
+					episodes.episodes[id] = &models.Episode{ContentID: id, SeriesID: "series", Title: "Complete", TmdbID: "123"}
+				}
+				if mixed {
+					episodes.episodes["incomplete"] = &models.Episode{ContentID: "incomplete", SeriesID: "series", Title: "TBA"}
+				}
+				_, err := pool.Exec(ctx, `INSERT INTO metadata_refresh_debt (target_type, content_id, next_refresh_at)
+					SELECT 'episode', 'episode-' || n, NOW() FROM generate_series(0, $1::int - 1) n;
+				`, count)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := pool.Exec(ctx, `INSERT INTO metadata_refresh_debt (target_type, content_id, next_refresh_at)
+					VALUES ('item', 'episode-0', NOW()), ('episode', 'unrelated', NOW())`); err != nil {
+					t.Fatal(err)
+				}
+				service := &MetadataService{itemRepo: items, episodeRepo: episodes, refreshDebtRepo: NewRefreshDebtRepository(pool)}
+				tracer.reset()
+				started := time.Now()
+				service.refreshSeriesEpisodeMetadataState(ctx, "series", now)
+				queries := tracer.count()
+				t.Logf("complete=%d mixed=%t queries=%d elapsed=%s", count, mixed, queries, time.Since(started))
+				wantQueries := 1
+				if mixed {
+					wantQueries += 2
+				}
+				if queries != wantQueries {
+					t.Fatalf("queries = %d, want %d", queries, wantQueries)
+				}
+				var remaining int
+				if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM metadata_refresh_debt`).Scan(&remaining); err != nil {
+					t.Fatal(err)
+				}
+				wantRemaining := 2
+				if mixed {
+					wantRemaining++
+					debt, err := service.refreshDebtRepo.GetTarget(ctx, RefreshTargetEpisode, "incomplete")
+					if err != nil || debt.ReasonMask != RefreshDebtReasonEpisodeIncomplete || !debt.NextRefreshAt.Equal(now.Add(24*time.Hour)) {
+						t.Fatalf("incomplete debt = %#v, error = %v", debt, err)
+					}
+				}
+				if remaining != wantRemaining || items.items["series"].EpisodeMetadataIncomplete != mixed {
+					t.Fatalf("remaining debt = %d, want %d; series incomplete = %t", remaining, wantRemaining, items.items["series"].EpisodeMetadataIncomplete)
+				}
+			})
+		}
+	}
+}

--- a/internal/metadata/refresh_debt_repo.go
+++ b/internal/metadata/refresh_debt_repo.go
@@ -288,6 +288,24 @@ func (r *RefreshDebtRepository) DeleteTargetDebt(ctx context.Context, targetType
 	return nil
 }
 
+// DeleteEpisodeDebts clears refresh debt for the supplied complete episode IDs.
+func (r *RefreshDebtRepository) DeleteEpisodeDebts(ctx context.Context, contentIDs []string) error {
+	if len(contentIDs) == 0 {
+		return nil
+	}
+	if err := r.requireConfigured(); err != nil {
+		return err
+	}
+	_, err := r.pool.Exec(ctx, `
+		DELETE FROM metadata_refresh_debt
+		WHERE target_type = 'episode' AND content_id = ANY($1::text[])
+	`, contentIDs)
+	if err != nil {
+		return fmt.Errorf("deleting episode metadata refresh debt: %w", err)
+	}
+	return nil
+}
+
 func (r *RefreshDebtRepository) MarkFailure(
 	ctx context.Context,
 	contentID string,

--- a/internal/metadata/refresh_debt_repo.go
+++ b/internal/metadata/refresh_debt_repo.go
@@ -288,18 +288,62 @@ func (r *RefreshDebtRepository) DeleteTargetDebt(ctx context.Context, targetType
 	return nil
 }
 
-// DeleteEpisodeDebts clears refresh debt for the supplied complete episode IDs.
-func (r *RefreshDebtRepository) DeleteEpisodeDebts(ctx context.Context, contentIDs []string) error {
-	if len(contentIDs) == 0 {
+// SnapshotEpisodeDebts captures short-lived PostgreSQL row-version tokens before
+// the caller reads episode completeness. xmin changes across transactions; ctid
+// also changes when a row is rewritten within the same transaction. These tokens
+// are only for the current cleanup, never durable row identifiers.
+func (r *RefreshDebtRepository) SnapshotEpisodeDebts(ctx context.Context, seriesID string) (map[string]string, error) {
+	if err := r.requireConfigured(); err != nil {
+		return nil, err
+	}
+	rows, err := r.pool.Query(ctx, `
+		SELECT d.content_id, d.xmin::text || ':' || d.ctid::text
+		FROM metadata_refresh_debt d
+		JOIN episodes e ON e.content_id = d.content_id
+		WHERE d.target_type = 'episode' AND e.series_id = $1
+	`, seriesID)
+	if err != nil {
+		return nil, fmt.Errorf("snapshotting episode metadata refresh debt: %w", err)
+	}
+	defer rows.Close()
+	versions := make(map[string]string)
+	for rows.Next() {
+		var id, version string
+		if err := rows.Scan(&id, &version); err != nil {
+			return nil, fmt.Errorf("scanning episode metadata refresh debt version: %w", err)
+		}
+		versions[id] = version
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating episode metadata refresh debt versions: %w", err)
+	}
+	return versions, nil
+}
+
+// DeleteEpisodeDebts clears only complete episode debt unchanged since the
+// snapshot. Keep the version predicate on the DELETE target: PostgreSQL rechecks
+// it against the new row version after waiting for a concurrent updater.
+func (r *RefreshDebtRepository) DeleteEpisodeDebts(ctx context.Context, contentIDs []string, versions map[string]string) error {
+	ids := make([]string, 0, len(contentIDs))
+	observedVersions := make([]string, 0, len(contentIDs))
+	for _, id := range contentIDs {
+		if version, ok := versions[id]; ok {
+			ids = append(ids, id)
+			observedVersions = append(observedVersions, version)
+		}
+	}
+	if len(ids) == 0 {
 		return nil
 	}
 	if err := r.requireConfigured(); err != nil {
 		return err
 	}
 	_, err := r.pool.Exec(ctx, `
-		DELETE FROM metadata_refresh_debt
-		WHERE target_type = 'episode' AND content_id = ANY($1::text[])
-	`, contentIDs)
+		DELETE FROM metadata_refresh_debt d
+		USING unnest($1::text[], $2::text[]) AS observed(content_id, row_version)
+		WHERE d.target_type = 'episode' AND d.content_id = observed.content_id
+		  AND d.xmin::text || ':' || d.ctid::text = observed.row_version
+	`, ids, observedVersions)
 	if err != nil {
 		return fmt.Errorf("deleting episode metadata refresh debt: %w", err)
 	}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -5580,8 +5580,8 @@ func (s *MetadataService) refreshSeriesEpisodeMetadataState(ctx context.Context,
 		return
 	}
 
-	incomplete := false
 	var completeEpisodeIDs []string
+	var actionableEpisodes []*models.Episode
 	for _, episode := range episodes {
 		if !EpisodeHasActionableMetadataDebt(episode, now) {
 			if s.refreshDebtRepo != nil && episode != nil {
@@ -5591,14 +5591,10 @@ func (s *MetadataService) refreshSeriesEpisodeMetadataState(ctx context.Context,
 			}
 			continue
 		}
-		incomplete = true
-		if err := s.syncVisibleEpisodeRefreshDebt(ctx, episode, now); err != nil {
-			slog.WarnContext(ctx, "metadata: failed to sync episode refresh debt", "component", "metadata",
-				"series_id", seriesID,
-				"episode_id", episode.ContentID,
-				"error", err)
-		}
+		actionableEpisodes = append(actionableEpisodes, episode)
 	}
+	// Clear the snapshot's complete episodes before other episode debt writes
+	// can delay cleanup and expose newer retries to the stale snapshot.
 	if len(completeEpisodeIDs) > 0 {
 		if err := s.refreshDebtRepo.DeleteEpisodeDebts(ctx, completeEpisodeIDs); err != nil {
 			slog.WarnContext(ctx, "metadata: failed to clear complete episode refresh debt", "component", "metadata",
@@ -5606,8 +5602,16 @@ func (s *MetadataService) refreshSeriesEpisodeMetadataState(ctx context.Context,
 		}
 	}
 
-	lastCheckedAt := now
-	s.updateEpisodeMetadataState(ctx, seriesID, incomplete, &lastCheckedAt)
+	for _, episode := range actionableEpisodes {
+		if err := s.syncVisibleEpisodeRefreshDebt(ctx, episode, now); err != nil {
+			slog.WarnContext(ctx, "metadata: failed to sync episode refresh debt", "component", "metadata",
+				"series_id", seriesID,
+				"episode_id", episode.ContentID,
+				"error", err)
+		}
+	}
+
+	s.updateEpisodeMetadataState(ctx, seriesID, len(actionableEpisodes) > 0, new(now))
 }
 
 func (s *MetadataService) syncVisibleEpisodeRefreshDebt(ctx context.Context, episode *models.Episode, now time.Time) error {

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -114,7 +114,8 @@ type metadataRefreshDebtRepo interface {
 	MarkTargetSuccess(ctx context.Context, targetType, contentID string, priority int, reasonMask int64, nextRefreshAt time.Time) error
 	DeleteDebt(ctx context.Context, contentID string) error
 	DeleteTargetDebt(ctx context.Context, targetType, contentID string) error
-	DeleteEpisodeDebts(ctx context.Context, contentIDs []string) error
+	SnapshotEpisodeDebts(ctx context.Context, seriesID string) (map[string]string, error)
+	DeleteEpisodeDebts(ctx context.Context, contentIDs []string, versions map[string]string) error
 }
 
 // metadataLibraryRepo defines library membership methods used by
@@ -5573,6 +5574,19 @@ func (s *MetadataService) refreshSeriesEpisodeMetadataState(ctx context.Context,
 		return
 	}
 
+	// Observe debt versions before reading completeness so a concurrent refresh's
+	// new or updated debt cannot be cleared using a stale episode snapshot.
+	var debtVersions map[string]string
+	if s.refreshDebtRepo != nil {
+		var err error
+		debtVersions, err = s.refreshDebtRepo.SnapshotEpisodeDebts(ctx, seriesID)
+		if err != nil {
+			slog.WarnContext(ctx, "metadata: failed to snapshot episode refresh debt", "component", "metadata",
+				"series_id", seriesID, "error", err)
+			return
+		}
+	}
+
 	episodes, err := s.episodeRepo.ListBySeries(ctx, seriesID)
 	if err != nil {
 		slog.WarnContext(ctx, "metadata: failed to list series episodes for completeness check", "component", "metadata",
@@ -5593,10 +5607,8 @@ func (s *MetadataService) refreshSeriesEpisodeMetadataState(ctx context.Context,
 		}
 		actionableEpisodes = append(actionableEpisodes, episode)
 	}
-	// Clear the snapshot's complete episodes before other episode debt writes
-	// can delay cleanup and expose newer retries to the stale snapshot.
 	if len(completeEpisodeIDs) > 0 {
-		if err := s.refreshDebtRepo.DeleteEpisodeDebts(ctx, completeEpisodeIDs); err != nil {
+		if err := s.refreshDebtRepo.DeleteEpisodeDebts(ctx, completeEpisodeIDs, debtVersions); err != nil {
 			slog.WarnContext(ctx, "metadata: failed to clear complete episode refresh debt", "component", "metadata",
 				"series_id", seriesID, "episode_count", len(completeEpisodeIDs), "error", err)
 		}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -114,6 +114,7 @@ type metadataRefreshDebtRepo interface {
 	MarkTargetSuccess(ctx context.Context, targetType, contentID string, priority int, reasonMask int64, nextRefreshAt time.Time) error
 	DeleteDebt(ctx context.Context, contentID string) error
 	DeleteTargetDebt(ctx context.Context, targetType, contentID string) error
+	DeleteEpisodeDebts(ctx context.Context, contentIDs []string) error
 }
 
 // metadataLibraryRepo defines library membership methods used by
@@ -5580,15 +5581,28 @@ func (s *MetadataService) refreshSeriesEpisodeMetadataState(ctx context.Context,
 	}
 
 	incomplete := false
+	var completeEpisodeIDs []string
 	for _, episode := range episodes {
-		if EpisodeHasActionableMetadataDebt(episode, now) {
-			incomplete = true
+		if !EpisodeHasActionableMetadataDebt(episode, now) {
+			if s.refreshDebtRepo != nil && episode != nil {
+				if id := strings.TrimSpace(episode.ContentID); id != "" {
+					completeEpisodeIDs = append(completeEpisodeIDs, id)
+				}
+			}
+			continue
 		}
+		incomplete = true
 		if err := s.syncVisibleEpisodeRefreshDebt(ctx, episode, now); err != nil {
 			slog.WarnContext(ctx, "metadata: failed to sync episode refresh debt", "component", "metadata",
 				"series_id", seriesID,
 				"episode_id", episode.ContentID,
 				"error", err)
+		}
+	}
+	if len(completeEpisodeIDs) > 0 {
+		if err := s.refreshDebtRepo.DeleteEpisodeDebts(ctx, completeEpisodeIDs); err != nil {
+			slog.WarnContext(ctx, "metadata: failed to clear complete episode refresh debt", "component", "metadata",
+				"series_id", seriesID, "episode_count", len(completeEpisodeIDs), "error", err)
 		}
 	}
 

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -421,10 +421,25 @@ func (r *fakeRefreshDebtRepo) DeleteDebt(ctx context.Context, contentID string) 
 	return r.DeleteTargetDebt(ctx, RefreshTargetItem, contentID)
 }
 
-func (r *fakeRefreshDebtRepo) DeleteEpisodeDebts(ctx context.Context, contentIDs []string) error {
+func (r *fakeRefreshDebtRepo) SnapshotEpisodeDebts(_ context.Context, _ string) (map[string]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	versions := make(map[string]string)
+	for _, debt := range r.debts {
+		if debt.TargetType == RefreshTargetEpisode {
+			versions[debt.ContentID] = fmt.Sprintf("%#v", debt)
+		}
+	}
+	return versions, nil
+}
+
+func (r *fakeRefreshDebtRepo) DeleteEpisodeDebts(_ context.Context, contentIDs []string, versions map[string]string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	for _, id := range contentIDs {
-		if err := r.DeleteTargetDebt(ctx, RefreshTargetEpisode, id); err != nil {
-			return err
+		key := fakeRefreshDebtKey(RefreshTargetEpisode, id)
+		if debt, ok := r.debts[key]; ok && versions[id] == fmt.Sprintf("%#v", debt) {
+			delete(r.debts, key)
 		}
 	}
 	return nil

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -421,6 +421,15 @@ func (r *fakeRefreshDebtRepo) DeleteDebt(ctx context.Context, contentID string) 
 	return r.DeleteTargetDebt(ctx, RefreshTargetItem, contentID)
 }
 
+func (r *fakeRefreshDebtRepo) DeleteEpisodeDebts(ctx context.Context, contentIDs []string) error {
+	for _, id := range contentIDs {
+		if err := r.DeleteTargetDebt(ctx, RefreshTargetEpisode, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *fakeRefreshDebtRepo) DeleteTargetDebt(_ context.Context, targetType, contentID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
## Problem

Related issue: #965

Completeness checks issue one DELETE per complete episode, even though the set to clear is already known.

## Approach

Snapshot existing episode-debt row versions before reading episode completeness. Partition complete and actionable episodes, then clear unchanged complete-episode debt in one array-bound DELETE before syncing incomplete episodes. The DELETE matches PostgreSQL `xmin` and `ctid`, preserving retries inserted or updated after the snapshot, including when it waits for a concurrent updater. The guard uses no application timestamps or schema changes.

## Validation

| Complete episodes / additional incomplete | Statements before | Statements after |
|---|---|---|
| 1 / 0; control | 1 | 2 |
| 100 / 0 | 100 | 2 |
| 1,000 / 0 | 1000 | 2 |
| 1,000 / 1 | 1002 | 4 |

Counts cover debt statements: one snapshot SELECT and one conditional DELETE, plus two statements per incomplete episode. Instrumented PostgreSQL integration tests use isolated tables in a disposable test database.

State and query-count checks passed for 1, 100, and 1,000 complete episodes, with and without an incomplete episode. Unrelated episode debt and item debt remain; incomplete debt retains its retry schedule.

Validation passed: `go test ./internal/metadata/...`, `go vet ./internal/metadata/...`, and changed-line `golangci-lint` (0 issues). With the test database configured, `go test ./internal/metadata -run 'TestRefreshSeriesEpisodeMetadataState|TestDeleteEpisodeDebts' -count=1 -v` passed without skipped selected cases.

New database regressions cover an absent debt row inserted after the episode snapshot, an existing row updated after it, a same-transaction tuple rewrite, and DELETE waiting on a concurrent updater. Each lost the retry when the previous unconditional DELETE was restored and passed with the version guard. An unchanged complete row is still deleted.

## Risks

The statement counts establish removed SQL work; no repeated elapsed-time or full-refresh benchmark is claimed. Version capture adds one SELECT, so the one-episode control costs one more statement. Row-version tokens exist only during the current cleanup. A snapshot error aborts the pass; a failed DELETE logs and leaves debt for a later pass. Concurrently changed debt is intentionally retained. No migrations or API changes; Apple and Android need no client updates. Jellyfin compatibility was considered; its performance was not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: GitHub review identified retry-deletion races. Deterministic database tests demonstrated lost retries with unconditional deletion and retained retries with the row-version guard. Independent code review and @ponytail-review cleared the final change.
