### PR TITLE
perf(catalog): avoid hydrating episodes for completion status

### DIFF
--- a/internal/api/handlers/user_state.go
+++ b/internal/api/handlers/user_state.go
@@ -82,42 +82,59 @@ func resolveItemUserStatesWithOptions(
 	}
 
 	progressIDs := append([]string{}, contentIDs...)
-	seriesEpisodes := map[string][]*models.Episode{}
-	seasonEpisodes := map[string][]*models.Episode{}
+	seriesEpisodes := map[string][]string{}
+	seasonEpisodes := map[string][]string{}
+	var seriesCompletion, seasonCompletion map[string]bool
 	if episodeRepo != nil {
-		if len(seriesIDs) > 0 {
-			seriesEpisodes, err = episodeRepo.ListBySeriesIDs(ctx, seriesIDs)
+		if completionStore, ok := store.(userstore.EpisodeParentCompletionStore); ok {
+			// Keep the existing path for stores without SQL completion support,
+			// and preserve its degradation behavior if the optional query fails.
+			if len(seriesIDs) > 0 {
+				seriesCompletion, err = completionStore.SeriesCompletion(ctx, profileID, seriesIDs)
+				if err != nil {
+					seriesCompletion = nil
+				}
+			}
+			if len(seasonIDs) > 0 {
+				seasonCompletion, err = completionStore.SeasonCompletion(ctx, profileID, seasonIDs)
+				if err != nil {
+					seasonCompletion = nil
+				}
+			}
+		}
+		if len(seriesIDs) > 0 && seriesCompletion == nil {
+			seriesEpisodes, err = episodeRepo.ListIDsBySeriesIDs(ctx, seriesIDs)
 			if err != nil {
 				return nil, err
 			}
 			for _, episodes := range seriesEpisodes {
-				for _, episode := range episodes {
-					if episode == nil || episode.ContentID == "" {
+				for _, episodeID := range episodes {
+					if episodeID == "" {
 						continue
 					}
-					if _, ok := seenContent[episode.ContentID]; ok {
+					if _, ok := seenContent[episodeID]; ok {
 						continue
 					}
-					seenContent[episode.ContentID] = struct{}{}
-					progressIDs = append(progressIDs, episode.ContentID)
+					seenContent[episodeID] = struct{}{}
+					progressIDs = append(progressIDs, episodeID)
 				}
 			}
 		}
-		if len(seasonIDs) > 0 {
-			seasonEpisodes, err = episodeRepo.ListBySeasonIDs(ctx, seasonIDs)
+		if len(seasonIDs) > 0 && seasonCompletion == nil {
+			seasonEpisodes, err = episodeRepo.ListIDsBySeasonIDs(ctx, seasonIDs)
 			if err != nil {
 				return nil, err
 			}
 			for _, episodes := range seasonEpisodes {
-				for _, episode := range episodes {
-					if episode == nil || episode.ContentID == "" {
+				for _, episodeID := range episodes {
+					if episodeID == "" {
 						continue
 					}
-					if _, ok := seenContent[episode.ContentID]; ok {
+					if _, ok := seenContent[episodeID]; ok {
 						continue
 					}
-					seenContent[episode.ContentID] = struct{}{}
-					progressIDs = append(progressIDs, episode.ContentID)
+					seenContent[episodeID] = struct{}{}
+					progressIDs = append(progressIDs, episodeID)
 				}
 			}
 		}
@@ -143,8 +160,14 @@ func resolveItemUserStatesWithOptions(
 		switch item.Type {
 		case "series":
 			state.Played = allEpisodesCompleted(seriesEpisodes[item.ContentID], progressMap)
+			if seriesCompletion != nil {
+				state.Played = seriesCompletion[item.ContentID]
+			}
 		case "season":
 			state.Played = allEpisodesCompleted(seasonEpisodes[item.ContentID], progressMap)
+			if seasonCompletion != nil {
+				state.Played = seasonCompletion[item.ContentID]
+			}
 		case "ebook":
 			state.Played = ebookProgressMap[item.ContentID].Progress >= models.EbookFinishedProgressThreshold
 		default:
@@ -168,15 +191,15 @@ func resolveEbookProgressForUserStates(
 	return options.EbookProgressStore.ListByContentIDs(ctx, options.UserID, profileID, contentIDs)
 }
 
-func allEpisodesCompleted(episodes []*models.Episode, progressMap map[string]userstore.WatchProgress) bool {
+func allEpisodesCompleted(episodes []string, progressMap map[string]userstore.WatchProgress) bool {
 	if len(episodes) == 0 {
 		return false
 	}
-	for _, episode := range episodes {
-		if episode == nil || episode.ContentID == "" {
+	for _, episodeID := range episodes {
+		if episodeID == "" {
 			return false
 		}
-		progress, ok := progressMap[episode.ContentID]
+		progress, ok := progressMap[episodeID]
 		if !ok || !progress.Completed {
 			return false
 		}

--- a/internal/api/handlers/user_state_episode_db_test.go
+++ b/internal/api/handlers/user_state_episode_db_test.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/userstore"
+	"github.com/Silo-Server/silo-server/internal/userstore/pgstore"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestEpisodeCompletionUserStates(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.MaxConns = 1
+	config.ConnConfig.RuntimeParams["plan_cache_mode"] = "force_generic_plan"
+	pool, err := pgxpool.NewWithConfig(t.Context(), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("state-episodes-%d", time.Now().UnixNano())
+	series, season, empty, episode1, episode2, orphan := prefix+"-series", prefix+"-season", prefix+"-empty", prefix+"-ep1", prefix+"-ep2", prefix+"-orphan"
+	var folderID int
+	if err := pool.QueryRow(t.Context(), `INSERT INTO media_folders (type,name,enabled) VALUES ('series',$1,true) RETURNING id`, prefix).Scan(&folderID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id=ANY($1)`, []string{series, empty})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id=$1`, folderID)
+	})
+	for _, stmt := range []struct {
+		sql  string
+		args []any
+	}{
+		{`INSERT INTO media_items (content_id,type,title) VALUES ($1,'series','Series'),($2,'series','Empty')`, []any{series, empty}},
+		{`INSERT INTO seasons (content_id,series_id,season_number) VALUES ($1,$2,1)`, []any{season, series}},
+		{`INSERT INTO episodes (content_id,series_id,season_id,season_number,episode_number,title)
+    VALUES ($1,$4,$5,1,1,'One'),($2,$4,$5,1,2,'Two'),($3,$4,$5,1,3,'Unavailable')`, []any{episode1, episode2, orphan, series, season}},
+		{`INSERT INTO episode_libraries (episode_id,media_folder_id) VALUES ($1,$3),($2,$3)`, []any{episode1, episode2, folderID}},
+	} {
+		if _, err := pool.Exec(t.Context(), stmt.sql, stmt.args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("sqlite", func(t *testing.T) {
+		checkEpisodeCompletionUserStates(t, pool, newProfileTestStore(t), "profile-1", "other-profile", series, season, empty, episode1, episode2)
+	})
+	var userID int
+	if err := pool.QueryRow(t.Context(), `INSERT INTO users (username,role) VALUES ($1,'user') RETURNING id`, prefix).Scan(&userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id=$1`, userID) })
+	profileID := fmt.Sprintf("00000000-0000-4000-8000-%012d", time.Now().UnixNano()%1_000_000_000_000)
+	otherProfileID := fmt.Sprintf("00000000-0000-4000-8001-%012d", time.Now().UnixNano()%1_000_000_000_000)
+	for _, id := range []string{profileID, otherProfileID} {
+		if _, err := pool.Exec(t.Context(), `INSERT INTO user_profiles (id,user_id,name) VALUES ($1,$2,'Completion fixture')`, id, userID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store, err := pgstore.NewPostgresProvider(pool).ForUser(t.Context(), userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Run("postgres", func(t *testing.T) {
+		checkEpisodeCompletionUserStates(t, pool, store, profileID, otherProfileID, series, season, empty, episode1, episode2)
+	})
+}
+
+// Hiding optional completion support exercises the original ID/progress path
+// against exactly the same store and catalog after each watch-state change.
+type completionFallbackStore struct{ userstore.UserStore }
+
+type failingCompletionStore struct{ userstore.UserStore }
+
+func (s failingCompletionStore) SeriesCompletion(context.Context, string, []string) (map[string]bool, error) {
+	return nil, errors.New("completion query unavailable")
+}
+
+func (s failingCompletionStore) SeasonCompletion(context.Context, string, []string) (map[string]bool, error) {
+	return nil, errors.New("completion query unavailable")
+}
+
+func checkEpisodeCompletionUserStates(t *testing.T, pool *pgxpool.Pool, store userstore.UserStore, profileID, otherProfileID, series, season, empty, episode1, episode2 string) {
+	t.Helper()
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := store.SetProgressAt(t.Context(), profileID, episode1, 100, 100, true, at); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddFavorite(t.Context(), profileID, series); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddToWatchlist(t.Context(), profileID, season); err != nil {
+		t.Fatal(err)
+	}
+	items := []*models.MediaItem{nil, {ContentID: series, Type: "series"}, {ContentID: season, Type: "season"}, {ContentID: empty, Type: "series"}, {ContentID: episode1, Type: "episode"}, {ContentID: series, Type: "series"}}
+	check := func(wantCompleted bool) {
+		t.Helper()
+		states, err := resolveItemUserStates(t.Context(), store, profileID, catalog.NewEpisodeRepository(pool), items)
+		if err != nil {
+			t.Fatal(err)
+		}
+		original, err := resolveItemUserStates(t.Context(), completionFallbackStore{store}, profileID, catalog.NewEpisodeRepository(pool), items)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(states, original) {
+			t.Fatalf("completion optimization changed user states: got %#v, want %#v", states, original)
+		}
+		failed, err := resolveItemUserStates(t.Context(), failingCompletionStore{store}, profileID, catalog.NewEpisodeRepository(pool), items)
+		if err != nil || !reflect.DeepEqual(failed, original) {
+			t.Fatalf("completion query failure changed fallback: %v", err)
+		}
+		if completionStore, ok := store.(userstore.EpisodeParentCompletionStore); ok {
+			// Call the capability directly as well: a SQL error must not let the
+			// handler's fallback hide a broken optimized query from this test.
+			seriesFlags, err := completionStore.SeriesCompletion(t.Context(), profileID, []string{series, empty, series, "unknown"})
+			if err != nil || len(seriesFlags) != 3 || seriesFlags[series] != wantCompleted || seriesFlags[empty] || seriesFlags["unknown"] {
+				t.Fatalf("series completion flags = %v, error = %v", seriesFlags, err)
+			}
+			seasonFlags, err := completionStore.SeasonCompletion(t.Context(), profileID, []string{season, "unknown"})
+			if err != nil || len(seasonFlags) != 2 || seasonFlags[season] != wantCompleted || seasonFlags["unknown"] {
+				t.Fatalf("season completion flags = %v, error = %v", seasonFlags, err)
+			}
+			for _, load := range []func(context.Context, string, []string) (map[string]bool, error){completionStore.SeriesCompletion, completionStore.SeasonCompletion} {
+				flags, err := load(t.Context(), profileID, nil)
+				if err != nil || len(flags) != 0 {
+					t.Fatalf("empty completion = %v, error = %v", flags, err)
+				}
+			}
+		}
+		if len(states) != 4 {
+			t.Fatalf("got %d states, want 4", len(states))
+		}
+		if states[series].Played != wantCompleted || states[season].Played != wantCompleted {
+			t.Fatalf("series/season completion = %v/%v, want %v", states[series].Played, states[season].Played, wantCompleted)
+		}
+		if states[empty].Played || !states[episode1].Played {
+			t.Fatal("empty-series or leaf completion changed")
+		}
+		if !states[series].IsFavorite || !states[season].InWatchlist {
+			t.Fatal("favorites/watchlist state changed")
+		}
+	}
+	check(false)
+	if err := store.AddHistory(t.Context(), userstore.WatchHistoryEntry{ProfileID: profileID, MediaItemID: episode2, WatchedAt: at.Format(time.RFC3339), Completed: true, Source: userstore.WatchHistorySourceTrakt}); err != nil {
+		t.Fatal(err)
+	}
+	check(true)
+	if err := store.RemoveHistoryItems(t.Context(), profileID, []string{episode2}, at.Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	check(false)
+	if err := store.SetProgressAt(t.Context(), profileID, episode2, 100, 100, true, at.Add(2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	check(true)
+	// Membership changes must take effect immediately, including an episode
+	// with no media-file row. Completion uses membership, not file presence.
+	if _, err := pool.Exec(t.Context(), `INSERT INTO episode_libraries (episode_id,media_folder_id)
+		SELECT content_id, (SELECT media_folder_id FROM episode_libraries WHERE episode_id=$2 LIMIT 1)
+		FROM episodes WHERE series_id=$1 AND episode_number=3`, series, episode1); err != nil {
+		t.Fatal(err)
+	}
+	check(false)
+	if _, err := pool.Exec(t.Context(), `DELETE FROM episode_libraries WHERE episode_id IN
+		(SELECT content_id FROM episodes WHERE series_id=$1 AND episode_number=3)`, series); err != nil {
+		t.Fatal(err)
+	}
+	check(true)
+	other, err := resolveItemUserStates(t.Context(), store, otherProfileID, catalog.NewEpisodeRepository(pool), items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other[series].Played || other[series].IsFavorite || other[season].InWatchlist {
+		t.Fatal("state leaked across profiles")
+	}
+}

--- a/internal/api/handlers/user_state_test.go
+++ b/internal/api/handlers/user_state_test.go
@@ -114,7 +114,7 @@ func TestResolveItemUserStatesIncludesCompletedHistory(t *testing.T) {
 }
 
 func TestAllEpisodesCompletedIncludesCompletedHistory(t *testing.T) {
-	episodes := []*models.Episode{{ContentID: "episode-progress"}, {ContentID: "episode-history"}}
+	episodes := []string{"episode-progress", "episode-history"}
 	progress := map[string]userstore.WatchProgress{
 		"episode-progress": {MediaItemID: "episode-progress", Completed: true},
 		"episode-history":  {MediaItemID: "episode-history", Completed: true},

--- a/internal/catalog/episode_ids_db_test.go
+++ b/internal/catalog/episode_ids_db_test.go
@@ -1,0 +1,141 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func seedCompletionEpisodes(tb testing.TB, count int) (*EpisodeRepository, string, string) {
+	tb.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		tb.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := tb.Context()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("completion-ids-%d", time.Now().UnixNano())
+	seriesID, seasonID := prefix+"-series", prefix+"-season"
+	var folderID, otherFolderID int
+	for _, id := range []*int{&folderID, &otherFolderID} {
+		if err := pool.QueryRow(ctx, `INSERT INTO media_folders (type,name,enabled) VALUES ('series',$1,true) RETURNING id`, prefix).Scan(id); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	tb.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id=$1`, seriesID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id=ANY($1)`, []int{folderID, otherFolderID})
+	})
+	statements := []struct {
+		sql  string
+		args []any
+	}{
+		{`INSERT INTO media_items (content_id,type,title,genres) VALUES ($1,'series','Completion fixture','{}')`, []any{seriesID}},
+		{`INSERT INTO seasons (content_id,series_id,season_number) VALUES ($1,$2,1)`, []any{seasonID, seriesID}},
+		{`INSERT INTO episodes (content_id,series_id,season_id,season_number,episode_number,title,overview)
+    SELECT $1 || '-episode-' || n,$2,$3,1,n,'Episode ' || n,repeat('Synthetic episode overview. ',80)
+    FROM generate_series(1,$4::int) n`, []any{prefix, seriesID, seasonID, count}},
+		{`INSERT INTO media_files (content_id,episode_id,media_folder_id,file_path)
+    SELECT $1,content_id,$2,content_id || '.mkv' FROM episodes WHERE series_id=$1 AND episode_number>1`, []any{seriesID, folderID}},
+		// Multiple folders must not duplicate an episode. Missing files deliberately
+		// retain membership and must keep the existing completion behavior.
+		{`INSERT INTO media_files (content_id,episode_id,media_folder_id,file_path,missing_since)
+    SELECT $1,content_id,$2,content_id || '-other.mkv',now() FROM episodes WHERE series_id=$1 AND episode_number=2`, []any{seriesID, otherFolderID}},
+		{`UPDATE media_files SET missing_since=now() WHERE content_id=$1 AND episode_id IN
+	    (SELECT content_id FROM episodes WHERE series_id=$1 AND episode_number=3)`, []any{seriesID}},
+		{`INSERT INTO episode_libraries (episode_id,media_folder_id)
+	    SELECT content_id,$2 FROM episodes WHERE series_id=$1 AND episode_number>1`, []any{seriesID, folderID}},
+		{`INSERT INTO episode_libraries (episode_id,media_folder_id)
+	    SELECT content_id,$2 FROM episodes WHERE series_id=$1 AND episode_number=2`, []any{seriesID, otherFolderID}},
+	}
+	for _, s := range statements {
+		if _, err := pool.Exec(ctx, s.sql, s.args...); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return NewEpisodeRepository(pool), seriesID, seasonID
+}
+
+func TestCompletionEpisodeIDsMatchFullEpisodeReads(t *testing.T) {
+	repo, seriesID, seasonID := seedCompletionEpisodes(t, 5)
+	for _, tc := range []struct {
+		name   string
+		parent string
+		full   func(context.Context, []string) (map[string][]*models.Episode, error)
+		ids    func(context.Context, []string) (map[string][]string, error)
+	}{
+		{"series", seriesID, repo.ListBySeriesIDs, repo.ListIDsBySeriesIDs},
+		{"season", seasonID, repo.ListBySeasonIDs, repo.ListIDsBySeasonIDs},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, requested := range [][]string{nil, {}, {"not-present"}, {tc.parent}, {tc.parent, tc.parent, "not-present"}} {
+				full, err := tc.full(t.Context(), requested)
+				if err != nil {
+					t.Fatal(err)
+				}
+				ids, err := tc.ids(t.Context(), requested)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := make(map[string][]string, len(full))
+				for parent, episodes := range full {
+					for _, ep := range episodes {
+						want[parent] = append(want[parent], ep.ContentID)
+					}
+					slices.Sort(want[parent])
+				}
+				for parent := range ids {
+					slices.Sort(ids[parent])
+				}
+				if !reflect.DeepEqual(ids, want) {
+					t.Fatalf("IDs differ: got %v, want %v", ids, want)
+				}
+				if slices.Contains(requested, tc.parent) && len(ids[tc.parent]) != 4 {
+					t.Fatalf("membership changed: got %d episodes, want 4", len(ids[tc.parent]))
+				}
+			}
+		})
+	}
+}
+
+// Compare metadata hydration with the ID-only completion read on the same
+// migrated, disposable database. No shared-dev rows are created by this benchmark.
+func BenchmarkCompletionEpisodeReads(b *testing.B) {
+	repo, seriesID, _ := seedCompletionEpisodes(b, 2001)
+	ids := []string{seriesID}
+	b.Run("full", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			rows, err := repo.ListBySeriesIDs(b.Context(), ids)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(rows[seriesID]) != 2000 {
+				b.Fatal("incomplete fixture")
+			}
+		}
+	})
+	b.Run("ids", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			rows, err := repo.ListIDsBySeriesIDs(b.Context(), ids)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(rows[seriesID]) != 2000 {
+				b.Fatal("incomplete fixture")
+			}
+		}
+	})
+}

--- a/internal/catalog/episode_repo.go
+++ b/internal/catalog/episode_repo.go
@@ -786,6 +786,43 @@ func (r *EpisodeRepository) ListBySeriesIDs(ctx context.Context, seriesIDs []str
 	return result, nil
 }
 
+// ListIDsBySeriesIDs returns the available episode IDs used to determine
+// whether a series is completed, without loading episode metadata.
+func (r *EpisodeRepository) ListIDsBySeriesIDs(ctx context.Context, seriesIDs []string) (map[string][]string, error) {
+	return r.listIDsByParent(ctx, "series_id", seriesIDs)
+}
+
+// ListIDsBySeasonIDs is the season counterpart of ListIDsBySeriesIDs.
+func (r *EpisodeRepository) ListIDsBySeasonIDs(ctx context.Context, seasonIDs []string) (map[string][]string, error) {
+	return r.listIDsByParent(ctx, "season_id", seasonIDs)
+}
+
+func (r *EpisodeRepository) listIDsByParent(ctx context.Context, parentColumn string, parentIDs []string) (map[string][]string, error) {
+	result := make(map[string][]string, len(parentIDs))
+	if len(parentIDs) == 0 {
+		return result, nil
+	}
+
+	// parentColumn comes only from the two fixed-column wrappers above.
+	// Completion is order-independent; preserve the same availability rule
+	// as ListBySeriesIDs and ListBySeasonIDs, including missing-file rows.
+	query := fmt.Sprintf(`SELECT content_id, %s FROM episodes
+		WHERE %s = ANY($1) AND %s`, parentColumn, parentColumn, episodeAvailabilityPredicate)
+	rows, err := r.pool.Query(ctx, query, parentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("listing episode ids by %s: %w", parentColumn, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var contentID, parentID string
+		if err := rows.Scan(&contentID, &parentID); err != nil {
+			return nil, fmt.Errorf("scanning episode ids by %s: %w", parentColumn, err)
+		}
+		result[parentID] = append(result[parentID], contentID)
+	}
+	return result, rows.Err()
+}
+
 // buildListBySeriesGroupedBySeasonQuery returns the SQL and bound args used by
 // ListBySeriesGroupedBySeason. Extracted so tests can assert SQL shape without
 // a live Postgres pool.

--- a/internal/notifications/interest_hooks.go
+++ b/internal/notifications/interest_hooks.go
@@ -39,12 +39,38 @@ func (p *interestTrackingProvider) ForUser(ctx context.Context, userID int) (use
 		return store, err
 	}
 	tracked := &interestTrackingStore{UserStore: store, userID: userID, system: p.system, updater: p.system.Interest}
-	// Preserve the interface upgrades callers probe for. Both are conditional
+	// Preserve the interface upgrades callers probe for. These are conditional
 	// on the backing store: advertising a capability it does not have would
 	// send callers down a fast path that can only fail.
 	registry, hasDevices := store.(userstore.DeviceRegistry)
 	rollup, hasRollup := store.(userstore.SeriesEpisodeRollupStore)
+	completion, hasCompletion := store.(userstore.EpisodeParentCompletionStore)
 	switch {
+	case hasDevices && hasRollup && hasCompletion:
+		return &interestTrackingStoreWithDevicesRollupAndCompletion{
+			interestTrackingStoreWithDevicesAndRollup: &interestTrackingStoreWithDevicesAndRollup{
+				interestTrackingStore: tracked, DeviceRegistry: registry, SeriesEpisodeRollupStore: rollup,
+			},
+			EpisodeParentCompletionStore: completion,
+		}, nil
+	case hasDevices && hasCompletion:
+		return &interestTrackingStoreWithDevicesAndCompletion{
+			interestTrackingStoreWithDevices: &interestTrackingStoreWithDevices{
+				interestTrackingStore: tracked, DeviceRegistry: registry,
+			},
+			EpisodeParentCompletionStore: completion,
+		}, nil
+	case hasRollup && hasCompletion:
+		return &interestTrackingStoreWithRollupAndCompletion{
+			interestTrackingStoreWithRollup: &interestTrackingStoreWithRollup{
+				interestTrackingStore: tracked, SeriesEpisodeRollupStore: rollup,
+			},
+			EpisodeParentCompletionStore: completion,
+		}, nil
+	case hasCompletion:
+		return &interestTrackingStoreWithCompletion{
+			interestTrackingStore: tracked, EpisodeParentCompletionStore: completion,
+		}, nil
 	case hasDevices && hasRollup:
 		return &interestTrackingStoreWithDevicesAndRollup{
 			interestTrackingStore:    tracked,
@@ -100,6 +126,28 @@ type interestTrackingStoreWithDevicesAndRollup struct {
 	userstore.SeriesEpisodeRollupStore
 }
 
+// Completion reads also need catalog tables, so preserve this capability only
+// for supporting backends while retaining all mutation hooks on the base wrapper.
+type interestTrackingStoreWithCompletion struct {
+	*interestTrackingStore
+	userstore.EpisodeParentCompletionStore
+}
+
+type interestTrackingStoreWithDevicesAndCompletion struct {
+	*interestTrackingStoreWithDevices
+	userstore.EpisodeParentCompletionStore
+}
+
+type interestTrackingStoreWithRollupAndCompletion struct {
+	*interestTrackingStoreWithRollup
+	userstore.EpisodeParentCompletionStore
+}
+
+type interestTrackingStoreWithDevicesRollupAndCompletion struct {
+	*interestTrackingStoreWithDevicesAndRollup
+	userstore.EpisodeParentCompletionStore
+}
+
 var _ userstore.SettingValueCompareAndSetter = (*interestTrackingStore)(nil)
 var _ userstore.SettingMutationTransactioner = (*interestTrackingStore)(nil)
 var _ userstore.SettingValueCompareAndSetter = (*interestTrackingStoreWithDevices)(nil)
@@ -110,9 +158,9 @@ var _ userstore.SettingMutationTransactioner = (*interestTrackingStoreWithDevice
 // needs an explicit forward below; the assertions make a missing one a compile
 // error instead of a silent production slowdown.
 //
-// SeriesEpisodeRollupStore is deliberately absent here: it is conditional on
-// the backing store, so it lives on the wrapper types above rather than being
-// forwarded unconditionally.
+// SeriesEpisodeRollupStore and EpisodeParentCompletionStore are conditional
+// on the backing store, so they live on the wrapper types above rather than
+// being forwarded unconditionally.
 var _ userstore.WatchedBatchWriter = (*interestTrackingStore)(nil)
 var _ userstore.VisibleHistoryAdder = (*interestTrackingStore)(nil)
 var _ userstore.HistoryVisibilityStore = (*interestTrackingStore)(nil)
@@ -122,6 +170,11 @@ var _ userstore.HistoryVisibilityStore = (*interestTrackingStoreWithDevices)(nil
 var _ userstore.SeriesEpisodeRollupStore = (*interestTrackingStoreWithRollup)(nil)
 var _ userstore.SeriesEpisodeRollupStore = (*interestTrackingStoreWithDevicesAndRollup)(nil)
 var _ userstore.DeviceRegistry = (*interestTrackingStoreWithDevicesAndRollup)(nil)
+
+var _ userstore.EpisodeParentCompletionStore = (*interestTrackingStoreWithCompletion)(nil)
+var _ userstore.EpisodeParentCompletionStore = (*interestTrackingStoreWithDevicesAndCompletion)(nil)
+var _ userstore.EpisodeParentCompletionStore = (*interestTrackingStoreWithRollupAndCompletion)(nil)
+var _ userstore.EpisodeParentCompletionStore = (*interestTrackingStoreWithDevicesRollupAndCompletion)(nil)
 
 // WithPreferenceSettingsTransaction preserves the optional atomic-settings
 // capability of the wrapped store. Preference writes do not affect interest

--- a/internal/notifications/interest_hooks_test.go
+++ b/internal/notifications/interest_hooks_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -326,5 +329,170 @@ func TestInterestTrackingStoreForwardsRollupWhenSupported(t *testing.T) {
 	}
 	if _, ok := wrapped.(userstore.SettingValueCompareAndSetter); !ok {
 		t.Error("rollup-capable wrapper dropped SettingValueCompareAndSetter")
+	}
+}
+
+// completionCapableStore records both completion entry points so the decorator
+// test exercises the production capability assertion and argument forwarding.
+type completionCapableStore struct {
+	call func(context.Context, string, string, []string) (map[string]bool, error)
+}
+
+func (s completionCapableStore) SeriesCompletion(ctx context.Context, profileID string, ids []string) (map[string]bool, error) {
+	return s.call(ctx, "series", profileID, ids)
+}
+
+func (s completionCapableStore) SeasonCompletion(ctx context.Context, profileID string, ids []string) (map[string]bool, error) {
+	return s.call(ctx, "season", profileID, ids)
+}
+
+func TestInterestTrackingStoreConditionalCapabilities(t *testing.T) {
+	for _, tc := range []struct {
+		name                        string
+		devices, rollup, completion bool
+		wrap                        func(userstore.UserStore, userstore.DeviceRegistry, userstore.SeriesEpisodeRollupStore, userstore.EpisodeParentCompletionStore) userstore.UserStore
+	}{
+		{"none", false, false, false, func(s userstore.UserStore, _ userstore.DeviceRegistry, _ userstore.SeriesEpisodeRollupStore, _ userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct{ userstore.UserStore }{s}
+		}},
+		{"devices", true, false, false, func(s userstore.UserStore, d userstore.DeviceRegistry, _ userstore.SeriesEpisodeRollupStore, _ userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct {
+				userstore.UserStore
+				userstore.DeviceRegistry
+			}{s, d}
+		}},
+		{"rollup", false, true, false, func(s userstore.UserStore, _ userstore.DeviceRegistry, r userstore.SeriesEpisodeRollupStore, _ userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct {
+				userstore.UserStore
+				userstore.SeriesEpisodeRollupStore
+			}{s, r}
+		}},
+		{"devices_rollup", true, true, false, func(s userstore.UserStore, d userstore.DeviceRegistry, r userstore.SeriesEpisodeRollupStore, _ userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct {
+				userstore.UserStore
+				userstore.DeviceRegistry
+				userstore.SeriesEpisodeRollupStore
+			}{s, d, r}
+		}},
+		{"completion", false, false, true, func(s userstore.UserStore, _ userstore.DeviceRegistry, _ userstore.SeriesEpisodeRollupStore, c userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct {
+				userstore.UserStore
+				userstore.EpisodeParentCompletionStore
+			}{s, c}
+		}},
+		{"devices_completion", true, false, true, func(s userstore.UserStore, d userstore.DeviceRegistry, _ userstore.SeriesEpisodeRollupStore, c userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct {
+				userstore.UserStore
+				userstore.DeviceRegistry
+				userstore.EpisodeParentCompletionStore
+			}{s, d, c}
+		}},
+		{"rollup_completion", false, true, true, func(s userstore.UserStore, _ userstore.DeviceRegistry, r userstore.SeriesEpisodeRollupStore, c userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct {
+				userstore.UserStore
+				userstore.SeriesEpisodeRollupStore
+				userstore.EpisodeParentCompletionStore
+			}{s, r, c}
+		}},
+		{"devices_rollup_completion", true, true, true, func(s userstore.UserStore, d userstore.DeviceRegistry, r userstore.SeriesEpisodeRollupStore, c userstore.EpisodeParentCompletionStore) userstore.UserStore {
+			return struct {
+				userstore.UserStore
+				userstore.DeviceRegistry
+				userstore.SeriesEpisodeRollupStore
+				userstore.EpisodeParentCompletionStore
+			}{s, d, r, c}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+			db, err := sql.Open("sqlite3", ":memory:")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = db.Close() })
+			if err := userdb.InitSchema(db); err != nil {
+				t.Fatal(err)
+			}
+			base := userdb.NewSQLiteUserStore(db)
+			rollup := &rollupCapableStore{UserStore: base}
+			completion := &completionCapableStore{}
+			inner := tc.wrap(base, base, rollup, completion)
+			updater := &InterestUpdater{pending: map[interestMutation]int{}}
+			provider := WrapUserStoreProvider(preferenceTransactionTestProvider{store: inner}, &System{Interest: updater})
+			wrapped, err := provider.ForUser(ctx, 7)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := wrapped.(userstore.DeviceRegistry); ok != tc.devices {
+				t.Fatalf("DeviceRegistry = %v, want %v", ok, tc.devices)
+			}
+			if _, ok := wrapped.(userstore.SeriesEpisodeRollupStore); ok != tc.rollup {
+				t.Fatalf("SeriesEpisodeRollupStore = %v, want %v", ok, tc.rollup)
+			}
+			capability, ok := wrapped.(userstore.EpisodeParentCompletionStore)
+			if ok != tc.completion {
+				t.Fatalf("EpisodeParentCompletionStore = %v, want %v", ok, tc.completion)
+			}
+			if tc.completion {
+				for _, method := range []struct {
+					name string
+					call func(context.Context, string, []string) (map[string]bool, error)
+				}{
+					{"series", capability.SeriesCompletion},
+					{"season", capability.SeasonCompletion},
+				} {
+					for _, wantErr := range []error{nil, errors.New("completion query failed")} {
+						ids := []string{"parent-1", "parent-2", "parent-1"}
+						want := map[string]bool{"parent-1": true, "parent-2": false}
+						called := false
+						completion.call = func(gotCtx context.Context, kind, profileID string, gotIDs []string) (map[string]bool, error) {
+							called = true
+							if gotCtx != ctx || kind != method.name || profileID != "p1" || !slices.Equal(gotIDs, ids) {
+								t.Fatalf("completion arguments changed: kind=%s profile=%s ids=%v", kind, profileID, gotIDs)
+							}
+							return want, wantErr
+						}
+						got, err := method.call(ctx, "p1", ids)
+						if !called || !maps.Equal(got, want) || !errors.Is(err, wantErr) {
+							t.Fatalf("%s: called=%v result=%v error=%v, want %v (%v)", method.name, called, got, err, want, wantErr)
+						}
+					}
+				}
+			}
+			if tc.rollup {
+				counts, err := wrapped.(userstore.SeriesEpisodeRollupStore).SeriesEpisodeWatchCounts(ctx, "p1", []string{"series-1"})
+				if err != nil || !rollup.called || counts["series-1"].WatchedCount != 2 {
+					t.Fatalf("rollup forwarding = %v (%v), called=%v", counts, err, rollup.called)
+				}
+			}
+			// Every variant must still route writes through interestTrackingStore.
+			if err := wrapped.CreateProfile(ctx, userstore.Profile{ID: "p1", Name: "Test"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := wrapped.AddFavorite(ctx, "p1", "series-1"); err != nil {
+				t.Fatal(err)
+			}
+			if _, queued := updater.pending[interestMutation{userID: 7, profileID: "p1", itemID: "series-1"}]; !queued {
+				t.Fatal("favorite mutation bypassed the interest hook")
+			}
+			if _, ok := wrapped.(userstore.WatchedBatchWriter); !ok {
+				t.Error("dropped WatchedBatchWriter")
+			}
+			if _, ok := wrapped.(userstore.VisibleHistoryAdder); !ok {
+				t.Error("dropped VisibleHistoryAdder")
+			}
+			if _, ok := wrapped.(userstore.HistoryVisibilityStore); !ok {
+				t.Error("dropped HistoryVisibilityStore")
+			}
+			if _, ok := wrapped.(userstore.PreferenceSettingsTransactioner); !ok {
+				t.Error("dropped PreferenceSettingsTransactioner")
+			}
+			if _, ok := wrapped.(userstore.SettingValueCompareAndSetter); !ok {
+				t.Error("dropped SettingValueCompareAndSetter")
+			}
+			if _, ok := wrapped.(userstore.SettingMutationTransactioner); !ok {
+				t.Error("dropped SettingMutationTransactioner")
+			}
+		})
 	}
 }

--- a/internal/userstore/pgstore/episode_completion.go
+++ b/internal/userstore/pgstore/episode_completion.go
@@ -1,0 +1,66 @@
+package pgstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Silo-Server/silo-server/internal/userstore"
+)
+
+var _ userstore.EpisodeParentCompletionStore = (*PostgresUserStore)(nil)
+
+func (s *PostgresUserStore) SeriesCompletion(ctx context.Context, profileID string, seriesIDs []string) (map[string]bool, error) {
+	return s.episodeParentCompletion(ctx, profileID, "series_id", seriesIDs)
+}
+
+func (s *PostgresUserStore) SeasonCompletion(ctx context.Context, profileID string, seasonIDs []string) (map[string]bool, error) {
+	return s.episodeParentCompletion(ctx, profileID, "season_id", seasonIDs)
+}
+
+func (s *PostgresUserStore) episodeParentCompletion(ctx context.Context, profileID, parentColumn string, parentIDs []string) (map[string]bool, error) {
+	result := make(map[string]bool, len(parentIDs))
+	if len(parentIDs) == 0 {
+		return result, nil
+	}
+	// parentColumn is supplied only by the two fixed-column wrappers above.
+	// Separate EXISTS checks distinguish empty parents from completed parents
+	// while allowing the incomplete-episode search to stop after one match.
+	query := fmt.Sprintf(`SELECT parent_id,
+		EXISTS (
+			SELECT 1 FROM episodes e WHERE e.%[1]s = parent_id
+			AND EXISTS (SELECT 1 FROM episode_libraries el WHERE el.episode_id = e.content_id)
+		) AND NOT EXISTS (
+			SELECT 1 FROM episodes e WHERE e.%[1]s = parent_id
+			AND EXISTS (SELECT 1 FROM episode_libraries el WHERE el.episode_id = e.content_id)
+			AND NOT EXISTS (
+				SELECT 1 FROM user_watch_progress wp
+				WHERE wp.user_id = $1 AND wp.profile_id = $2
+				  AND wp.media_item_id = e.content_id AND wp.completed
+				  AND NOT EXISTS (
+					SELECT 1 FROM user_history_hidden_items hh
+					WHERE hh.user_id = wp.user_id AND hh.profile_id = wp.profile_id
+					  AND hh.media_item_id = wp.media_item_id AND wp.updated_at <= hh.hidden_before
+				  )
+			) AND NOT EXISTS (
+				SELECT 1 FROM user_watch_history h
+				WHERE h.user_id = $1 AND h.profile_id = $2
+				  AND h.media_item_id = e.content_id AND h.completed
+				`+completedHistoryVisibleSQL+`
+			)
+		) AS completed
+		FROM unnest($3::text[]) AS parents(parent_id)`, parentColumn)
+	rows, err := s.pool.Query(ctx, query, s.userID, profileID, parentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("loading episode parent completion: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var parentID string
+		var completed bool
+		if err := rows.Scan(&parentID, &completed); err != nil {
+			return nil, fmt.Errorf("scanning episode parent completion: %w", err)
+		}
+		result[parentID] = completed
+	}
+	return result, rows.Err()
+}

--- a/internal/userstore/progress_helpers.go
+++ b/internal/userstore/progress_helpers.go
@@ -134,6 +134,17 @@ type SeriesEpisodeRollupStore interface {
 	SeriesEpisodeWatchCounts(ctx context.Context, profileID string, seriesIDs []string) (map[string]SeriesWatchCounts, error)
 }
 
+// EpisodeParentCompletionStore determines whether every available episode of a
+// series or season is completed. Empty parents are not completed. Implementations
+// must use the same progress and completed-history visibility rules as
+// ListProgressWithCompletedHistory, and count episode-library membership as
+// availability, including missing files. Callers needing only a played flag can
+// stop at the first incomplete episode instead of materializing all child IDs.
+type EpisodeParentCompletionStore interface {
+	SeriesCompletion(ctx context.Context, profileID string, seriesIDs []string) (map[string]bool, error)
+	SeasonCompletion(ctx context.Context, profileID string, seasonIDs []string) (map[string]bool, error)
+}
+
 // CompletedHistoryItemMap returns the latest completed-history item row for a
 // scoped item query. Lookup failures degrade to an empty map so user-data
 // enrichment can keep returning progress rows.


### PR DESCRIPTION
## Problem

Related issue: #965

Rendering series and season cards loads every available child episode's metadata just to determine whether the parent is played. Long series make this response assembly unnecessarily expensive.

## Approach

Let PostgreSQL answer parent completion directly, stopping at the first incomplete available episode. Preserve completed progress, visible completed history, hidden-history watermarks, account/profile scope, and the existing membership definition, including missing files. The notifications provider conditionally forwards this capability alongside device and rollup interfaces. Empty parents remain unplayed. Stores without the optional capability, or queries that fail, use an ID-only fallback instead of hydrating episode models.

## Validation

The fallback's 2,000-episode benchmark reduced allocated bytes from 6.90 MB to 0.423 MB per operation (94%). The PostgreSQL completion query for a sampled 50-show row took a median 3.43 ms; this is a query measurement, not an endpoint before/after claim. The initial endpoint samples used the ID-only fallback because the notifications decorator hid the capability; that integration gap is now fixed. The standalone SQL timing does not establish an endpoint speedup for the newly enabled path.

Database-backed tests compare complete optimized and fallback user-state results through progress/history updates, hidden history, membership changes, missing files, empty parents, duplicate inputs, profile isolation, and optional-query failure. Focused race tests passed; live response parity checks passed for the initial patch. The decorator follow-up passed the full notifications suite, race tests, and changed-line lint, with coverage of all eight device/rollup/completion capability combinations and retained mutation hooks.

Full pre-PR gate passed on the combined changes: Go build, gofmt, vet, changed-line golangci-lint, and make test-go; web frozen install, lint, format, build, and tests; settings bindings, playback fixtures, and local-path checks. The initial playback timing failure passed five isolated retries and the full rerun. Database-backed regression tests ran separately; a broader PostgreSQL catalog run retains the previously reproduced baseline failure in TestEpisodeSearchPostgresAndDocumentSource (nil recommendation vector).

## Risks

Fully completed series still require checking every available episode. This adds an internal store capability; the API contract and client behavior are unchanged.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell and multi-agent collaboration tools; GitHub CLI; Modern Go Guidelines CLI.
- Model(s): `gpt-6-astra` for implementation and independent review.
- Involvement: AI-assisted at the maintainer's request; implementation and testing performed by Codex, pending maintainer review.
- Adversarial review: Independent Codex review read the complete diff, existing completion/history SQL, access and snapshot handling, pagination/history integration, manga scanning, and read-model maintenance triggers. The initial independent review found no defects. Automated PR review then identified the missing notifications-decorator capability forwarding; it was fixed and independently checked against all wrapper combinations and mutation hooks. The reviewer also checked the lint-only constant change and parent-cascade test correction.
