### PR TITLE
fix(artwork): remove availability probes from catalog reads

### DIFF
--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1640,6 +1640,9 @@ func main() {
 				presignTTL = 4 * time.Hour
 			}
 			imageResolver.SetS3Presigner(deps.S3Public, deps.S3Public.EffectivePresignTTL(presignTTL))
+			imageResolver.SetArtworkAvailabilityReader(metadata.NewArtworkDeliveryStore(
+				deps.DB, deps.S3Public.ArtworkDeliveryScope(), deps.S3Public.UsesExternalDelivery(),
+			))
 		}
 		deps.ImageResolver = imageResolver
 		deps.PluginImageResolver = imageResolver
@@ -2537,6 +2540,10 @@ func main() {
 			taskMgr.Register(tasks.NewBackfillMetadataImagesTask(metadataImageCacheProcessor))
 		}
 		if deps.S3Public != nil {
+			taskMgr.Register(tasks.NewVerifyArtworkDeliveryTask(
+				metadata.NewArtworkDeliveryStore(deps.DB, deps.S3Public.ArtworkDeliveryScope(), deps.S3Public.UsesExternalDelivery()),
+				deps.S3Public,
+			))
 			identity := tasks.ArtworkStorageIdentity(cfg.S3.Public.Endpoint, cfg.S3.Public.Bucket, cfg.S3.Public.KeyPrefix)
 			// Seed the fingerprint on first boot. After a provider change the
 			// stored (old) identity survives this call, so the startup preflight

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -81,6 +81,7 @@ GET /api/v1/images/capability
 {
   "schema_version": 1,
   "param": "image_size",
+  "season_list_artwork_param": "include_artwork",
   "sizes": ["small", "medium", "large", "original"],
   "widths": {
     "poster": { "small": 300, "medium": 500, "large": 780 },
@@ -96,30 +97,49 @@ GET /api/v1/images/capability
 A `404` here means the server predates `image_size`. Keep using the server's
 defaults rather than sending a parameter it will ignore.
 
-## Fallback while artwork is being regenerated
+## Publication and fallback
 
-The wide rungs (780px posters and stills, 1280px logos) were added after this
-ladder shipped, so artwork cached by an earlier version has no object at those
-keys. A one-shot background pass regenerates it, and until that pass reaches a
-given image the server serves the next narrower rung it does have, ending at the
-original. With public or token-authenticated delivery, the server checks the
-same client-facing GET path rather than treating an S3 storage HEAD as proof
-that the public URL works.
+Catalog reads select cached artwork from durable publication and delivery
+records. They never issue storage HEAD requests or fetch artwork delivery URLs.
+The publisher records the exact variant keys after every upload succeeds;
+partially uploaded revisions are not advertised. The revision remains part of
+each key, so an old manifest cannot establish availability for new artwork.
 
-The practical consequence for a client is that shortly after a server upgrade,
-`image_size=large` may return an image narrower than the table above. The server
-validates the selected URL through its own delivery route and falls back
-automatically; no client action is required to pick up the correct width once
-the pass completes. URLs served from a fallback carry a shortened expiry so the
-real rung is picked up promptly rather than a day later. Externally delivered
-wide-rung URLs are also revalidated on that shorter cadence, because public
-delivery health can change independently of the backing object. The first
-delivery error in a batch stops later entries from probing the same failing
-endpoint, bounding browse latency during an outage. This safe fallback is why
-the capability endpoint can continue advertising the `large` request semantic
-while a deployment's wide-rung backfill is incomplete. The check does not prove
-client renderability or delivery from every CDN edge; a remote client may still
-reach an edge with transient edge-local state.
+A bounded background task verifies both storage and the client-facing GET path.
+Publication makes a revision eligible for verification. Workers claim up to 100
+revisions per run, use at most 12 concurrent checks, and stop after one minute.
+Completed checks become eligible again after 15 minutes; a large backlog can
+extend that interval. A worker failure leaves a recoverable two-minute lease.
+Delivery verification is scoped to the storage and delivery configuration.
+Transport errors preserve the last completed verdict and are retried. Confirmed
+storage loss schedules image caching for regenerable provider artwork while
+retaining catalog pointers and surviving variants;
+delivery-only failures retain the catalog pointers and are checked again.
+
+Before external delivery is verified, the server avoids newly added wide rungs
+and selects a published smaller size or original. Legacy artwork without a
+publication manifest uses an established smaller size until the ladder backfill
+regenerates it. A completed delivery check restricts selection to working keys.
+If none remain, the URL is empty and the client should display its placeholder.
+Images can still fail at a particular client or CDN edge; this must not prevent
+rendering titles, episode counts, progress, or navigation.
+
+`image_size=large` expresses the preferred size; the response may contain a
+smaller variant. The server caches resolved artwork URLs for at most five minutes
+so background recovery becomes visible without waiting for signature expiry.
+Cold resolver caches read the same durable records and never rediscover image
+availability through network probes.
+
+## Season selectors without artwork
+
+`GET /api/v1/catalog/series/{id}/seasons?include_artwork=false` skips poster URL
+preparation and omits poster thumbhashes. Season metadata, counts, and user data
+are unchanged. The default is `true`. Invalid boolean values return
+`400 invalid_include_artwork`.
+
+The images capability response advertises this option as
+`"season_list_artwork_param": "include_artwork"`. tvOS uses it for text-only
+season selectors; clients that render season posters should keep the default.
 
 ## Jellyfin compatibility
 
@@ -127,3 +147,8 @@ The Jellyfin-protocol surface maps its own `MaxWidth`/`MaxHeight`/`FillWidth`/
 `FillHeight` parameters onto the same ladder: up to 320px is `small`, 780px to
 1199px is `large`, 1200px and above is `original`, and everything else is
 `medium`.
+
+The shared cached-artwork resolver applies the same persisted availability
+selection to Jellyfin image URL resolution. Its protocol parameters and image
+response shapes are unchanged; image fetching remains independent of catalog
+metadata responses.

--- a/docs/images-api.md
+++ b/docs/images-api.md
@@ -99,6 +99,9 @@ defaults rather than sending a parameter it will ignore.
 
 ## Publication and fallback
 
+Historical GC manifests are verified in the background before they become
+publication records; their listed keys alone do not prove upload completion.
+
 Catalog reads select cached artwork from durable publication and delivery
 records. They never issue storage HEAD requests or fetch artwork delivery URLs.
 The publisher records the exact variant keys after every upload succeeds;

--- a/internal/api/handlers/catalog_resources.go
+++ b/internal/api/handlers/catalog_resources.go
@@ -214,6 +214,11 @@ func (h *CatalogResourceHandler) HandleGetItemEpisodes(w http.ResponseWriter, r 
 }
 
 func (h *CatalogResourceHandler) HandleGetSeasons(w http.ResponseWriter, r *http.Request) {
+	includeArtwork, valid := seasonListArtwork(r)
+	if !valid {
+		writeError(w, http.StatusBadRequest, "invalid_include_artwork", "include_artwork must be true or false")
+		return
+	}
 	filter, ok := h.items.accessFilterOrError(w, r)
 	if !ok {
 		return
@@ -261,6 +266,16 @@ func (h *CatalogResourceHandler) HandleGetSeasons(w http.ResponseWriter, r *http
 			}
 			progressMap, hasProgressMap := h.items.progressMapForEpisodes(r, flattenEpisodeGroups(episodesBySeason))
 
+			var posterURLs map[string]catalog.ResolvedImageURL
+			if includeArtwork && h.items.detailSvc != nil {
+				paths := make([]string, 0, len(seasons))
+				for _, season := range seasons {
+					if len(episodesBySeason[season.SeasonNumber]) > 0 && season.PosterPath != "" {
+						paths = append(paths, sizedPosterPath(season.PosterPath, filter.ImageSize))
+					}
+				}
+				posterURLs = h.items.detailSvc.PresignURLsWithExpiry(r.Context(), paths, requestVariantHint("featured", filter.ImageSize))
+			}
 			resp := make([]seasonResponse, 0, len(seasons))
 			for _, s := range seasons {
 				episodes := episodesBySeason[s.SeasonNumber]
@@ -271,7 +286,14 @@ func (h *CatalogResourceHandler) HandleGetSeasons(w http.ResponseWriter, r *http
 				if hasProgressMap {
 					userData = catalog.EpisodeRollupUserData(episodes, progressMap)
 				}
-				sr := h.items.seasonResponseFromEpisodes(r, s, episodes, userData, filter.ImageSize)
+				// Construct metadata without resolving each season again.
+				season := *s
+				season.PosterPath = ""
+				if !includeArtwork {
+					season.PosterThumbhash = ""
+				}
+				sr := h.items.seasonResponseFromEpisodes(r, &season, episodes, userData, filter.ImageSize)
+				sr.PosterURL = posterURLs[sizedPosterPath(s.PosterPath, filter.ImageSize)].URL
 				resp = append(resp, sr)
 			}
 
@@ -619,4 +641,14 @@ func (h *CatalogResourceHandler) enrichViewerState(r *http.Request, detail *cata
 	}
 
 	detail.UserRating = &rating.Rating
+}
+
+// seasonListArtwork allows text-only selectors to omit all poster preparation.
+func seasonListArtwork(r *http.Request) (bool, bool) {
+	value := r.URL.Query().Get("include_artwork")
+	if value == "" {
+		return true, true
+	}
+	include, err := strconv.ParseBool(value)
+	return include, err == nil
 }

--- a/internal/api/handlers/catalog_seasons_artwork_test.go
+++ b/internal/api/handlers/catalog_seasons_artwork_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/access"
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/scanner"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type seasonsNoProbeStore struct {
+	t     *testing.T
+	signs int
+}
+
+func (s *seasonsNoProbeStore) Bucket() string             { return "test" }
+func (s *seasonsNoProbeStore) UsesExternalDelivery() bool { return true }
+func (s *seasonsNoProbeStore) PresignGetURL(_ context.Context, _, key string, _ time.Duration) (string, error) {
+	s.signs++
+	return "https://images.example/" + key, nil
+}
+func (s *seasonsNoProbeStore) ObjectExists(context.Context, string, string) (bool, error) {
+	s.t.Fatal("metadata probed storage")
+	return false, nil
+}
+func (s *seasonsNoProbeStore) ObjectAvailable(context.Context, string, string) (bool, error) {
+	s.t.Fatal("metadata probed delivery")
+	return false, nil
+}
+
+func TestSeasonListArtworkHTTP(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := t.Context()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("season-artwork-%d", time.Now().UnixNano())
+	var library int
+	if err := pool.QueryRow(ctx, `INSERT INTO media_folders(type,name) VALUES('tv',$1) RETURNING id`, prefix).Scan(&library); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_folders WHERE id=$1`, library)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id LIKE $1`, prefix+"%")
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path LIKE $1`, "tmdb/series/"+prefix+"/%")
+	})
+	if _, err := pool.Exec(ctx, `INSERT INTO media_items(content_id,type,title,genres,default_metadata_language) VALUES($1,'series','Synthetic Series','{}','en')`, prefix); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO media_item_libraries(content_id,media_folder_id) VALUES($1,$2)`, prefix, library); err != nil {
+		t.Fatal(err)
+	}
+	seasons := catalog.NewSeasonRepository(pool)
+	episodes := catalog.NewEpisodeRepository(pool)
+	for i := range 38 {
+		id := fmt.Sprintf("%s-S%02d", prefix, i)
+		poster := fmt.Sprintf("tmdb/series/%s/seasons/%d/poster/original.rev.webp", prefix, i%37)
+		if err := seasons.Upsert(ctx, &models.Season{ContentID: id, SeriesID: prefix, SeasonNumber: i, Title: fmt.Sprintf("Season %d", i), PosterPath: poster, PosterThumbhash: "placeholder", DefaultMetadataLanguage: "en"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := episodes.Upsert(ctx, &models.Episode{ContentID: id + "-E1", SeriesID: prefix, SeasonID: id, SeasonNumber: i, EpisodeNumber: 1, Title: "Episode", DefaultMetadataLanguage: "en"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pool.Exec(ctx, `INSERT INTO episode_libraries(episode_id,media_folder_id) VALUES($1,$2)`, id+"-E1", library); err != nil {
+			t.Fatal(err)
+		}
+	}
+	itemsRepo := catalog.NewItemRepository(pool)
+	var baseline []seasonResponse
+	for _, size := range []string{"small", "large"} {
+		for _, include := range []string{"true", "false"} {
+			t.Run(size+"/"+include, func(t *testing.T) {
+				resolver := metadata.NewPluginImageResolver()
+				t.Cleanup(resolver.Close)
+				storage := &seasonsNoProbeStore{t: t}
+				resolver.SetS3Presigner(storage, time.Hour)
+				resolver.SetArtworkAvailabilityReader(metadata.NewArtworkDeliveryStore(pool, "test", true))
+				svc := catalog.NewDetailService(itemsRepo, episodes, seasons, catalog.NewPersonRepository(pool), scanner.NewFileRepository(pool))
+				svc.SetImageResolver(resolver)
+				items := &ItemsHandler{itemRepo: itemsRepo, seasonRepo: seasons, episodeRepo: episodes, detailSvc: svc}
+				router := chi.NewRouter()
+				router.Get("/series/{id}/seasons", NewCatalogResourceHandler(items).HandleGetSeasons)
+				req := httptest.NewRequest(http.MethodGet, "/series/"+prefix+"/seasons?image_size="+size+"&include_artwork="+include, nil).WithContext(access.SetScope(t.Context(), access.Scope{}))
+				rec := httptest.NewRecorder()
+				started := time.Now()
+				router.ServeHTTP(rec, req)
+				t.Logf("38-season response: %s", time.Since(started))
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+				}
+				var result seasonsResponse
+				if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+					t.Fatal(err)
+				}
+				if len(result.Seasons) != 38 {
+					t.Fatalf("got %d seasons", len(result.Seasons))
+				}
+				if include == "false" && storage.signs != 0 {
+					t.Fatalf("omitted artwork still signed %d URLs", storage.signs)
+				}
+				if include == "true" && storage.signs != 37 {
+					t.Fatalf("expected 37 distinct posters, signed %d", storage.signs)
+				}
+				for i := range result.Seasons {
+					if include == "false" && (result.Seasons[i].PosterURL != "" || result.Seasons[i].PosterThumbhash != "") {
+						t.Fatal("artwork was not omitted")
+					}
+					result.Seasons[i].PosterURL = ""
+					result.Seasons[i].PosterThumbhash = ""
+				}
+				if baseline == nil {
+					baseline = result.Seasons
+				} else if !reflect.DeepEqual(baseline, result.Seasons) {
+					t.Fatal("non-artwork metadata changed")
+				}
+			})
+		}
+	}
+}

--- a/internal/api/handlers/images_capability.go
+++ b/internal/api/handlers/images_capability.go
@@ -36,7 +36,8 @@ type imageSizeWidths struct {
 // that predates image_size: it should keep using the server's per-context
 // defaults instead of sending a parameter that would be ignored.
 type imagesCapabilityResponse struct {
-	SchemaVersion int `json:"schema_version"`
+	SchemaVersion          int    `json:"schema_version"`
+	SeasonListArtworkParam string `json:"season_list_artwork_param"`
 	// Param is the query parameter name, so a client does not hardcode it.
 	Param string `json:"param"`
 	// Sizes is every value the parameter accepts, narrowest first. Sending
@@ -64,11 +65,12 @@ func HandleImagesCapability(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(imagesCapabilityResponse{
-		SchemaVersion:      1,
-		Param:              imagesize.QueryParam,
-		Sizes:              imagesize.All,
-		Widths:             widths,
-		OriginalMaxWidthPx: imageutil.MaxCachedOriginalDimension,
+		SchemaVersion:          1,
+		SeasonListArtworkParam: "include_artwork",
+		Param:                  imagesize.QueryParam,
+		Sizes:                  imagesize.All,
+		Widths:                 widths,
+		OriginalMaxWidthPx:     imageutil.MaxCachedOriginalDimension,
 	})
 }
 

--- a/internal/api/handlers/images_capability_test.go
+++ b/internal/api/handlers/images_capability_test.go
@@ -30,6 +30,9 @@ func TestHandleImagesCapability(t *testing.T) {
 	if got.Param != "image_size" {
 		t.Errorf("param = %q, want image_size", got.Param)
 	}
+	if got.SeasonListArtworkParam != "include_artwork" {
+		t.Errorf("season artwork parameter = %q", got.SeasonListArtworkParam)
+	}
 	wantSizes := []imagesize.Size{imagesize.Small, imagesize.Medium, imagesize.Large, imagesize.Original}
 	if len(got.Sizes) != len(wantSizes) {
 		t.Fatalf("sizes = %v, want %v", got.Sizes, wantSizes)

--- a/internal/catalog/artwork_selection.go
+++ b/internal/catalog/artwork_selection.go
@@ -73,10 +73,20 @@ func (t *ArtworkRevisionTracker) TrackArtworkRevision(ctx context.Context, origi
 	// exact manifest: the objects exist again once the cacher finishes.
 	_, err := t.pool.Exec(ctx, `
 		INSERT INTO artwork_revision_gc_candidates (
-			original_path, image_type, object_keys, not_before, next_attempt_at
-		) VALUES ($1, $2, $3, $4, $4)
+			original_path, image_type, object_keys, published_keys, not_before, next_attempt_at
+		) VALUES ($1, $2, $3, $3, $4, $4)
 		ON CONFLICT (original_path) DO UPDATE SET
 			object_keys = EXCLUDED.object_keys,
+            published_keys = CASE
+                WHEN cardinality(EXCLUDED.object_keys) > 0 THEN EXCLUDED.object_keys
+                WHEN artwork_revision_gc_candidates.deleted_at IS NOT NULL THEN '{}'::text[]
+                ELSE coalesce(artwork_revision_gc_candidates.published_keys, '{}'::text[]) END,
+            delivery_next_check = NOW(),
+            delivery_lease = '',
+            delivery_keys = CASE WHEN artwork_revision_gc_candidates.deleted_at IS NOT NULL
+                THEN '{}'::text[] ELSE artwork_revision_gc_candidates.delivery_keys END,
+            delivery_checked_at = CASE WHEN artwork_revision_gc_candidates.deleted_at IS NOT NULL
+                THEN NULL ELSE artwork_revision_gc_candidates.delivery_checked_at END,
 			image_type = CASE
 				WHEN artwork_revision_gc_candidates.image_type = '' THEN EXCLUDED.image_type
 				ELSE artwork_revision_gc_candidates.image_type

--- a/internal/metadata/artwork_delivery.go
+++ b/internal/metadata/artwork_delivery.go
@@ -29,7 +29,8 @@ func (s *ArtworkDeliveryStore) ArtworkAvailability(ctx context.Context, paths []
         delivery_scope = $2 AND delivery_checked_at IS NOT NULL
         FROM artwork_revision_gc_candidates
         WHERE original_path = ANY($1)
-          AND (published_keys IS NOT NULL OR deleted_at IS NOT NULL)`, paths, s.scope)
+          AND (published_keys IS NOT NULL OR deleted_at IS NOT NULL
+               OR (delivery_scope = $2 AND delivery_checked_at IS NOT NULL))`, paths, s.scope)
 	if err != nil {
 		return nil, err
 	}
@@ -76,13 +77,13 @@ func (s *ArtworkDeliveryStore) Reconcile(ctx context.Context, checker ArtworkDel
 	lease := uuid.NewString()
 	rows, err := s.pool.Query(ctx, `WITH due AS (
         SELECT id FROM artwork_revision_gc_candidates
-        WHERE deleted_at IS NULL AND cardinality(published_keys) > 0
+        WHERE deleted_at IS NULL AND cardinality(coalesce(published_keys, object_keys)) > 0
           AND delivery_next_check <= NOW()
         ORDER BY delivery_next_check, id LIMIT 100 FOR UPDATE SKIP LOCKED
     ) UPDATE artwork_revision_gc_candidates m
       SET delivery_next_check = NOW() + INTERVAL '2 minutes', delivery_lease = $1
       FROM due WHERE m.id = due.id
-      RETURNING m.id, m.original_path, m.published_keys`, lease)
+      RETURNING m.id, m.original_path, coalesce(m.published_keys, m.object_keys)`, lease)
 	if err != nil {
 		return ArtworkDeliveryStats{}, err
 	}
@@ -160,9 +161,10 @@ func (s *ArtworkDeliveryStore) verifyRevision(ctx context.Context, checker Artwo
 	// overwrite a newer publication or resurrect a garbage-collected revision.
 	tag, err := s.pool.Exec(ctx, `UPDATE artwork_revision_gc_candidates
         SET delivery_keys = $3, delivery_scope = $4, delivery_checked_at = NOW(),
+            published_keys = CASE WHEN published_keys IS NULL AND $6 THEN $5 ELSE published_keys END,
             delivery_next_check = NOW() + INTERVAL '15 minutes', delivery_lease = ''
-        WHERE id = $1 AND delivery_lease = $2 AND published_keys = $5 AND deleted_at IS NULL`,
-		revision.id, lease, available, s.scope, revision.keys)
+        WHERE id = $1 AND delivery_lease = $2 AND coalesce(published_keys, object_keys) = $5 AND deleted_at IS NULL`,
+		revision.id, lease, available, s.scope, revision.keys, !storageMissing)
 	if err != nil {
 		return stats, "", fmt.Errorf("record artwork delivery: %w", err)
 	}

--- a/internal/metadata/artwork_delivery.go
+++ b/internal/metadata/artwork_delivery.go
@@ -1,0 +1,178 @@
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"golang.org/x/sync/errgroup"
+)
+
+// ArtworkDeliveryStore reads publication manifests and reconciles delivery on
+// workers. Scope identifies storage plus the current client-facing URL policy.
+type ArtworkDeliveryStore struct {
+	pool     *pgxpool.Pool
+	scope    string
+	external bool
+}
+
+func NewArtworkDeliveryStore(pool *pgxpool.Pool, scope string, external bool) *ArtworkDeliveryStore {
+	return &ArtworkDeliveryStore{pool: pool, scope: scope, external: external}
+}
+
+func (s *ArtworkDeliveryStore) ArtworkAvailability(ctx context.Context, paths []string) (map[string]ArtworkAvailability, error) {
+	rows, err := s.pool.Query(ctx, `SELECT original_path,
+        CASE WHEN deleted_at IS NULL THEN published_keys ELSE '{}'::text[] END,
+        CASE WHEN deleted_at IS NULL THEN delivery_keys ELSE '{}'::text[] END,
+        delivery_scope = $2 AND delivery_checked_at IS NOT NULL
+        FROM artwork_revision_gc_candidates
+        WHERE original_path = ANY($1)
+          AND (published_keys IS NOT NULL OR deleted_at IS NOT NULL)`, paths, s.scope)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	states := make(map[string]ArtworkAvailability)
+	for rows.Next() {
+		var path string
+		state := ArtworkAvailability{External: s.external}
+		if err := rows.Scan(&path, &state.Published, &state.Deliverable, &state.Verified); err != nil {
+			return nil, err
+		}
+		// For direct S3 delivery a completed check can also detect deletions.
+		if state.Verified {
+			state.External = true
+		}
+		states[path] = state
+	}
+	return states, rows.Err()
+}
+
+type ArtworkDeliveryChecker interface {
+	ObjectExists(context.Context, string, string) (bool, error)
+	ObjectAvailable(context.Context, string, string) (bool, error)
+	Bucket() string
+}
+
+type ArtworkDeliveryStats struct {
+	Checked int `json:"checked"`
+	Missing int `json:"missing"`
+	Errors  int `json:"errors"`
+}
+
+type artworkDeliveryRevision struct {
+	id   int64
+	path string
+	keys []string
+}
+
+// Reconcile checks at most 100 revisions, with 12 workers and a one-minute
+// runtime bound. The durable lease is recoverable after worker/node failure.
+func (s *ArtworkDeliveryStore) Reconcile(ctx context.Context, checker ArtworkDeliveryChecker) (ArtworkDeliveryStats, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	lease := uuid.NewString()
+	rows, err := s.pool.Query(ctx, `WITH due AS (
+        SELECT id FROM artwork_revision_gc_candidates
+        WHERE deleted_at IS NULL AND cardinality(published_keys) > 0
+          AND delivery_next_check <= NOW()
+        ORDER BY delivery_next_check, id LIMIT 100 FOR UPDATE SKIP LOCKED
+    ) UPDATE artwork_revision_gc_candidates m
+      SET delivery_next_check = NOW() + INTERVAL '2 minutes', delivery_lease = $1
+      FROM due WHERE m.id = due.id
+      RETURNING m.id, m.original_path, m.published_keys`, lease)
+	if err != nil {
+		return ArtworkDeliveryStats{}, err
+	}
+	var batch []artworkDeliveryRevision
+	for rows.Next() {
+		var revision artworkDeliveryRevision
+		if err := rows.Scan(&revision.id, &revision.path, &revision.keys); err != nil {
+			rows.Close()
+			return ArtworkDeliveryStats{}, err
+		}
+		batch = append(batch, revision)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return ArtworkDeliveryStats{}, err
+	}
+	results := make([]ArtworkDeliveryStats, len(batch))
+	repairs := make([]string, len(batch))
+	var group errgroup.Group
+	group.SetLimit(12)
+	for i, revision := range batch {
+		group.Go(func() error {
+			var err error
+			results[i], repairs[i], err = s.verifyRevision(ctx, checker, lease, revision)
+			return err
+		})
+	}
+	err = group.Wait()
+	var stats ArtworkDeliveryStats
+	for _, result := range results {
+		stats.Checked += result.Checked
+		stats.Missing += result.Missing
+		stats.Errors += result.Errors
+	}
+	if err == nil {
+		paths := make([]string, 0, len(repairs))
+		for _, path := range repairs {
+			if path != "" {
+				paths = append(paths, path)
+			}
+		}
+		if len(paths) > 0 {
+			err = s.repairMissingRevisions(ctx, paths)
+		}
+	}
+	return stats, err
+}
+
+func (s *ArtworkDeliveryStore) verifyRevision(ctx context.Context, checker ArtworkDeliveryChecker, lease string, revision artworkDeliveryRevision) (ArtworkDeliveryStats, string, error) {
+	stats := ArtworkDeliveryStats{Checked: 1}
+	available := make([]string, 0, len(revision.keys))
+	var storageMissing bool
+	for _, key := range revision.keys {
+		probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		exists, err := checker.ObjectExists(probeCtx, checker.Bucket(), key)
+		if err == nil && exists && s.external {
+			exists, err = checker.ObjectAvailable(probeCtx, checker.Bucket(), key)
+		} else if err == nil && !exists {
+			storageMissing = true
+		}
+		cancel()
+		if err != nil {
+			// Preserve the last completed verdict on transport/auth errors.
+			// The lease expires soon; no catalog pointers are cleared.
+			stats.Errors++
+			return stats, "", nil //nolint:nilerr // Probe failures are counted and retried after the lease; they do not abort other revisions.
+		}
+		if exists {
+			available = append(available, key)
+		} else {
+			stats.Missing++
+		}
+	}
+	// Publishing/re-uploading invalidates the lease. A stale verifier cannot
+	// overwrite a newer publication or resurrect a garbage-collected revision.
+	tag, err := s.pool.Exec(ctx, `UPDATE artwork_revision_gc_candidates
+        SET delivery_keys = $3, delivery_scope = $4, delivery_checked_at = NOW(),
+            delivery_next_check = NOW() + INTERVAL '15 minutes', delivery_lease = ''
+        WHERE id = $1 AND delivery_lease = $2 AND published_keys = $5 AND deleted_at IS NULL`,
+		revision.id, lease, available, s.scope, revision.keys)
+	if err != nil {
+		return stats, "", fmt.Errorf("record artwork delivery: %w", err)
+	}
+	if tag.RowsAffected() > 0 && storageMissing {
+		return stats, revision.path, nil
+	}
+	return stats, "", nil
+}
+
+func (s *ArtworkDeliveryStore) repairMissingRevisions(ctx context.Context, paths []string) error {
+	_, err := NewImageCacheJobRepository(s.pool).EnqueueArtworkRepair(ctx, paths, 100)
+	return err
+}

--- a/internal/metadata/artwork_delivery_test.go
+++ b/internal/metadata/artwork_delivery_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,14 +19,24 @@ type deliveryTestChecker struct {
 	existing    map[string]bool
 	available   map[string]bool
 	err         error
-	beforeCheck func()
+	beforeCheck func() error
+	mu          sync.Mutex
+	hookErr     error
 }
 
 func (c *deliveryTestChecker) Bucket() string { return "test" }
 func (c *deliveryTestChecker) ObjectExists(_ context.Context, _, key string) (bool, error) {
-	if c.beforeCheck != nil {
-		c.beforeCheck()
-		c.beforeCheck = nil
+	c.mu.Lock()
+	hook := c.beforeCheck
+	c.beforeCheck = nil
+	c.mu.Unlock()
+	if hook != nil {
+		if err := hook(); err != nil {
+			c.mu.Lock()
+			c.hookErr = err
+			c.mu.Unlock()
+			return false, err
+		}
 	}
 	if c.existing != nil {
 		return c.existing[key], c.err
@@ -138,9 +150,15 @@ func TestArtworkDeliveryPublicationAndReconciliation(t *testing.T) {
 	track(keys)
 	checker.err = nil
 	checker.available = map[string]bool{}
-	checker.beforeCheck = func() { track(keys) }
+	checker.beforeCheck = func() error { return tracker.TrackArtworkRevision(ctx, original, "poster", keys) }
 	if _, err := store.Reconcile(ctx, checker); err != nil {
 		t.Fatal(err)
+	}
+	checker.mu.Lock()
+	hookErr := checker.hookErr
+	checker.mu.Unlock()
+	if hookErr != nil {
+		t.Fatal(hookErr)
 	}
 	if got := selectPublishedVariant(large, read(), true); got != large {
 		t.Fatalf("stale worker overwrote publication: %q", got)
@@ -188,4 +206,90 @@ func TestArtworkDeliveryPublicationAndReconciliation(t *testing.T) {
 		t.Fatalf("repair status = %s", jobStatus)
 	}
 
+}
+
+func TestDeliveryCheckerConcurrentHook(t *testing.T) {
+	var calls atomic.Int32
+	hookFailure := errors.New("publication failed")
+	checker := &deliveryTestChecker{beforeCheck: func() error {
+		calls.Add(1)
+		return hookFailure
+	}}
+	var group sync.WaitGroup
+	for range 32 {
+		group.Go(func() { _, _ = checker.ObjectExists(t.Context(), "test", "key") })
+	}
+	group.Wait()
+	if calls.Load() != 1 {
+		t.Fatalf("hook called %d times", calls.Load())
+	}
+	if !errors.Is(checker.hookErr, hookFailure) {
+		t.Fatalf("lost hook error: %v", checker.hookErr)
+	}
+}
+
+func TestArtworkDeliveryVerifiesLegacyManifests(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := t.Context()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	prefix := fmt.Sprintf("tmdb/movies/legacy-delivery-%d", time.Now().UnixNano())
+	complete := prefix + "/poster/original.rev.webp"
+	partial := prefix + "/backdrop/original.rev.webp"
+	completeKeys := []string{complete, variantKey(complete, "w780")}
+	partialKeys := []string{partial, variantKey(partial, "w1920")}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path = ANY($1)`, []string{complete, partial})
+	})
+	for path, keys := range map[string][]string{complete: completeKeys, partial: partialKeys} {
+		if _, err := pool.Exec(ctx, `INSERT INTO artwork_revision_gc_candidates(original_path,object_keys,not_before) VALUES($1,$2,NOW())`, path, keys); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store := NewArtworkDeliveryStore(pool, "legacy-endpoint", true)
+	states, err := store.ArtworkAvailability(ctx, []string{complete, partial})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(states) != 0 {
+		t.Fatal("unverified legacy manifests became publication records")
+	}
+	checker := &deliveryTestChecker{
+		existing:  map[string]bool{complete: true, completeKeys[1]: true, partial: true},
+		available: map[string]bool{complete: true, completeKeys[1]: true, partial: true},
+	}
+	if _, err := store.Reconcile(ctx, checker); err != nil {
+		t.Fatal(err)
+	}
+	states, err = store.ArtworkAvailability(ctx, []string{complete, partial})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !states[complete].Verified || len(states[complete].Published) != 2 {
+		t.Fatal("storage-verified legacy artwork was not promoted")
+	}
+	if state := states[partial]; !state.Verified || len(state.Published) != 0 || selectPublishedVariant(partialKeys[1], state, true) != partial {
+		t.Fatal("partial legacy delivery verdict did not select the surviving original")
+	}
+	checker.existing[partialKeys[1]] = true
+	checker.available[partialKeys[1]] = true
+	if _, err := pool.Exec(ctx, `UPDATE artwork_revision_gc_candidates SET delivery_next_check=NOW() WHERE original_path=$1`, partial); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Reconcile(ctx, checker); err != nil {
+		t.Fatal(err)
+	}
+	states, err = store.ArtworkAvailability(ctx, []string{partial})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !states[partial].Verified || len(states[partial].Published) != 2 {
+		t.Fatal("repaired legacy artwork was not promoted")
+	}
 }

--- a/internal/metadata/artwork_delivery_test.go
+++ b/internal/metadata/artwork_delivery_test.go
@@ -1,0 +1,191 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type deliveryTestChecker struct {
+	existing    map[string]bool
+	available   map[string]bool
+	err         error
+	beforeCheck func()
+}
+
+func (c *deliveryTestChecker) Bucket() string { return "test" }
+func (c *deliveryTestChecker) ObjectExists(_ context.Context, _, key string) (bool, error) {
+	if c.beforeCheck != nil {
+		c.beforeCheck()
+		c.beforeCheck = nil
+	}
+	if c.existing != nil {
+		return c.existing[key], c.err
+	}
+	return true, c.err
+}
+func (c *deliveryTestChecker) ObjectAvailable(_ context.Context, _, key string) (bool, error) {
+	return c.available[key], c.err
+}
+
+func TestArtworkDeliveryPublicationAndReconciliation(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := t.Context()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	original := fmt.Sprintf("tmdb/movies/delivery-%d/poster/original.rev.webp", time.Now().UnixNano())
+	large, medium := variantKey(original, "w780"), variantKey(original, "w500")
+	keys := []string{original, large, medium}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM artwork_revision_gc_candidates WHERE original_path=$1`, original)
+	})
+	tracker := catalog.NewArtworkRevisionTracker(pool)
+	store := NewArtworkDeliveryStore(pool, "delivery-a", true)
+	read := func() ArtworkAvailability {
+		t.Helper()
+		states, err := store.ArtworkAvailability(ctx, []string{original})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return states[original]
+	}
+	track := func(keys []string) {
+		t.Helper()
+		if err := tracker.TrackArtworkRevision(ctx, original, "poster", keys); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A legacy path displaced from one reference can still serve another.
+	// GC registration alone is not evidence of an incomplete publication.
+	if _, err := pool.Exec(ctx, `INSERT INTO artwork_revision_gc_candidates(original_path,image_type,not_before)
+        VALUES($1,'poster',NOW())`, original); err != nil {
+		t.Fatal(err)
+	}
+	legacyStates, err := store.ArtworkAvailability(ctx, []string{original})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, known := legacyStates[original]; known {
+		t.Fatal("legacy GC-only row became a known empty publication")
+	}
+	if got := selectPublishedVariant(large, legacyStates[original], false); got != medium {
+		t.Fatalf("legacy fallback = %q", got)
+	}
+	track(nil)
+	if got := selectPublishedVariant(large, read(), true); got != "" {
+		t.Fatalf("partial publication advertised %q", got)
+	}
+	track(keys)
+	if got := selectPublishedVariant(large, read(), true); got != medium {
+		t.Fatalf("unverified delivery advertised %q", got)
+	}
+	// Beginning another upload does not discard previously published variants.
+	track(nil)
+	if !slices.Contains(read().Published, large) {
+		t.Fatal("retry discarded publication")
+	}
+	checker := &deliveryTestChecker{available: map[string]bool{original: true, medium: true}}
+	stats, err := store.Reconcile(ctx, checker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Checked < 1 || stats.Missing < 1 {
+		t.Fatalf("stats: %+v", stats)
+	}
+	if got := selectPublishedVariant(large, read(), true); got != medium {
+		t.Fatalf("missing delivery advertised %q", got)
+	}
+	// A new scope must not inherit another endpoint's delivery verification.
+	states, err := NewArtworkDeliveryStore(pool, "delivery-b", true).ArtworkAvailability(ctx, []string{original})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if states[original].Verified {
+		t.Fatal("verification crossed delivery configuration")
+	}
+	// Publication wakes verification; a delivery recovery restores the large URL.
+	track(keys)
+	checker.available[large] = true
+	if _, err := store.Reconcile(ctx, checker); err != nil {
+		t.Fatal(err)
+	}
+	if got := selectPublishedVariant(large, read(), true); got != large {
+		t.Fatalf("recovery got %q", got)
+	}
+	// Transport errors retain the last completed verdict and schedule retry.
+	track(keys)
+	checker.err = errors.New("delivery unavailable")
+	if _, err := store.Reconcile(ctx, checker); err != nil {
+		t.Fatal(err)
+	}
+	if got := selectPublishedVariant(large, read(), true); got != large {
+		t.Fatalf("outage erased last verdict: %q", got)
+	}
+	// A concurrent publication fences the in-flight verifier's stale result.
+	track(keys)
+	checker.err = nil
+	checker.available = map[string]bool{}
+	checker.beforeCheck = func() { track(keys) }
+	if _, err := store.Reconcile(ctx, checker); err != nil {
+		t.Fatal(err)
+	}
+	if got := selectPublishedVariant(large, read(), true); got != large {
+		t.Fatalf("stale worker overwrote publication: %q", got)
+	}
+	if _, err := store.Reconcile(ctx, checker); err != nil {
+		t.Fatal(err)
+	}
+	if got := selectPublishedVariant(large, read(), true); got != "" {
+		t.Fatalf("known unavailable revision advertised %q", got)
+	}
+	// GC tombstones must never regain URLs via legacy fallback.
+	if _, err := pool.Exec(ctx, `UPDATE artwork_revision_gc_candidates SET deleted_at=NOW() WHERE original_path=$1`, original); err != nil {
+		t.Fatal(err)
+	}
+	if got := selectPublishedVariant(large, read(), true); got != "" {
+		t.Fatalf("deleted revision advertised %q", got)
+	}
+	// Storage loss queues regeneration without changing catalog artwork pointers.
+	track(keys)
+	contentID := fmt.Sprintf("delivery-repair-%d", time.Now().UnixNano())
+	if _, err := pool.Exec(ctx, `INSERT INTO media_items(content_id,type,title,genres,poster_path,poster_source_path,tmdb_id)
+        VALUES($1,'movie','Delivery repair','{}',$2,'https://images.example/source.jpg','123')`, contentID, original); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM media_items WHERE content_id=$1`, contentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM metadata_image_cache_jobs WHERE target_content_id=$1`, contentID)
+	})
+	checker.existing = map[string]bool{original: true, medium: true}
+	checker.available = map[string]bool{original: true, medium: true}
+	if _, err := store.Reconcile(ctx, checker); err != nil {
+		t.Fatal(err)
+	}
+	var savedPath, jobStatus string
+	if err := pool.QueryRow(ctx, `SELECT poster_path FROM media_items WHERE content_id=$1`, contentID).Scan(&savedPath); err != nil {
+		t.Fatal(err)
+	}
+	if savedPath != original {
+		t.Fatal("repair replaced the catalog pointer")
+	}
+	if err := pool.QueryRow(ctx, `SELECT status FROM metadata_image_cache_jobs WHERE target_content_id=$1`, contentID).Scan(&jobStatus); err != nil {
+		t.Fatal(err)
+	}
+	if jobStatus != "queued" {
+		t.Fatalf("repair status = %s", jobStatus)
+	}
+
+}

--- a/internal/metadata/image_cache_job_repo.go
+++ b/internal/metadata/image_cache_job_repo.go
@@ -772,6 +772,19 @@ func (r *ImageCacheJobRepository) DeleteSucceededBefore(ctx context.Context, bef
 }
 
 func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Context, limit int) (int, error) {
+	return r.enqueueProviderArtwork(ctx, limit, []string{})
+}
+
+// EnqueueArtworkRepair regenerates confirmed missing cached revisions without
+// replacing catalog pointers. Surviving variants keep serving during repair.
+func (r *ImageCacheJobRepository) EnqueueArtworkRepair(ctx context.Context, paths []string, limit int) (int, error) {
+	if len(paths) == 0 {
+		return 0, nil
+	}
+	return r.enqueueProviderArtwork(ctx, limit, paths)
+}
+
+func (r *ImageCacheJobRepository) enqueueProviderArtwork(ctx context.Context, limit int, repairPaths []string) (int, error) {
 	if r == nil || r.pool == nil || limit <= 0 {
 		return 0, nil
 	}
@@ -802,7 +815,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			FROM media_items mi
 			WHERE mi.poster_source_path LIKE '%://%'
 			  AND lower(mi.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (mi.poster_path LIKE '%://%' OR coalesce(mi.poster_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (mi.poster_path LIKE '%://%' OR coalesce(mi.poster_path, '') = '')) OR mi.poster_path = ANY($2))
 			UNION ALL
 			SELECT
 				'backdrop'::text,
@@ -820,7 +833,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			FROM media_items mi
 			WHERE mi.backdrop_source_path LIKE '%://%'
 			  AND lower(mi.backdrop_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (mi.backdrop_path LIKE '%://%' OR coalesce(mi.backdrop_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (mi.backdrop_path LIKE '%://%' OR coalesce(mi.backdrop_path, '') = '')) OR mi.backdrop_path = ANY($2))
 			UNION ALL
 			SELECT
 				'logo'::text,
@@ -838,7 +851,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			FROM media_items mi
 			WHERE mi.logo_source_path LIKE '%://%'
 			  AND lower(mi.logo_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (mi.logo_path LIKE '%://%' OR coalesce(mi.logo_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (mi.logo_path LIKE '%://%' OR coalesce(mi.logo_path, '') = '')) OR mi.logo_path = ANY($2))
 			UNION ALL
 			SELECT
 				'poster'::text,
@@ -857,7 +870,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			JOIN media_items mi ON mi.content_id = loc.content_id
 			WHERE loc.poster_source_path LIKE '%://%'
 			  AND lower(loc.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.poster_path LIKE '%://%' OR coalesce(loc.poster_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (loc.poster_path LIKE '%://%' OR coalesce(loc.poster_path, '') = '')) OR loc.poster_path = ANY($2))
 			UNION ALL
 			SELECT
 				'backdrop'::text,
@@ -876,7 +889,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			JOIN media_items mi ON mi.content_id = loc.content_id
 			WHERE loc.backdrop_source_path LIKE '%://%'
 			  AND lower(loc.backdrop_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.backdrop_path LIKE '%://%' OR coalesce(loc.backdrop_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (loc.backdrop_path LIKE '%://%' OR coalesce(loc.backdrop_path, '') = '')) OR loc.backdrop_path = ANY($2))
 			UNION ALL
 			SELECT
 				'logo'::text,
@@ -895,7 +908,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			JOIN media_items mi ON mi.content_id = loc.content_id
 			WHERE loc.logo_source_path LIKE '%://%'
 			  AND lower(loc.logo_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.logo_path LIKE '%://%' OR coalesce(loc.logo_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (loc.logo_path LIKE '%://%' OR coalesce(loc.logo_path, '') = '')) OR loc.logo_path = ANY($2))
 			UNION ALL
 			SELECT
 				'poster'::text,
@@ -914,7 +927,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			JOIN media_items mi ON mi.content_id = s.series_id
 			WHERE s.poster_source_path LIKE '%://%'
 			  AND lower(s.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (s.poster_path LIKE '%://%' OR coalesce(s.poster_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (s.poster_path LIKE '%://%' OR coalesce(s.poster_path, '') = '')) OR s.poster_path = ANY($2))
 			UNION ALL
 			SELECT
 				'poster'::text,
@@ -934,7 +947,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			JOIN media_items mi ON mi.content_id = s.series_id
 			WHERE loc.poster_source_path LIKE '%://%'
 			  AND lower(loc.poster_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (loc.poster_path LIKE '%://%' OR coalesce(loc.poster_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (loc.poster_path LIKE '%://%' OR coalesce(loc.poster_path, '') = '')) OR loc.poster_path = ANY($2))
 			UNION ALL
 			SELECT
 				'still'::text,
@@ -953,7 +966,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			JOIN media_items mi ON mi.content_id = e.series_id
 			WHERE e.still_source_path LIKE '%://%'
 			  AND lower(e.still_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (e.still_path LIKE '%://%' OR coalesce(e.still_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (e.still_path LIKE '%://%' OR coalesce(e.still_path, '') = '')) OR e.still_path = ANY($2))
 			UNION ALL
 			SELECT
 				'profile'::text,
@@ -971,7 +984,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 			FROM people p
 			WHERE p.photo_source_path LIKE '%://%'
 			  AND lower(p.photo_source_path) NOT LIKE ALL (@nonProviderSchemes)
-			  AND (p.photo_path LIKE '%://%' OR coalesce(p.photo_path, '') = '')
+			  AND ((cardinality($2::text[]) = 0 AND (p.photo_path LIKE '%://%' OR coalesce(p.photo_path, '') = '')) OR p.photo_path = ANY($2))
 		),
 		candidates AS (
 			SELECT ac.*
@@ -998,7 +1011,7 @@ func (r *ImageCacheJobRepository) EnqueueExistingProviderArtwork(ctx context.Con
 		       COALESCE(imdb_id, '') AS imdb_id
 		FROM candidates
 	`, "@nonProviderSchemes", nonProviderImageSchemesSQL)
-	rows, err := r.pool.Query(ctx, query, limit)
+	rows, err := r.pool.Query(ctx, query, limit, repairPaths)
 	if err != nil {
 		return 0, fmt.Errorf("enqueueing existing provider artwork: %w", err)
 	}

--- a/internal/metadata/image_ladder_fallback.go
+++ b/internal/metadata/image_ladder_fallback.go
@@ -104,6 +104,9 @@ func selectPublishedVariant(key string, state ArtworkAvailability, known bool) s
 		keys = state.Deliverable
 	}
 	candidate := key
+	if keyVariant(key) == artworkkey.OriginalVariant && !slices.Contains(keys, key) {
+		candidate = variantKey(key, imagesize.Variant(imageType, imagesize.Large))
+	}
 	for {
 		if slices.Contains(keys, candidate) {
 			return candidate

--- a/internal/metadata/image_ladder_fallback.go
+++ b/internal/metadata/image_ladder_fallback.go
@@ -2,127 +2,37 @@ package metadata
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"path"
+	"slices"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/Silo-Server/silo-server/internal/artworkkey"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/imagesize"
 )
 
-const (
-	// existsCacheTTL is how long a confirmed-present object stays confirmed.
-	// Cached artwork is immutable per revision, so a hit cannot go stale except
-	// by deletion, which the reconciler already repairs.
-	existsCacheTTL = 24 * time.Hour
-	// externalAvailabilityCacheTTL is shorter because a public/token delivery
-	// path can stop serving an object independently of the backing S3 API.
-	externalAvailabilityCacheTTL = 15 * time.Minute
-	// missingExistsCacheTTL is how long a confirmed-absent object stays absent.
-	// It is short because absence is the transient state: the ladder backfill is
-	// generating the rung right now, and every viewer is being served a narrower
-	// image until it lands.
-	missingExistsCacheTTL = 15 * time.Minute
-)
-
-// s3ImageExistenceChecker is the existence half of the S3 surface. The presigner
-// is *s3client.Client in production, which implements it; a deployment whose
-// presigner does not simply skips the fallback and presigns what was asked for.
-type s3ImageExistenceChecker interface {
-	ObjectExists(ctx context.Context, bucket, key string) (bool, error)
+// ArtworkAvailability is durable knowledge about one immutable revision.
+// Verified distinguishes a completed delivery check (including no usable keys)
+// from publication that has not yet been checked through external delivery.
+type ArtworkAvailability struct {
+	Published   []string
+	Deliverable []string
+	External    bool
+	Verified    bool
 }
 
-// s3ImageDeliveryChecker verifies newly added ladder rungs through the
-// separately authenticated URL path used by clients. External delivery is not
-// equivalent to storage existence: an S3 HEAD can succeed while the public
-// endpoint still returns 404.
-type s3ImageDeliveryChecker interface {
-	ObjectAvailable(ctx context.Context, bucket, key string) (bool, error)
-	UsesExternalDelivery() bool
+type ArtworkAvailabilityReader interface {
+	ArtworkAvailability(context.Context, []string) (map[string]ArtworkAvailability, error)
 }
 
-type imageAvailabilityCheck func(ctx context.Context, bucket, key string) (bool, error)
-
-type imageAvailabilityPolicy struct {
-	check           imageAvailabilityCheck
-	presentTTL      time.Duration
-	fallbackOnError bool
-}
-
-func availabilityPolicy(presigner s3ImagePresigner) imageAvailabilityPolicy {
-	if checker, ok := presigner.(s3ImageDeliveryChecker); ok && checker.UsesExternalDelivery() {
-		return imageAvailabilityPolicy{
-			check:           checker.ObjectAvailable,
-			presentTTL:      externalAvailabilityCacheTTL,
-			fallbackOnError: true,
-		}
-	}
-	if checker, ok := presigner.(s3ImageExistenceChecker); ok {
-		return imageAvailabilityPolicy{
-			check:      checker.ObjectExists,
-			presentTTL: existsCacheTTL,
-		}
-	}
-	return imageAvailabilityPolicy{}
-}
-
-var errExternalDeliveryBatchUnavailable = errors.New("external artwork delivery unavailable for batch")
-
-// withBatchFailureCircuit stops a delivery outage from consuming one probe
-// timeout per worker wave. Checks already in flight may finish, but after the
-// first error no later entry in this batch reaches the external endpoint.
-func (p imageAvailabilityPolicy) withBatchFailureCircuit() imageAvailabilityPolicy {
-	if !p.fallbackOnError || p.check == nil {
-		return p
-	}
-
-	check := p.check
-	var failed atomic.Bool
-	p.check = func(ctx context.Context, bucket, key string) (bool, error) {
-		if failed.Load() {
-			return false, errExternalDeliveryBatchUnavailable
-		}
-		exists, err := check(ctx, bucket, key)
-		if err != nil && !failed.CompareAndSwap(false, true) {
-			return false, errExternalDeliveryBatchUnavailable
-		}
-		return exists, err
-	}
-	return p
-}
-
-// ladderTypesWithAddedRung lists the image types that gained a rung in the
-// current artworkkey.LadderVersion. Artwork cached by an older version has no
-// object at the new rung until the ladder backfill regenerates it, so these —
-// and only these — are worth an existence check before presigning. Every other
-// rung has been generated for as long as the artwork has existed.
-//
-// The rung itself is not spelled out: at this version each of these types gained
-// its widest variant, so the check reads it back off the ladder and cannot drift
-// from artworkkey.VariantWidths. Revisit both this set and that assumption
-// whenever LadderVersion is bumped.
+// These types gained their widest rung in the current ladder version. Legacy
+// artwork without a manifest can safely use only an established lower rung.
 var ladderTypesWithAddedRung = map[string]bool{
 	ImageCacheImagePoster: true,
 	ImageCacheImageStill:  true,
 	ImageCacheImageLogo:   true,
-}
-
-// needsExistenceCheck reports whether a cached artwork key names a rung that
-// might not have been generated yet, along with the image type governing its
-// ladder.
-func needsExistenceCheck(key string) (imageType string, ok bool) {
-	imageType = catalog.ImageTypeFromCachedPath(key)
-	if imageType == "" || !ladderTypesWithAddedRung[imageType] {
-		return "", false
-	}
-	return imageType, imagesize.Variant(imageType, imagesize.Large) == keyVariant(key)
 }
 
 // keyVariant extracts the variant name from a cached artwork key, e.g.
@@ -147,165 +57,74 @@ func variantKey(key, variant string) string {
 	return artworkkey.Variant(original, variant)
 }
 
-// ladderExistenceConcurrency bounds how many artwork availability checks run at
-// once for one batch. It keeps a large browse page off a serial chain of probes
-// without letting one request open a hundred storage or delivery connections.
-const ladderExistenceConcurrency = 12
-
-// ladderKey is the outcome of walking the ladder for one requested key.
-type ladderKey struct {
-	key             string
-	fellBack        bool
-	revalidateAfter time.Duration
-}
-
-// resolveLadderKeys walks the ladder for a whole batch with bounded concurrency,
-// returning the key to presign for each entry. Entries needing no check (every
-// rung but the newly-added one, which is the overwhelming majority) resolve to
-// themselves without touching storage.
-func (r *PluginImageResolver) resolveLadderKeys(
-	ctx context.Context,
-	policy imageAvailabilityPolicy,
-	bucket string,
-	entries []resolveEntry,
-) map[string]ladderKey {
-	resolved := make(map[string]ladderKey, len(entries))
+// resolvePublishedLadderKeys performs one catalog lookup and local selection.
+// Neither cold caches nor missing manifests cause storage or delivery probes.
+func resolvePublishedLadderKeys(ctx context.Context, reader ArtworkAvailabilityReader, entries []resolveEntry) map[string]string {
+	originals := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		resolved[entry.originalPath] = ladderKey{key: entry.originalPath}
-	}
-	if policy.check == nil {
-		return resolved
-	}
-
-	// Only the entries that can actually miss are worth a goroutine.
-	pending := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if _, ok := needsExistenceCheck(entry.originalPath); ok {
-			pending = append(pending, entry.originalPath)
+		if catalog.ImageTypeFromCachedPath(entry.originalPath) != "" {
+			originals = append(originals, variantKey(entry.originalPath, artworkkey.OriginalVariant))
 		}
 	}
-	if len(pending) == 0 {
-		return resolved
+	var states map[string]ArtworkAvailability
+	if reader != nil && len(originals) > 0 {
+		var err error
+		states, err = reader.ArtworkAvailability(ctx, originals)
+		if err != nil {
+			slog.WarnContext(ctx, "artwork publication lookup failed; using established variants", "error", err)
+		}
 	}
-	policy = policy.withBatchFailureCircuit()
-
-	var (
-		mu    sync.Mutex
-		group errgroup.Group
-	)
-	group.SetLimit(ladderExistenceConcurrency)
-	for _, path := range pending {
-		group.Go(func() error {
-			key, fellBack := r.resolveLadderKey(ctx, policy, bucket, path)
-			mu.Lock()
-			resolved[path] = ladderKey{
-				key:             key,
-				fellBack:        fellBack,
-				revalidateAfter: policy.presentTTL,
-			}
-			mu.Unlock()
-			return nil
-		})
+	resolved := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key := entry.originalPath
+		state, known := states[variantKey(key, artworkkey.OriginalVariant)]
+		resolved[key] = selectPublishedVariant(key, state, known)
 	}
-	// resolveLadderKey never returns an error — a failed check degrades according
-	// to the selected storage or external-delivery policy.
-	_ = group.Wait()
 	return resolved
 }
 
-// resolveLadderKey returns the key to presign for a requested rung, walking down
-// the ladder when the requested one has not been generated yet. The second
-// return reports whether the answer is a fallback rather than what was asked
-// for, which the caller uses to shorten how long it caches the resolved URL.
-//
-// A storage-only check that errors is not treated as absence: storage being
-// briefly unreachable must not permanently downgrade everyone's artwork. An
-// external-delivery error does fall back because it cannot prove that the URL
-// handed to a client will work. Errors are never cached in either mode.
-func (r *PluginImageResolver) resolveLadderKey(ctx context.Context, policy imageAvailabilityPolicy, bucket, key string) (string, bool) {
-	imageType, ok := needsExistenceCheck(key)
-	if !ok {
-		return key, false
+func selectPublishedVariant(key string, state ArtworkAvailability, known bool) string {
+	imageType := catalog.ImageTypeFromCachedPath(key)
+	if imageType == "" {
+		return key
 	}
-
+	if !known || (state.External && !state.Verified) {
+		// An unverified external path is not proof the newly added size works.
+		if ladderTypesWithAddedRung[imageType] && keyVariant(key) == imagesize.Variant(imageType, imagesize.Large) {
+			if lower, ok := imagesize.NextLower(imageType, keyVariant(key)); ok {
+				key = variantKey(key, lower)
+			}
+		}
+		if !known {
+			return key
+		}
+	}
+	keys := state.Published
+	if state.External && state.Verified {
+		keys = state.Deliverable
+	}
 	candidate := key
 	for {
-		exists, err := r.objectExists(ctx, policy.check, policy.presentTTL, bucket, candidate)
-		if err != nil {
-			if !policy.fallbackOnError {
-				slog.DebugContext(ctx, "artwork existence check failed", "component", "metadata", "key", candidate, "error", err)
-				return key, false
-			}
-			if !errors.Is(err, errExternalDeliveryBatchUnavailable) {
-				slog.WarnContext(ctx, "external artwork delivery check failed; using lower rung", "component", "metadata", "key", candidate, "error", err)
-			}
-			next, hasNext := imagesize.NextLower(imageType, keyVariant(candidate))
-			if !hasNext {
-				return variantKey(key, artworkkey.OriginalVariant), true
-			}
-			// A delivery-wide error is likely to repeat for every candidate. The
-			// lower rungs predate the current ladder version, so select the next
-			// established one without multiplying timeout or rate-limit load.
-			return variantKey(key, next), true
+		if slices.Contains(keys, candidate) {
+			return candidate
 		}
-		if exists {
-			return candidate, candidate != key
+		lower, ok := imagesize.NextLower(imageType, keyVariant(candidate))
+		if !ok {
+			break
 		}
-		next, hasNext := imagesize.NextLower(imageType, keyVariant(candidate))
-		if !hasNext {
-			// The original is the terminal fallback: it predates every rung, so
-			// checking it would spend a request to learn nothing actionable.
-			return variantKey(key, artworkkey.OriginalVariant), true
-		}
-		candidate = variantKey(key, next)
+		candidate = variantKey(key, lower)
 	}
+	original := variantKey(key, artworkkey.OriginalVariant)
+	if slices.Contains(keys, original) {
+		return original
+	}
+	// A known empty manifest or failed delivery is a placeholder, not a guess.
+	return ""
 }
 
-// objectExists answers from the availability cache when it can. Present and
-// absent answers are cached with different lifetimes; an error is not cached.
-func (r *PluginImageResolver) objectExists(
-	ctx context.Context,
-	check imageAvailabilityCheck,
-	presentTTL time.Duration,
-	bucket string,
-	key string,
-) (bool, error) {
-	cacheKey := bucket + "\x00" + key
-	if r.existsCache != nil {
-		if value, ok := r.existsCache.Get(cacheKey); ok {
-			return value, nil
-		}
+func minURLExpiry(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
 	}
-
-	exists, err := check(ctx, bucket, key)
-	if err != nil {
-		return false, err
-	}
-
-	if r.existsCache != nil {
-		ttl := missingExistsCacheTTL
-		if exists {
-			ttl = presentTTL
-		}
-		r.existsCache.Set(cacheKey, exists, ttl)
-	}
-	return exists, nil
-}
-
-// fallbackURLExpiry shortens a presigned URL's advertised validity when it
-// points at a fallback rung, so the resolved-URL cache releases it about as soon
-// as the missing rung could have been backfilled. Without this a viewer could
-// keep receiving the narrow image for a full day after the real one landed.
-func fallbackURLExpiry(expiry time.Time, now time.Time) time.Time {
-	return revalidatedURLExpiry(expiry, now, missingExistsCacheTTL)
-}
-
-// revalidatedURLExpiry makes the resolved-URL cache release an externally
-// verified URL when its delivery-path availability is due to be checked again.
-func revalidatedURLExpiry(expiry time.Time, now time.Time, ttl time.Duration) time.Time {
-	clamped := now.Add(ttl + resolvedURLCacheSafetyMargin)
-	if clamped.Before(expiry) {
-		return clamped
-	}
-	return expiry
+	return b
 }

--- a/internal/metadata/image_ladder_fallback_test.go
+++ b/internal/metadata/image_ladder_fallback_test.go
@@ -2,415 +2,86 @@ package metadata
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
 
-// fakeS3ImageStore is a presigner that also answers existence checks, standing
-// in for *s3client.Client.
-type fakeS3ImageStore struct {
-	mu               sync.Mutex
-	existing         map[string]bool
-	deliverable      map[string]bool
-	deliveryErrors   map[string]error
-	externalDelivery bool
-	err              error
-	checks           []string
-	deliveryChecks   []string
-	presigns         []string
-	deliveryStarted  chan<- string
-	deliveryRelease  <-chan struct{}
+type manifestReader map[string]ArtworkAvailability
+
+func (m manifestReader) ArtworkAvailability(context.Context, []string) (map[string]ArtworkAvailability, error) {
+	return m, nil
 }
 
-func newFakeS3ImageStore(existing ...string) *fakeS3ImageStore {
-	store := &fakeS3ImageStore{existing: map[string]bool{}}
-	for _, key := range existing {
-		store.existing[key] = true
-	}
-	return store
+type noProbeStore struct{ t *testing.T }
+
+func (s noProbeStore) Bucket() string { return "media" }
+func (s noProbeStore) PresignGetURL(_ context.Context, _, key string, _ time.Duration) (string, error) {
+	return "https://images.example/" + key, nil
 }
-
-func (s *fakeS3ImageStore) Bucket() string { return "media" }
-
-func (s *fakeS3ImageStore) UsesExternalDelivery() bool { return s.externalDelivery }
-
-func (s *fakeS3ImageStore) PresignGetURL(_ context.Context, bucket, key string, _ time.Duration) (string, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.presigns = append(s.presigns, key)
-	return "https://s3.example.com/" + bucket + "/" + key, nil
+func (s noProbeStore) ObjectExists(context.Context, string, string) (bool, error) {
+	s.t.Fatal("catalog read checked storage")
+	return false, nil
 }
-
-func (s *fakeS3ImageStore) ObjectExists(_ context.Context, _ string, key string) (bool, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.checks = append(s.checks, key)
-	if s.err != nil {
-		return false, s.err
-	}
-	return s.existing[key], nil
+func (s noProbeStore) ObjectAvailable(context.Context, string, string) (bool, error) {
+	s.t.Fatal("catalog read checked delivery")
+	return false, nil
 }
+func (s noProbeStore) UsesExternalDelivery() bool { return true }
 
-func (s *fakeS3ImageStore) ObjectAvailable(ctx context.Context, _ string, key string) (bool, error) {
-	s.mu.Lock()
-	s.deliveryChecks = append(s.deliveryChecks, key)
-	started := s.deliveryStarted
-	release := s.deliveryRelease
-	err := s.deliveryErrors[key]
-	if err == nil {
-		err = s.err
-	}
-	deliverable := s.deliverable[key]
-	s.mu.Unlock()
-
-	if started != nil {
-		select {
-		case started <- key:
-		case <-ctx.Done():
-			return false, ctx.Err()
+func TestCatalogArtworkColdReadsNeverProbe(t *testing.T) {
+	// Recreate both resolver caches on every iteration, including 37 distinct
+	// season posters. A store whose probe methods fail proves independence
+	// from slow, missing, or unavailable delivery without a timing threshold.
+	for range 2 {
+		resolver := NewPluginImageResolver()
+		t.Cleanup(resolver.Close)
+		resolver.SetS3Presigner(noProbeStore{t}, time.Hour)
+		manifest := manifestReader{}
+		var paths []string
+		for i := range 37 {
+			key := fmt.Sprintf("tmdb/series/1/seasons/%d/poster/w780.rev.webp", i)
+			paths = append(paths, key)
+			original := variantKey(key, "original")
+			manifest[original] = ArtworkAvailability{Published: []string{key, variantKey(key, "w500"), original}, External: true}
 		}
-	}
-	if release != nil {
-		select {
-		case <-release:
-		case <-ctx.Done():
-			return false, ctx.Err()
+		resolver.SetArtworkAvailabilityReader(manifest)
+		urls := resolver.ResolveImageURLs(t.Context(), paths, "large")
+		if len(urls) != 37 {
+			t.Fatalf("got %d URLs", len(urls))
 		}
-	}
-	if err != nil {
-		return false, err
-	}
-	return deliverable, nil
-}
-
-func (s *fakeS3ImageStore) checkCount() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.checks)
-}
-
-func newResolverWithStore(t *testing.T, store *fakeS3ImageStore) *PluginImageResolver {
-	t.Helper()
-	resolver := NewPluginImageResolver()
-	t.Cleanup(resolver.Close)
-	resolver.SetS3Presigner(store, 30*time.Minute)
-	return resolver
-}
-
-func resolvedKey(t *testing.T, resolver *PluginImageResolver, path string) string {
-	t.Helper()
-	got := resolver.ResolveImageURLWithExpiry(context.Background(), path, "featured")
-	if got.URL == "" {
-		t.Fatalf("resolving %q returned no URL", path)
-	}
-	return strings.TrimPrefix(got.URL, "https://s3.example.com/media/")
-}
-
-func TestLadderFallbackServesRequestedRungWhenPresent(t *testing.T) {
-	const key = "tmdb/movies/550/poster/w780.abc123.webp"
-	store := newFakeS3ImageStore(key)
-	resolver := newResolverWithStore(t, store)
-
-	if got := resolvedKey(t, resolver, key); got != key {
-		t.Fatalf("resolved key = %q, want the requested rung %q", got, key)
-	}
-}
-
-func TestLadderFallbackWalksDownToAnExistingRung(t *testing.T) {
-	const requested = "tmdb/movies/550/poster/w780.abc123.webp"
-	const present = "tmdb/movies/550/poster/w500.abc123.webp"
-	store := newFakeS3ImageStore(present)
-	resolver := newResolverWithStore(t, store)
-
-	if got := resolvedKey(t, resolver, requested); got != present {
-		t.Fatalf("resolved key = %q, want the next lower rung %q", got, present)
-	}
-}
-
-func TestLadderFallbackEndsAtTheOriginal(t *testing.T) {
-	const requested = "tvdb/series/73141/seasons/22/episodes/9/still/w780.webp"
-	store := newFakeS3ImageStore() // nothing exists
-	resolver := newResolverWithStore(t, store)
-
-	want := "tvdb/series/73141/seasons/22/episodes/9/still/original.webp"
-	if got := resolvedKey(t, resolver, requested); got != want {
-		t.Fatalf("resolved key = %q, want the original as the terminal fallback %q", got, want)
-	}
-	// The original is never checked — it predates every rung.
-	for _, checked := range store.checks {
-		if strings.Contains(checked, "/original.") {
-			t.Fatalf("checked %q; the original should be the unchecked terminal fallback", checked)
+		for _, key := range paths {
+			if !strings.HasSuffix(urls[key], variantKey(key, "w500")) {
+				t.Fatalf("unverified variant advertised: %s", urls[key])
+			}
 		}
 	}
 }
 
-func TestLadderFallbackWalksLogoLadder(t *testing.T) {
-	const requested = "tmdb/series/1396/logo/w1280.rev.webp"
-	const present = "tmdb/series/1396/logo/w500.rev.webp"
-	store := newFakeS3ImageStore(present)
-	resolver := newResolverWithStore(t, store)
-
-	if got := resolvedKey(t, resolver, requested); got != present {
-		t.Fatalf("resolved key = %q, want %q", got, present)
-	}
-}
-
-// A storage HEAD is not proof that a separately authenticated public URL is
-// fetchable. The ladder must check the same delivery path the client will use.
-func TestLadderFallbackUsesClientDeliveryAvailability(t *testing.T) {
-	tests := []struct {
-		name      string
-		requested string
-		present   string
+func TestSelectPublishedVariant(t *testing.T) {
+	const key = "tmdb/series/1/poster/w780.rev.webp"
+	medium, small, original := variantKey(key, "w500"), variantKey(key, "w300"), variantKey(key, "original")
+	for _, tc := range []struct {
+		name  string
+		state ArtworkAvailability
+		known bool
+		want  string
 	}{
-		{
-			name:      "poster",
-			requested: "tmdb/movies/550/poster/w780.rev.webp",
-			present:   "tmdb/movies/550/poster/w500.rev.webp",
-		},
-		{
-			name:      "still",
-			requested: "tmdb/series/1396/seasons/1/episodes/1/still/w780.rev.webp",
-			present:   "tmdb/series/1396/seasons/1/episodes/1/still/w500.rev.webp",
-		},
-		{
-			name:      "logo",
-			requested: "tmdb/series/1396/logo/w1280.rev.webp",
-			present:   "tmdb/series/1396/logo/w500.rev.webp",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			store := newFakeS3ImageStore(tt.requested, tt.present)
-			store.externalDelivery = true
-			store.deliverable = map[string]bool{tt.present: true}
-			resolver := newResolverWithStore(t, store)
-
-			if got := resolvedKey(t, resolver, tt.requested); got != tt.present {
-				t.Fatalf("resolved key = %q, want client-fetchable rung %q", got, tt.present)
-			}
-			if len(store.deliveryChecks) == 0 || store.deliveryChecks[0] != tt.requested {
-				t.Fatalf("delivery checks = %v, want requested rung checked first", store.deliveryChecks)
-			}
-			if len(store.checks) != 0 {
-				t.Fatalf("storage checks = %v, want client-delivery checks", store.checks)
-			}
-		})
-	}
-}
-
-func TestLadderFallbackRechecksExternalDeliveryForPromotion(t *testing.T) {
-	const requested = "tmdb/movies/550/poster/w780.rev.webp"
-	const present = "tmdb/movies/550/poster/w500.rev.webp"
-	store := newFakeS3ImageStore(requested, present)
-	store.externalDelivery = true
-	store.deliverable = map[string]bool{present: true}
-	resolver := newResolverWithStore(t, store)
-
-	if got := resolvedKey(t, resolver, requested); got != present {
-		t.Fatalf("initial resolved key = %q, want fallback %q", got, present)
-	}
-
-	store.mu.Lock()
-	store.deliverable[requested] = true
-	store.mu.Unlock()
-	// Expiry drives these invalidations in production; do it directly so the
-	// unit test proves promotion without waiting for the real TTL.
-	resolver.existsCache.InvalidatePrefix("")
-	resolver.urlCache.InvalidatePrefix("")
-
-	if got := resolvedKey(t, resolver, requested); got != requested {
-		t.Fatalf("resolved key after delivery recovery = %q, want %q", got, requested)
-	}
-}
-
-func TestLadderFallbackUsesLowerRungWhenDeliveryCheckErrors(t *testing.T) {
-	const requested = "tmdb/movies/550/poster/w780.rev.webp"
-	const present = "tmdb/movies/550/poster/w500.rev.webp"
-	store := newFakeS3ImageStore(requested, present)
-	store.externalDelivery = true
-	store.deliverable = map[string]bool{present: true}
-	store.deliveryErrors = map[string]error{requested: errors.New("delivery unavailable")}
-	resolver := newResolverWithStore(t, store)
-
-	if got := resolvedKey(t, resolver, requested); got != present {
-		t.Fatalf("resolved key = %q, want lower fetchable rung %q", got, present)
-	}
-	if len(store.deliveryChecks) != 1 || store.deliveryChecks[0] != requested {
-		t.Fatalf("delivery checks = %v, want one bounded check of requested rung", store.deliveryChecks)
-	}
-}
-
-func TestLadderFallbackStopsDeliveryProbesAfterBatchFailure(t *testing.T) {
-	const entryCount = ladderExistenceConcurrency * 4
-
-	started := make(chan string, entryCount)
-	release := make(chan struct{})
-	unblock := sync.OnceFunc(func() { close(release) })
-	t.Cleanup(unblock)
-
-	store := newFakeS3ImageStore()
-	store.externalDelivery = true
-	store.err = errors.New("delivery unavailable")
-	store.deliveryStarted = started
-	store.deliveryRelease = release
-	resolver := newResolverWithStore(t, store)
-
-	entries := make([]resolveEntry, 0, entryCount)
-	for i := range entryCount {
-		entries = append(entries, resolveEntry{
-			originalPath: fmt.Sprintf("tmdb/movies/%d/poster/w780.rev.webp", i),
-		})
-	}
-
-	resolved := make(chan map[string]ladderKey, 1)
-	go func() {
-		resolved <- resolver.resolveLadderKeys(t.Context(), availabilityPolicy(store), store.Bucket(), entries)
-	}()
-
-	waitCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
-	defer cancel()
-	for range ladderExistenceConcurrency {
-		select {
-		case <-started:
-		case <-waitCtx.Done():
-			t.Fatalf("delivery probes started = %d, want initial worker set of %d", len(started), ladderExistenceConcurrency)
-		}
-	}
-	select {
-	case key := <-started:
-		t.Fatalf("delivery probe %q exceeded the %d-worker limit before release", key, ladderExistenceConcurrency)
-	default:
-	}
-
-	unblock()
-	var got map[string]ladderKey
-	select {
-	case got = <-resolved:
-	case <-waitCtx.Done():
-		t.Fatal("ladder batch did not fall back after delivery failure")
-	}
-
-	store.mu.Lock()
-	deliveryChecks := append([]string(nil), store.deliveryChecks...)
-	store.mu.Unlock()
-	if len(deliveryChecks) > ladderExistenceConcurrency {
-		t.Fatalf("delivery checks = %d, want at most the initial worker set of %d", len(deliveryChecks), ladderExistenceConcurrency)
-	}
-	for _, entry := range entries {
-		want := strings.Replace(entry.originalPath, "/w780.", "/w500.", 1)
-		if result := got[entry.originalPath]; result.key != want || !result.fellBack {
-			t.Errorf("resolved[%q] = %#v, want fallback key %q", entry.originalPath, result, want)
-		}
-	}
-}
-
-// A rung that has always existed must not cost a HEAD request.
-func TestLadderFallbackSkipsEstablishedRungs(t *testing.T) {
-	store := newFakeS3ImageStore()
-	resolver := newResolverWithStore(t, store)
-
-	for _, key := range []string{
-		"tmdb/movies/550/poster/w500.abc123.webp",
-		"tmdb/movies/550/poster/w300.abc123.webp",
-		"tmdb/movies/550/backdrop/w1920.abc123.webp",
-		"tmdb/movies/550/poster/original.abc123.webp",
-		"tmdb/series/1396/logo/w500.rev.webp",
+		{"legacy", ArtworkAvailability{}, false, medium},
+		{"published", ArtworkAvailability{Published: []string{key, original}}, true, key},
+		{"missing large", ArtworkAvailability{Published: []string{small, original}}, true, small},
+		{"original only", ArtworkAvailability{Published: []string{original}}, true, original},
+		{"delivery verified", ArtworkAvailability{Published: []string{key, medium, original}, External: true, Verified: true, Deliverable: []string{key}}, true, key},
+		{"delivery missing", ArtworkAvailability{Published: []string{key, medium, original}, External: true, Verified: true, Deliverable: []string{medium}}, true, medium},
+		{"delivery down", ArtworkAvailability{Published: []string{key, original}, External: true, Verified: true}, true, ""},
+		{"unpublished", ArtworkAvailability{}, true, ""},
 	} {
-		if got := resolvedKey(t, resolver, key); got != key {
-			t.Errorf("resolved key = %q, want %q untouched", got, key)
-		}
-	}
-	if store.checkCount() != 0 {
-		t.Fatalf("existence checks = %v, want none for established rungs", store.checks)
-	}
-}
-
-// Storage being briefly unreachable must not downgrade artwork, and must not be
-// remembered as absence.
-func TestLadderFallbackPresignsRequestedKeyOnCheckError(t *testing.T) {
-	const requested = "tmdb/movies/550/poster/w780.abc123.webp"
-	store := newFakeS3ImageStore()
-	store.err = errors.New("s3 unavailable")
-	resolver := newResolverWithStore(t, store)
-
-	if got := resolvedKey(t, resolver, requested); got != requested {
-		t.Fatalf("resolved key = %q, want the requested rung presigned optimistically", got)
-	}
-
-	// Nothing was cached, so a later request checks again rather than inheriting
-	// a phantom "missing".
-	store.err = nil
-	store.existing[requested] = true
-	resolver.urlCache.InvalidatePrefix("")
-	if got := resolvedKey(t, resolver, requested); got != requested {
-		t.Fatalf("resolved key after recovery = %q, want %q", got, requested)
-	}
-	if store.checkCount() < 2 {
-		t.Fatalf("existence checks = %v, want the failed check not to have been cached", store.checks)
-	}
-}
-
-func TestLadderFallbackCachesExistenceAnswers(t *testing.T) {
-	const requested = "tmdb/movies/550/poster/w780.abc123.webp"
-	const present = "tmdb/movies/550/poster/w500.abc123.webp"
-	store := newFakeS3ImageStore(present)
-	resolver := newResolverWithStore(t, store)
-
-	resolvedKey(t, resolver, requested)
-	first := store.checkCount()
-	resolver.urlCache.InvalidatePrefix("")
-	resolvedKey(t, resolver, requested)
-
-	if store.checkCount() != first {
-		t.Fatalf("existence checks = %d, want the first %d answers reused from cache", store.checkCount(), first)
-	}
-}
-
-// A fallback URL must leave the resolved-URL cache about as soon as the real
-// rung could have been backfilled, not a full presign window later.
-func TestLadderFallbackClampsResolvedURLLifetime(t *testing.T) {
-	const requested = "tmdb/movies/550/poster/w780.abc123.webp"
-	const present = "tmdb/movies/550/poster/w500.abc123.webp"
-	store := newFakeS3ImageStore(present)
-	resolver := newResolverWithStore(t, store)
-
-	fallback := resolver.ResolveImageURLWithExpiry(context.Background(), requested, "featured")
-	if fallback.ExpiresAt == nil {
-		t.Fatal("fallback URL has no expiry")
-	}
-	if got := time.Until(*fallback.ExpiresAt); got > missingExistsCacheTTL+resolvedURLCacheSafetyMargin {
-		t.Fatalf("fallback expiry in %v, want at most %v", got, missingExistsCacheTTL+resolvedURLCacheSafetyMargin)
-	}
-
-	// A key served at the rung that was asked for keeps the full window.
-	direct := resolver.ResolveImageURLWithExpiry(context.Background(), present, "featured")
-	if direct.ExpiresAt == nil {
-		t.Fatal("direct URL has no expiry")
-	}
-	if got := time.Until(*direct.ExpiresAt); got <= missingExistsCacheTTL+resolvedURLCacheSafetyMargin {
-		t.Fatalf("direct expiry in %v, want the full presign window", got)
-	}
-}
-
-func TestLadderFallbackClampsExternallyVerifiedURLLifetime(t *testing.T) {
-	const requested = "tmdb/movies/550/poster/w780.abc123.webp"
-	store := newFakeS3ImageStore(requested)
-	store.externalDelivery = true
-	store.deliverable = map[string]bool{requested: true}
-	resolver := newResolverWithStore(t, store)
-
-	resolved := resolver.ResolveImageURLWithExpiry(t.Context(), requested, "featured")
-	if resolved.ExpiresAt == nil {
-		t.Fatal("externally verified URL has no expiry")
-	}
-	if got := time.Until(*resolved.ExpiresAt); got > externalAvailabilityCacheTTL+resolvedURLCacheSafetyMargin {
-		t.Fatalf("externally verified expiry in %v, want at most %v", got, externalAvailabilityCacheTTL+resolvedURLCacheSafetyMargin)
+		t.Run(tc.name, func(t *testing.T) {
+			if got := selectPublishedVariant(key, tc.state, tc.known); got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/metadata/image_ladder_fallback_test.go
+++ b/internal/metadata/image_ladder_fallback_test.go
@@ -115,3 +115,30 @@ func TestKeyVariant(t *testing.T) {
 		}
 	}
 }
+
+func TestOriginalArtworkFallsBackToResizedVariant(t *testing.T) {
+	original := "tmdb/movies/550/poster/original.abc123.webp"
+	large, medium := variantKey(original, "w780"), variantKey(original, "w500")
+	for _, tc := range []struct {
+		name string
+		keys []string
+		want string
+	}{
+		{"original preferred", []string{original, large}, original},
+		{"largest survivor", []string{medium, large}, large},
+		{"lower survivor", []string{medium}, medium},
+		{"none available", nil, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, verified := range []bool{false, true} {
+				state := ArtworkAvailability{Published: tc.keys}
+				if verified {
+					state = ArtworkAvailability{Published: []string{original, large, medium}, External: true, Verified: true, Deliverable: tc.keys}
+				}
+				if got := selectPublishedVariant(original, state, true); got != tc.want {
+					t.Fatalf("verified=%v: got %q, want %q", verified, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/metadata/image_resolver.go
+++ b/internal/metadata/image_resolver.go
@@ -63,16 +63,13 @@ type pluginImageResolverSourceEntry struct {
 // by parsing the prefix, routing to the correct plugin, and returning resolved URLs.
 // It implements catalog.ImageResolver and the catalog expiry-aware resolver extension.
 type PluginImageResolver struct {
-	mu           sync.RWMutex
-	sources      map[string][]pluginImageResolverSourceEntry
-	s3Presigner  s3ImagePresigner
-	s3PresignTTL time.Duration
-	urlCache     *cache.TTLCache[catalog.ResolvedImageURL]
-	// existsCache remembers which cached artwork rungs are actually in the
-	// bucket, so the ladder fallback costs at most one HEAD per key per window
-	// rather than one per request.
-	existsCache *cache.TTLCache[bool]
-	group       singleflight.Group
+	mu                  sync.RWMutex
+	sources             map[string][]pluginImageResolverSourceEntry
+	s3Presigner         s3ImagePresigner
+	s3PresignTTL        time.Duration
+	urlCache            *cache.TTLCache[catalog.ResolvedImageURL]
+	artworkAvailability ArtworkAvailabilityReader
+	group               singleflight.Group
 }
 
 // NewPluginImageResolver creates a new resolver with no registered sources.
@@ -81,7 +78,6 @@ func NewPluginImageResolver() *PluginImageResolver {
 		sources:      make(map[string][]pluginImageResolverSourceEntry),
 		s3PresignTTL: 15 * time.Minute,
 		urlCache:     cache.NewTTLCache[catalog.ResolvedImageURL](),
-		existsCache:  cache.NewTTLCache[bool](),
 	}
 }
 
@@ -151,13 +147,19 @@ func (r *PluginImageResolver) SetS3Presigner(presigner s3ImagePresigner, ttl tim
 	}
 }
 
+// SetArtworkAvailabilityReader supplies durable publication/delivery metadata.
+// Catalog reads never use the storage client to discover availability.
+func (r *PluginImageResolver) SetArtworkAvailabilityReader(reader ArtworkAvailabilityReader) {
+	r.mu.Lock()
+	r.artworkAvailability = reader
+	r.mu.Unlock()
+	r.urlCache.InvalidatePrefix("")
+}
+
 // Close stops the resolver cache sweeper.
 func (r *PluginImageResolver) Close() {
 	if r.urlCache != nil {
 		r.urlCache.Close()
-	}
-	if r.existsCache != nil {
-		r.existsCache.Close()
 	}
 }
 
@@ -324,34 +326,25 @@ func (r *PluginImageResolver) resolveS3Batch(
 	if presigner == nil {
 		return resolved
 	}
-	// Only the cached-key path walks the ladder: plugin- and http-resolved
-	// images do not live in this bucket and choose their own variant.
-	policy := availabilityPolicy(presigner)
+	r.mu.RLock()
+	availability := r.artworkAvailability
+	r.mu.RUnlock()
 	now := time.Now()
 	expiresAt := now.Add(ttl)
-
-	// Walk the ladder for the whole batch before presigning any of it. Each walk
-	// can cost one or more storage HEADs or public-delivery probes, and a browse
-	// page resolves a hundred images: done one after another that is seconds of
-	// latency in front of the JSON. Presigning itself is local signing work, so
-	// only this part is worth parallelizing.
-	ladderKeys := r.resolveLadderKeys(ctx, policy, presigner.Bucket(), entries)
+	ladderKeys := resolvePublishedLadderKeys(ctx, availability, entries)
 
 	for _, entry := range entries {
-		resolvedKey := ladderKeys[entry.originalPath]
-		key := resolvedKey.key
-		fellBack := resolvedKey.fellBack
+		key := ladderKeys[entry.originalPath]
+		if key == "" {
+			continue
+		}
 		url, err := presigner.PresignGetURL(ctx, presigner.Bucket(), key, ttl)
 		if err != nil {
 			slog.ErrorContext(ctx, "s3 image resolution failed", "component", "metadata", "path", key, "error", err)
 			continue
 		}
-		expiry := expiresAt
-		if fellBack {
-			expiry = fallbackURLExpiry(expiry, now)
-		} else if resolvedKey.revalidateAfter > 0 {
-			expiry = revalidatedURLExpiry(expiry, now, resolvedKey.revalidateAfter)
-		}
+		// Availability may improve or degrade independently of URL signatures.
+		expiry := minURLExpiry(expiresAt, now.Add(5*time.Minute+resolvedURLCacheSafetyMargin))
 		resolved[entry.originalPath] = catalog.ResolvedImageURL{URL: url, ExpiresAt: &expiry}
 	}
 	return resolved

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -42,9 +42,7 @@ const (
 // S3-compatible backends require parts of at least 5 MiB (except the last).
 const streamUploadPartSize = 8 * 1024 * 1024
 
-// publicDeliveryProbeTimeout bounds request-path latency when the external
-// artwork endpoint is unavailable. Ladder resolution probes candidates in
-// descending order, so an unbounded client could stall a whole browse page.
+// publicDeliveryProbeTimeout bounds background artwork delivery verification.
 const publicDeliveryProbeTimeout = 5 * time.Second
 
 // BucketConfig holds the configuration for connecting to a single S3 bucket.
@@ -442,6 +440,16 @@ func (c *Client) ObjectExists(ctx context.Context, bucket, key string) (bool, er
 	}
 
 	return true, nil
+}
+
+// ArtworkDeliveryScope invalidates verification when storage or delivery
+// configuration changes. Only a digest is persisted; credentials stay private.
+func (c *Client) ArtworkDeliveryScope() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		c.endpoint, c.bucket, c.keyPrefix, c.publicEndpoint, c.urlAuth,
+		c.tokenParam, c.tokenSecret,
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])
 }
 
 // ObjectAvailable reports whether a client-facing read URL is fetchable now.

--- a/internal/s3client/client.go
+++ b/internal/s3client/client.go
@@ -443,11 +443,12 @@ func (c *Client) ObjectExists(ctx context.Context, bucket, key string) (bool, er
 }
 
 // ArtworkDeliveryScope invalidates verification when storage or delivery
-// configuration changes. Only a digest is persisted; credentials stay private.
+// endpoint or URL policy changes. Credentials are excluded from this persisted
+// digest. Rotated credentials sign fresh URLs and use normal background checks.
 func (c *Client) ArtworkDeliveryScope() string {
 	sum := sha256.Sum256([]byte(strings.Join([]string{
 		c.endpoint, c.bucket, c.keyPrefix, c.publicEndpoint, c.urlAuth,
-		c.tokenParam, c.tokenSecret,
+		c.tokenParam,
 	}, "\x00")))
 	return hex.EncodeToString(sum[:])
 }

--- a/internal/s3client/client_test.go
+++ b/internal/s3client/client_test.go
@@ -464,3 +464,16 @@ func parseQuery(raw string) url.Values {
 	}
 	return values
 }
+
+func TestArtworkDeliveryScopeExcludesCredentials(t *testing.T) {
+	client := &Client{endpoint: "https://storage.example", bucket: "artwork", publicEndpoint: "https://images.example", tokenSecret: "first-secret"}
+	scope := client.ArtworkDeliveryScope()
+	client.tokenSecret = "rotated-secret"
+	if got := client.ArtworkDeliveryScope(); got != scope {
+		t.Fatal("credential entered persisted scope digest")
+	}
+	client.publicEndpoint = "https://other-images.example"
+	if got := client.ArtworkDeliveryScope(); got == scope {
+		t.Fatal("delivery endpoint change did not change scope")
+	}
+}

--- a/internal/taskmanager/tasks/verify_artwork_delivery.go
+++ b/internal/taskmanager/tasks/verify_artwork_delivery.go
@@ -1,0 +1,45 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/metadata"
+	"github.com/Silo-Server/silo-server/internal/taskmanager"
+)
+
+var _ taskmanager.Task = (*VerifyArtworkDeliveryTask)(nil)
+
+type VerifyArtworkDeliveryTask struct {
+	store   *metadata.ArtworkDeliveryStore
+	checker metadata.ArtworkDeliveryChecker
+}
+
+func NewVerifyArtworkDeliveryTask(store *metadata.ArtworkDeliveryStore, checker metadata.ArtworkDeliveryChecker) *VerifyArtworkDeliveryTask {
+	return &VerifyArtworkDeliveryTask{store: store, checker: checker}
+}
+func (t *VerifyArtworkDeliveryTask) Key() string  { return "verify_artwork_delivery" }
+func (t *VerifyArtworkDeliveryTask) Name() string { return "Verify Artwork Delivery" }
+func (t *VerifyArtworkDeliveryTask) Description() string {
+	return "Checks published artwork through storage and client delivery URLs in bounded batches, and schedules repair for missing storage objects."
+}
+func (t *VerifyArtworkDeliveryTask) Category() taskmanager.TaskCategory {
+	return taskmanager.TaskCategoryMetadata
+}
+func (t *VerifyArtworkDeliveryTask) IsHidden() bool { return false }
+
+func (t *VerifyArtworkDeliveryTask) DefaultTriggers() []taskmanager.TriggerConfig {
+	return []taskmanager.TriggerConfig{
+		{Type: taskmanager.TriggerTypeStartup},
+		{Type: taskmanager.TriggerTypeInterval, IntervalMs: int64(time.Minute / time.Millisecond)},
+	}
+}
+func (t *VerifyArtworkDeliveryTask) Execute(ctx context.Context, progress taskmanager.ProgressReporter) error {
+	stats, err := t.store.Reconcile(ctx, t.checker)
+	if err != nil {
+		return err
+	}
+	progress.Report(100, fmt.Sprintf("Checked %d revisions: %d missing objects, %d probe errors", stats.Checked, stats.Missing, stats.Errors))
+	return nil
+}

--- a/migrations/sql/20260907025245_artwork_delivery_state.sql
+++ b/migrations/sql/20260907025245_artwork_delivery_state.sql
@@ -10,10 +10,10 @@ ALTER TABLE artwork_revision_gc_candidates
     ADD COLUMN delivery_checked_at timestamptz,
     ADD COLUMN delivery_next_check timestamptz NOT NULL DEFAULT NOW(),
     ADD COLUMN delivery_lease text NOT NULL DEFAULT '';
-UPDATE artwork_revision_gc_candidates SET published_keys = object_keys
-WHERE deleted_at IS NULL AND cardinality(object_keys) > 0;
+-- Historical nonempty GC manifests could be recorded before upload. The
+-- background verifier establishes publication only after checking storage.
 CREATE INDEX artwork_delivery_due_idx ON artwork_revision_gc_candidates (delivery_next_check, id)
-WHERE deleted_at IS NULL AND cardinality(published_keys) > 0;
+WHERE deleted_at IS NULL AND cardinality(coalesce(published_keys, object_keys)) > 0;
 
 -- +goose Down
 DROP INDEX artwork_delivery_due_idx;

--- a/migrations/sql/20260907025245_artwork_delivery_state.sql
+++ b/migrations/sql/20260907025245_artwork_delivery_state.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- Keep successful publication separate from the GC manifest, which is emptied
+-- before a retry uploads and may include objects that never finished uploading.
+-- NULL means a legacy GC-only record; an empty array means publication began
+-- but has not completed. Displacement triggers must keep the NULL default.
+ALTER TABLE artwork_revision_gc_candidates
+    ADD COLUMN published_keys text[],
+    ADD COLUMN delivery_keys text[] NOT NULL DEFAULT '{}',
+    ADD COLUMN delivery_scope text NOT NULL DEFAULT '',
+    ADD COLUMN delivery_checked_at timestamptz,
+    ADD COLUMN delivery_next_check timestamptz NOT NULL DEFAULT NOW(),
+    ADD COLUMN delivery_lease text NOT NULL DEFAULT '';
+UPDATE artwork_revision_gc_candidates SET published_keys = object_keys
+WHERE deleted_at IS NULL AND cardinality(object_keys) > 0;
+CREATE INDEX artwork_delivery_due_idx ON artwork_revision_gc_candidates (delivery_next_check, id)
+WHERE deleted_at IS NULL AND cardinality(published_keys) > 0;
+
+-- +goose Down
+DROP INDEX artwork_delivery_due_idx;
+ALTER TABLE artwork_revision_gc_candidates
+    DROP COLUMN published_keys,
+    DROP COLUMN delivery_keys,
+    DROP COLUMN delivery_scope,
+    DROP COLUMN delivery_checked_at,
+    DROP COLUMN delivery_next_check,
+    DROP COLUMN delivery_lease;


### PR DESCRIPTION
## Problem

Related issue: #825

Requests for large cached artwork could perform storage or delivery probes while building catalog JSON. A season list resolved posters individually, so a series with many seasons could wait on a sequence of image requests before returning titles, episode counts, or progress.

## Approach

Select cached variants from durable publication and delivery records. The publisher records exact successfully uploaded keys; a bounded, leased background task checks storage and client-facing delivery, then queues regeneration for missing provider objects without replacing catalog pointers. Legacy GC-only records remain distinct from pending uploads and deleted revisions. Background checks establish publication for historical manifests; partial results select verified surviving objects while missing objects remain eligible for repair.

Batch season poster resolution and expose `include_artwork=false` through the images capability. The companion tvOS change (Silo-Server/silo-apple#271) uses it for text season selectors. Android keeps season artwork for its detail flow; Jellyfin uses the shared resolver.

## Validation

The full CONTRIBUTING gate passed: Go build, formatting, vet, CI-style lint, and `make test-go`; web install, lint, formatting, build, and `make test-web` (362 files / 3,112 tests); settings bindings, playback fixtures, and local-path checks. Lint was rerun successfully with an isolated cache after stale shared-cache results. The migration also applied successfully to a fresh PostgreSQL database.

Focused database and race tests cover publication, delivery failures/recovery, scope changes, stale-worker fencing, legacy manifests, tombstones, and repair queueing. A cold-resolver HTTP fixture with 38 seasons and 37 posters asserts zero availability probes and unchanged non-image metadata across small, large, and omitted artwork. The companion tvOS change passed simulator build, install, and launch.

The review follow-up passed focused PostgreSQL race tests, S3/image-cache package race tests, and CI-style lint. A broader metadata race run exposed a race in the unchanged `TestRunLadderBackfillDrainsEachBatchAndCompletes` test fixtures.

## Risks

Requires the new database migration and a write-free maintenance window across all server nodes. The transactional ALTER TABLE and index build hold table locks; do not apply this migration during a rolling upgrade with active catalog/artwork writers. Verification is asynchronous and resolved URLs are cached; large backlogs can extend verification intervals. Clients may receive a smaller known variant or an empty URL for their placeholder. Live deployment latency has not been remeasured.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tools: Codex multi-agent collaboration, shell/Go tooling, GitHub CLI, pnpm, and the Silo simulator build helper.
- Model: `gpt-6-astra`.
- Involvement: AI-assisted at the maintainer's request; pending maintainer review.
- Adversarial review: two independent static passes covered publication/GC state, worker leases and repair, API contracts, and client consumers. Both identified the legacy GC-only manifest ambiguity; it was fixed, regression-tested, and rechecked by a reviewer. No remaining concrete findings were reported.
