### PR TITLE
perf(web): load hero backdrops near the active slide

### DIFF
--- a/web/src/components/HeroBanner.test.tsx
+++ b/web/src/components/HeroBanner.test.tsx
@@ -1,7 +1,7 @@
 import { MemoryRouter } from "react-router";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { SectionItem } from "@/api/types";
 
@@ -232,6 +232,93 @@ describe("HeroBanner", () => {
 
     unmount();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("starts only the active and two adjacent backdrop requests, including wraparound", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={Array.from({ length: 10 }, (_, index) =>
+            movieSlide({ content_id: `movie-${index}`, backdrop_url: `/movie-${index}.jpg` }),
+          )}
+        />
+      </MemoryRouter>,
+    );
+    const images = Array.from(container.querySelectorAll("img"));
+
+    expect(images.map((image) => image.getAttribute("src"))).toEqual([
+      "/movie-0.jpg",
+      "/movie-1.jpg",
+      "/movie-9.jpg",
+    ]);
+    expect(images[0]).toHaveAttribute("fetchpriority", "high");
+    expect(images.slice(1).every((image) => image.getAttribute("fetchpriority") === "low")).toBe(
+      true,
+    );
+  });
+
+  it("loads neighbors on next and previous navigation and preserves loaded backdrops", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HeroBanner
+          items={Array.from({ length: 10 }, (_, index) =>
+            movieSlide({ content_id: `movie-${index}`, backdrop_url: `/movie-${index}.jpg` }),
+          )}
+        />
+      </MemoryRouter>,
+    );
+    const loadedNeighbor = container.querySelector('img[src="/movie-9.jpg"]')!;
+    fireEvent.load(loadedNeighbor);
+    const sources = () =>
+      Array.from(container.querySelectorAll("img"), (image) => image.getAttribute("src"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
+    expect(sources()).toEqual(["/movie-0.jpg", "/movie-1.jpg", "/movie-2.jpg", "/movie-9.jpg"]);
+    expect(container.querySelector('img[src="/movie-9.jpg"]')).toBe(loadedNeighbor);
+    expect(container.querySelector('img[fetchpriority="high"]')).toHaveAttribute(
+      "src",
+      "/movie-1.jpg",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Previous slide" }));
+    fireEvent.click(screen.getByRole("button", { name: "Previous slide" }));
+    expect(sources()).toEqual(["/movie-0.jpg", "/movie-8.jpg", "/movie-9.jpg"]);
+    expect(container.querySelector('img[fetchpriority="high"]')).toHaveAttribute(
+      "src",
+      "/movie-9.jpg",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
+    expect(sources()).toEqual(["/movie-0.jpg", "/movie-1.jpg", "/movie-9.jpg"]);
+  });
+
+  it("does not eagerly load a replacement URL on a distant loaded slide", () => {
+    const slides = Array.from({ length: 10 }, (_, index) =>
+      movieSlide({ content_id: `movie-${index}`, backdrop_url: `/movie-${index}.jpg` }),
+    );
+    const { container, rerender } = render(
+      <MemoryRouter>
+        <HeroBanner items={slides} />
+      </MemoryRouter>,
+    );
+    fireEvent.load(container.querySelector('img[src="/movie-9.jpg"]')!);
+    fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
+    rerender(
+      <MemoryRouter>
+        <HeroBanner
+          items={slides.map((slide, index) =>
+            index === 9 ? { ...slide, backdrop_url: "/replacement.jpg" } : slide,
+          )}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(container.querySelector('img[src="/replacement.jpg"]')).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Previous slide" }));
+    const replacement = container.querySelector('img[src="/replacement.jpg"]');
+    expect(replacement).toHaveClass("opacity-0");
+    fireEvent.load(replacement!);
+    expect(replacement).toHaveClass("opacity-100");
   });
 
   it("does not retain outgoing backdrop motion for reduced motion", () => {

--- a/web/src/components/HeroBanner.test.tsx
+++ b/web/src/components/HeroBanner.test.tsx
@@ -292,6 +292,37 @@ describe("HeroBanner", () => {
     expect(sources()).toEqual(["/movie-0.jpg", "/movie-1.jpg", "/movie-9.jpg"]);
   });
 
+  it.each([0, 1])("keeps loaded slide %i visible while its URL refreshes", (index) => {
+    const slides = Array.from({ length: 10 }, (_, index) =>
+      movieSlide({ content_id: `movie-${index}`, backdrop_url: `/movie-${index}.jpg` }),
+    );
+    const { container, rerender } = render(
+      <MemoryRouter>
+        <HeroBanner items={slides} />
+      </MemoryRouter>,
+    );
+    const image = container.querySelector(`img[src="/movie-${index}.jpg"]`)!;
+    expect(image).toHaveClass("opacity-0");
+    fireEvent.load(image);
+    expect(image).toHaveClass("opacity-100");
+
+    rerender(
+      <MemoryRouter>
+        <HeroBanner
+          items={slides.map((slide, slideIndex) =>
+            slideIndex === index ? { ...slide, backdrop_url: "/refreshed.jpg" } : slide,
+          )}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(container.querySelector('img[src="/refreshed.jpg"]')).toBe(image);
+    expect(image).toHaveClass("opacity-100");
+    fireEvent.load(image);
+    expect(image).toHaveClass("opacity-100");
+    expect(container.querySelectorAll("img")).toHaveLength(3);
+  });
+
   it("does not eagerly load a replacement URL on a distant loaded slide", () => {
     const slides = Array.from({ length: 10 }, (_, index) =>
       movieSlide({ content_id: `movie-${index}`, backdrop_url: `/movie-${index}.jpg` }),
@@ -301,7 +332,8 @@ describe("HeroBanner", () => {
         <HeroBanner items={slides} />
       </MemoryRouter>,
     );
-    fireEvent.load(container.querySelector('img[src="/movie-9.jpg"]')!);
+    const image = container.querySelector('img[src="/movie-9.jpg"]')!;
+    fireEvent.load(image);
     fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
     rerender(
       <MemoryRouter>
@@ -314,11 +346,15 @@ describe("HeroBanner", () => {
     );
 
     expect(container.querySelector('img[src="/replacement.jpg"]')).toBeNull();
+    expect(container.querySelector('img[src="/movie-9.jpg"]')).toBe(image);
     fireEvent.click(screen.getByRole("button", { name: "Previous slide" }));
     const replacement = container.querySelector('img[src="/replacement.jpg"]');
-    expect(replacement).toHaveClass("opacity-0");
+    expect(replacement).toBe(image);
+    expect(replacement).toHaveClass("opacity-100");
     fireEvent.load(replacement!);
     expect(replacement).toHaveClass("opacity-100");
+    fireEvent.click(screen.getByRole("button", { name: "Next slide" }));
+    expect(container.querySelector('img[src="/replacement.jpg"]')).toBe(image);
   });
 
   it("does not retain outgoing backdrop motion for reduced motion", () => {

--- a/web/src/components/HeroBanner.tsx
+++ b/web/src/components/HeroBanner.tsx
@@ -59,13 +59,16 @@ const HeroBackdropSlide = memo(function HeroBackdropSlide({
   index,
   isActive,
   keepsMotion,
+  shouldLoad,
 }: {
   slide: SectionItem;
   index: number;
   isActive: boolean;
   keepsMotion: boolean;
+  shouldLoad: boolean;
 }) {
-  const [loaded, setLoaded] = useState(false);
+  const [loadedUrl, setLoadedUrl] = useState<string | null>(null);
+  const loaded = loadedUrl === slide.backdrop_url;
   const thumbhash = slide.backdrop_thumbhash ? decodeThumbhash(slide.backdrop_thumbhash) : "";
 
   return (
@@ -82,10 +85,11 @@ const HeroBackdropSlide = memo(function HeroBackdropSlide({
           : undefined
       }
     >
-      {slide.backdrop_url && (
+      {slide.backdrop_url && (shouldLoad || loaded) && (
         <img
           src={slide.backdrop_url}
           alt=""
+          fetchPriority={isActive ? "high" : "low"}
           className={cn(
             "h-full w-full object-cover object-[center_20%] transition-opacity duration-(--duration-slow)",
             isActive && "will-change-transform",
@@ -98,7 +102,7 @@ const HeroBackdropSlide = memo(function HeroBackdropSlide({
             filter:
               "brightness(var(--hero-backdrop-brightness, 0.78)) saturate(var(--hero-backdrop-saturate, 0.95))",
           }}
-          onLoad={() => setLoaded(true)}
+          onLoad={() => setLoadedUrl(slide.backdrop_url)}
         />
       )}
     </div>
@@ -248,7 +252,7 @@ export default function HeroBanner({
         if (!e.currentTarget.contains(e.relatedTarget)) resume();
       }}
     >
-      {/* Backdrop layers – all stacked, crossfade via opacity */}
+      {/* Preload neighbors in both directions; retain loaded backdrops for crossfades. */}
       {slides.map((slide, i) => (
         <HeroBackdropSlide
           key={slide.content_id ?? i}
@@ -256,6 +260,12 @@ export default function HeroBanner({
           index={i}
           isActive={i === activeIndex}
           keepsMotion={i === activeIndex || i === outgoingIndex}
+          shouldLoad={
+            i === activeIndex ||
+            i === outgoingIndex ||
+            i === (activeIndex + 1) % slideCount ||
+            i === (activeIndex - 1 + slideCount) % slideCount
+          }
         />
       ))}
 

--- a/web/src/components/HeroBanner.tsx
+++ b/web/src/components/HeroBanner.tsx
@@ -68,7 +68,9 @@ const HeroBackdropSlide = memo(function HeroBackdropSlide({
   shouldLoad: boolean;
 }) {
   const [loadedUrl, setLoadedUrl] = useState<string | null>(null);
-  const loaded = loadedUrl === slide.backdrop_url;
+  // Keep the browser's loaded image visible while a refreshed URL is pending.
+  // Distant slides retain their loaded source until they become a neighbor.
+  const imageUrl = shouldLoad ? slide.backdrop_url : loadedUrl;
   const thumbhash = slide.backdrop_thumbhash ? decodeThumbhash(slide.backdrop_thumbhash) : "";
 
   return (
@@ -85,15 +87,15 @@ const HeroBackdropSlide = memo(function HeroBackdropSlide({
           : undefined
       }
     >
-      {slide.backdrop_url && (shouldLoad || loaded) && (
+      {slide.backdrop_url && imageUrl && (
         <img
-          src={slide.backdrop_url}
+          src={imageUrl}
           alt=""
           fetchPriority={isActive ? "high" : "low"}
           className={cn(
             "h-full w-full object-cover object-[center_20%] transition-opacity duration-(--duration-slow)",
             isActive && "will-change-transform",
-            loaded ? "opacity-100" : "opacity-0",
+            loadedUrl ? "opacity-100" : "opacity-0",
           )}
           style={{
             animation: keepsMotion
@@ -102,7 +104,7 @@ const HeroBackdropSlide = memo(function HeroBackdropSlide({
             filter:
               "brightness(var(--hero-backdrop-brightness, 0.78)) saturate(var(--hero-backdrop-saturate, 0.95))",
           }}
-          onLoad={() => setLoadedUrl(slide.backdrop_url)}
+          onLoad={() => setLoadedUrl(imageUrl)}
         />
       )}
     </div>


### PR DESCRIPTION
## Problem

Related issue: #965

Every stacked hero slide mounts an image source immediately, so a hidden slide starts a request alongside the active backdrop.

## Approach

Initially load the active slide and both wrapped neighbors, prioritize the active image, and retain loaded/outgoing images for the existing crossfade. Retain the loaded image while signed URLs refresh; distant slides keep their old loaded source until they become eligible for replacement.

## Validation

| Initial workload | Before | After |
|---|---|---|
| 10-slide component fixture | 10 image sources | 3 image sources |
| 12-slide browser fixture | 12 image requests | 3 image requests |
| Active / neighbor priority | Browser default | high / low / low |

A temporary fictional-content fixture using the actual component confirmed the initial request budget. Browser checks verified next, previous, and wraparound navigation. Tests cover retained loaded nodes, replaced URLs, rapid transitions, reduced motion, and existing actions.

From `web/`, `pnpm exec vitest run src/components/HeroBanner.test.tsx` passed (34 tests), and `pnpm run build` passed.

## Risks

This is an initial request budget, not a cap on cumulative downloads or retained images after navigation. Appearance and existing transitions are preserved. No repeatable LCP or cross-origin image-byte savings were measured. No API changes; Apple and Android need no client updates.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: A GitHub review identified a signed-URL refresh visibility regression. The fix passed regression tests and independent code-review and @ponytail-review, with no remaining findings.
