### PR TITLE
perf(catalog): batch credit photo URL resolution

### DIFF
--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -1993,8 +1993,38 @@ func applyWorkSummaryValue(detail *ItemDetail, summary *WorkSummary) {
 
 // personCredits converts ItemPerson slice to PersonCredit slice with presigned URLs.
 func (s *DetailService) personCredits(ctx context.Context, people []models.ItemPerson, filter AccessFilter) []PersonCredit {
+	photoPaths := make([]string, len(people))
+	paths := make([]string, 0, len(people))
+	seen := make(map[string]struct{}, len(people))
+	variant := imagesize.PluginVariantFeatured
+	if filter.ImageSize != imagesize.Unset {
+		variant = sizeToVariant(string(filter.ImageSize))
+	}
+	for i, person := range people {
+		path := person.PhotoPath
+		if path == "" || path == "-" || strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+			continue
+		}
+		// An absent size preserves the stored key and historical plugin hint;
+		// explicit sizes use the same profile ladder as individual resolution.
+		if filter.ImageSize != imagesize.Unset {
+			path = cachedImageVariantPath(path, artworkkey.ImageProfile, string(filter.ImageSize))
+		}
+		photoPaths[i] = path
+		if _, ok := seen[path]; !ok {
+			seen[path] = struct{}{}
+			paths = append(paths, path)
+		}
+	}
+	photoURLs := s.PresignURLsWithExpiry(ctx, paths, variant)
+	for _, path := range paths {
+		if photoURLs[path].URL == "" {
+			// Partial batch implementations retain their individual fallback.
+			photoURLs[path] = s.PresignURLWithExpiry(ctx, path, variant)
+		}
+	}
 	credits := make([]PersonCredit, 0, len(people))
-	for _, p := range people {
+	for i, p := range people {
 		pc := PersonCredit{
 			PersonID:  p.ID,
 			Name:      p.Name,
@@ -2006,15 +2036,10 @@ func (s *DetailService) personCredits(ctx context.Context, people []models.ItemP
 			TvdbID:    p.TvdbID,
 			PlexGUID:  p.PlexGUID,
 		}
-		if p.PhotoPath != "" && p.PhotoPath != "-" {
-			// Without an explicit size the stored key is presigned as-is, which
-			// is what this has always returned. An explicit size resolves the
-			// profile ladder instead, the same as every other image on the page.
-			if filter.ImageSize == imagesize.Unset {
-				pc.PhotoURL = s.PresignURL(ctx, p.PhotoPath, imagesize.PluginVariantFeatured)
-			} else {
-				pc.PhotoURL = s.PresignImageURL(ctx, p.PhotoPath, artworkkey.ImageProfile, string(filter.ImageSize))
-			}
+		if strings.HasPrefix(p.PhotoPath, "http://") || strings.HasPrefix(p.PhotoPath, "https://") {
+			pc.PhotoURL = p.PhotoPath
+		} else if photoPaths[i] != "" {
+			pc.PhotoURL = photoURLs[photoPaths[i]].URL
 		}
 		if p.PhotoThumbhash != "" && p.PhotoThumbhash != "-" {
 			pc.PhotoThumbhash = p.PhotoThumbhash

--- a/internal/catalog/person_credit_batch_test.go
+++ b/internal/catalog/person_credit_batch_test.go
@@ -1,0 +1,223 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/imagesize"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type creditPhotoResolver struct {
+	batches, singles int
+	paths            []string
+	missingBatch     bool
+	emptyBatch       bool
+}
+
+func (r *creditPhotoResolver) ResolveImageURL(_ context.Context, path, variant string) string {
+	r.singles++
+	if strings.Contains(path, "unavailable") {
+		return ""
+	}
+	return "resolved:" + variant + ":" + path
+}
+
+func (r *creditPhotoResolver) ResolveImageURLs(_ context.Context, paths []string, variant string) map[string]string {
+	r.batches++
+	r.paths = append(r.paths, paths...)
+	result := make(map[string]string, len(paths))
+	for _, path := range paths {
+		if r.missingBatch {
+			continue
+		}
+		if r.emptyBatch || strings.Contains(path, "unavailable") {
+			result[path] = ""
+			continue
+		}
+		result[path] = "resolved:" + variant + ":" + path
+	}
+	return result
+}
+
+type expiringCreditPhotoResolver struct{ creditPhotoResolver }
+
+func (*expiringCreditPhotoResolver) ResolveImageURL(context.Context, string, string) string {
+	panic("must use expiry-aware single resolution")
+}
+
+func (*expiringCreditPhotoResolver) ResolveImageURLs(context.Context, []string, string) map[string]string {
+	panic("must use expiry-aware batch resolution")
+}
+
+func (r *expiringCreditPhotoResolver) ResolveImageURLWithExpiry(ctx context.Context, path, variant string) ResolvedImageURL {
+	return ResolvedImageURL{URL: r.creditPhotoResolver.ResolveImageURL(ctx, path, variant), ExpiresAt: new(time.Now().Add(time.Hour))}
+}
+
+func (r *expiringCreditPhotoResolver) ResolveImageURLsWithExpiry(ctx context.Context, paths []string, variant string) map[string]ResolvedImageURL {
+	urls := r.creditPhotoResolver.ResolveImageURLs(ctx, paths, variant)
+	result := make(map[string]ResolvedImageURL, len(urls))
+	for path, url := range urls {
+		result[path] = ResolvedImageURL{URL: url, ExpiresAt: new(time.Now().Add(time.Hour))}
+	}
+	return result
+}
+
+func creditPhotoPeople() []models.ItemPerson {
+	paths := []string{testPhotoPath, "plug://people/second.jpg", testPhotoPath, "https://example.invalid/person.jpg", "http://example.invalid/other.jpg", "", "-", "other://unavailable.jpg"}
+	people := make([]models.ItemPerson, len(paths))
+	for i, path := range paths {
+		people[i] = models.ItemPerson{Person: models.Person{ID: int64(i + 1), Name: fmt.Sprintf("Person %d", i), PhotoPath: path, PhotoThumbhash: "hash", TmdbID: "tmdb", ImdbID: "imdb", TvdbID: "tvdb", PlexGUID: "plex"}, Kind: models.PersonKindActor, Character: "Character", SortOrder: i}
+	}
+	people[2].Kind = models.PersonKindDirector
+	people[5].PhotoThumbhash = ""
+	people[6].PhotoThumbhash = "-"
+	return people
+}
+
+func TestPersonCreditPhotoBatchPreservesCredits(t *testing.T) {
+	for _, size := range []imagesize.Size{imagesize.Unset, imagesize.Small, imagesize.Medium, imagesize.Large, imagesize.Original} {
+		for _, expiring := range []bool{false, true} {
+			for _, mode := range []string{"complete", "missing", "empty"} {
+				t.Run(fmt.Sprintf("size=%s/expiring=%t/batch=%s", size, expiring, mode), func(t *testing.T) {
+					recorder := &creditPhotoResolver{missingBatch: mode == "missing", emptyBatch: mode == "empty"}
+					var resolver ImageResolver = recorder
+					if expiring {
+						extended := &expiringCreditPhotoResolver{creditPhotoResolver: *recorder}
+						recorder = &extended.creditPhotoResolver
+						resolver = extended
+					}
+					service := &DetailService{imageResolver: resolver}
+					people := creditPhotoPeople()
+					original := slices.Clone(people)
+					got := service.personCredits(t.Context(), people, AccessFilter{ImageSize: size})
+					if !reflect.DeepEqual(people, original) {
+						t.Fatal("mutated input credits")
+					}
+					// The old individual helpers are the behavior oracle for URL normalization
+					// and fallbacks; all other credit fields must preserve source ordering.
+					reference := &DetailService{imageResolver: &creditPhotoResolver{}}
+					want := make([]PersonCredit, len(people))
+					for i, person := range people {
+						photo := reference.PresignURL(t.Context(), person.PhotoPath, imagesize.PluginVariantFeatured)
+						if size != imagesize.Unset {
+							photo = reference.PresignImageURL(t.Context(), person.PhotoPath, "profile", string(size))
+						}
+						hash := person.PhotoThumbhash
+						if hash == "-" {
+							hash = ""
+						}
+						want[i] = PersonCredit{PersonID: person.ID, Name: person.Name, Kind: person.Kind, Character: person.Character, SortOrder: person.SortOrder, TmdbID: person.TmdbID, ImdbID: person.ImdbID, TvdbID: person.TvdbID, PlexGUID: person.PlexGUID, PhotoURL: photo, PhotoThumbhash: hash}
+					}
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("credits = %#v, want %#v", got, want)
+					}
+					wantSingles := 1 // The unavailable photo gets one fallback, then stays empty.
+					if mode != "complete" {
+						wantSingles = 3
+					}
+					if recorder.batches != 1 || recorder.singles != wantSingles || len(recorder.paths) != 3 {
+						t.Fatalf("batch=%d singles=%d paths=%v, want one batch of three distinct paths and %d fallbacks", recorder.batches, recorder.singles, recorder.paths, wantSingles)
+					}
+					cast, crew := splitCastCrew(got)
+					wantCast, wantCrew := splitCastCrew(want)
+					if !reflect.DeepEqual(cast, wantCast) || !reflect.DeepEqual(crew, wantCrew) {
+						t.Fatal("cast/crew presentation changed")
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestPersonCreditPhotoBatchSkipsDirectAndMissingPaths(t *testing.T) {
+	for _, size := range []imagesize.Size{imagesize.Unset, imagesize.Large} {
+		recorder := &creditPhotoResolver{}
+		service := &DetailService{imageResolver: recorder}
+		people := creditPhotoPeople()[3:7]
+		got := service.personCredits(t.Context(), people, AccessFilter{ImageSize: size})
+		if recorder.batches != 0 || recorder.singles != 0 {
+			t.Fatal("direct or missing paths reached the resolver")
+		}
+		for i, credit := range got {
+			want := people[i].PhotoPath
+			if want == "-" {
+				want = ""
+			}
+			if credit.PhotoURL != want {
+				t.Fatalf("photo %d = %q, want %q", i, credit.PhotoURL, want)
+			}
+		}
+		if got := service.personCredits(t.Context(), nil, AccessFilter{ImageSize: size}); got == nil || len(got) != 0 {
+			t.Fatalf("empty credits = %#v, want non-nil empty slice", got)
+		}
+	}
+}
+
+func TestPersonCreditPhotoBatchWithoutResolver(t *testing.T) {
+	service := &DetailService{}
+	for _, size := range []imagesize.Size{imagesize.Unset, imagesize.Large} {
+		got := service.personCredits(t.Context(), creditPhotoPeople(), AccessFilter{ImageSize: size})
+		for i, credit := range got {
+			if i == 3 || i == 4 {
+				continue
+			}
+			if credit.PhotoURL != "" {
+				t.Fatalf("unresolved photo = %q", credit.PhotoURL)
+			}
+		}
+	}
+}
+
+func TestPersonCreditPhotoBatchCoalescesNormalizedKeys(t *testing.T) {
+	recorder := &creditPhotoResolver{missingBatch: true}
+	service := &DetailService{imageResolver: recorder}
+	people := []models.ItemPerson{
+		{Person: models.Person{PhotoPath: testPhotoPath}},
+		{Person: models.Person{PhotoPath: "tmdb/people/287/profile/w500.abc123.webp"}},
+	}
+	got := service.personCredits(t.Context(), people, AccessFilter{ImageSize: imagesize.Large})
+	if got[0].PhotoURL != got[1].PhotoURL || got[0].PhotoURL == "" {
+		t.Fatalf("equivalent stored rungs produced different URLs: %#v", got)
+	}
+	if recorder.batches != 1 || len(recorder.paths) != 1 || recorder.singles != 1 {
+		t.Fatalf("normalized aliases resolved repeatedly: %#v", recorder)
+	}
+}
+
+func BenchmarkPersonCreditPhotos(b *testing.B) {
+	for _, count := range []int{10, 100, 500} {
+		for _, duplicate := range []bool{false, true} {
+			for _, size := range []imagesize.Size{imagesize.Unset, imagesize.Medium} {
+				b.Run(fmt.Sprintf("credits=%d/duplicates=%t/size=%s", count, duplicate, size), func(b *testing.B) {
+					recorder := &creditPhotoResolver{}
+					service := &DetailService{imageResolver: recorder}
+					people := make([]models.ItemPerson, count)
+					for i := range people {
+						id := i
+						if duplicate {
+							id /= 2
+						}
+						people[i].PhotoPath = fmt.Sprintf("plug://people/%d.jpg", id)
+					}
+					b.ReportAllocs()
+					for b.Loop() {
+						recorder.paths = recorder.paths[:0]
+						service.personCredits(b.Context(), people, AccessFilter{ImageSize: size})
+					}
+					b.ReportMetric(float64(recorder.batches)/float64(b.N), "batch-calls/op")
+					b.ReportMetric(float64(recorder.singles)/float64(b.N), "single-calls/op")
+				})
+			}
+		}
+	}
+}
+
+// PersonCreditsForTesting lets external integration tests use the production
+// PluginImageResolver without creating a catalog -> metadata import cycle.
+var PersonCreditsForTesting = (*DetailService).personCredits

--- a/internal/catalog/person_credit_plugin_test.go
+++ b/internal/catalog/person_credit_plugin_test.go
@@ -1,0 +1,136 @@
+package catalog_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/imagesize"
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+type creditPhotoPlugin struct {
+	calls, paths int
+	expiresAt    *time.Time
+}
+
+func (p *creditPhotoPlugin) ResolveImageURL(ctx context.Context, path, variant string) (string, error) {
+	result, err := p.ResolveImageURLWithExpiry(ctx, path, variant)
+	return result.URL, err
+}
+
+func (p *creditPhotoPlugin) ResolveImageURLs(ctx context.Context, paths []string, variant string) (map[string]string, error) {
+	values, err := p.ResolveImageURLsWithExpiry(ctx, paths, variant)
+	result := make(map[string]string, len(values))
+	for path, value := range values {
+		result[path] = value.URL
+	}
+	return result, err
+}
+
+func (p *creditPhotoPlugin) ResolveImageURLWithExpiry(ctx context.Context, path, variant string) (catalog.ResolvedImageURL, error) {
+	values, err := p.ResolveImageURLsWithExpiry(ctx, []string{path}, variant)
+	return values[path], err
+}
+
+func (p *creditPhotoPlugin) ResolveImageURLsWithExpiry(_ context.Context, paths []string, variant string) (map[string]catalog.ResolvedImageURL, error) {
+	p.calls++
+	p.paths += len(paths)
+	result := make(map[string]catalog.ResolvedImageURL, len(paths))
+	for _, path := range paths {
+		result[path] = catalog.ResolvedImageURL{URL: "https://example.invalid/" + variant + "/" + path, ExpiresAt: p.expiresAt}
+	}
+	return result, nil
+}
+
+func pluginCreditPeople(count int, duplicates bool) []models.ItemPerson {
+	people := make([]models.ItemPerson, count)
+	for i := range people {
+		id := i
+		if duplicates {
+			id /= 2
+		}
+		people[i].PhotoPath = fmt.Sprintf("photos://person-%d.jpg", id)
+	}
+	return people
+}
+
+func TestPersonCreditPhotosThroughPluginResolver(t *testing.T) {
+	for _, size := range []imagesize.Size{imagesize.Unset, imagesize.Medium} {
+		t.Run(string(size), func(t *testing.T) {
+			resolver := metadata.NewPluginImageResolver()
+			t.Cleanup(resolver.Close)
+			source := &creditPhotoPlugin{expiresAt: new(time.Now().Add(time.Hour))}
+			other := &creditPhotoPlugin{expiresAt: source.expiresAt}
+			resolver.RegisterSource("photos", source)
+			resolver.RegisterSource("other", other)
+			service := &catalog.DetailService{}
+			service.SetImageResolver(resolver)
+			people := pluginCreditPeople(100, true)
+			people[99].PhotoPath = "other://different.jpg"
+			for _, warm := range []bool{false, true} {
+				source.calls, source.paths, other.calls, other.paths = 0, 0, 0, 0
+				got := catalog.PersonCreditsForTesting(service, t.Context(), people, catalog.AccessFilter{ImageSize: size})
+				if len(got) != len(people) {
+					t.Fatalf("got %d credits", len(got))
+				}
+				for i, credit := range got {
+					path := fmt.Sprintf("person-%d.jpg", i/2)
+					if i == 99 {
+						path = "different.jpg"
+					}
+					if want := "https://example.invalid/featured/" + path; credit.PhotoURL != want {
+						t.Fatalf("credit %d URL=%q, want %q", i, credit.PhotoURL, want)
+					}
+				}
+				wantCalls, wantPaths := 1, 50
+				if warm {
+					wantCalls, wantPaths = 0, 0
+				}
+				if source.calls != wantCalls || source.paths != wantPaths || other.calls != wantCalls || other.paths != wantCalls {
+					t.Fatalf("warm=%t primary=%d calls/%d paths other=%d calls/%d paths", warm, source.calls, source.paths, other.calls, other.paths)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkPersonCreditPhotosPluginResolver(b *testing.B) {
+	for _, count := range []int{10, 100, 500} {
+		for _, warm := range []bool{false, true} {
+			for _, duplicate := range []bool{false, true} {
+				b.Run(fmt.Sprintf("credits=%d/warm=%t/duplicates=%t", count, warm, duplicate), func(b *testing.B) {
+					resolver := metadata.NewPluginImageResolver()
+					b.Cleanup(resolver.Close)
+					source := &creditPhotoPlugin{expiresAt: new(time.Now().Add(time.Hour))}
+					registrations := []metadata.PluginImageResolverSourceRegistration{{Scheme: "photos", Source: source}}
+					resolver.ReplaceSources(registrations)
+					service := &catalog.DetailService{}
+					service.SetImageResolver(resolver)
+					people := pluginCreditPeople(count, duplicate)
+					filter := catalog.AccessFilter{}
+					if warm {
+						catalog.PersonCreditsForTesting(service, b.Context(), people, filter)
+					}
+					source.calls, source.paths = 0, 0
+					b.ReportAllocs()
+					for b.Loop() {
+						if !warm {
+							// Exclude cache invalidation: time only credit conversion and real
+							// resolver work with cold URL entries, using a zero-latency provider.
+							b.StopTimer()
+							resolver.ReplaceSources(registrations)
+							b.StartTimer()
+						}
+						catalog.PersonCreditsForTesting(service, b.Context(), people, filter)
+					}
+					b.ReportMetric(float64(source.calls)/float64(b.N), "provider-calls/op")
+					b.ReportMetric(float64(source.paths)/float64(b.N), "provider-paths/op")
+				})
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: #965

Detail construction resolves each cast/crew photo separately. A cold set of 100 distinct photos from one plugin crosses the production resolver’s provider boundary 100 times.

## Approach

Normalize and deduplicate photo paths locally, resolve a batch through the existing helper, and map results back in credit order. Keep unset stored keys/featured hints, explicit profile ladders, direct URLs, sentinels, and expiry-aware/plain resolvers. Missing or empty batch entries receive one singleton fallback per distinct normalized path.

## Validation

| Distinct photos / cache | Provider calls/op | Median elapsed/op before → after | B/op before → after |
|---|---|---|---|
| 10 / cold | 10 → 1 | 84.21 → 110.40 µs | 27,539 → 10,338 |
| 100 / cold | 100 → 1 | 728.00 → 208.38 µs | 276,409 → 87,380 |
| 100 / warm | 0 → 0 | 73.67 → 135.43 µs | 56,385 → 36,184 |
| 500 / cold | 500 → 1 | 2907.89 → 1341.43 µs | 1,382,095 → 597,440 |

Five repetitions of 1,000 operations per version. An original-source overlay and final source used identical harnesses. The actual PluginImageResolver used a deterministic fake provider with no networking or artificial delay. Cold cache invalidation is outside the timed region; warm cases prefill its real cache.

Photo/presign tests and the database-backed `TestGetItemDetailsByIDs_MatchesGetItemDetail` passed. Tests cover all sizes, duplicate/normalized aliases, missing/empty responses, unavailable photos, preserved fields/order/cast-crew output, and real plugin mixed-provider cold/warm behavior.

Branch validation passed: `make test-go`, `go build ./...`, `go vet ./...`, focused photo/detail database tests, and changed-line `golangci-lint` (0 issues).

## Risks

Host timings varied widely; warm 100-photo and cold 10-photo medians regressed. The trivial string-only resolver generally incurs more elapsed time/bytes from collection overhead. Cold 100-photo allocations fall 2,101→252, but no universal latency speedup, provider RPC latency, HTTP p50/p95, or S3 gain is claimed. Total failures can add the initial batch before singleton retries. No new cache, resolver protocol, storage behavior, API shape, or client change.

No public API changes; Apple and Android need no client updates. Shared behavior remains compatible with Jellyfin clients, which were not separately benchmarked.

## Checklist

- [x] I read and can explain the complete diff. (AI review; human verification is not claimed.)
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell tools with Go, pnpm/Vitest and `gh`; Codex collaboration tools; `mcp__cua_repl` browser automation.
- Model(s): `gpt-6-astra` — Medium exploration and independent final review; High implementation.
- Involvement: AI-assisted, maintainer-requested; not human-verified.
- Adversarial review: Independent code-review and @ponytail-review of the production diff and tests found no qualifying correctness defects or behavior-preserving simplifications.
