### PR TITLE
perf(api): fetch versions without full detail hydration

### DIFF
--- a/internal/api/handlers/catalog_resources.go
+++ b/internal/api/handlers/catalog_resources.go
@@ -74,7 +74,7 @@ func (h *CatalogResourceHandler) HandleGetItemVersions(w http.ResponseWriter, r 
 		return
 	}
 
-	detail, err := h.items.detailSvc.GetItemDetail(r.Context(), id, filter)
+	versions, err := h.items.detailSvc.GetItemVersions(r.Context(), id, filter)
 	if err != nil {
 		if isNotFound(err) {
 			if _, _, ok := parseSyntheticSeasonID(id); ok {
@@ -89,12 +89,12 @@ func (h *CatalogResourceHandler) HandleGetItemVersions(w http.ResponseWriter, r 
 	}
 
 	if !h.items.requestCanViewFilePaths(r) {
-		for i := range detail.Versions {
-			detail.Versions[i].FilePath = ""
+		for i := range versions {
+			versions[i].FilePath = ""
 		}
 	}
 
-	writeJSON(w, http.StatusOK, detail.Versions)
+	writeJSON(w, http.StatusOK, versions)
 }
 
 // HandleGetMangaFiles returns the local file listing for a manga series (the

--- a/internal/api/handlers/catalog_versions_test.go
+++ b/internal/api/handlers/catalog_versions_test.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/access"
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
+	"github.com/Silo-Server/silo-server/internal/auth"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/scanner"
+)
+
+func TestCatalogVersionsHTTP(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(t.Context(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	exec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(t.Context(), query, args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	prefix := fmt.Sprintf("versions-http-%d-", time.Now().UnixNano())
+	var library int
+	if err := pool.QueryRow(t.Context(), `INSERT INTO media_folders (type,name) VALUES ('movies',$1) RETURNING id`, prefix).Scan(&library); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		if _, err := pool.Exec(ctx, `DELETE FROM media_folders WHERE id=$1`, library); err != nil {
+			t.Error(err)
+		}
+		if _, err := pool.Exec(ctx, `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"%"); err != nil {
+			t.Error(err)
+		}
+	})
+	for _, kind := range []string{"movie", "audiobook", "series"} {
+		exec(`INSERT INTO media_items (content_id,type,title,genres,default_metadata_language) VALUES ($1,$2,$2,'{}','en')`, prefix+kind, kind)
+		exec(`INSERT INTO media_item_libraries (content_id,media_folder_id) VALUES ($1,$2)`, prefix+kind, library)
+		if kind == "series" {
+			continue
+		}
+		count := 2
+		if kind == "audiobook" {
+			count = 8
+		}
+		for i := range count {
+			exec(`INSERT INTO media_files (content_id,media_folder_id,file_path,file_size,duration,resolution,codec_audio,audio_tracks) VALUES ($1,$2,$3,1000,600,'1080p','aac','[{"language":"en","default":true}]')`, prefix+kind, library, fmt.Sprintf("/media/%s/part-%02d.mkv", prefix+kind, i))
+		}
+	}
+	seasonID := prefix + "season"
+	seasonRepo := catalog.NewSeasonRepository(pool)
+	if err := seasonRepo.Upsert(t.Context(), &models.Season{ContentID: seasonID, SeriesID: prefix + "series", SeasonNumber: 1, Title: "Season", DefaultMetadataLanguage: "en"}); err != nil {
+		t.Fatal(err)
+	}
+	svc := catalog.NewDetailService(catalog.NewItemRepository(pool), catalog.NewEpisodeRepository(pool), seasonRepo, catalog.NewPersonRepository(pool), scanner.NewFileRepository(pool))
+	items := &ItemsHandler{detailSvc: svc}
+	h := NewCatalogResourceHandler(items)
+	router := chi.NewRouter()
+	router.Get("/catalog/items/{id}/versions", h.HandleGetItemVersions)
+	router.Get("/items/{id}/versions", items.HandleGetItemVersions)
+	request := func(path string, admin bool, scope access.Scope) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, path, nil).WithContext(access.SetScope(t.Context(), scope))
+		if admin {
+			r = r.WithContext(apimw.SetClaims(r.Context(), &auth.Claims{Role: "admin"}))
+		}
+		return r
+	}
+	for _, legacy := range []bool{false, true} {
+		for _, admin := range []bool{false, true} {
+			t.Run(fmt.Sprintf("legacy=%t/admin=%t", legacy, admin), func(t *testing.T) {
+				route := "/catalog/items/"
+				if legacy {
+					route = "/items/"
+				}
+				r := request(route+prefix+"movie/versions", admin, access.Scope{})
+				rec := httptest.NewRecorder()
+				router.ServeHTTP(rec, r)
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+				}
+				var versions []catalog.FileVersion
+				if err := json.Unmarshal(rec.Body.Bytes(), &versions); err != nil {
+					t.Fatal(err)
+				}
+				if len(versions) != 2 {
+					t.Fatalf("want two versions, got %d", len(versions))
+				}
+				for _, v := range versions {
+					if (v.FilePath != "") != admin {
+						t.Fatalf("path visibility differs for admin=%t: %q", admin, v.FilePath)
+					}
+				}
+				if legacy && rec.Header().Get("Deprecation") == "" {
+					t.Fatal("legacy route lost deprecation header")
+				}
+			})
+		}
+	}
+	for _, tc := range []struct {
+		name, id string
+		scope    access.Scope
+		status   int
+	}{
+		{"missing", "missing-versions-http", access.Scope{}, 404},
+		{"forbidden", prefix + "movie", access.Scope{AllowedLibraryIDs: []int{}}, 404},
+		{"series", prefix + "series", access.Scope{}, 200},
+		{"season", seasonID, access.Scope{}, 200},
+		{"synthetic", prefix + "series-S9", access.Scope{}, 200},
+		{"synthetic forbidden preserves empty", prefix + "series-S9", access.Scope{AllowedLibraryIDs: []int{}}, 200},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, request("/catalog/items/"+tc.id+"/versions", false, tc.scope))
+			if rec.Code != tc.status {
+				t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+			}
+			if tc.status == 200 && strings.TrimSpace(rec.Body.String()) != "[]" {
+				t.Fatalf("expected empty array: %s", rec.Body.String())
+			}
+		})
+	}
+	// Pair the old handler's full-detail work with the current endpoint using the
+	// same real file repository and warm database. This measures handler work in
+	// process; it does not include network transport or a production media server.
+	for _, kind := range []string{"movie", "audiobook"} {
+		t.Run("paired/"+kind, func(t *testing.T) {
+			oldHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				filter, ok := items.accessFilterOrError(w, r)
+				if !ok {
+					return
+				}
+				detail, err := svc.GetItemDetail(r.Context(), prefix+kind, filter)
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeJSON(w, http.StatusOK, detail.Versions)
+			})
+			var before, after []time.Duration
+			var bytes int
+			for i := range 32 {
+				outputs := [2]*httptest.ResponseRecorder{}
+				for j := range 2 {
+					which := (i + j) % 2
+					r := request("/catalog/items/"+prefix+kind+"/versions", true, access.Scope{})
+					rec := httptest.NewRecorder()
+					start := time.Now()
+					if which == 0 {
+						oldHandler.ServeHTTP(rec, r)
+					} else {
+						router.ServeHTTP(rec, r)
+					}
+					elapsed := time.Since(start)
+					outputs[which] = rec
+					if i >= 2 {
+						if which == 0 {
+							before = append(before, elapsed)
+						} else {
+							after = append(after, elapsed)
+						}
+					}
+				}
+				if outputs[0].Code != 200 || outputs[1].Code != 200 || outputs[0].Body.String() != outputs[1].Body.String() {
+					t.Fatalf("before/after response differs: %s / %s", outputs[0].Body.String(), outputs[1].Body.String())
+				}
+				bytes = outputs[1].Body.Len()
+			}
+			slices.Sort(before)
+			slices.Sort(after)
+			t.Logf("30 paired warm in-process HTTP requests; %s: p50 %s -> %s; p95 %s -> %s; identical %d-byte JSON", kind, before[14], after[14], before[28], after[28], bytes)
+		})
+	}
+}

--- a/internal/catalog/detail.go
+++ b/internal/catalog/detail.go
@@ -1307,6 +1307,75 @@ func (s *DetailService) LocalizeEpisodeModels(ctx context.Context, episodes []*m
 
 // GetItemDetail retrieves a full item detail with presigned URLs and file versions.
 func (s *DetailService) GetItemDetail(ctx context.Context, contentID string, filter AccessFilter) (*ItemDetail, error) {
+	target, err := s.resolveDetailTarget(ctx, contentID, filter)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case target.item != nil:
+		return s.buildMediaItemDetail(ctx, target.item, contentID, filter, nil)
+	case target.season != nil:
+		return s.buildSeasonDetail(ctx, target.season, filter)
+	case target.episode != nil:
+		seriesCtx, err := s.buildSeriesDetailContext(ctx, target.episode.SeriesID, filter)
+		if err != nil {
+			return nil, err
+		}
+		return s.buildEpisodeDetail(ctx, target.episode, seriesCtx, filter)
+	default:
+		return s.buildExtraItemDetail(ctx, target.extra, filter)
+	}
+}
+
+const detailTypeAudiobook = "audiobook"
+
+// GetItemVersions builds the browse version selector without loading unrelated
+// presentation data. It shares detail authorization and playback metadata, but
+// does not require localization, credits, artwork, or recommendations to succeed.
+func (s *DetailService) GetItemVersions(ctx context.Context, contentID string, filter AccessFilter) ([]FileVersion, error) {
+	target, err := s.resolveDetailTarget(ctx, contentID, filter)
+	if err != nil {
+		return nil, err
+	}
+	var files []*models.MediaFile
+	audioPreferenceContentID := contentID
+	switch {
+	case target.season != nil || (target.item != nil && target.item.Type == playableTypeSeries):
+		return []FileVersion{}, nil
+	case target.item != nil:
+		files, err = s.fileFetcher.GetByContentID(ctx, contentID)
+	case target.episode != nil:
+		files, err = s.fileFetcher.GetByEpisodeID(ctx, contentID)
+		audioPreferenceContentID = target.episode.SeriesID
+	default:
+		fetcher, ok := s.fileFetcher.(extraFileFetcher)
+		if !ok {
+			return nil, ErrItemNotFound
+		}
+		files, err = fetcher.GetByExtraID(ctx, contentID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fetching file versions: %w", err)
+	}
+	files = FilterMediaFilesByAccess(files, filter)
+	if target.item != nil && target.item.Type == detailTypeAudiobook {
+		sortAudiobookMediaFiles(files)
+	}
+	files = s.prepareBrowseFiles(ctx, files)
+	versions, _, _, _, _, _, _ := s.buildPlaybackInfo(ctx, files, filter, audioPreferenceContentID)
+	return versions, nil
+}
+
+// detailTarget is exactly one authorized catalog row. Keeping target resolution
+// shared prevents versions-only reads from drifting from detail access rules.
+type detailTarget struct {
+	item    *models.MediaItem
+	season  *models.Season
+	episode *models.Episode
+	extra   *models.MediaExtra
+}
+
+func (s *DetailService) resolveDetailTarget(ctx context.Context, contentID string, filter AccessFilter) (*detailTarget, error) {
 	item, err := s.itemRepo.GetByID(ctx, contentID)
 	switch {
 	case err == nil:
@@ -1316,7 +1385,7 @@ func (s *DetailService) GetItemDetail(ctx context.Context, contentID string, fil
 		if err := s.validatePresentationItemAccess(ctx, filter, contentID); err != nil {
 			return nil, err
 		}
-		return s.buildMediaItemDetail(ctx, item, contentID, filter, nil)
+		return &detailTarget{item: item}, nil
 	case !errors.Is(err, ErrItemNotFound):
 		return nil, err
 	}
@@ -1333,7 +1402,7 @@ func (s *DetailService) GetItemDetail(ctx context.Context, contentID string, fil
 		if err := s.validatePresentationItemAccess(ctx, filter, season.SeriesID); err != nil {
 			return nil, err
 		}
-		return s.buildSeasonDetail(ctx, season, filter)
+		return &detailTarget{season: season}, nil
 	} else if !errors.Is(err, ErrSeasonNotFound) {
 		return nil, err
 	}
@@ -1345,11 +1414,23 @@ func (s *DetailService) GetItemDetail(ctx context.Context, contentID string, fil
 	episode, err := s.episodeRepo.GetByID(ctx, contentID)
 	if err != nil {
 		if errors.Is(err, ErrEpisodeNotFound) {
-			// Fourth tier: a local extra. Serving it from GetItemDetail keeps
-			// per-item consumers that resolve arbitrary content ids
-			// (jellycompat PlaybackInfo in particular) playable without a
-			// separate lookup path.
-			return s.buildExtraItemDetail(ctx, contentID, filter)
+			if s.extraRepo == nil {
+				return nil, ErrItemNotFound
+			}
+			extra, err := s.extraRepo.GetByID(ctx, contentID)
+			if err != nil {
+				if errors.Is(err, ErrExtraNotFound) {
+					return nil, ErrItemNotFound
+				}
+				return nil, err
+			}
+			if err := s.itemRepo.EnsureAccessible(ctx, extra.ParentID, filter); err != nil {
+				return nil, err
+			}
+			if err := s.validatePresentationItemAccess(ctx, filter, extra.ParentID); err != nil {
+				return nil, err
+			}
+			return &detailTarget{extra: extra}, nil
 		}
 		return nil, err
 	}
@@ -1359,33 +1440,13 @@ func (s *DetailService) GetItemDetail(ctx context.Context, contentID string, fil
 	if err := s.validatePresentationItemAccess(ctx, filter, episode.ContentID); err != nil {
 		return nil, err
 	}
-	seriesCtx, err := s.buildSeriesDetailContext(ctx, episode.SeriesID, filter)
-	if err != nil {
-		return nil, err
-	}
-	return s.buildEpisodeDetail(ctx, episode, seriesCtx, filter)
+	return &detailTarget{episode: episode}, nil
 }
 
 // buildExtraItemDetail resolves a local extra as a minimal ItemDetail:
 // title/kind plus the ordinary playback surface (versions, subtitles) built
 // from its backing files. Access control is the parent item's.
-func (s *DetailService) buildExtraItemDetail(ctx context.Context, contentID string, filter AccessFilter) (*ItemDetail, error) {
-	if s.extraRepo == nil {
-		return nil, ErrItemNotFound
-	}
-	extra, err := s.extraRepo.GetByID(ctx, contentID)
-	if err != nil {
-		if errors.Is(err, ErrExtraNotFound) {
-			return nil, ErrItemNotFound
-		}
-		return nil, err
-	}
-	if err := s.itemRepo.EnsureAccessible(ctx, extra.ParentID, filter); err != nil {
-		return nil, err
-	}
-	if err := s.validatePresentationItemAccess(ctx, filter, extra.ParentID); err != nil {
-		return nil, err
-	}
+func (s *DetailService) buildExtraItemDetail(ctx context.Context, extra *models.MediaExtra, filter AccessFilter) (*ItemDetail, error) {
 	fetcher, ok := s.fileFetcher.(extraFileFetcher)
 	if !ok {
 		return nil, ErrItemNotFound
@@ -1879,7 +1940,7 @@ func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.M
 		}
 
 		files = FilterMediaFilesByAccess(files, filter)
-		if item.Type == "audiobook" {
+		if item.Type == detailTypeAudiobook {
 			sortAudiobookMediaFiles(files)
 		}
 		files = s.prepareBrowseFiles(ctx, files)
@@ -1906,7 +1967,7 @@ func (s *DetailService) buildMediaItemDetail(ctx context.Context, item *models.M
 		detail.Extras = s.fetchItemExtras(ctx, contentID, pf)
 	}
 
-	if item.Type == "audiobook" {
+	if item.Type == detailTypeAudiobook {
 		detail.Audiobook = s.buildAudiobookExtension(ctx, item, detail.Versions, crewCredits, filter)
 	}
 	if item.Type == "ebook" {

--- a/internal/catalog/detail_versions_test.go
+++ b/internal/catalog/detail_versions_test.go
@@ -1,0 +1,347 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/settingscontract"
+)
+
+type versionsQueryCounter struct{ calls atomic.Int64 }
+
+func (c *versionsQueryCounter) TraceQueryStart(ctx context.Context, _ *pgx.Conn, _ pgx.TraceQueryStartData) context.Context {
+	c.calls.Add(1)
+	return ctx
+}
+func (*versionsQueryCounter) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+type versionsImageCounter struct{ calls atomic.Int64 }
+
+func (c *versionsImageCounter) ResolveImageURL(_ context.Context, path, _ string) string {
+	c.calls.Add(1)
+	return "https://images.invalid/" + path
+}
+func (c *versionsImageCounter) ResolveImageURLs(_ context.Context, paths []string, _ string) map[string]string {
+	c.calls.Add(1)
+	out := make(map[string]string, len(paths))
+	for _, path := range paths {
+		out[path] = "https://images.invalid/" + path
+	}
+	return out
+}
+
+type versionsFileFetcher struct {
+	files map[string][]*models.MediaFile
+	err   error
+}
+
+func (f *versionsFileFetcher) GetByContentID(_ context.Context, id string) ([]*models.MediaFile, error) {
+	return slices.Clone(f.files[id]), f.err
+}
+func (f *versionsFileFetcher) GetByEpisodeID(ctx context.Context, id string) ([]*models.MediaFile, error) {
+	return f.GetByContentID(ctx, id)
+}
+func (f *versionsFileFetcher) GetByExtraID(ctx context.Context, id string) ([]*models.MediaFile, error) {
+	return f.GetByContentID(ctx, id)
+}
+
+type versionsFixture struct {
+	svc     *DetailService
+	queries *versionsQueryCounter
+	images  *versionsImageCounter
+	files   *versionsFileFetcher
+	ids     map[string]string
+	library int
+}
+
+// Catalog reads use real PostgreSQL repositories. File metadata is in memory so
+// rich probe data can exercise the shared builder without the scanner import cycle.
+func newVersionsFixture(t testing.TB) *versionsFixture {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counter := &versionsQueryCounter{}
+	cfg.ConnConfig.Tracer = counter
+	pool, err := pgxpool.NewWithConfig(t.Context(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(t.Context(), sql, args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f := &versionsFixture{queries: counter, images: &versionsImageCounter{}, files: &versionsFileFetcher{files: map[string][]*models.MediaFile{}}, ids: map[string]string{}}
+	prefix := fmt.Sprintf("versions-%d-", time.Now().UnixNano())
+	if err := pool.QueryRow(t.Context(), `INSERT INTO media_folders (type,name) VALUES ('movies',$1) RETURNING id`, prefix).Scan(&f.library); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		ctx := context.Background()
+		if _, err := pool.Exec(ctx, `DELETE FROM media_folders WHERE id=$1`, f.library); err != nil {
+			t.Error(err)
+		}
+		if _, err := pool.Exec(ctx, `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"%"); err != nil {
+			t.Error(err)
+		}
+		if _, err := pool.Exec(ctx, `DELETE FROM people WHERE name LIKE $1`, prefix+"%"); err != nil {
+			t.Error(err)
+		}
+	})
+	for _, kind := range []string{"movie", "audiobook", "ebook", "manga", "series"} {
+		id := prefix + kind
+		f.ids[kind] = id
+		exec(`INSERT INTO media_items (content_id,type,title,overview,genres,content_rating,default_metadata_language,poster_path) VALUES ($1,$2,$3,'Overview','{}','PG','en','tmdb/poster/original.jpg')`, id, kind, kind)
+		exec(`INSERT INTO media_item_libraries (content_id,media_folder_id) VALUES ($1,$2)`, id, f.library)
+	}
+	f.ids["season"] = prefix + "season"
+	f.ids["episode"] = prefix + "episode"
+	f.ids["extra"] = prefix + "extra"
+	if err := NewSeasonRepository(pool).Upsert(t.Context(), &models.Season{ContentID: f.ids["season"], SeriesID: f.ids["series"], SeasonNumber: 1, Title: "Season", DefaultMetadataLanguage: "en"}); err != nil {
+		t.Fatal(err)
+	}
+	exec(`INSERT INTO episodes (content_id,series_id,season_id,season_number,episode_number,title) VALUES ($1,$2,$3,1,1,'Episode')`, f.ids["episode"], f.ids["series"], f.ids["season"])
+	exec(`INSERT INTO episode_libraries (episode_id,media_folder_id) VALUES ($1,$2)`, f.ids["episode"], f.library)
+	exec(`INSERT INTO media_extras (content_id,parent_id,kind,title) VALUES ($1,$2,'featurette','Extra')`, f.ids["extra"], f.ids["movie"])
+	for _, kind := range []string{"movie", "audiobook", "ebook", "manga", "episode", "extra"} {
+		id := f.ids[kind]
+		for i := range 2 {
+			file := &models.MediaFile{ID: i + 1, ContentID: id, MediaFolderID: f.library, FilePath: fmt.Sprintf("/media/%s/part-%d.mkv", kind, i+1), Container: "mkv", Resolution: []string{"1080p", "2160p"}[i], CodecVideo: "h264", CodecAudio: "aac", FileSize: int64(1000 + i), Duration: 600,
+				VideoTracks: []models.VideoTrack{{Codec: "h264"}}, AudioTracks: []models.AudioTrack{{Language: "en", Default: true}, {Language: "fr"}}, SubtitleTracks: []models.SubtitleTrack{{Language: "en", Codec: "srt"}}, Chapters: []models.MediaChapter{{Index: 0, Title: "Opening", StartSeconds: 0, EndSeconds: 50}}, IntroStart: new(1.0), IntroEnd: new(8.0), CreditsStart: new(550.0), CreditsEnd: new(590.0)}
+			if kind == "audiobook" {
+				file.PresentationKind = "multipart"
+				file.PresentationGroupKey = "book"
+				file.PresentationPartIndex = 2 - i
+				file.PresentationPartTotal = 2
+			}
+			f.files.files[id] = append(f.files.files[id], file)
+		}
+	}
+	// A presentation-heavy movie demonstrates the dependency work the endpoint
+	// should avoid, without assigning artificial network latency to the resolver.
+	for i := range 40 {
+		personID := time.Now().UnixNano()
+		if err := pool.QueryRow(t.Context(), `INSERT INTO people (id,name,photo_path) VALUES ($1,$2,$3) RETURNING id`, personID, fmt.Sprintf("%sperson-%d", prefix, i), fmt.Sprintf("tmdb/people/%d/original.jpg", i)).Scan(&personID); err != nil {
+			t.Fatal(err)
+		}
+		exec(`INSERT INTO item_people (id,person_id,content_id,kind,sort_order) VALUES ($1,$1,$2,$3,$4)`, personID, f.ids["movie"], int16(models.PersonKindActor), i)
+	}
+	f.svc = NewDetailService(NewItemRepository(pool), NewEpisodeRepository(pool), NewSeasonRepository(pool), NewPersonRepository(pool), f.files)
+	f.svc.SetImageResolver(f.images)
+	return f
+}
+
+func TestGetItemVersionsMatchesDetail(t *testing.T) {
+	f := newVersionsFixture(t)
+	store := newDetailTestStore(t)
+	setProfileAudioLanguage(t, store, "en")
+	setScopedAudioLanguageForDevice(t, store, settingscontract.ScopeProfileDevice, "", 0, "versions-test-device", "fr")
+	setScopedAudioLanguage(t, store, settingscontract.ScopeProfileSeries, f.ids["series"], 0, "fr")
+	f.svc.SetUserStoreProvider(testDetailUserStoreProvider{store: store})
+	for _, kind := range []string{"movie", "audiobook", "ebook", "manga", "series", "season", "episode", "extra"} {
+		for _, restricted := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/restricted=%t", kind, restricted), func(t *testing.T) {
+				filter := AccessFilter{UserID: 1, ProfileID: "profile-1", DeviceID: "versions-test-device", SelectedFileID: 2, ProfilePreferredLanguage: "fr"}
+				if restricted {
+					filter.AllowedLibraryIDs = []int{f.library}
+					filter.PresentationLibraryID = new(f.library)
+					filter.MaxContentRating = "PG"
+					filter.MaxPlaybackQuality = "1080p"
+				}
+				detail, err := f.svc.GetItemDetail(t.Context(), f.ids[kind], filter)
+				if err != nil {
+					t.Fatal(err)
+				}
+				versions, err := f.svc.GetItemVersions(t.Context(), f.ids[kind], filter)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want, _ := json.Marshal(detail.Versions)
+				got, _ := json.Marshal(versions)
+				if string(got) != string(want) {
+					t.Fatalf("version JSON differs:\ngot %s\nwant %s", got, want)
+				}
+				if kind == "series" || kind == "season" {
+					if string(got) != "[]" {
+						t.Fatalf("want empty JSON array, got %s", got)
+					}
+				} else if len(versions) == 0 {
+					t.Fatal("expected playable versions")
+				}
+				if kind == "episode" && *versions[0].EffectiveAudioTrackIndex != 1 {
+					t.Fatalf("episode must inherit series French audio preference: %+v", versions[0])
+				}
+			})
+		}
+	}
+}
+
+func TestGetItemVersionsAccessAndMissing(t *testing.T) {
+	f := newVersionsFixture(t)
+	for _, kind := range []string{"movie", "series", "season", "episode", "extra"} {
+		for name, filter := range map[string]AccessFilter{
+			"empty allowlist": {AllowedLibraryIDs: []int{}}, "other library": {AllowedLibraryIDs: []int{f.library + 1}}, "disabled library": {DisabledLibraryIDs: []int{f.library}}, "rating": {MaxContentRating: "G"}, "wrong presentation library": {PresentationLibraryID: new(f.library + 1)},
+		} {
+			t.Run(kind+"/"+name, func(t *testing.T) {
+				_, oldErr := f.svc.GetItemDetail(t.Context(), f.ids[kind], filter)
+				_, err := f.svc.GetItemVersions(t.Context(), f.ids[kind], filter)
+				if !errors.Is(oldErr, ErrItemNotFound) || !errors.Is(err, ErrItemNotFound) {
+					t.Fatalf("detail=%v versions=%v; want not found", oldErr, err)
+				}
+			})
+		}
+	}
+	if _, err := f.svc.GetItemVersions(t.Context(), "missing-versions-item", AccessFilter{}); !errors.Is(err, ErrItemNotFound) {
+		t.Fatalf("missing target: %v", err)
+	}
+	sentinel := errors.New("file repository unavailable")
+	f.files.err = sentinel
+	for _, kind := range []string{"movie", "episode", "extra"} {
+		if _, err := f.svc.GetItemVersions(t.Context(), f.ids[kind], AccessFilter{}); !errors.Is(err, sentinel) {
+			t.Fatalf("%s: lost file error: %v", kind, err)
+		}
+	}
+}
+
+func TestGetItemVersionsSkipsPresentationAndPlaybackSafety(t *testing.T) {
+	f := newVersionsFixture(t)
+	ensurer := &recordingProbeEnsurer{}
+	racer := &recordingCopySafetyRacer{}
+	f.svc.probeEnsurer = ensurer
+	f.svc.copySafetyRacer = racer
+	for _, kind := range []string{"movie", "audiobook", "ebook", "series", "season", "episode", "extra"} {
+		filter := AccessFilter{ProfilePreferredLanguage: "fr"}
+		f.queries.calls.Store(0)
+		f.images.calls.Store(0)
+		if _, err := f.svc.GetItemDetail(t.Context(), f.ids[kind], filter); err != nil {
+			t.Fatal(err)
+		}
+		oldQueries, oldImages := f.queries.calls.Load(), f.images.calls.Load()
+		f.queries.calls.Store(0)
+		f.images.calls.Store(0)
+		ensurer.probeCalls = nil
+		if _, err := f.svc.GetItemVersions(t.Context(), f.ids[kind], filter); err != nil {
+			t.Fatal(err)
+		}
+		queries, images := f.queries.calls.Load(), f.images.calls.Load()
+		t.Logf("%s: SQL %d -> %d; image resolver calls %d -> %d (file fetcher in memory)", kind, oldQueries, queries, oldImages, images)
+		if queries >= oldQueries {
+			t.Errorf("%s did not eliminate presentation queries", kind)
+		}
+		if images != 0 {
+			t.Errorf("%s resolved unreturned presentation images", kind)
+		}
+		if len(ensurer.probeCalls) != len(f.files.files[f.ids[kind]]) {
+			t.Errorf("%s skipped browse probe repair", kind)
+		}
+	}
+	if len(ensurer.cachedCalls) != 0 || len(racer.raced) != 0 {
+		t.Fatal("versions triggered playback safety work")
+	}
+	// A broken localization dependency must no longer prevent version selection.
+	cfg, err := pgxpool.ParseConfig(os.Getenv("SILO_TEST_DATABASE_URL"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed, err := pgxpool.NewWithConfig(t.Context(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed.Close()
+	f.svc.itemLocRepo = NewMediaItemLocalizationRepository(closed)
+	filter := AccessFilter{ProfilePreferredLanguage: "fr"}
+	if _, err := f.svc.GetItemDetail(t.Context(), f.ids["movie"], filter); err == nil {
+		t.Fatal("full detail should fail with unavailable localization")
+	}
+	if _, err := f.svc.GetItemVersions(t.Context(), f.ids["movie"], filter); err != nil {
+		t.Fatalf("versions depend on localization: %v", err)
+	}
+}
+
+func TestGetItemVersionsKeepsChapterImagesAndEmptyFiles(t *testing.T) {
+	f := newVersionsFixture(t)
+	file := f.files.files[f.ids["movie"]][0]
+	file.Chapters[0].ThumbnailPath = "chapters/movie/original.jpg"
+	file.ExternalSubtitles = []models.ExternalSubtitle{{Path: "/media/movie.fr.srt", Language: "fr", Format: "srt", Forced: true}}
+	detail, err := f.svc.GetItemDetail(t.Context(), f.ids["movie"], AccessFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.images.calls.Store(0)
+	versions, err := f.svc.GetItemVersions(t.Context(), f.ids["movie"], AccessFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := json.Marshal(detail.Versions)
+	got, _ := json.Marshal(versions)
+	if string(want) != string(got) {
+		t.Fatal("chapter/subtitle metadata differs")
+	}
+	if f.images.calls.Load() != 1 {
+		t.Fatal("versions must still resolve the returned chapter thumbnail")
+	}
+	f.files.files[f.ids["movie"]] = nil
+	versions, err = f.svc.GetItemVersions(t.Context(), f.ids["movie"], AccessFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty, _ := json.Marshal(versions)
+	if string(empty) != "[]" {
+		t.Fatalf("no files: want [], got %s", empty)
+	}
+	// Optional repositories and extra-file support retain their existing fallback.
+	f.svc.fileFetcher = &batchEquivFileFetcher{}
+	if _, err := f.svc.GetItemVersions(t.Context(), f.ids["extra"], AccessFilter{}); !errors.Is(err, ErrItemNotFound) {
+		t.Fatalf("unsupported extra fetcher: %v", err)
+	}
+	f.svc.seasonRepo = nil
+	if _, err := f.svc.GetItemVersions(t.Context(), f.ids["episode"], AccessFilter{}); !errors.Is(err, ErrItemNotFound) {
+		t.Fatalf("missing season repository: %v", err)
+	}
+}
+
+func BenchmarkGetItemVersions(b *testing.B) {
+	f := newVersionsFixture(b)
+	for _, kind := range []string{"movie", "audiobook", "episode"} {
+		for _, full := range []bool{true, false} {
+			b.Run(fmt.Sprintf("%s/full_detail=%t", kind, full), func(b *testing.B) {
+				filter := AccessFilter{ProfilePreferredLanguage: "fr"}
+				b.ReportAllocs()
+				f.queries.calls.Store(0)
+				f.images.calls.Store(0)
+				for b.Loop() {
+					var err error
+					if full {
+						_, err = f.svc.GetItemDetail(b.Context(), f.ids[kind], filter)
+					} else {
+						_, err = f.svc.GetItemVersions(b.Context(), f.ids[kind], filter)
+					}
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.ReportMetric(float64(f.queries.calls.Load())/float64(b.N), "SQL/op")
+				b.ReportMetric(float64(f.images.calls.Load())/float64(b.N), "image-calls/op")
+			})
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: #965

The item versions endpoint builds a complete item detail and returns only its versions. Each versions request therefore loads unrelated localization, credits, artwork, extras and book recommendations. This adds database and resolver work and makes version selection depend on presentation services.

## Approach

Add `DetailService.GetItemVersions`, sharing authorized target resolution with full detail and reusing the existing browse preparation and version builder. Both canonical and deprecated native versions routes use this method.

The version JSON, library and rating access, presentation-library checks, quality restrictions, audio preferences, multipart ordering, chapter/subtitle metadata and file-path policy stay the same. Episodes retain parent-series audio defaults. Series, real seasons and synthetic seasons retain empty-array behavior. Returned chapter thumbnails still resolve; browse reads still avoid playback safety scans.

## Validation

With `SILO_TEST_DATABASE_URL` configured, the database tests compare complete version JSON across eight media types under default and restricted profiles. They cover access denial, file errors, empty files, chapter thumbnails and optional repository fallbacks. Real-file HTTP tests verify canonical/deprecated routes, path visibility and season behavior. Full-detail batch equivalence still passes.

- `go test ./internal/catalog ./internal/api/handlers -run 'TestGetItemVersions|TestCatalogVersionsHTTP|TestGetItemDetailsByIDs_MatchesGetItemDetail' -count=1 -v` — passed against disposable PostgreSQL.
- `go test ./internal/catalog ./internal/api/handlers ./internal/jellycompat -count=1` — passed all three packages.
- `go vet ./internal/catalog ./internal/api/handlers ./internal/jellycompat` — passed.
- `golangci-lint run --new-from-patch=<complete change patch> ./internal/catalog/... ./internal/api/handlers/...` — 0 issues, including both new test files. Formatting and `git diff --check` passed.

Deterministic catalog SQL reads, measured through pgx tracing: movie **7→2**, audiobook/ebook **9→2**, series **7→2**, season **8→3**, episode **8→4**, extra **7→5**. The 40-credit movie fixture reduces presentation image resolver calls **41→0**. These counts use in-memory file metadata and exclude the file-fetch query shared by both playable paths; resolver calls are not a count of network requests.

Five serial trials of 30 paired warm HTTP requests per fixture used a precompiled handler test binary, PostgreSQL and real scanner file rows. The before path builds full detail; the after path calls the current versions handler. All 150 measured pairs per fixture returned byte-identical JSON. Median per-run timings:

| Fixture | Full-detail p50 | Versions p50 | Full-detail p95 | Versions p95 |
| --- | ---: | ---: | ---: | ---: |
| Movie, two files | 1.530 ms | 0.772 ms | 1.926 ms | 0.958 ms |
| Audiobook, eight files | 2.172 ms | 0.848 ms | 3.389 ms | 1.270 ms |

The timing run used `-test.run '^TestCatalogVersionsHTTP$/^paired$' -test.count=5 -test.v`, after confirming no Go compiler or linter jobs were active. These measurements include handler work and serialization, but exclude network transport and whole-page load.

The isolated branch also passed `make test-go`, `go build ./...`, `go vet ./...`, and changed-line lint. The unchanged web and generated-artifact gates passed on the combined performance tree.

## Risks

Version selection deliberately succeeds when an unrelated localization or presentation dependency fails; a failing localization-pool test verifies that distinction. Target lookup, authorization and file-fetch errors remain dependencies. No response fields, migrations or playback-safety behavior change. Apple and Android require no follow-up or capability negotiation; Jellyfin keeps using full detail, whose regression coverage passes.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop app, with Codex collaboration agents.
- Tool(s): Codex shell and file tools; Modern Go Guidelines CLI; independent `code-review` and `ponytail-review` skills.
- Model(s): `gpt-6-astra` with high reasoning for implementation and medium reasoning for independent review.
- Involvement: AI-assisted; implementation and automated validation performed by Codex.
- Adversarial review: Independent correctness and over-engineering reviews of the complete branch change completed with no findings.
