### PR TITLE
fix(web): prevent player controls overlapping in narrow windows

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -1424,6 +1424,12 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     animation: player-breathe 2.6s ease-in-out infinite;
   }
 
+  .player-controls {
+    container-type: size;
+    container-name: player-controls;
+    contain: layout;
+  }
+
   /* Bottom HUD rail — title/time on the left, utilities on the right. */
   .player-hud {
     background: linear-gradient(
@@ -2592,5 +2598,70 @@ html[data-navigation-direction]::view-transition-new(main-content) {
   .impersonation-end-btn:focus-visible {
     border-color: var(--impersonation-accent);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--impersonation-accent) 28%, transparent);
+  }
+}
+
+@layer utilities {
+  /* On laptops, keep transport centered in the bottom row. Only phone-sized
+     players move it over the picture, where touch controls already live. */
+  @container player-controls (min-width: 48rem) {
+    .player-controls[data-compact="true"][data-touch="false"] .player-compact-transport {
+      top: auto;
+      bottom: 1.25rem;
+      height: 4rem;
+    }
+
+    .player-controls[data-compact="true"][data-touch="false"] .player-hud {
+      z-index: auto;
+    }
+
+    .player-controls[data-compact="true"][data-touch="false"] .player-compact-row {
+      min-height: 4rem;
+    }
+
+    .player-controls[data-compact="true"][data-touch="false"] .player-compact-metadata {
+      max-width: calc(50% - 12rem);
+      margin-right: auto;
+    }
+
+    .player-controls[data-compact="true"][data-touch="false"] .player-quality-trigger {
+      width: 2.5rem;
+      padding-inline: 0;
+    }
+
+    .player-controls[data-compact="true"][data-touch="false"] .player-quality-trigger > span {
+      display: none;
+    }
+  }
+
+  @container player-controls (height < 20rem) {
+    .player-compact-transport {
+      bottom: 4rem;
+    }
+  }
+
+  .player-controls[data-compact="true"] .player-hud {
+    animation: none;
+  }
+
+  /* Compact desktop menus stay anchored inside the player at every width. */
+  .player-controls[data-compact="true"] .player-menu-surface {
+    position: fixed;
+    right: max(0.75rem, env(safe-area-inset-right));
+    bottom: max(0.75rem, env(safe-area-inset-bottom));
+    width: min(20rem, calc(100cqw - 1.5rem));
+    min-width: 0;
+    max-width: none;
+    max-height: calc(100cqh - 1.5rem);
+    margin: 0;
+    overflow-y: auto;
+    z-index: 60;
+  }
+
+  .player-overflow-menu {
+    border: 1px solid rgb(255 255 255 / 0.1);
+    border-radius: 0.75rem;
+    background: rgb(12 12 12 / 0.98);
+    box-shadow: 0 12px 40px rgb(0 0 0 / 0.4);
   }
 }

--- a/web/src/player/components/PlayerControls.test.tsx
+++ b/web/src/player/components/PlayerControls.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 
+import type { ComponentProps } from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PlayerControls } from "./PlayerControls";
 
-function renderControls(markerEditAvailable: boolean) {
+function renderControls(
+  markerEditAvailable: boolean,
+  overrides: Partial<ComponentProps<typeof PlayerControls>> = {},
+) {
   return render(
     <PlayerControls
       visible
@@ -45,6 +49,7 @@ function renderControls(markerEditAvailable: boolean) {
       onVolumeChange={vi.fn()}
       onMutedChange={vi.fn()}
       onFullscreenToggle={vi.fn()}
+      {...overrides}
     />,
   );
 }
@@ -83,6 +88,52 @@ describe("PlayerControls", () => {
     expect(screen.getByRole("button", { name: "Edit markers" })).toBeInTheDocument();
     expect(screen.getByRole("slider", { name: "Volume" })).toBeInTheDocument();
   });
+
+  it.each(["overflow", "Audio tracks", "Chapters"])(
+    "does not reopen %s after widening and narrowing the player",
+    (menu) => {
+      const width = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(1024);
+      let resize = () => {};
+      vi.stubGlobal(
+        "ResizeObserver",
+        class {
+          constructor(callback: ResizeObserverCallback) {
+            resize = () => callback([], {} as ResizeObserver);
+          }
+          observe() {}
+          disconnect() {}
+        },
+      );
+      renderControls(true, {
+        audioTracks: [{ language: "en" }, { language: "fr" }],
+        activeAudioIndex: 0,
+        onAudioSelect: vi.fn(),
+        chapters: [
+          { index: 0, title: "Opening", start_seconds: 0, end_seconds: 120, source: "embedded" },
+        ],
+      });
+      const openMenu = () => {
+        fireEvent.click(screen.getByRole("button", { name: "More player options" }));
+        if (menu !== "overflow") {
+          fireEvent.click(screen.getByRole("menuitem", { name: menu }));
+        }
+        expect(screen.getByRole("menu")).toBeInTheDocument();
+      };
+      openMenu();
+
+      width.mockReturnValue(1920);
+      act(resize);
+      expect(screen.queryByRole("menu")).toBeNull();
+      width.mockReturnValue(1024);
+      act(resize);
+      expect(screen.queryByRole("menu")).toBeNull();
+      expect(screen.getByRole("button", { name: "More player options" })).toHaveAttribute(
+        "aria-expanded",
+        "false",
+      );
+      openMenu();
+    },
+  );
 
   it("hides marker editing when unavailable", () => {
     renderControls(false);

--- a/web/src/player/components/PlayerControls.test.tsx
+++ b/web/src/player/components/PlayerControls.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PlayerControls } from "./PlayerControls";
 
@@ -50,7 +50,39 @@ function renderControls(markerEditAvailable: boolean) {
 }
 
 describe("PlayerControls", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("moves desktop secondary controls into overflow as the player narrows", () => {
+    const width = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(1024);
+    let resize = () => {};
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resize = () => callback([], {} as ResizeObserver);
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+
+    renderControls(true);
+    expect(screen.queryByRole("button", { name: "Edit markers" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "More player options" }));
+    expect(screen.getByRole("menuitem", { name: "Edit markers" })).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "Volume" })).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    width.mockReturnValue(1920);
+    act(resize);
+    expect(screen.queryByRole("button", { name: "More player options" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Edit markers" })).toBeInTheDocument();
+    expect(screen.getByRole("slider", { name: "Volume" })).toBeInTheDocument();
+  });
 
   it("hides marker editing when unavailable", () => {
     renderControls(false);

--- a/web/src/player/components/PlayerControls.tsx
+++ b/web/src/player/components/PlayerControls.tsx
@@ -178,6 +178,13 @@ export function PlayerControls({
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [audioOpen, setAudioOpen] = useState(false);
   const [chaptersOpen, setChaptersOpen] = useState(false);
+  // Discard compact menus when switching layouts so they cannot reappear
+  // after a resize or fullscreen round trip.
+  if (!compactControls && (overflowOpen || audioOpen || chaptersOpen)) {
+    setOverflowOpen(false);
+    setAudioOpen(false);
+    setChaptersOpen(false);
+  }
   const safeDuration = duration > 0 ? duration : 0;
   const handleSkipBack = () => onSeek(Math.max(0, currentTime - SKIP_BACK_SECONDS));
   const handleSkipForward = () =>

--- a/web/src/player/components/PlayerControls.tsx
+++ b/web/src/player/components/PlayerControls.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import {
   Info,
   ListVideo,
@@ -162,6 +162,19 @@ export function PlayerControls({
   onSurfaceTap,
 }: PlayerControlsProps) {
   const isCoarsePointer = useCoarsePointer();
+  const controlsRef = useRef<HTMLDivElement>(null);
+  const [narrowPlayer, setNarrowPlayer] = useState(false);
+  const compactControls = isCoarsePointer || narrowPlayer;
+
+  useLayoutEffect(() => {
+    const element = controlsRef.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const measure = () => setNarrowPlayer(element.clientWidth < 1536);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [audioOpen, setAudioOpen] = useState(false);
   const [chaptersOpen, setChaptersOpen] = useState(false);
@@ -176,6 +189,9 @@ export function PlayerControls({
 
   return (
     <div
+      ref={controlsRef}
+      data-compact={compactControls}
+      data-touch={isCoarsePointer}
       className={`player-controls absolute inset-0 z-10 transition-opacity duration-300 ${
         visible ? "opacity-100" : "pointer-events-none opacity-0"
       }`}
@@ -188,8 +204,8 @@ export function PlayerControls({
       {/* Touch transport cluster. pointer-events pass through the empty area
           so surface taps still toggle controls / double-tap-seek; only the
           cluster itself is interactive. */}
-      {isCoarsePointer && (
-        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-[max(0.75rem,env(safe-area-inset-left))]">
+      {compactControls && (
+        <div className="player-compact-transport pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-[max(0.75rem,env(safe-area-inset-left))]">
           <div
             className="pointer-events-auto flex items-center gap-2"
             onClick={(event) => event.stopPropagation()}
@@ -254,10 +270,7 @@ export function PlayerControls({
         </div>
       )}
 
-      {/* ───── BOTTOM HUD ─────
-          Three-column grid: metadata left, main playback cluster center,
-          utility rail right. Seek bar spans the full width above the row
-          so the playhead is always anchored to the frame edge.           */}
+      {/* Narrow players use centered transport and a compact bottom utility row. */}
       <div
         className="player-hud player-rise absolute inset-x-0 bottom-0 z-10 px-[max(0.75rem,env(safe-area-inset-left))] pt-4 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:px-[max(1.5rem,env(safe-area-inset-left))] sm:pr-[max(1.5rem,env(safe-area-inset-right))] sm:pb-[max(1.25rem,env(safe-area-inset-bottom))]"
         onClick={(e) => e.stopPropagation()}
@@ -274,13 +287,9 @@ export function PlayerControls({
           onSeek={onSeek}
         />
 
-        {/* Grid keeps the playback cluster visually locked to the centerline
-            of the frame regardless of how long the title or utility rail is.
-            `minmax(0,1fr)` forces the side columns to honor 1fr behaviour
-            rather than growing with their content — the cluster stays put. */}
-        {isCoarsePointer ? (
-          <div className="mt-2 flex min-w-0 items-center gap-2">
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        {compactControls ? (
+          <div className="player-compact-row mt-2 flex min-w-0 items-center gap-2">
+            <div className="player-compact-metadata flex min-w-0 flex-1 flex-col gap-0.5">
               {title ? (
                 <div
                   className="truncate text-[15px] leading-tight font-semibold tracking-tight text-white"
@@ -342,7 +351,7 @@ export function PlayerControls({
             </button>
           </div>
         ) : (
-          <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 sm:gap-5">
+          <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-5">
             {/* ─── Left: Title / episode / time ─── */}
             <div className="flex min-w-0 flex-col gap-0.5">
               {title ? (
@@ -366,7 +375,7 @@ export function PlayerControls({
                     <span className="text-white/25">·</span>
                   </>
                 ) : null}
-                <span className="font-mono text-[11px] tracking-[0.12em] text-white/75 normal-case tabular-nums">
+                <span className="shrink-0 font-mono text-[11px] tracking-[0.12em] whitespace-nowrap text-white/75 normal-case tabular-nums">
                   {formatTime(currentTime)}
                   <span className="mx-1 text-white/30">/</span>
                   {formatTime(duration)}
@@ -446,7 +455,7 @@ export function PlayerControls({
 
             {/* ─── Right: Utility rail ─── */}
             <div className="flex items-center justify-end gap-0.5">
-              <div className="hidden sm:pointer-fine:block">
+              <div className="shrink-0">
                 <VolumeControl
                   volume={volume}
                   muted={muted}
@@ -455,7 +464,7 @@ export function PlayerControls({
                 />
               </div>
 
-              <div className="player-hud-divider mx-1 hidden sm:block" />
+              <div className="player-hud-divider mx-1" />
 
               {onAudioSelect && (
                 <AudioTrackMenu
@@ -546,9 +555,31 @@ export function PlayerControls({
         )}
       </div>
 
-      {isCoarsePointer && overflowOpen && (
-        <PlayerMenuSurface className="" onClose={() => setOverflowOpen(false)}>
+      {compactControls && overflowOpen && !isCoarsePointer && (
+        <button
+          type="button"
+          className="absolute inset-0 z-40"
+          aria-label="Close menu"
+          onClick={(event) => {
+            event.stopPropagation();
+            setOverflowOpen(false);
+          }}
+        />
+      )}
+      {compactControls && overflowOpen && (
+        <PlayerMenuSurface className="player-overflow-menu" onClose={() => setOverflowOpen(false)}>
           <div className="py-1">
+            {!isCoarsePointer && (
+              <div className="flex items-center justify-between border-b border-white/10 px-5 py-3 text-sm text-white/80">
+                <span>Volume</span>
+                <VolumeControl
+                  volume={volume}
+                  muted={muted}
+                  onVolumeChange={onVolumeChange}
+                  onMutedChange={onMutedChange}
+                />
+              </div>
+            )}
             {onAudioSelect && audioTracks.length > 0 && (
               <OverflowAction
                 icon={<AudioLines className="h-5 w-5" />}
@@ -602,7 +633,7 @@ export function PlayerControls({
           </div>
         </PlayerMenuSurface>
       )}
-      {isCoarsePointer && onAudioSelect && (
+      {compactControls && onAudioSelect && (
         <AudioTrackMenu
           tracks={audioTracks}
           activeIndex={activeAudioIndex}
@@ -613,7 +644,7 @@ export function PlayerControls({
           hideTrigger
         />
       )}
-      {isCoarsePointer && (
+      {compactControls && (
         <ChaptersMenu
           chapters={chapters ?? []}
           currentTime={currentTime}

--- a/web/src/player/components/PlayerMenuSurface.tsx
+++ b/web/src/player/components/PlayerMenuSurface.tsx
@@ -17,17 +17,21 @@ export function PlayerMenuSurface({
   const isCoarsePointer = useCoarsePointer();
 
   useEffect(() => {
-    if (!isCoarsePointer) return;
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isCoarsePointer, onClose]);
+  }, [onClose]);
 
   if (!isCoarsePointer) {
     return (
-      <div role="menu" className={className} onKeyDown={onKeyDown}>
+      <div
+        role="menu"
+        className={`player-menu-surface ${className}`}
+        onKeyDown={onKeyDown}
+        onClick={(event) => event.stopPropagation()}
+      >
         {children}
       </div>
     );

--- a/web/src/player/components/QualityMenu.tsx
+++ b/web/src/player/components/QualityMenu.tsx
@@ -101,7 +101,7 @@ export function QualityMenu({
     <div ref={menuRef} className="relative" onBlur={handleBlur}>
       <button
         type="button"
-        className="player-utility-btn sm:w-auto sm:gap-1.5 sm:px-3"
+        className="player-quality-trigger player-utility-btn sm:w-auto sm:gap-1.5 sm:px-3"
         onClick={() => setOpen((v) => !v)}
         aria-label="Quality"
         aria-expanded={open}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Shrinking a desktop player lets the volume and utility controls overlap the playback buttons, blocking clicks.

## Approach

Use the existing compact controls when the player is narrower than 1536 pixels. Keep transport centered in the bottom row at laptop widths and over the video in phone-sized windows. Move secondary actions and desktop volume into the overflow menu, and constrain menus to the player bounds. Wide players retain the full control row. Switching to that layout clears compact-menu state so menus do not reopen on a later resize.

Add regression coverage for resizing between compact and wide desktop controls, volume access, Escape dismissal, and preventing overflow, audio, and chapter menus from reopening after a resize round trip.

## Validation

- Go build, vet, formatting, and changed-line golangci-lint v2.12.2: passed.
- `make test-go`: passed on rerun. The initial concurrent run hit 25 ms policy-evaluation timeouts in `TestPermissionEffectivePermissionParity` and `TestResolveViewerScopeParity`; an uncached policy-package rerun and the subsequent full Go gate both passed.
- Web dependency install, lint, formatting, and production build: passed. ESLint reports 174 existing warnings and no errors; the changed components are lint-clean.
- `make test-web`: 362 test files and 3,112 tests passed, including the new resize regression.
- Settings bindings, playback fixtures, local-path checks, and `git diff --check`: passed.

Browser validation used Playwright with Chrome on macOS: 22 layout cases from 320×240 to 3840×2160, including touch emulation and an embedded player, plus actual playback interactions at 14 viewport configurations. Play/pause, seeking, volume, mute, fullscreen entry/exit, and overflow actions passed with no JavaScript page errors.

## Risks

Windows Edge and physical touch devices have not been tested directly. This changes only the web player; API contracts, native Apple/Android clients, and Jellyfin compatibility need no changes.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop app
- Tool(s): Codex; Playwright with Chrome for browser validation
- Model(s): gpt-6-astra
- Involvement: AI-assisted implementation, tests, and PR preparation, with human design feedback.
- Adversarial review: The implementing agent reviewed resize transitions, pointer modes, menu event propagation, and stacking. Browser bounds and hit-testing checks exposed menu clipping and a control-layer obstruction; both were corrected and the checks rerun. No independent reviewer was used.
