### PR TITLE
perf(catalog): skip unnecessary playback progress reads

### DIFF
--- a/internal/catalog/playable_targets.go
+++ b/internal/catalog/playable_targets.go
@@ -308,8 +308,6 @@ func (r *PlayableTargetResolver) Resolve(ctx context.Context, q PlayableTargetQu
 	defer rows.Close()
 	candidates := make(map[string][]string, len(ids))
 	hints := make(map[string]string, len(ids))
-	allCandidateIDs := make([]string, 0, len(ids))
-	seenCandidateIDs := make(map[string]struct{}, len(ids))
 	for rows.Next() {
 		var ord int64
 		var playContentID string
@@ -329,17 +327,14 @@ func (r *PlayableTargetResolver) Resolve(ctx context.Context, q PlayableTargetQu
 			continue
 		}
 		candidates[key] = append(candidates[key], playContentID)
-		if _, ok := seenCandidateIDs[playContentID]; !ok {
-			seenCandidateIDs[playContentID] = struct{}{}
-			allCandidateIDs = append(allCandidateIDs, playContentID)
-		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating playable poster targets: %w", err)
 	}
 	progress := map[string]userstore.WatchProgress{}
-	if q.ProgressStore != nil && len(allCandidateIDs) > 0 {
-		progress, err = listPlayableTargetProgress(ctx, q.ProgressStore, q.ProfileID, allCandidateIDs)
+	if q.ProgressStore != nil {
+		progressIDs := playableTargetProgressIDs(candidates, hints)
+		progress, err = listPlayableTargetProgress(ctx, q.ProgressStore, q.ProfileID, progressIDs)
 		if err != nil {
 			return nil, fmt.Errorf("listing progress for playable poster targets: %w", err)
 		}
@@ -355,6 +350,25 @@ func (r *PlayableTargetResolver) Resolve(ctx context.Context, q PlayableTargetQu
 		result[key] = hint
 	}
 	return result, nil
+}
+
+// Progress can only affect a card with several candidates and no validated
+// anchor. A leaf shared with such a card must still participate in its ranking.
+func playableTargetProgressIDs(candidates map[string][]string, hints map[string]string) []string {
+	var ids []string
+	seen := make(map[string]struct{})
+	for key, targets := range candidates {
+		if _, hinted := hints[key]; hinted || len(targets) < 2 {
+			continue
+		}
+		for _, id := range targets {
+			if _, ok := seen[id]; !ok {
+				seen[id] = struct{}{}
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
 }
 
 // listPlayableTargetProgress fetches progress in batches: the PostgreSQL store

--- a/internal/catalog/playable_targets_benchmark_test.go
+++ b/internal/catalog/playable_targets_benchmark_test.go
@@ -1,0 +1,120 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type playableTargetBenchmarkProgressStore struct {
+	delegate PlayableTargetProgressStore
+	queries  int
+	ids      int
+}
+
+func (s *playableTargetBenchmarkProgressStore) ListProgressByMediaItems(ctx context.Context, profile string, ids []string) (map[string]userstore.WatchProgress, error) {
+	s.queries++
+	s.ids += len(ids)
+	return s.delegate.ListProgressByMediaItems(ctx, profile, ids)
+}
+
+// This benchmark requires a disposable migrated database. It reports progress
+// query counts alongside timings so removed work is visible even when
+// connection latency varies between runs.
+func BenchmarkPlayableTargetReadQueries(b *testing.B) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		b.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(b.Context(), dsn)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("catalog-perf-%d", time.Now().UnixNano())
+	movieIDs := make([]string, 100)
+	for i := range movieIDs {
+		movieIDs[i] = fmt.Sprintf("%s-movie-%03d", prefix, i)
+	}
+	seriesID := prefix + "-series"
+	profileID := prefix + "-profile"
+	var userID, folderID int
+	if err := pool.QueryRow(b.Context(), `INSERT INTO users (email, username, role, enabled)
+		VALUES ($1, $1, 'user', TRUE) RETURNING id`, prefix+"@example.invalid").Scan(&userID); err != nil {
+		b.Fatal(err)
+	}
+	if err := pool.QueryRow(b.Context(), `INSERT INTO media_folders (type, name, enabled)
+		VALUES ('mixed', $1, TRUE) RETURNING id`, prefix).Scan(&folderID); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		ctx := context.Background()
+		_, _ = pool.Exec(ctx, `DELETE FROM media_items WHERE content_id = ANY($1)`, append(movieIDs, seriesID))
+		_, _ = pool.Exec(ctx, `DELETE FROM media_folders WHERE id = $1`, folderID)
+		_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+	})
+	statements := []struct {
+		sql  string
+		args []any
+	}{
+		{`INSERT INTO user_profiles (id, user_id, name) VALUES ($1, $2, 'Benchmark')`, []any{profileID, userID}},
+		{`INSERT INTO media_items (content_id, type, title, status, genres)
+			SELECT id, 'movie', id, 'matched', '{}'::text[] FROM unnest($1::text[]) id`, []any{movieIDs}},
+		{`INSERT INTO media_items (content_id, type, title, status, genres)
+			VALUES ($1, 'series', $1, 'matched', '{}')`, []any{seriesID}},
+		{`INSERT INTO media_files (content_id, media_folder_id, file_path)
+			SELECT id, $2, id || '.mkv' FROM unnest($1::text[]) id`, []any{movieIDs, folderID}},
+		{`INSERT INTO episodes (content_id, series_id, season_number, episode_number, title)
+			SELECT $1 || '-episode-' || n, $1, 1, n, 'Episode ' || n FROM generate_series(1, 200) n`, []any{seriesID}},
+		{`INSERT INTO media_files (episode_id, media_folder_id, file_path)
+			SELECT content_id, $2, content_id || '.mkv' FROM episodes WHERE series_id = $1`, []any{seriesID, folderID}},
+	}
+	for _, statement := range statements {
+		if _, err := pool.Exec(b.Context(), statement.sql, statement.args...); err != nil {
+			b.Fatal(err)
+		}
+	}
+	// Give both benchmark binaries plans based on the fixture cardinalities,
+	// rather than empty-table estimates left over from initial migrations.
+	if _, err := pool.Exec(b.Context(), `ANALYZE media_items; ANALYZE episodes; ANALYZE media_files; ANALYZE media_folders`); err != nil {
+		b.Fatal(err)
+	}
+	delegate, err := pgstore.NewPostgresProvider(pool).ForUser(b.Context(), userID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name  string
+		items []PlayableTargetInput
+	}{
+		{name: "movie-targets-100", items: func() []PlayableTargetInput {
+			items := make([]PlayableTargetInput, len(movieIDs))
+			for i, id := range movieIDs {
+				items[i] = PlayableTargetInput{ContentID: id, Type: "movie"}
+			}
+			return items
+		}()},
+		{name: "hinted-series-200-episodes", items: []PlayableTargetInput{{ContentID: seriesID, Type: "series", PreferredContentID: seriesID + "-episode-100"}}},
+		{name: "unhinted-series-200-episodes", items: []PlayableTargetInput{{ContentID: seriesID, Type: "series"}}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			store := &playableTargetBenchmarkProgressStore{delegate: delegate}
+			resolver := NewPlayableTargetResolver(pool)
+			query := PlayableTargetQuery{UserID: userID, ProfileID: profileID, Items: tc.items, ProgressStore: store,
+				Access: AccessFilter{AllowedLibraryIDs: []int{folderID}}}
+			for b.Loop() {
+				if _, err := resolver.Resolve(b.Context(), query); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(store.queries)/float64(b.N), "progress-queries/op")
+			b.ReportMetric(float64(store.ids)/float64(b.N), "progress-IDs/op")
+		})
+	}
+}

--- a/internal/catalog/playable_targets_db_test.go
+++ b/internal/catalog/playable_targets_db_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -149,10 +150,11 @@ func TestPlayableTargetResolverProfileStateAvailabilityAndAccess(t *testing.T) {
 		{ContentID: deniedSeries, Type: "series"},
 	}
 	resolver := NewPlayableTargetResolver(pool)
-	progressStore, err := pgstore.NewPostgresProvider(pool).ForUser(ctx, userID)
+	postgresProgressStore, err := pgstore.NewPostgresProvider(pool).ForUser(ctx, userID)
 	if err != nil {
 		t.Fatalf("create postgres progress store: %v", err)
 	}
+	progressStore := &recordingProgressStore{delegate: postgresProgressStore}
 	targetsA, err := resolver.Resolve(ctx, PlayableTargetQuery{
 		UserID: userID, ProfileID: profileA, Items: inputs,
 		Access: AccessFilter{AllowedLibraryIDs: []int{allowedFolderID}}, ProgressStore: progressStore,
@@ -172,6 +174,24 @@ func TestPlayableTargetResolverProfileStateAvailabilityAndAccess(t *testing.T) {
 	if !reflect.DeepEqual(targetsA, wantA) {
 		t.Fatalf("profile A targets = %#v, want %#v", targetsA, wantA)
 	}
+	if slices.Contains(progressStore.ids, movie) || !slices.Contains(progressStore.ids, episode1) {
+		t.Fatalf("progress lookup should omit leaf-only movies but retain episodes shared with series: %v", progressStore.ids)
+	}
+
+	t.Run("leaf cards do not query progress", func(t *testing.T) {
+		store := &recordingProgressStore{delegate: postgresProgressStore}
+		_, err := resolver.Resolve(t.Context(), PlayableTargetQuery{
+			UserID: userID, ProfileID: profileA,
+			Items:  []PlayableTargetInput{{ContentID: movie, Type: "movie"}, {ContentID: episode1, Type: "episode"}},
+			Access: AccessFilter{AllowedLibraryIDs: []int{allowedFolderID}}, ProgressStore: store,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(store.batchSizes) != 0 {
+			t.Fatalf("leaf-only progress queries = %v, want none", store.batchSizes)
+		}
+	})
 
 	cappedInput := PlayableTargetInput{ContentID: movie, Type: "movie"}
 	qualityCapped, err := resolver.Resolve(ctx, PlayableTargetQuery{
@@ -211,6 +231,7 @@ func TestPlayableTargetResolverProfileStateAvailabilityAndAccess(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			progressStore.batchSizes = nil
 			input := PlayableTargetInput{ContentID: series, Type: "series", PreferredContentID: tc.hint}
 			targets, err := resolver.Resolve(ctx, PlayableTargetQuery{
 				UserID: userID, ProfileID: profileA,
@@ -220,6 +241,9 @@ func TestPlayableTargetResolverProfileStateAvailabilityAndAccess(t *testing.T) {
 			})
 			if err != nil || targets[input.Key()] != tc.want {
 				t.Fatalf("hinted target = %#v, err %v; want %s", targets, err, tc.want)
+			}
+			if tc.want == tc.hint && len(progressStore.batchSizes) != 0 {
+				t.Fatalf("validated hint issued progress queries: %v", progressStore.batchSizes)
 			}
 		})
 	}

--- a/internal/catalog/playable_targets_progress_test.go
+++ b/internal/catalog/playable_targets_progress_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/userstore"
@@ -10,15 +11,39 @@ import (
 
 type recordingProgressStore struct {
 	batchSizes []int
+	ids        []string
+	delegate   PlayableTargetProgressStore
 }
 
-func (s *recordingProgressStore) ListProgressByMediaItems(_ context.Context, _ string, mediaItemIDs []string) (map[string]userstore.WatchProgress, error) {
+func (s *recordingProgressStore) ListProgressByMediaItems(ctx context.Context, profileID string, mediaItemIDs []string) (map[string]userstore.WatchProgress, error) {
 	s.batchSizes = append(s.batchSizes, len(mediaItemIDs))
+	s.ids = append(s.ids, mediaItemIDs...)
+	if s.delegate != nil {
+		return s.delegate.ListProgressByMediaItems(ctx, profileID, mediaItemIDs)
+	}
 	result := make(map[string]userstore.WatchProgress, len(mediaItemIDs))
 	for _, id := range mediaItemIDs {
 		result[id] = userstore.WatchProgress{MediaItemID: id, PositionSeconds: 1}
 	}
 	return result, nil
+}
+
+func TestPlayableTargetProgressIDsOnlyLoadsAmbiguousUnhintedCards(t *testing.T) {
+	candidates := map[string][]string{
+		"movie":        {"movie"},
+		"empty":        nil,
+		"one-episode":  {"episode-1"},
+		"hinted":       {"episode-1", "episode-2", "hinted-only"},
+		"series":       {"episode-1", "episode-2"},
+		"same-series":  {"episode-1", "episode-2"},
+		"invalid-hint": {"episode-3", "episode-4"},
+	}
+	ids := playableTargetProgressIDs(candidates, map[string]string{"hinted": "episode-2"})
+	slices.Sort(ids)
+	want := []string{"episode-1", "episode-2", "episode-3", "episode-4"}
+	if !slices.Equal(ids, want) {
+		t.Fatalf("progress IDs = %v, want %v", ids, want)
+	}
 }
 
 // The PostgreSQL store binds one parameter per ID, so a page of long-running


### PR DESCRIPTION
## Problem

Related issue: #965

Playback-target resolution reads watch progress even for a single-candidate card or a validated preferred target whose result does not depend on progress.

## Approach

Collect progress IDs only for unhinted cards with multiple candidates. Preserve candidates shared with ambiguous cards, and keep availability, access, quality, and hint validation ahead of this decision.

## Validation

| Workload | Before median | After median | Progress queries / IDs before → after |
|---|---|---|---|
| 100 movie cards | 1.058 ms | 0.710 ms | 1 / 100 → 0 / 0 |
| Hinted series, 200 episodes | 1.014 ms | 0.574 ms | 1 / 200 → 0 / 0 |
| Unhinted series, 200 episodes; control | 0.927 ms | 0.982 ms | 1 / 200 → 1 / 200 |

Five samples of 100 operations with real PostgreSQL, identical fixtures, original-source overlays, and ANALYZE after seeding. The captured benchmark was named BenchmarkCatalogReadQueries; this isolated branch now owns the independent `BenchmarkPlayableTargetReadQueries` fixture.

Focused profile/access/quality, valid and invalid hints, shared candidates, leaf-only calls, repeated cards, and large progress-batch regressions passed.

Branch validation passed: `go test ./internal/catalog/...` and `golangci-lint run --new-from-merge-base=origin/main --timeout=10m ./internal/catalog/...` (0 issues). Database regressions also passed with `go test ./internal/catalog -run 'TestPlayable'` and the test database configured; no selected cases were skipped.

## Risks

The unchanged control moved +5.9%; statement counts are stronger evidence than small latency differences. These are resolver benchmarks, not endpoint timings. No migrations or API changes; Apple and Android need no client updates. Jellyfin compatibility was considered; its performance was not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
