### PR TITLE
perf(catalog): cover recently added TV parent lookups

### DIFF
--- a/migrations/sql/20260905192000_cover_recent_tv_episode_series.sql
+++ b/migrations/sql/20260905192000_cover_recent_tv_episode_series.sql
@@ -1,0 +1,28 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- TV availability grouping needs only the episode ID and its parent series.
+-- Cover those reads without fetching metadata from every matching episode.
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'idx_episodes_content_series'
+          AND NOT i.indisvalid
+    ) THEN
+        DROP INDEX public.idx_episodes_content_series;
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_episodes_content_series
+    ON public.episodes (content_id) INCLUDE (series_id);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_episodes_content_series;


### PR DESCRIPTION
## Problem

Related issue: #965

Recently Added TV groups episode availability by parent series and scan run. Looking up each parent through the episode primary key fetches wide metadata rows across large libraries.

## Approach

Add a concurrent index on episodes(content_id) including series_id. This extends the performance investigation with an index-only schema change; query semantics are unchanged. The Goose migration removes an invalid index left by an interrupted build before retrying and supplies a concurrent down migration.

## Validation

An isolated index trial reduced the main-library query median from 2,177 to 1,455 ms and shared-buffer accesses from about 8.07 million to 4.07 million. A three-library query improved from 2,591 to 2,194 ms. These are PostgreSQL execution times from three samples per case, not HTTP or p95 claims.

Before/after ordered API responses, counts, card types, playback targets, and user state matched. Migration up/down/up and index validity checks passed. Recently Added TV and scanner membership/provenance regression tests passed, and the index was validated in a running development deployment.

Full pre-PR gate passed on the combined changes: Go build, gofmt, vet, changed-line golangci-lint, and make test-go; web frozen install, lint, format, build, and tests; settings bindings, playback fixtures, and local-path checks. The initial playback timing failure passed five isolated retries and the full rerun. Database-backed regression tests ran separately; a broader PostgreSQL catalog run retains the previously reproduced baseline failure in TestEpisodeSearchPostgresAndDocumentSource (nil recommendation vector).

## Risks

The index occupied approximately 137 MB on the measured dataset and adds write maintenance; scanner throughput was not benchmarked. Event aggregation still scans the library on a cache miss. Maintained event summaries remain separate follow-up work.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tool(s): Codex shell and multi-agent collaboration tools; GitHub CLI; Modern Go Guidelines CLI.
- Model(s): `gpt-6-astra` for implementation and independent review.
- Involvement: AI-assisted at the maintainer's request; implementation and testing performed by Codex, pending maintainer review.
- Adversarial review: Independent Codex review read the complete diff, existing completion/history SQL, access and snapshot handling, pagination/history integration, manga scanning, and read-model maintenance triggers. No correctness defects found. The reviewer also checked the lint-only constant change and parent-cascade test correction.
