### PR TITLE
perf(catalog): infer exact totals for terminal pages

### DIFF
--- a/internal/catalog/query_executor.go
+++ b/internal/catalog/query_executor.go
@@ -104,9 +104,16 @@ func (e *QueryExecutor) executePreviewPagePlan(ctx context.Context, build previe
 	}
 
 	if includeTotal {
-		countSQL, countArgs := build.countSQL()
-		if err := e.Pool.QueryRow(ctx, countSQL, countArgs...).Scan(&total); err != nil {
-			return nil, 0, false, fmt.Errorf("counting preview items: %w", err)
+		// No extra row means this page exhausted the matches (or reached the
+		// configured cap). An empty offset may have overshot the actual end,
+		// and a zero limit fetches nothing, so neither proves an exact total.
+		if !hasMore && build.limit > 0 && (len(items) > 0 || build.offset == 0) {
+			total = build.offset + len(items)
+		} else {
+			countSQL, countArgs := build.countSQL()
+			if err := e.Pool.QueryRow(ctx, countSQL, countArgs...).Scan(&total); err != nil {
+				return nil, 0, false, fmt.Errorf("counting preview items: %w", err)
+			}
 		}
 		hasMore = total > build.offset+len(items)
 		return items, total, hasMore, nil

--- a/internal/catalog/query_executor_total_benchmark_test.go
+++ b/internal/catalog/query_executor_total_benchmark_test.go
@@ -1,0 +1,98 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type previewTotalBenchmarkTracer struct{ counts int }
+
+func (tracer *previewTotalBenchmarkTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	if strings.Contains(data.SQL, "SELECT COUNT(*)") {
+		tracer.counts++
+	}
+	return ctx
+}
+
+func (*previewTotalBenchmarkTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {
+}
+
+// This benchmark requires a disposable migrated database. Only the 100 movies
+// visible to these preview requests are needed; playback fixtures are separate.
+func BenchmarkPreviewPageExactTotalQueries(b *testing.B) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		b.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		b.Fatal(err)
+	}
+	tracer := &previewTotalBenchmarkTracer{}
+	config.ConnConfig.Tracer = tracer
+	pool, err := pgxpool.NewWithConfig(b.Context(), config)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("preview-total-perf-%d", time.Now().UnixNano())
+	movieIDs := make([]string, 100)
+	for i := range movieIDs {
+		movieIDs[i] = fmt.Sprintf("%s-movie-%03d", prefix, i)
+	}
+	if _, err := pool.Exec(b.Context(), `INSERT INTO media_items (content_id, type, title, status, genres)
+		SELECT id, 'movie', id, 'matched', '{}'::text[] FROM unnest($1::text[]) id`, movieIDs); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = ANY($1)`, movieIDs)
+	})
+	if _, err := pool.Exec(b.Context(), `ANALYZE media_items`); err != nil {
+		b.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name               string
+		limit, offset, cap int
+		empty              bool
+	}{
+		{name: "short-first-page", limit: 120},
+		{name: "short-final-page", limit: 20, offset: 90},
+		{name: "empty-first-page", limit: 20, empty: true},
+		{name: "capped-first-page", limit: 20, cap: 5},
+		{name: "full-first-page", limit: 20},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			executor := &QueryExecutor{Pool: pool}
+			definition := QueryDefinition{Sort: QuerySort{Field: "title", Order: "asc"}}
+			if tc.cap > 0 {
+				definition.Limit = new(tc.cap)
+			}
+			access := AccessFilter{AllowedContentIDs: movieIDs}
+			if tc.empty {
+				access.AllowedContentIDs = []string{}
+			}
+			wantTotal := len(access.AllowedContentIDs)
+			if tc.cap > 0 {
+				wantTotal = min(wantTotal, tc.cap)
+			}
+			items, total, _, err := executor.PreviewPage(b.Context(), definition, access, tc.limit, tc.offset, true)
+			if err != nil || total != wantTotal || len(items) != min(tc.limit, max(0, wantTotal-tc.offset)) {
+				b.Fatalf("fixture preview: items=%d total=%d error=%v, want total=%d", len(items), total, err, wantTotal)
+			}
+			tracer.counts = 0
+			for b.Loop() {
+				if _, _, _, err := executor.PreviewPage(b.Context(), definition, access, tc.limit, tc.offset, true); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(tracer.counts)/float64(b.N), "count-queries/op")
+		})
+	}
+}

--- a/internal/catalog/query_executor_total_db_test.go
+++ b/internal/catalog/query_executor_total_db_test.go
@@ -1,0 +1,99 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type previewCountTracer struct{ counts int }
+
+func (tracer *previewCountTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	if strings.Contains(data.SQL, "SELECT COUNT(*) FROM (") {
+		tracer.counts++
+	}
+	return ctx
+}
+
+func (*previewCountTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+func TestQueryExecutorTerminalPageTotals(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracer := &previewCountTracer{}
+	config.ConnConfig.Tracer = tracer
+	pool, err := pgxpool.NewWithConfig(t.Context(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	ids := make([]string, 23)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("preview-total-%d-%02d", time.Now().UnixNano(), i)
+	}
+	_, err = pool.Exec(t.Context(), `INSERT INTO media_items (content_id, type, title, status, genres)
+		SELECT id, 'movie', id, 'matched', '{}'::text[] FROM unnest($1::text[]) id`, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id = ANY($1)`, ids)
+	})
+	executor := &QueryExecutor{Pool: pool}
+	for _, tc := range []struct {
+		name                            string
+		limit, offset, cap, total, size int
+		counts                          int
+		empty, hasMore, skipTotal       bool
+	}{
+		{name: "full first page counts", limit: 20, total: 23, size: 20, counts: 1, hasMore: true},
+		{name: "short first page", limit: 30, total: 23, size: 23},
+		{name: "short final page", limit: 20, offset: 20, total: 23, size: 3},
+		{name: "exactly full final page has no extra row", limit: 23, total: 23, size: 23},
+		{name: "empty first page", limit: 20, empty: true},
+		{name: "empty deep page counts", limit: 20, offset: 40, total: 23, counts: 1},
+		{name: "empty exact end counts", limit: 20, offset: 23, total: 23, counts: 1},
+		{name: "cap on first page", limit: 20, cap: 5, total: 5, size: 5},
+		{name: "cap on later page", limit: 20, offset: 20, cap: 22, total: 22, size: 2},
+		{name: "terminal before cap", limit: 20, offset: 20, cap: 25, total: 23, size: 3},
+		{name: "offset at cap counts", limit: 20, offset: 5, cap: 5, total: 5, counts: 1},
+		{name: "offset beyond cap counts", limit: 20, offset: 30, cap: 5, total: 5, counts: 1},
+		{name: "short catalog before cap counts beyond end", limit: 20, offset: 25, cap: 30, total: 23, counts: 1},
+		{name: "skip total with extra row", limit: 20, size: 20, hasMore: true, skipTotal: true},
+		{name: "skip total final page", limit: 20, offset: 20, size: 3, skipTotal: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			definition := QueryDefinition{Sort: QuerySort{Field: "title", Order: "asc"}}
+			if tc.cap > 0 {
+				definition.Limit = new(tc.cap)
+			}
+			access := AccessFilter{AllowedContentIDs: ids}
+			if tc.empty {
+				access.AllowedContentIDs = []string{}
+			}
+			tracer.counts = 0
+			items, total, hasMore, err := executor.PreviewPage(t.Context(), definition, access, tc.limit, tc.offset, !tc.skipTotal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(items) != tc.size || total != tc.total || hasMore != tc.hasMore {
+				t.Fatalf("page = (size %d, total %d, hasMore %v), want (%d, %d, %v)", len(items), total, hasMore, tc.size, tc.total, tc.hasMore)
+			}
+			if tracer.counts != tc.counts {
+				t.Fatalf("COUNT queries = %d, want %d", tracer.counts, tc.counts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: #965

Preview pages execute a separate exact COUNT even when their fetched rows already prove the end of the result set.

## Approach

Infer the exact total only when the extra-row check proves a terminal page. Preserve counting for pages with more results, ambiguous empty offsets, and zero limits caused by a cap. Totals stay exact.

## Validation

| 100-movie fixture | Before median | After median | COUNT queries/op |
|---|---|---|---|
| short-first-page | 1.696 ms | 1.337 ms | 1 → 0 |
| short-final-page | 1.278 ms | 0.679 ms | 1 → 0 |
| empty-first-page | 0.454 ms | 0.224 ms | 1 → 0 |
| capped-first-page | 0.798 ms | 0.659 ms | 1 → 0 |
| full-first-page | 1.117 ms | 4.308 ms | 1 → 1 |

Five samples of 100 operations on the same analyzed 100-movie PostgreSQL fixture. Original production source was selected through an overlay.

Fifteen database regressions passed, covering short/full/empty pages, exact end offsets, configured caps, offsets at and beyond a cap, and skip-total requests.

Branch validation passed: `go test ./internal/catalog/...` and `golangci-lint run --new-from-merge-base=origin/main --timeout=10m ./internal/catalog/...` (0 issues). Database regressions also passed with `go test ./internal/catalog -run 'TestQueryExecutorTerminalPageTotals'` and the test database configured; no selected cases were skipped.

## Risks

The unchanged full-page control rose from 1.117 to 4.308 ms despite retaining one COUNT and approximately identical allocations. That points to substantial host/environment variation; these runs do not establish a consistent elapsed-time benefit. The deterministic win is removing a COUNT only where the page proves the total. No migrations or API changes; Apple and Android need no client updates. Jellyfin compatibility was considered; its performance was not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
