### PR TITLE
perf(web): defer playback settings code until navigation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,7 +51,6 @@ import { isTasteSeedDismissed } from "@/lib/tasteSeed";
 import { OnboardingGate } from "@/components/onboarding/OnboardingGate";
 import { useOnboardingState } from "@/hooks/queries/onboarding";
 import SettingsLayout from "@/pages/SettingsLayout";
-import PlaybackSettings from "@/pages/settings/PlaybackSettings";
 import {
   WatchPlaybackBar,
   WatchPlaybackHost,
@@ -91,6 +90,7 @@ const Collections = lazy(importCollections);
 const CollectionEditor = lazy(() => import("@/pages/CollectionEditor"));
 const Notifications = lazy(() => import("@/pages/Notifications"));
 const DeviceSettings = lazy(() => import("@/pages/settings/DeviceSettings"));
+const PlaybackSettings = lazy(() => import("@/pages/settings/PlaybackSettings"));
 const NotificationsSettings = lazy(() => import("@/pages/settings/NotificationsSettings"));
 const Requests = lazy(() => import("@/pages/Requests"));
 const RequestBrowse = lazy(() => import("@/pages/RequestBrowse"));

--- a/web/src/pages/Catalog.test.tsx
+++ b/web/src/pages/Catalog.test.tsx
@@ -338,17 +338,18 @@ describe("Catalog page", () => {
     expect(latestNavigateTo).toBeNull();
   });
 
-  it("renders user settings inside the main app layout", () => {
+  it("renders user settings inside the main app layout", async () => {
     appInitialEntries = ["/settings/playback"];
 
-    const markup = renderToStaticMarkup(
+    render(
       <QueryClientProvider client={new QueryClient()}>
         <App />
       </QueryClientProvider>,
     );
 
-    expect(markup).toContain('data-kind="app-layout"');
-    expect(markup).toContain("Settings");
+    const settings = await screen.findByText("Playback settings");
+    expect(settings.closest('[data-kind="app-layout"]')).not.toBeNull();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
   it("lets an administrator without an active profile open account settings", async () => {


### PR DESCRIPTION
## Problem

Related issue: #965

The application entry imports the playback-settings feature before a user navigates to that route.

## Approach

Use a module-scope React.lazy import under the existing route Suspense boundary. Update the settings-route assertion in Catalog.test.tsx to wait for the lazy page while verifying it remains inside the main layout.

## Validation

| Initial static-import closure | Before | After | Reduction |
|---|---:|---:|---:|
| Minified | 1,577,589 B | 1,562,422 B | 15,167 B (0.96%) |
| Gzip | 462,333 B | 457,820 B | 4,513 B (0.98%) |
| Brotli | 371,735 B | 368,416 B | 3,319 B (0.89%) |

Each comparison uses the baseline and this change alone, following static imports recursively from the production entry. Dynamic imports and other assets are excluded.

From `web/`, `pnpm exec vitest run src/pages/Catalog.test.tsx` passed (28 tests), and `pnpm run build` passed.

The route assertion waits for the settings controls and confirms they remain inside the main layout. Its test file is excluded from the configured full web gate, so the focused run above verifies it explicitly.

## Risks

First navigation now waits for the feature chunk through the existing loading boundary. The feature download is deferred, so reduced initial bytes do not establish a user-latency improvement. No API changes; Apple and Android need no client updates.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
