### PR TITLE
perf(catalog): reuse single-item localization reads

### DIFF
--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -1803,8 +1803,22 @@ func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.M
 		pendingTranslation = pf.pendingTranslation
 		item = pf.localizedItem
 	} else {
-		pendingTranslation = s.PendingTranslationLanguage(ctx, item, filter)
-		localizedItem, err := s.LocalizeItemModel(ctx, item, filter)
+		// Share the language and row with the pending-translation decision,
+		// just as the batch detail path does.
+		targets, localizations, err := s.loadItemLocalizations(ctx, []*models.MediaItem{item}, filter)
+		var localizedItem *models.MediaItem
+		if err != nil && strings.TrimSpace(item.Overview) != "" && s.itemLocRepo != nil {
+			// PendingTranslationLanguage historically suppressed its lookup
+			// error before the required localization read. Preserve that retry
+			// on failure without repeating successful lookups.
+			localizedItem, err = s.LocalizeItemModel(ctx, item, filter)
+		} else if err == nil {
+			language, loc := targets[item.ContentID], localizations[item.ContentID]
+			if s.itemLocRepo != nil {
+				pendingTranslation = pendingTranslationLanguageWith(item, language, loc)
+			}
+			localizedItem = s.localizeItemModelWith(item, language, loc)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("localizing item detail: %w", err)
 		}

--- a/internal/catalog/detail_batch_equivalence_test.go
+++ b/internal/catalog/detail_batch_equivalence_test.go
@@ -104,7 +104,7 @@ func batchEquivExec(t *testing.T, pool *pgxpool.Pool, sql string, args ...any) {
 // Unlike the jellycompat handler test (which stubs the content service so both
 // paths return the same canned *ItemDetail), this drives the genuinely-batched
 // repository code: ItemRepository.GetByIDs vs GetByID, EnsureAccessibleIDs vs
-// EnsureAccessible, MediaItemLocalizationRepository.GetByContentIDs vs Get, and
+// EnsureAccessible, localization grouped by target language, and
 // PersonRepository.ListForItems vs ListForItem all run against a real Postgres.
 // Media files and work summaries route through interface fakes that serve the
 // batch and per-item method shapes from one backing map (mirroring the real

--- a/internal/catalog/detail_localization_query_test.go
+++ b/internal/catalog/detail_localization_query_test.go
@@ -1,0 +1,221 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/access"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type detailLocalizationTracer struct {
+	folders, folderPaths, localizations int
+}
+
+func (tracer *detailLocalizationTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	switch {
+	case strings.Contains(data.SQL, "FROM media_item_localizations"):
+		tracer.localizations++
+	case strings.Contains(data.SQL, "FROM media_folders"):
+		tracer.folders++
+	case strings.Contains(data.SQL, "FROM media_folder_paths"):
+		tracer.folderPaths++
+	}
+	return ctx
+}
+
+func (*detailLocalizationTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+func detailLocalizationFixture(t testing.TB) (*DetailService, *pgxpool.Pool, *detailLocalizationTracer) {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracer := &detailLocalizationTracer{}
+	config.ConnConfig.Tracer = tracer
+	config.MaxConns = 1
+	pool, err := pgxpool.NewWithConfig(t.Context(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	// Session-local fixtures exercise real repository SQL without adding
+	// catalog entries or changing the shared migrated schema.
+	_, err = pool.Exec(t.Context(), `
+		CREATE TEMP TABLE media_item_localizations (LIKE public.media_item_localizations INCLUDING DEFAULTS INCLUDING INDEXES);
+		CREATE TEMP TABLE media_folders (LIKE public.media_folders INCLUDING DEFAULTS);
+		CREATE TEMP TABLE media_folder_paths (LIKE public.media_folder_paths INCLUDING DEFAULTS);
+		INSERT INTO media_folders (id, type, name, metadata_language)
+		VALUES (1, 'series', 'French', 'fr'), (2, 'series', 'English', 'en');
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	localizations := NewMediaItemLocalizationRepository(pool)
+	for _, row := range []*models.MediaItemLocalization{
+		{ContentID: "translated", Language: "fr", Title: "Titre", Overview: "Description"},
+		{ContentID: "translated", Language: "no", Title: "Tittel", Overview: "Beskrivelse"},
+		{ContentID: "partial", Language: "fr", Title: "Partial title"},
+	} {
+		if err := localizations.Upsert(t.Context(), row); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &DetailService{itemLocRepo: localizations, folderRepo: NewFolderRepository(pool)}, pool, tracer
+}
+
+func localizationDetailItem(id, overview string) *models.MediaItem {
+	return &models.MediaItem{
+		ContentID: id, Type: "series", Title: "Base title", Overview: overview,
+		DefaultMetadataLanguage: "en", OriginalLanguage: "no",
+	}
+}
+
+func TestBuildMediaItemDetailSharesLocalization(t *testing.T) {
+	service, _, tracer := detailLocalizationFixture(t)
+	for _, tc := range []struct {
+		name, id, overview, original, title, localizedOverview, pending string
+		filter                                                          AccessFilter
+		folders, localizations                                          int
+		noRepo                                                          bool
+	}{
+		{name: "translated", id: "translated", overview: "Base overview", original: "no", title: "Titre", localizedOverview: "Description", filter: AccessFilter{PresentationLibraryID: new(1)}, folders: 1, localizations: 1},
+		{name: "base language", id: "translated", overview: "Base overview", original: "no", title: "Base title", localizedOverview: "Base overview", filter: AccessFilter{PresentationLibraryID: new(2)}, folders: 1},
+		{name: "base profile language needs no database", id: "translated", overview: "Base overview", original: "no", title: "Base title", localizedOverview: "Base overview", filter: AccessFilter{ProfilePreferredLanguage: "en"}},
+		{name: "missing localization", id: "missing", overview: "Base overview", title: "Base title", localizedOverview: "Base overview", pending: "fr", filter: AccessFilter{PresentationLibraryID: new(1)}, folders: 1, localizations: 1},
+		{name: "partial localization", id: "partial", overview: "Base overview", title: "Partial title", localizedOverview: "Base overview", pending: "fr", filter: AccessFilter{PresentationLibraryID: new(1)}, folders: 1, localizations: 1},
+		{name: "blank overview suppresses pending", id: "missing", overview: "  ", title: "Base title", localizedOverview: "  ", filter: AccessFilter{PresentationLibraryID: new(1)}, folders: 1, localizations: 1},
+		{name: "missing repository suppresses pending", id: "missing", overview: "Base overview", title: "Base title", localizedOverview: "Base overview", filter: AccessFilter{PresentationLibraryID: new(1)}, folders: 1, noRepo: true},
+		{name: "original language", id: "translated", overview: "Base overview", original: "nor", title: "Tittel", localizedOverview: "Beskrivelse", filter: AccessFilter{PresentationLibraryID: new(1), ProfilePreferredLanguage: access.OriginalMetadataLanguage}, folders: 1, localizations: 1},
+		{name: "unknown original uses library", id: "translated", overview: "Base overview", title: "Titre", localizedOverview: "Description", filter: AccessFilter{PresentationLibraryID: new(1), ProfilePreferredLanguage: access.OriginalMetadataLanguage}, folders: 1, localizations: 1},
+		{name: "source exception", id: "translated", overview: "Base overview", original: "nor", title: "Tittel", localizedOverview: "Beskrivelse", filter: AccessFilter{ProfilePreferredLanguage: "fr", MetadataLanguageOverrides: map[string]string{"no": access.OriginalMetadataLanguage}}, localizations: 1},
+		{name: "explicit language bypasses exception", id: "translated", overview: "Base overview", original: "no", title: "Titre", localizedOverview: "Description", filter: AccessFilter{PresentationLanguage: "fr", MetadataLanguageOverrides: map[string]string{"no": access.OriginalMetadataLanguage}}, localizations: 1},
+		{name: "no target language", id: "translated", overview: "Base overview", title: "Base title", localizedOverview: "Base overview"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			item := localizationDetailItem(tc.id, tc.overview)
+			item.OriginalLanguage = tc.original
+			original := *item
+			repo := service.itemLocRepo
+			if tc.noRepo {
+				service.itemLocRepo = nil
+			}
+			defer func() { service.itemLocRepo = repo }()
+			*tracer = detailLocalizationTracer{}
+			detail, err := service.buildMediaItemDetail(t.Context(), item, item.ContentID, tc.filter, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if detail.Title != tc.title || detail.Overview != tc.localizedOverview || detail.PendingTranslationLanguage != tc.pending {
+				t.Fatalf("localized fields = (%q, %q, %q), want (%q, %q, %q)", detail.Title, detail.Overview, detail.PendingTranslationLanguage, tc.title, tc.localizedOverview, tc.pending)
+			}
+			if tracer.folders != tc.folders || tracer.folderPaths != tc.folders || tracer.localizations != tc.localizations {
+				t.Fatalf("reads = %#v, want %d folders/paths and %d localizations", tracer, tc.folders, tc.localizations)
+			}
+			if !reflect.DeepEqual(*item, original) {
+				t.Fatal("detail construction mutated the source item")
+			}
+		})
+	}
+}
+
+type failingDetailFolder struct {
+	delegate *FolderRepository
+	calls    int
+	err      error
+	once     bool
+}
+
+func (folder *failingDetailFolder) GetByID(ctx context.Context, id int) (*models.MediaFolder, error) {
+	folder.calls++
+	if !folder.once || folder.calls == 1 {
+		return nil, folder.err
+	}
+	return folder.delegate.GetByID(ctx, id)
+}
+
+func TestBuildMediaItemDetailLocalizationErrors(t *testing.T) {
+	service, pool, tracer := detailLocalizationFixture(t)
+	filter := AccessFilter{PresentationLibraryID: new(1)}
+	item := localizationDetailItem("missing", "Base overview")
+	t.Run("advisory language error remains suppressed before required retry", func(t *testing.T) {
+		folder := &failingDetailFolder{delegate: NewFolderRepository(pool), err: errors.New("transient folder failure"), once: true}
+		service.folderRepo = folder
+		detail, err := service.buildMediaItemDetail(t.Context(), item, item.ContentID, filter, nil)
+		if err != nil || detail == nil || detail.Title != item.Title || detail.PendingTranslationLanguage != "" || folder.calls != 2 {
+			t.Fatalf("detail=%#v error=%v folder calls=%d", detail, err, folder.calls)
+		}
+	})
+	t.Run("required language error still fails", func(t *testing.T) {
+		folder := &failingDetailFolder{err: ErrFolderNotFound}
+		service.folderRepo = folder
+		if got := service.PendingTranslationLanguage(t.Context(), item, filter); got != "" {
+			t.Fatalf("pending language on failure = %q", got)
+		}
+		folder.calls = 0
+		_, err := service.buildMediaItemDetail(t.Context(), item, item.ContentID, filter, nil)
+		if !errors.Is(err, ErrItemNotFound) || folder.calls != 2 {
+			t.Fatalf("error=%v folder calls=%d, want item-not-found after two lookups", err, folder.calls)
+		}
+		withoutOverview := localizationDetailItem("missing", "")
+		folder.calls = 0
+		_, err = service.buildMediaItemDetail(t.Context(), withoutOverview, withoutOverview.ContentID, filter, nil)
+		if !errors.Is(err, ErrItemNotFound) || folder.calls != 1 {
+			t.Fatalf("error=%v folder calls=%d, want one required lookup without advisory work", err, folder.calls)
+		}
+	})
+	t.Run("localization query failure is suppressed only by advisory helper", func(t *testing.T) {
+		service.folderRepo = NewFolderRepository(pool)
+		if _, err := pool.Exec(t.Context(), `ALTER TABLE pg_temp.media_item_localizations RENAME COLUMN language TO unavailable_language`); err != nil {
+			t.Fatal(err)
+		}
+		if got := service.PendingTranslationLanguage(t.Context(), item, filter); got != "" {
+			t.Fatalf("pending language on localization failure = %q", got)
+		}
+		*tracer = detailLocalizationTracer{}
+		_, err := service.buildMediaItemDetail(t.Context(), item, item.ContentID, filter, nil)
+		if err == nil || !strings.Contains(err.Error(), "localizing item detail") || tracer.localizations != 2 {
+			t.Fatalf("error=%v localization reads=%d, want required failure after two reads", err, tracer.localizations)
+		}
+	})
+}
+
+func BenchmarkBuildMediaItemDetailLocalization(b *testing.B) {
+	service, _, tracer := detailLocalizationFixture(b)
+	for _, tc := range []struct {
+		name   string
+		item   *models.MediaItem
+		filter AccessFilter
+	}{
+		{name: "translated-library", item: localizationDetailItem("translated", "Base overview"), filter: AccessFilter{PresentationLibraryID: new(1)}},
+		{name: "base-library", item: localizationDetailItem("translated", "Base overview"), filter: AccessFilter{PresentationLibraryID: new(2)}},
+		{name: "pending-library", item: localizationDetailItem("missing", "Base overview"), filter: AccessFilter{PresentationLibraryID: new(1)}},
+		{name: "translated-profile", item: localizationDetailItem("translated", "Base overview"), filter: AccessFilter{ProfilePreferredLanguage: "fr"}},
+		{name: "base-profile-control", item: localizationDetailItem("translated", "Base overview"), filter: AccessFilter{ProfilePreferredLanguage: "en"}},
+		{name: "blank-overview-control", item: localizationDetailItem("translated", ""), filter: AccessFilter{ProfilePreferredLanguage: "fr"}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			*tracer = detailLocalizationTracer{}
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := service.buildMediaItemDetail(b.Context(), tc.item, tc.item.ContentID, tc.filter, nil); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(tracer.folders)/float64(b.N), "language-lookups/op")
+			b.ReportMetric(float64(tracer.localizations)/float64(b.N), "localization-queries/op")
+			b.ReportMetric(float64(tracer.folders+tracer.folderPaths+tracer.localizations)/float64(b.N), "SQL-queries/op")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: #965

Successful single-item detail construction resolves language and localization twice: once for pending translation and again for translated fields.

## Approach

Reuse the existing batch localization loader for the single item and share its resolved values. Preserve the suppressed advisory failure followed by the required lookup retry; callers without advisory work retain a single required attempt.

## Validation

| Detail-builder workload | Before median | After median | SQL statements/op |
|---|---|---|---|
| Translated library language | 1.246 ms | 0.660 ms | 6 → 3 |
| Base library language | 0.835 ms | 0.438 ms | 4 → 2 |
| Pending library translation | 1.213 ms | 0.626 ms | 6 → 3 |
| Translated profile language | 0.436 ms | 0.205 ms | 2 → 1 |
| Base profile; control | 0.623 µs | 0.602 µs | 0 → 0 |
| Blank overview; control | 0.216 ms | 0.215 ms | 1 → 1 |

Five samples of 100 operations using original-source overlays and session-local PostgreSQL fixtures with real folder/localization repositories. A library lookup includes folder-row and folder-path queries.

Twelve normal/base/pending cases passed, including language overrides, missing/partial rows, nil repository, and source-model non-mutation. Error cases passed against both original and final source; full single/batch detail equivalence also passed.

Branch validation passed: `go test ./internal/catalog/...` and `golangci-lint run --new-from-merge-base=origin/main --timeout=10m ./internal/catalog/...` (0 issues). Database regressions also passed with `go test ./internal/catalog -run 'TestBuildMediaItemDetail(LocalizationErrors|SharesLocalization)|TestGetItemDetailsByIDs_MatchesGetItemDetail'` and the test database configured; no selected cases were skipped.

## Risks

The reused loader adds map overhead where no duplicate SQL existed: base-profile bytes/op 2,376 → 2,532; blank-overview bytes/op 4,912 → 6,096. Timings call the detail builder with unrelated repositories absent, not the complete Items HTTP route. No migrations or API changes; Apple and Android need no client updates. Jellyfin compatibility was considered; its performance was not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
