### PR TITLE
perf(metadata): reuse wanted-title normalization across matches

### DIFF
--- a/internal/metadata/match_confidence.go
+++ b/internal/metadata/match_confidence.go
@@ -249,9 +249,28 @@ func TitleScore(want, candidate string) float64 {
 	if w == c {
 		return 1
 	}
+	wv, wok := titleVolume(want)
+	return preparedWantedTitle{normalised: w, volume: wv, hasVolume: wok}.score(candidate, c)
+}
 
-	if wv, wok := titleVolume(want); wok {
-		if cv, cok := titleVolume(candidate); cok && wv != cv {
+type preparedWantedTitle struct {
+	normalised string
+	volume     volumeIdentity
+	hasVolume  bool
+}
+
+// score accepts the already-normalised candidate so TitleScore can keep its
+// empty/exact fast paths without parsing volumes or normalising twice.
+func (want preparedWantedTitle) score(candidate, c string) float64 {
+	w := want.normalised
+	if w == "" || c == "" {
+		return 0
+	}
+	if w == c {
+		return 1
+	}
+	if want.hasVolume {
+		if cv, cok := titleVolume(candidate); cok && want.volume != cv {
 			return 0
 		}
 	}
@@ -316,6 +335,11 @@ type bestMatchSelection struct {
 func selectBestMatchYear(want string, wantYear int, results []SearchResult) (bestMatchSelection, bool) {
 	best := bestMatchSelection{}
 	found := false
+	if len(results) == 0 {
+		return best, false
+	}
+	wanted := preparedWantedTitle{normalised: normaliseTitle(want)}
+	wanted.volume, wanted.hasVolume = titleVolume(want)
 
 	for _, r := range results {
 		name := r.Name
@@ -329,19 +353,19 @@ func selectBestMatchYear(want string, wantYear int, results []SearchResult) (bes
 		// wrong-volume primary would persist IDs for a different book --
 		// "Dungeon In My Closet, Book 5" must not be accepted for volume 2 via
 		// its generic "Dungeon In My Closet" alias.
-		if wv, wok := titleVolume(want); wok {
-			if cv, cok := titleVolume(name); cok && cv != wv {
+		if wanted.hasVolume {
+			if cv, cok := titleVolume(name); cok && cv != wanted.volume {
 				continue
 			}
 		}
 
-		score := TitleScore(want, name)
+		score := wanted.score(name, normaliseTitle(name))
 		matchedTitle := name
 
 		// Aliases are provider-confirmed titles for the same work, so a
 		// translated or regional spelling should not be penalized.
 		for _, alias := range r.TitleAliases {
-			if s := TitleScore(want, alias.Title); s > score {
+			if s := wanted.score(alias.Title, normaliseTitle(alias.Title)); s > score {
 				score = s
 				matchedTitle = alias.Title
 			}

--- a/internal/metadata/match_confidence_benchmark_test.go
+++ b/internal/metadata/match_confidence_benchmark_test.go
@@ -1,0 +1,50 @@
+package metadata
+
+import (
+	"fmt"
+	"testing"
+)
+
+// These fixtures measure title selection CPU work, without provider or I/O
+// latency. Large result and alias counts exercise the upper end of the work.
+func BenchmarkSelectBestMatchYear(b *testing.B) {
+	for _, fixture := range []struct {
+		name, want string
+		titles     []string
+		aliases    []string
+	}{
+		{
+			name: "english", want: "Mother of Storms",
+			titles:  []string{"Mother of Storms (Unabridged)", "Mother of Storms: A Novel", "The Storm Mother", "A Gathering Storm", "Looking for a Miracle", "Storm Front"},
+			aliases: []string{"Mother of Storms", "The Mother of Storms", "Storm Mother", "La mère des tempêtes", "嵐の母", "Mutter der Stürme", "Mother of Storms: Special Edition", "Mother of Storms: A Novel", "Mother of Storms (Audiobook)", "Storms"},
+		},
+		{
+			name: "volume", want: "Op-Center 4 - Acts of War",
+			titles:  []string{"Tom Clancy's Op-Center #4: Acts of War", "Acts of War", "Op-Center 4", "Tom Clancy's Op-Center, Book 3", "Op-Center: Mirror Image", "Acts of War (Unabridged)"},
+			aliases: []string{"Op-Center", "Acts of War", "Op-Center Book IV: Acts of War", "Actes de guerre", "Krigshandlinger", "Acts of War (Unabridged)", "Op-Center Vol. 4", "Tom Clancy's Acts of War", "Acts of War: Special Edition", "Op-Center, Book 4"},
+		},
+		{
+			name: "non-latin", want: "進撃の巨人",
+			titles:  []string{"Attack on Titan", "進撃の巨人", "Shingeki no Kyojin", "進撃！巨人中学校", "進撃の巨人 Before the Fall", "進撃の巨人 (Light Novel)"},
+			aliases: []string{"進撃の巨人", "Attack on Titan", "Shingeki no Kyojin", "L’Attaque des Titans", "Атака титанов", "Ataque a los Titanes", "進撃の巨人 完全版", "Attack on Titan: Special Edition", "진격의 거인", "進擊的巨人"},
+		},
+	} {
+		for _, count := range []int{1, 20, 100} {
+			for _, aliasCount := range []int{0, 3, 10} {
+				b.Run(fmt.Sprintf("%s/candidates=%d/aliases=%d", fixture.name, count, aliasCount), func(b *testing.B) {
+					results := make([]SearchResult, count)
+					for i := range results {
+						results[i] = SearchResult{Name: fixture.titles[i%len(fixture.titles)], Year: 1994 + i%5}
+						for alias := range aliasCount {
+							results[i].TitleAliases = append(results[i].TitleAliases, TitleAlias{Title: fixture.aliases[(i+alias)%len(fixture.aliases)]})
+						}
+					}
+					b.ReportAllocs()
+					for b.Loop() {
+						selectBestMatchYear(fixture.want, 1996, results)
+					}
+				})
+			}
+		}
+	}
+}

--- a/internal/metadata/match_confidence_prepared_test.go
+++ b/internal/metadata/match_confidence_prepared_test.go
@@ -1,0 +1,98 @@
+package metadata
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTitleScoreMatchesOriginalAlgorithm(t *testing.T) {
+	titles := []string{
+		"", "   ", "!!!", "(Unabridged)", "0", "#0", "1", "999", "1000", "2026",
+		"Dungeon In My Closet 2", "Dungeon In My Closet, Book 5", "Dungeon In My Closet",
+		"The Dark Tower Book II", "The Dark Tower Book 2", "The Dark Tower Book 3",
+		"Dragon Saga Books 1–3", "Dragon Saga Books 1-3", "Dragon Saga Books 2–4",
+		"Slaughterhouse-Five", "Slaughterhouse 5", "Malcolm X", "Malcolm 10",
+		"進撃の巨人", "進撃の巨人 完全版", "三体", "三体全集", "Café", "Cafe\u0301",
+		"Blåbærsyltetøy", "Атака титанов", "الأمير الصغير", "A Man in Full",
+		"echo echo storm", "echo storm storm", "echo storm", "abcdefghijk", "abcdefghijkl",
+	}
+	for _, pair := range productionPairs {
+		titles = append(titles, pair.want, pair.got)
+	}
+	for _, want := range titles {
+		for _, candidate := range titles {
+			if got, original := TitleScore(want, candidate), originalTitleScore(want, candidate); got != original {
+				t.Fatalf("TitleScore(%q, %q) = %v, original = %v", want, candidate, got, original)
+			}
+		}
+	}
+}
+
+func TestPreparedTitlePreservesYearTieBoundary(t *testing.T) {
+	t.Setenv("SILO_METADATA_MATCH_MIN_SCORE", "")
+	words := strings.Fields("amber birch cedar dawn ember forest granite harbor island jasmine kettle lantern meadow nickel ocean pine quartz river silver timber umber valley willow yellow zephyr brook copper desert elm feather garden hazel ivy juniper maple orchard pebble rose stone violet")
+	want := strings.Join(words, " ")
+	results := []SearchResult{
+		{Name: strings.Join(words[:len(words)-1], " "), Year: 1900},
+		{Name: strings.Join(words[:len(words)-2], " "), Year: 1999},
+		{Name: strings.Join(words[:len(words)-6], " "), Year: 2000},
+	}
+	first, second, third := originalTitleScore(want, results[0].Name), originalTitleScore(want, results[1].Name), originalTitleScore(want, results[2].Name)
+	if first-second <= 0 || first-second >= scoreTieEpsilon || second-third <= scoreTieEpsilon {
+		t.Fatalf("fixture does not bracket the year tie tolerance: %v, %v, %v", first, second, third)
+	}
+	got, ok := selectBestMatchYear(want, 2000, results)
+	original, originalOK := originalSelectBestMatchYear(want, 2000, results)
+	if !ok || !originalOK || !reflect.DeepEqual(got, original) || got.result.Year != 1999 {
+		t.Fatalf("year tie result = %#v/%t, original = %#v/%t", got, ok, original, originalOK)
+	}
+}
+
+func TestSelectBestMatchYearMatchesOriginalAlgorithm(t *testing.T) {
+	wants := []string{"", "!!!", "0", "2026", "進撃の巨人", "Café", "Malcolm X", "Dungeon In My Closet 2", "Dragon Saga Books 1–3", "echo echo storm"}
+	results := []SearchResult{
+		{Name: "Dungeon In My Closet, Book 5", TitleAliases: []TitleAlias{{Title: "Dungeon In My Closet 2"}}},
+		{Name: "   ", OriginalTitle: "進撃の巨人", Year: 2013},
+		{Name: "Attack on Titan", TitleAliases: []TitleAlias{{Title: "進撃の巨人"}, {Title: "進撃の巨人 (Light Novel)"}}, Year: 2010},
+		{Name: "Café", Year: 2000},
+		{Name: "Cafe\u0301", Year: 2026},
+		{Name: "Dragon Saga Books 2–4", TitleAliases: []TitleAlias{{Title: "Dragon Saga Books 1-3"}}},
+		{Name: "Dragon Saga Books 1-3"},
+		{Name: "Malcolm 10", TitleAliases: []TitleAlias{{Title: "Malcolm X"}}},
+		{Name: "echo storm storm", Year: 2025},
+		{Name: "echo echo storm", Year: 1994},
+		{Name: "0"}, {Name: "2026"}, {Name: "!!!"}, {},
+	}
+	for _, pair := range productionPairs {
+		wants = append(wants, pair.want)
+		results = append(results, SearchResult{Name: pair.got, Year: 1994}, SearchResult{
+			Name: pair.got, Year: 2026, TitleAliases: []TitleAlias{{Title: pair.want}, {Title: pair.got + " (Unabridged)"}},
+		})
+	}
+	for i := range results {
+		results[i].ProviderIDs = map[string]string{"fixture": fmt.Sprint(i)}
+	}
+	rng := rand.New(rand.NewPCG(42, 965))
+	for _, threshold := range []string{"", "0.5", "0.9", "1", "invalid"} {
+		t.Run("threshold="+threshold, func(t *testing.T) {
+			t.Setenv("SILO_METADATA_MATCH_MIN_SCORE", threshold)
+			for range 5 {
+				rng.Shuffle(len(results), func(i, j int) { results[i], results[j] = results[j], results[i] })
+				for _, want := range wants {
+					for _, year := range []int{0, 1994, 2026} {
+						for _, count := range []int{0, 1, len(results)} {
+							got, ok := selectBestMatchYear(want, year, results[:count])
+							original, originalOK := originalSelectBestMatchYear(want, year, results[:count])
+							if ok != originalOK || !reflect.DeepEqual(got, original) {
+								t.Fatalf("want=%q year=%d candidates=%d: got %#v/%t, original %#v/%t", want, year, count, got, ok, original, originalOK)
+							}
+						}
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/metadata/match_confidence_reference_test.go
+++ b/internal/metadata/match_confidence_reference_test.go
@@ -1,0 +1,96 @@
+package metadata
+
+// These reference functions preserve the pre-optimization scoring and selection
+// algorithms. Shared normalization, volume parsing, and tie-break helpers are
+// intentionally unchanged by this patch.
+import "strings"
+
+func originalTitleScore(want, candidate string) float64 {
+	w, c := normaliseTitle(want), normaliseTitle(candidate)
+	if w == "" || c == "" {
+		return 0
+	}
+	if w == c {
+		return 1
+	}
+
+	if wv, wok := titleVolume(want); wok {
+		if cv, cok := titleVolume(candidate); cok && wv != cv {
+			return 0
+		}
+	}
+
+	score := diceCoefficient(w, c)
+
+	// One title fully containing the other is strong evidence: providers
+	// routinely return "Title (Series Book 2)" for "Title", and our scanner
+	// routinely has "Series 2 - Title" for "Title".
+	// The floor applies to the *contained* title, not the containing one: a
+	// long candidate does not make a short query specific.
+	if shorter := min(len(w), len(c)); shorter >= minContainmentLen {
+		if strings.Contains(w, c) || strings.Contains(c, w) {
+			if containment := 0.9; containment > score {
+				score = containment
+			}
+		}
+	}
+	return score
+}
+
+func originalSelectBestMatchYear(want string, wantYear int, results []SearchResult) (bestMatchSelection, bool) {
+	best := bestMatchSelection{}
+	found := false
+
+	for _, r := range results {
+		name := r.Name
+		if strings.TrimSpace(name) == "" {
+			name = r.OriginalTitle
+		}
+
+		// A volume stated on the primary title that contradicts the wanted
+		// volume disqualifies the whole result, aliases included. Aliases are
+		// often the volume-less series name, and letting one rescue a
+		// wrong-volume primary would persist IDs for a different book --
+		// "Dungeon In My Closet, Book 5" must not be accepted for volume 2 via
+		// its generic "Dungeon In My Closet" alias.
+		if wv, wok := titleVolume(want); wok {
+			if cv, cok := titleVolume(name); cok && cv != wv {
+				continue
+			}
+		}
+
+		score := originalTitleScore(want, name)
+		matchedTitle := name
+
+		// Aliases are provider-confirmed titles for the same work, so a
+		// translated or regional spelling should not be penalized.
+		for _, alias := range r.TitleAliases {
+			if s := originalTitleScore(want, alias.Title); s > score {
+				score = s
+				matchedTitle = alias.Title
+			}
+		}
+
+		switch {
+		case score > best.score+scoreTieEpsilon:
+			best = bestMatchSelection{result: r, score: score, matchedTitle: matchedTitle}
+			found = true
+		case found && score > best.score-scoreTieEpsilon:
+			// Effectively tied on title. Prefer the nearer year when both are
+			// known; otherwise keep the incumbent.
+			if yearIsCloser(wantYear, r.Year, best.result.Year) {
+				best = bestMatchSelection{result: r, score: score, matchedTitle: matchedTitle}
+			}
+		}
+	}
+
+	// Strictly greater, not >=. A two-word title sharing exactly one word with
+	// a two-word candidate scores precisely 0.5 -- "Malcolm X" against
+	// "Malcolm 10" -- and that is the weakest possible evidence, not a match.
+	// Nothing correct is lost: in the calibration sample the worst true match
+	// scores 0.86.
+	if !found || best.score <= matchThreshold() {
+		return bestMatchSelection{}, false
+	}
+	return best, true
+}


### PR DESCRIPTION
## Problem

Related issue: #965

Metadata candidate selection repeatedly normalizes the same wanted title and parses its volume for each result and alias. This repeats CPU work and allocations as provider result sets grow.

## Approach

Prepare the wanted title and volume once per selection and reuse them while scoring candidates. Keep the existing scoring rules, primary wrong-volume guard, alias selection, and year tie breaks. Public `TitleScore` retains its empty and exact-match fast paths. The prepared value is local to one selection; no cache or invalidation is needed.

## Validation

- `go test ./internal/metadata/...` — passed.
- Differential tests against the original algorithms verify exact scores and selected results for volume identities, aliases, Unicode, empty/numeric titles, configurable thresholds, result order, and year tie boundaries.
- `go vet ./internal/metadata/...` — passed.
- `golangci-lint run --allow-serial-runners --new-from-patch=<complete-change.patch> ./internal/metadata/...` — passed, `0 issues.`
- `git diff --check` — passed.

CPU benchmarks used `go test ./internal/metadata -run '^$' -bench BenchmarkSelectBestMatchYear -benchmem -benchtime=200ms -count=6`. The baseline used original production source from `3131494e52e069fc1ac10e1a31503c797d09f26e` through a Go overlay. Baseline and optimized runs executed serially on Apple M4 Max. The 27 cases cover 1/20/100 candidates and 0/3/10 aliases across English, volume-bearing, and non-Latin titles.

| Case | Before | After | Allocations before → after |
| --- | ---: | ---: | ---: |
| english/candidates=20/aliases=3 | 518.38 µs | 154.84 µs | 3,699 → 1,211 |
| english/candidates=100/aliases=10 | 6,402.75 µs | 1,972.95 µs | 46,845 → 16,016 |
| volume/candidates=20/aliases=3 | 1,177.56 µs | 482.81 µs | 5,148 → 2,624 |
| non-latin/candidates=100/aliases=10 | 3,499.79 µs | 1,655.52 µs | 35,307 → 14,788 |

Across the matrix, geometric-mean time decreased 56.12%, allocated bytes 50.62%, and allocation count 54.83%. All 20/100-candidate timing differences were significant (p=0.002, n=6). Some intervals remain wide. English one-candidate/no-alias timing was inconclusive (6.507 → 7.915 µs, p=0.065; 45 allocations unchanged), as was English one-candidate/three-alias timing (p=0.310). These are CPU-only measurements, not end-to-end provider latency measurements.

The isolated branch also passed `make test-go`, `go build ./...`, `go vet ./...`, and changed-line lint. The unchanged web and generated-artifact gates passed on the combined performance tree.

## Risks

Matching behavior must remain identical: choosing a different work can persist incorrect provider IDs. Differential tests compare the complete selection, including the matched alias and score, against the original algorithm. No API, schema, configuration, or client changes are required.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop app.
- Tool(s): Codex coding agent and collaboration tools; Modern Go Guidelines CLI.
- Model(s): `gpt-6-astra` with high reasoning for implementation; `gpt-6-astra` with medium reasoning for independent review.
- Involvement: AI-assisted; implementation and validation performed by Codex on behalf of the maintainer.
- Adversarial review: independent code-review and ponytail-review of the production and test changes completed with no findings.
