### PR TITLE
perf(search): bound initial Meilisearch candidate hydration

### DIFF
--- a/internal/catalog/search_meilisearch_batch_db_test.go
+++ b/internal/catalog/search_meilisearch_batch_db_test.go
@@ -1,0 +1,143 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func meilisearchBatchFixture(t testing.TB, density string) (*MeilisearchSearchProvider, []string, *atomic.Int64, *atomic.Int64) {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(t.Context(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("meili-batch-%d-", time.Now().UnixNano())
+	_, err = pool.Exec(t.Context(), `INSERT INTO media_items (content_id, type, title)
+		SELECT $1 || n, CASE WHEN $2 IN ('sparse', 'moderate') AND n % CASE WHEN $2 = 'moderate' THEN 2 ELSE 10 END <> 0 THEN 'audiobook' ELSE 'movie' END,
+		'Meili batch fixture' FROM generate_series(0, 299) n`, prefix, density)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"%")
+	})
+	ids := make([]string, 300)
+	var accessible []string
+	stride := 10
+	if density == "moderate" {
+		stride = 2
+	}
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%s%d", prefix, i)
+		if density == "dense" || i%stride == 0 {
+			accessible = append(accessible, ids[i])
+		} else if density == "stale" {
+			ids[i] += "-deleted"
+		}
+	}
+	requests, candidates := &atomic.Int64{}, &atomic.Int64{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req meilisearchSearchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		requests.Add(1)
+		start := min(req.Offset, len(ids))
+		end := min(start+req.Limit, len(ids))
+		hits := make([]map[string]string, 0, end-start)
+		for _, id := range ids[start:end] {
+			hits = append(hits, map[string]string{"content_id": id})
+		}
+		candidates.Add(int64(len(hits)))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"hits": hits, "estimatedTotalHits": len(ids)})
+	}))
+	t.Cleanup(server.Close)
+	client, err := newMeilisearchClient(server.URL, "", time.Second*5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &MeilisearchSearchProvider{itemRepo: NewItemRepository(pool), client: client}, accessible, requests, candidates
+}
+
+func TestMeilisearchBatchPagination(t *testing.T) {
+	for _, density := range []string{"dense", "moderate", "sparse", "stale"} {
+		t.Run(density, func(t *testing.T) {
+			provider, ids, requests, candidates := meilisearchBatchFixture(t, density)
+			for _, limit := range []int{1, 20} {
+				for _, offset := range []int{0, 20, len(ids) - 1, len(ids)} {
+					requests.Store(0)
+					candidates.Store(0)
+					result, err := provider.searchMeilisearch(t.Context(), CatalogSearchRequest{Query: "fixture", Limit: limit, Offset: offset, Access: AccessFilter{ExcludedMediaTypes: []string{"audiobook"}}}, "fixture", true)
+					if err != nil {
+						t.Fatal(err)
+					}
+					want := ids[min(offset, len(ids)):min(offset+limit, len(ids))]
+					if len(result.Items) != len(want) {
+						t.Fatalf("offset %d returned %d items, want %d", offset, len(result.Items), len(want))
+					}
+					for i, item := range result.Items {
+						if item.ContentID != want[i] {
+							t.Fatalf("offset %d item %d = %q, want %q", offset, i, item.ContentID, want[i])
+						}
+					}
+					if result.HasMore != (offset+len(want) < len(ids)) {
+						t.Fatalf("offset %d HasMore = %t", offset, result.HasMore)
+					}
+					wantTotal := offset + len(want)
+					if result.HasMore {
+						wantTotal++
+					}
+					if result.Total != wantTotal || result.TotalExact {
+						t.Fatalf("offset %d total = %d exact = %t, want lower bound %d", offset, result.Total, result.TotalExact, wantTotal)
+					}
+					if offset == 0 {
+						wantRequests, wantCandidates := int64(3), int64(242)
+						if limit == 1 {
+							wantRequests, wantCandidates = 2, 104
+						}
+						if density == "dense" || density == "moderate" {
+							wantRequests, wantCandidates = 1, int64(2*(limit+1))
+						}
+						if requests.Load() != wantRequests || candidates.Load() != wantCandidates {
+							t.Fatalf("requests/candidates = %d/%d, want %d/%d", requests.Load(), candidates.Load(), wantRequests, wantCandidates)
+						}
+					}
+					t.Logf("limit=%d offset=%d requests=%d candidates=%d", limit, offset, requests.Load(), candidates.Load())
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMeilisearchCandidateHydration(b *testing.B) {
+	for _, density := range []string{"dense", "moderate", "sparse", "stale"} {
+		b.Run(density, func(b *testing.B) {
+			provider, _, requests, candidates := meilisearchBatchFixture(b, density)
+			req := CatalogSearchRequest{Query: "fixture", Limit: 20, Access: AccessFilter{ExcludedMediaTypes: []string{"audiobook"}}}
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := provider.searchMeilisearch(b.Context(), req, "fixture", true); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(requests.Load())/float64(b.N), "requests/op")
+			b.ReportMetric(float64(candidates.Load())/float64(b.N), "candidates/op")
+		})
+	}
+}

--- a/internal/catalog/search_meilisearch_provider.go
+++ b/internal/catalog/search_meilisearch_provider.go
@@ -349,6 +349,12 @@ func (p *MeilisearchSearchProvider) searchMeilisearch(ctx context.Context, req C
 			return nil, fmt.Errorf("meilisearch candidate scan cap reached")
 		}
 		nextLimit := batchSize
+		if scanned == 0 {
+			// Allow some filtered or stale hits without another round trip,
+			// while avoiding a full batch for small pages. Later rounds retain
+			// the larger backfill batches for sparse access.
+			nextLimit = min(nextLimit, 2*target)
+		}
 		if remaining := meilisearchCandidateScanCap - scanned; remaining < nextLimit {
 			nextLimit = remaining
 		}


### PR DESCRIPTION
## Problem

Related issue: #965

Small first-page searches hydrate 100 Meili candidates even when far fewer are needed to fill the accessible page and prove has_more.

## Approach

Bound the first request by the existing batch size and twice the required page-plus-extra target: 42 candidates for limit 20/offset 0. Retain larger subsequent batches for filtering, stale IDs, and sparse access; keep scan caps and lower-bound totals.

## Validation

| First-page fixture | Candidates/op | Requests/op | Before median | After median |
|---|---|---|---|---|
| Dense | 100 → 42 | 1 → 1 | 0.916 ms | 0.694 ms |
| 50% filtered | 100 → 42 | 1 → 1 | 1.412 ms | 0.561 ms |
| 90% filtered | 300 → 242 | 3 → 3 | 1.670 ms | 1.685 ms |
| Mostly stale | 300 → 242 | 3 → 3 | 1.719 ms | 1.573 ms |

Three samples with deterministic HTTP search hits and real PostgreSQL access filtering/hydration. The 50%-filtered baseline ran separately and ranged 0.928–1.660 ms.

Pagination tests passed for dense/moderate/sparse/stale fixtures, limits 1/20, first/later/final/end offsets, order, size, has_more, and lower-bound total semantics.

Branch validation passed: `go test ./internal/catalog/...` and `golangci-lint run --new-from-merge-base=origin/main --timeout=10m ./internal/catalog/...` (0 issues). Database regressions also passed with `go test ./internal/catalog -run 'TestMeilisearchBatchPagination'` and the test database configured; no selected cases were skipped.

## Risks

Candidate/request counts are deterministic; fixture times exclude actual Meili ranking and network latency. Dense allocations fall 361,203 → 179,389 B/op, but sparse timing is effectively unchanged. No migrations or API changes; Apple and Android need no client updates. Jellyfin compatibility was considered; its performance was not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
