### PR TITLE
perf(search): remove redundant PostgreSQL ranking window

### DIFF
--- a/internal/catalog/search_postgres_mixed.go
+++ b/internal/catalog/search_postgres_mixed.go
@@ -77,9 +77,11 @@ const mediaSearchTitleVector = `(
 
 const mediaSearchOverviewVector = `to_tsvector('english', COALESCE(mi.overview, ''))`
 
-const mixedSearchOrder = `exact_title_match DESC, contiguous_title_match DESC, year_match DESC,
-	phrase_rank DESC, title_prefix_rank DESC, overview_rank DESC,
-	LOWER(title) ASC, content_id ASC`
+func mixedSearchOrder(prefix string) string {
+	return fmt.Sprintf(`%[1]sexact_title_match DESC, %[1]scontiguous_title_match DESC, %[1]syear_match DESC,
+	%[1]sphrase_rank DESC, %[1]stitle_prefix_rank DESC, %[1]soverview_rank DESC,
+	LOWER(%[1]stitle) ASC, %[1]scontent_id ASC`, prefix)
+}
 
 // buildMixedSearchSQLFromParsed builds one ranked candidate set from the two
 // physical catalog sources. The scored CTE deliberately carries only ranking
@@ -303,11 +305,11 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 	args = append(args, limit, offset)
 
 	pageCTE := fmt.Sprintf(`, page AS (
-		SELECT scored.*, ROW_NUMBER() OVER (ORDER BY %s) AS ordinal%s
+		SELECT scored.*%s
 		%s
 		ORDER BY %s
 		LIMIT $%d OFFSET $%d
-	)`, mixedSearchOrder, pageTotalColumn, postFilter, mixedSearchOrder, limitIdx, offsetIdx)
+	)`, pageTotalColumn, postFilter, mixedSearchOrder(""), limitIdx, offsetIdx)
 
 	hydratedRelation := fmt.Sprintf(`LATERAL (
 		SELECT %s
@@ -325,7 +327,7 @@ func (r *ItemRepository) buildMixedSearchSQLFromParsed(
 		SELECT %s%s
 		FROM page
 		JOIN %s ON true
-		ORDER BY page.ordinal`, qualifiedItemColumns("hydrated"), finalTotalColumn, hydratedRelation)
+		ORDER BY %s`, qualifiedItemColumns("hydrated"), finalTotalColumn, hydratedRelation, mixedSearchOrder("page."))
 	countSQL = scoredCTE + fmt.Sprintf("\nSELECT COUNT(*)\n%s", postFilter)
 	return dataSQL, countSQL, args
 }


### PR DESCRIPTION
## Problem

Related issue: #965

Mixed PostgreSQL search computes ROW_NUMBER solely to preserve page order after hydration, adding a ranking window that is unnecessary for the response.

## Approach

Remove the ordinal window and explicitly order hydrated results by the same qualified ranking tuple. Keep title/year/rank tie-breaks, content-ID ordering, and the requested exact-total window.

## Validation

| Query / scope / offset | Before EXPLAIN median | After EXPLAIN median |
|---|---|---|
| star / episodes / 0 | 89.291 ms | 42.916 ms |
| love / episodes / 0 | 126.095 ms | 76.154 ms |
| love / mixed / 0 | 2,185.490 ms | 1,818.815 ms |
| breaking bad / mixed / 0; narrow control | 1.506 ms | 2.287 ms |

Three read-only EXPLAIN (ANALYZE, BUFFERS) executions per query shape. The comparison covered three queries, episode and mixed scopes, and offsets 0/20: 12 cases. Ordered IDs and page totals matched; final generated SQL and arguments matched the measured candidate after whitespace normalization. The empty episode page at offset 20 had no row from which to extract a total.

Targeted search tests passed. The broader database test TestEpisodeSearchPostgresAndDocumentSource has a pre-existing vector-map assertion mismatch reproduced against original source; no fully green database-enabled suite is claimed.

Branch validation passed: `go test ./internal/catalog/...` and `golangci-lint run --new-from-merge-base=origin/main --timeout=10m ./internal/catalog/...` (0 issues).

## Risks

Broad mixed search still takes roughly 1–2 seconds in these SQL samples; scoring and exact totals remain. Narrow-query regressions and shared-host variation prevent a universal speedup claim. No migrations or API changes; Apple and Android need no client updates. Jellyfin compatibility was considered; its performance was not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
