### PR TITLE
perf(catalog): hydrate only the requested episode page

### DIFF
--- a/internal/catalog/browse.go
+++ b/internal/catalog/browse.go
@@ -1355,14 +1355,14 @@ func browseItemColumns(alias string) string {
 // mangaCountColumns returns two index-backed correlated subqueries feeding the
 // "X Volumes · X Chapters" poster chip: distinct volume tokens (many chapter
 // rows can share one volume) and loose chapter rows without a volume token.
-// They return 0 for non-manga rows (no matching manga_chapters), which the
-// scan path nils out so only manga cards carry the counts. The subqueries are
-// functionally dependent on alias.content_id (the media_items PK, which leads
+// Only manga rows need these lookups. The scan path already nils the counts
+// for other types; the CASE avoids doing that discarded work in mixed scopes.
+// The subqueries depend on alias.content_id (the media_items PK, which leads
 // browseGroupByColumns), so they remain valid under the dedup GROUP BY without
 // being listed there.
 func mangaCountColumns(alias string) string {
-	return "(SELECT count(*) FROM manga_chapters mc WHERE mc.series_content_id = " + alias + ".content_id AND (mc.volume IS NULL OR mc.volume = '')) AS manga_chapter_count, " +
-		"(SELECT count(DISTINCT mc.volume) FROM manga_chapters mc WHERE mc.series_content_id = " + alias + ".content_id AND mc.volume IS NOT NULL AND mc.volume <> '') AS manga_volume_count"
+	return "CASE WHEN " + alias + ".type = 'manga' THEN (SELECT count(*) FROM manga_chapters mc WHERE mc.series_content_id = " + alias + ".content_id AND (mc.volume IS NULL OR mc.volume = '')) END AS manga_chapter_count, " +
+		"CASE WHEN " + alias + ".type = 'manga' THEN (SELECT count(DISTINCT mc.volume) FROM manga_chapters mc WHERE mc.series_content_id = " + alias + ".content_id AND mc.volume IS NOT NULL AND mc.volume <> '') END AS manga_volume_count"
 }
 
 // nullMangaCountColumns substitutes NULL placeholders for the manga count

--- a/internal/catalog/episode_page_hydration_db_test.go
+++ b/internal/catalog/episode_page_hydration_db_test.go
@@ -1,0 +1,119 @@
+package catalog
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDeferredEpisodeHydrationMatchesOriginalPage(t *testing.T) {
+	repo, seriesID, _ := seedCompletionEpisodes(t, 9)
+	_, otherSeriesID, _ := seedCompletionEpisodes(t, 5)
+	ctx := t.Context()
+	var folderID int
+	if err := repo.pool.QueryRow(ctx, `SELECT media_folder_id FROM episode_libraries el JOIN episodes e ON e.content_id=el.episode_id WHERE e.series_id=$1 ORDER BY media_folder_id LIMIT 1`, seriesID).Scan(&folderID); err != nil {
+		t.Fatal(err)
+	}
+	for _, stmt := range []struct {
+		sql  string
+		args []any
+	}{
+		{`INSERT INTO media_item_libraries (content_id,media_folder_id) VALUES ($1,$2) ON CONFLICT DO NOTHING`, []any{seriesID, folderID}},
+		{`UPDATE media_items SET content_rating=CASE WHEN content_id=$1 THEN 'PG' ELSE 'R' END WHERE content_id=ANY($2)`, []any{seriesID, []string{seriesID, otherSeriesID}}},
+		{`UPDATE episodes SET title=CASE WHEN episode_number%3=0 THEN '' WHEN episode_number%2=0 THEN 'Same Title' ELSE title END,
+    created_at='2026-01-01'::timestamptz + episode_number*interval '1 hour' WHERE series_id=ANY($1)`, []any{[]string{seriesID, otherSeriesID}}},
+	} {
+		if _, err := repo.pool.Exec(ctx, stmt.sql, stmt.args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := repo.ListIDsBySeriesIDs(ctx, []string{seriesID, otherSeriesID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := append(rows[seriesID], rows[otherSeriesID]...)
+	cutoff := time.Date(2026, 1, 1, 5, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name     string
+		access   AccessFilter
+		snapshot *time.Time
+		cap      *int
+	}{
+		{name: "unrestricted", access: AccessFilter{AllowedContentIDs: ids}},
+		{name: "rating", access: AccessFilter{AllowedContentIDs: ids, MaxContentRating: "PG"}},
+		{name: "library", access: AccessFilter{AllowedContentIDs: ids, AllowedLibraryIDs: []int{folderID}}},
+		{name: "denied-library", access: AccessFilter{AllowedContentIDs: ids, DisabledLibraryIDs: []int{folderID}}},
+		{name: "no-libraries", access: AccessFilter{AllowedContentIDs: ids, AllowedLibraryIDs: []int{}}},
+		{name: "no-items", access: AccessFilter{AllowedContentIDs: []string{}}},
+		{name: "title-prefix", access: AccessFilter{AllowedContentIDs: ids, NamePrefix: "Same"}},
+		{name: "snapshot", access: AccessFilter{AllowedContentIDs: ids}, snapshot: &cutoff},
+		{name: "capped", access: AccessFilter{AllowedContentIDs: ids}, cap: new(4)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, order := range []string{"asc", "desc"} {
+				for _, offset := range []int{1, 4, 20} {
+					def := QueryDefinition{MediaScope: "episode", Sort: QuerySort{Field: "title", Order: order}, Limit: tc.cap}
+					executor := &QueryExecutor{Pool: repo.pool, Scope: "episode", SnapshotAt: tc.snapshot}
+					plan, err := executor.buildPreviewPagePlan(def, tc.access, 3, offset)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !plan.deferEpisodeHydration {
+						t.Fatal("expected deferred hydration")
+					}
+					original := plan
+					original.deferEpisodeHydration = false
+					for _, includeTotal := range []bool{false, true} {
+						got, total, more, err := executor.executePreviewPagePlan(t.Context(), plan, includeTotal)
+						if err != nil {
+							t.Fatal(err)
+						}
+						want, wantTotal, wantMore, err := executor.executePreviewPagePlan(t.Context(), original, includeTotal)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if !reflect.DeepEqual(got, want) || total != wantTotal || more != wantMore {
+							t.Fatalf("page changed: order=%s offset=%d includeTotal=%v; got total=%d more=%v, want total=%d more=%v", order, offset, includeTotal, total, more, wantTotal, wantMore)
+						}
+					}
+				}
+			}
+		})
+	}
+	// A metadata edit between requests must be visible; there is no added cache.
+	if _, err := repo.pool.Exec(ctx, `UPDATE episodes SET overview='Updated overview' WHERE series_id=$1`, seriesID); err != nil {
+		t.Fatal(err)
+	}
+	items, _, _, err := (&QueryExecutor{Pool: repo.pool, Scope: "episode"}).PreviewPage(t.Context(), QueryDefinition{MediaScope: "episode", Sort: QuerySort{Field: "title", Order: "asc"}}, AccessFilter{AllowedContentIDs: rows[seriesID]}, 3, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) == 0 {
+		t.Fatal("expected an updated page")
+	}
+	for _, item := range items {
+		if item.Overview != "Updated overview" {
+			t.Fatal("stale metadata")
+		}
+	}
+}
+
+func TestDeferredEpisodeHydrationScope(t *testing.T) {
+	for _, tc := range []struct {
+		scope, sort string
+		offset      int
+		want        bool
+	}{
+		{"episode", "title", 20, true}, {"episode", "title", 0, false},
+		{"movie", "title", 20, false}, {"manga", "title", 20, false},
+		{"episode", "year", 20, false}, {"episode", "added_at", 20, false},
+	} {
+		plan, err := (&QueryExecutor{Scope: tc.scope}).buildPreviewPagePlan(QueryDefinition{MediaScope: tc.scope, Sort: QuerySort{Field: tc.sort}}, AccessFilter{}, 20, tc.offset)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if plan.deferEpisodeHydration != tc.want {
+			t.Fatalf("scope=%s sort=%s offset=%d: deferred=%v, want %v", tc.scope, tc.sort, tc.offset, plan.deferEpisodeHydration, tc.want)
+		}
+	}
+}

--- a/internal/catalog/manga_counts_db_test.go
+++ b/internal/catalog/manga_counts_db_test.go
@@ -1,0 +1,66 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestMixedCatalogMangaCounts(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	pool, err := pgxpool.New(t.Context(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("manga-counts-%d", time.Now().UnixNano())
+	manga, empty, movie, ebook := prefix+"-manga", prefix+"-empty", prefix+"-movie", prefix+"-ebook"
+	ids := []string{manga, empty, movie, ebook}
+	for i := range 5 {
+		ids = append(ids, fmt.Sprintf("%s-chapter-%d", prefix, i))
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id=ANY($1)`, ids)
+	})
+	if _, err := pool.Exec(t.Context(), `INSERT INTO media_items (content_id,type,title)
+   VALUES ($1,'manga','A'),($2,'manga','B'),($3,'movie','C'),($4,'ebook','D')`, manga, empty, movie, ebook); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(t.Context(), `INSERT INTO media_items (content_id,type,title) SELECT id,'ebook','Chapter' FROM unnest($1::text[]) id`, ids[4:]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(t.Context(), `INSERT INTO manga_chapters (chapter_content_id,series_content_id,volume)
+   VALUES ($1,$6,NULL),($2,$6,''),($3,$6,'1'),($4,$6,'1'),($5,$6,'2')`, ids[4], ids[5], ids[6], ids[7], ids[8], manga); err != nil {
+		t.Fatal(err)
+	}
+	items, total, more, err := (&QueryExecutor{Pool: pool}).PreviewPage(t.Context(), QueryDefinition{}, AccessFilter{AllowedContentIDs: ids}, 20, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 4 || total != 4 || more {
+		t.Fatalf("page = %d items, total %d, more %v; want 4/4/false", len(items), total, more)
+	}
+	for _, item := range items {
+		switch item.ContentID {
+		case manga:
+			if item.MangaChapterCount == nil || *item.MangaChapterCount != 2 || item.MangaVolumeCount == nil || *item.MangaVolumeCount != 2 {
+				t.Fatalf("manga counts = %v/%v, want 2/2", item.MangaChapterCount, item.MangaVolumeCount)
+			}
+		case empty:
+			if item.MangaChapterCount == nil || *item.MangaChapterCount != 0 || item.MangaVolumeCount == nil || *item.MangaVolumeCount != 0 {
+				t.Fatal("empty manga must retain explicit zero counts")
+			}
+		default:
+			if item.MangaChapterCount != nil || item.MangaVolumeCount != nil {
+				t.Fatal("non-manga item must omit counts")
+			}
+		}
+	}
+}

--- a/internal/catalog/query_executor.go
+++ b/internal/catalog/query_executor.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Silo-Server/silo-server/internal/models"
 )
 
+const querySortTitle = "title"
+
 type QueryExecutor struct {
 	Pool  *pgxpool.Pool
 	Scope string
@@ -433,7 +435,7 @@ func (e *QueryExecutor) buildPreviewPagePlan(
 		// paths. Only the built-in episode relation guarantees the unique IDs
 		// and simple, deterministic title sort required by deferred hydration.
 		deferEpisodeHydration: isEpisodeCatalogScope(effectiveScope) && offset > 0 &&
-			NormalizeQuerySort(def.Sort).Field == "title" && len(sortPlan.Joins) == 0 && len(ctes) == 0,
+			NormalizeQuerySort(def.Sort).Field == querySortTitle && len(sortPlan.Joins) == 0 && len(ctes) == 0,
 	}, nil
 }
 

--- a/internal/catalog/query_executor.go
+++ b/internal/catalog/query_executor.go
@@ -140,15 +140,16 @@ type previewPagePlan struct {
 	fromClausePaged string
 	// fromClauseCount is the FROM clause for exact totals. It includes filter
 	// joins, but intentionally excludes sort-only joins.
-	fromClauseCount string
-	whereClause     string
-	args            []any
-	orderBy         string
-	sortArgs        []any
-	limit           int
-	offset          int
-	maxResults      int
-	limitArgIdx     int
+	fromClauseCount       string
+	whereClause           string
+	args                  []any
+	orderBy               string
+	sortArgs              []any
+	limit                 int
+	offset                int
+	maxResults            int
+	limitArgIdx           int
+	deferEpisodeHydration bool
 }
 
 // countSQL renders a count-only query that returns the total number of rows
@@ -209,6 +210,21 @@ func (p previewPagePlan) pagedSQL(includeTotal bool) (string, []any) {
 	withClause := ""
 	if len(p.ctes) > 0 {
 		withClause = "WITH " + strings.Join(p.ctes, ",\n") + "\n"
+	}
+	// Source-specific builders can add CTEs after the base plan is built.
+	// Keep those plans on the original renderer with their complete bindings.
+	if p.deferEpisodeHydration && len(p.ctes) == 0 {
+		// The episode base has one row per content ID. Selecting those IDs
+		// first lets PostgreSQL prune metadata/season joins from the skipped
+		// prefix. Hydrate and sort only the selected page in the same statement
+		// snapshot; the original title order includes the content-ID tie-break.
+		sql := fmt.Sprintf(`WITH page_ids AS MATERIALIZED (
+			SELECT mi.content_id %s %s %s LIMIT $%d%s
+		) SELECT %s %s
+		JOIN page_ids ON page_ids.content_id = mi.content_id
+		%s`, p.fromClausePaged, p.whereClause, p.orderBy, p.limitArgIdx, offsetClause,
+			selectList, p.fromClausePaged, p.orderBy)
+		return sql, args
 	}
 	sql := fmt.Sprintf(
 		`%sSELECT %s %s %s %s LIMIT $%d%s`,
@@ -413,6 +429,11 @@ func (e *QueryExecutor) buildPreviewPagePlan(
 		offset:          offset,
 		maxResults:      maxResults,
 		limitArgIdx:     limitArgIdx,
+		// Keep non-episode relations, sort joins and history CTEs on their existing
+		// paths. Only the built-in episode relation guarantees the unique IDs
+		// and simple, deterministic title sort required by deferred hydration.
+		deferEpisodeHydration: isEpisodeCatalogScope(effectiveScope) && offset > 0 &&
+			NormalizeQuerySort(def.Sort).Field == "title" && len(sortPlan.Joins) == 0 && len(ctes) == 0,
 	}, nil
 }
 


### PR DESCRIPTION
## Problem

Related issue: #965

Deep episode title pages hydrate metadata for the skipped prefix, and non-manga rows run manga count subqueries whose results are discarded.

## Approach

Select episode IDs with the existing filters, ordering, and pagination before hydrating the requested page in the same SQL statement. Limit this path to episode title sorts with a positive offset and no sort joins or history CTEs. Evaluate manga counts only for manga rows, preserving explicit zero counts there and omitted fields elsewhere.

## Validation

On a million-result episode catalog, the median HTTP time at offset 500,000 with totals disabled fell from 7.78 s to 3.57 s across three samples per deployment. Ordered normalized responses matched. Shallow-page SQL timings were essentially unchanged; offset traversal still grows with the skipped prefix.

Database tests compare complete models, totals, and has_more with the original renderer across ascending/descending and tied/blank titles, access restrictions, library scopes, snapshots, prefixes, caps, and empty pages. Mixed manga tests preserve count and field-omission behavior. Focused race and history regression tests passed.

Full pre-PR gate passed on the combined changes: Go build, gofmt, vet, changed-line golangci-lint, and make test-go; web frozen install, lint, format, build, and tests; settings bindings, playback fixtures, and local-path checks. The initial playback timing failure passed five isolated retries and the full rerun. Database-backed regression tests ran separately; a broader PostgreSQL catalog run retains the previously reproduced baseline failure in TestEpisodeSearchPostgresAndDocumentSource (nil recommendation vector).

## Risks

The optimization relies on unique episode IDs and deterministic title ordering. Other sorts and history plans retain the original renderer. This preserves the API contract; it does not introduce cursor pagination.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell and multi-agent collaboration tools; GitHub CLI; Modern Go Guidelines CLI.
- Model(s): `gpt-6-astra` for implementation and independent review.
- Involvement: AI-assisted at the maintainer's request; implementation and testing performed by Codex, pending maintainer review.
- Adversarial review: Independent Codex review read the complete diff, existing completion/history SQL, access and snapshot handling, pagination/history integration, manga scanning, and read-model maintenance triggers. No correctness defects found. The reviewer also checked the lint-only constant change and parent-cascade test correction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Catalog previews now display chapter and volume counts for manga entries, including explicit zero counts when applicable.
  - Non-manga catalog entries no longer display manga-specific chapter or volume counts.
  - Episode catalog pages with offsets now load selected results more efficiently while preserving filtering, sorting, pagination, snapshots, and total-count behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->