### PR TITLE
perf(web): defer the audiobook player until playback

### DIFF
--- a/web/src/pages/audiobooks/player/audiobookPlaybackContext.test.tsx
+++ b/web/src/pages/audiobooks/player/audiobookPlaybackContext.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, act, waitFor } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import type { AudiobookPlayerProps } from "./AudiobookPlayer";
+import {
+  AudiobookPlaybackProvider,
+  useAudiobookPlaybackController,
+} from "./audiobookPlaybackContext";
+
+const playerModule = vi.hoisted(() => {
+  let resolve!: () => void;
+  return {
+    requested: vi.fn(),
+    ready: new Promise<void>((done) => {
+      resolve = done;
+    }),
+    resolve: () => resolve(),
+  };
+});
+
+vi.mock("./AudiobookPlayer", async () => {
+  playerModule.requested();
+  await playerModule.ready;
+  return {
+    default: ({ title, onClose }: AudiobookPlayerProps) => (
+      <div aria-label="Audiobook player">
+        {title}
+        <button onClick={onClose}>Close player</button>
+      </div>
+    ),
+  };
+});
+
+function PlaybackControls() {
+  const playback = useAudiobookPlaybackController()!;
+  return (
+    <>
+      <input aria-label="Library search" defaultValue="Unchanged page" />
+      <button
+        onClick={() =>
+          playback.startPlayback({ contentId: "book-1", title: "First book", files: [] })
+        }
+      >
+        Start audiobook
+      </button>
+      <button onClick={playback.stopPlayback}>Stop audiobook</button>
+    </>
+  );
+}
+
+it("loads the player on demand, preserves the page while pending, and honors cancellation", async () => {
+  render(
+    <AudiobookPlaybackProvider>
+      <PlaybackControls />
+    </AudiobookPlaybackProvider>,
+  );
+  const search = screen.getByRole("textbox", { name: "Library search" });
+  fireEvent.change(search, { target: { value: "My search" } });
+  expect(playerModule.requested).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByRole("button", { name: "Start audiobook" }));
+  await waitFor(() => expect(playerModule.requested).toHaveBeenCalledOnce());
+  expect(search).toBeVisible();
+  expect(search).toHaveValue("My search");
+  expect(screen.queryByLabelText("Audiobook player")).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: "Stop audiobook" }));
+  await act(async () => playerModule.resolve());
+  expect(screen.queryByLabelText("Audiobook player")).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: "Start audiobook" }));
+  expect(await screen.findByLabelText("Audiobook player")).toHaveTextContent("First book");
+  expect(screen.getByRole("textbox", { name: "Library search" })).toBe(search);
+  expect(search).toHaveValue("My search");
+  fireEvent.click(screen.getByRole("button", { name: "Close player" }));
+  expect(screen.queryByLabelText("Audiobook player")).not.toBeInTheDocument();
+});

--- a/web/src/pages/audiobooks/player/audiobookPlaybackContext.tsx
+++ b/web/src/pages/audiobooks/player/audiobookPlaybackContext.tsx
@@ -1,4 +1,13 @@
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
+import {
+  createContext,
+  lazy,
+  Suspense,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   getAccessToken,
   getAuthContextVersion,
@@ -9,10 +18,9 @@ import {
 import type { AudiobookFile } from "@/lib/audiobooks/types";
 import { PlayerConfigProvider, type PlayerConfig } from "@/player/context/PlayerConfigContext";
 import { storage } from "@/utils/storage";
-import AudiobookPlayer, {
-  type AudiobookPlayerControls,
-  type AudiobookPlayerStatus,
-} from "./AudiobookPlayer";
+import type { AudiobookPlayerControls, AudiobookPlayerStatus } from "./AudiobookPlayer";
+
+const AudiobookPlayer = lazy(() => import("./AudiobookPlayer"));
 
 export interface AudiobookPlaybackStartInput {
   contentId: string;
@@ -102,20 +110,22 @@ export function AudiobookPlaybackProvider({ children }: { children: ReactNode })
       {children}
       {activeRequest && (
         <PlayerConfigProvider config={playerConfig}>
-          <AudiobookPlayer
-            key={`${activeRequest.contentId}-${activeRequest.requestKey}`}
-            contentId={activeRequest.contentId}
-            title={activeRequest.title}
-            author={activeRequest.author}
-            narrator={activeRequest.narrator}
-            posterUrl={activeRequest.posterUrl}
-            files={activeRequest.files}
-            initialPositionSeconds={activeRequest.initialPositionSeconds}
-            autoPlay={activeRequest.autoPlay}
-            onClose={stopPlayback}
-            onPlaybackStateChange={setActive}
-            onControlsChange={setControls}
-          />
+          <Suspense fallback={null}>
+            <AudiobookPlayer
+              key={`${activeRequest.contentId}-${activeRequest.requestKey}`}
+              contentId={activeRequest.contentId}
+              title={activeRequest.title}
+              author={activeRequest.author}
+              narrator={activeRequest.narrator}
+              posterUrl={activeRequest.posterUrl}
+              files={activeRequest.files}
+              initialPositionSeconds={activeRequest.initialPositionSeconds}
+              autoPlay={activeRequest.autoPlay}
+              onClose={stopPlayback}
+              onPlaybackStateChange={setActive}
+              onControlsChange={setControls}
+            />
+          </Suspense>
         </PlayerConfigProvider>
       )}
     </AudiobookPlaybackControllerContext.Provider>


### PR DESCRIPTION
## Problem

Related issue: #965

The application-wide audiobook context eagerly imports the player even when playback is never requested.

## Approach

Keep player types as type-only imports and load the implementation lazily. A local Suspense boundary covers only the player, preserving the surrounding page while the import is pending.

## Validation

| Initial static-import closure | Before | After | Reduction |
|---|---:|---:|---:|
| Minified | 1,577,589 B | 1,516,793 B | 60,796 B (3.85%) |
| Gzip | 462,333 B | 445,189 B | 17,144 B (3.71%) |
| Brotli | 371,735 B | 358,555 B | 13,180 B (3.55%) |

Each comparison uses the baseline and this change alone, following static imports recursively from the production entry. Dynamic imports and other assets are excluded.

From `web/`, `pnpm exec vitest run src/pages/audiobooks/player/audiobookPlaybackContext.test.tsx` passed (1 test), and `pnpm run build` passed.

The import-gated test verifies no player load before playback, preserved page/input state while loading, cancellation before import completion, no delayed start after cancellation, subsequent playback, and closing.

## Risks

A first audiobook start may include module-loading latency. Existing playback UI and API shapes remain unchanged. The player’s feature bytes are downloaded when needed; the bundle measurement does not establish playback-start latency.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration; High implementation and review.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
