### PR TITLE
perf(sections): cut the fixed cost out of the home sections response

### DIFF
--- a/internal/api/handlers/sections.go
+++ b/internal/api/handlers/sections.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -589,23 +591,79 @@ func (h *SectionHandler) HandleLibraryLayout(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// slowHomeSectionsThreshold is the phase-timing alarm for GET /home/sections.
+// It is deliberately well below the endpoint's typical duration: a threshold set
+// at the middle of the distribution almost never fires and reports nothing about
+// where the time went.
+const slowHomeSectionsThreshold = 500 * time.Millisecond
+
+// sectionPhaseTimer records how long each phase of a sections request took.
+// Without it the endpoint is one opaque duration: FetchAll has its own alarm,
+// but the response-enrichment pass that follows it had no timing at all.
+type sectionPhaseTimer struct {
+	start  time.Time
+	last   time.Time
+	phases []any
+}
+
+func newSectionPhaseTimer() *sectionPhaseTimer {
+	now := time.Now()
+	return &sectionPhaseTimer{start: now, last: now}
+}
+
+func (t *sectionPhaseTimer) mark(name string) {
+	now := time.Now()
+	t.phases = append(t.phases, name+"_ms", now.Sub(t.last).Milliseconds())
+	t.last = now
+}
+
+// log emits the whole breakdown as one line: WARN past the threshold, DEBUG
+// below it, so the phases are always available without making a slow request
+// indistinguishable from a fast one.
+func (t *sectionPhaseTimer) log(ctx context.Context, attrs ...any) {
+	total := time.Since(t.start)
+	all := append([]any{"total_ms", total.Milliseconds()}, attrs...)
+	all = append(all, t.phases...)
+	if total >= slowHomeSectionsThreshold {
+		slog.WarnContext(ctx, "slow home sections request", all...)
+		return
+	}
+	slog.DebugContext(ctx, "home sections timing", all...)
+}
+
 // HandleHomeSections handles GET /home/sections
 func (h *SectionHandler) HandleHomeSections(w http.ResponseWriter, r *http.Request) {
 	if !rejectInvalidImageSize(w, r) {
 		return
 	}
+	timer := newSectionPhaseTimer()
 	resolved, libraryIDs, accessFilter, profileID, err := h.loadResolvedHomeSections(r)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load sections")
 		return
 	}
+	timer.mark("resolve")
 
 	userID := apimw.GetUserID(r.Context())
 	resolved = h.maybeInjectNextUp(r.Context(), resolved, userID)
+	timer.mark("next_up")
+
 	withItems := h.fetcher.FetchAll(r.Context(), resolved, nil, libraryIDs, userID, profileID, accessFilter)
+	timer.mark("fetch_all")
+
 	withItems = applyDiversityFilter(withItems)
 	withItems = dropEmptySeasonalSections(withItems)
-	writeJSON(w, http.StatusOK, h.buildSectionsResponse(r, withItems, nil))
+	response := h.buildSectionsResponse(r, withItems, nil)
+	timer.mark("build_response")
+
+	writeJSON(w, http.StatusOK, response)
+	timer.mark("write")
+
+	itemCount := 0
+	for _, section := range withItems {
+		itemCount += len(section.Items)
+	}
+	timer.log(r.Context(), "section_count", len(withItems), "item_count", itemCount)
 }
 
 // HandleHomeSectionItems handles GET /home/sections/{id}/items
@@ -1257,7 +1315,6 @@ type sectionItemImageURLs struct {
 func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sections.SectionWithItems, libraryID *int) homeSectionsResponse {
 	deduplicateSectionItems(r.Context(), withItems)
 
-	overlaySummaries := make(map[string]*models.OverlaySummary)
 	contentIDs := make([]string, 0)
 	seen := make(map[string]struct{})
 	for _, section := range withItems {
@@ -1272,24 +1329,50 @@ func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sect
 			contentIDs = append(contentIDs, item.ContentID)
 		}
 	}
-	if len(contentIDs) > 0 && h.fetcher != nil {
-		summaries, err := h.fetcher.ListOverlaySummaries(r.Context(), contentIDs, requestAccessFilter(r))
-		if err != nil {
-			slog.ErrorContext(r.Context(), "loading overlay summaries", "component", "api", "error", err)
-		} else {
-			overlaySummaries = summaries
-		}
-	}
 
-	resp := homeSectionsResponse{
-		Sections: make([]resolvedSectionResponse, 0, len(withItems)),
-	}
 	allItems := make([]*models.MediaItem, 0)
 	for _, s := range withItems {
 		allItems = append(allItems, s.Items...)
 	}
+
+	// The six enrichment lookups below are independent of one another — they are
+	// only combined when the cards are assembled — but each is a database round
+	// trip over every card on the page. Run serially they added up to the larger
+	// half of a home request, so they run together. Concurrency stays at six,
+	// matching the fan-out FetchAll already takes, so peak pool usage per request
+	// is unchanged (the two phases never overlap).
+	overlaySummaries := make(map[string]*models.OverlaySummary)
 	playTargets := map[string]string{}
-	if h.playableTargets != nil {
+	var userStates map[string]*itemUserStateResponse
+	var imageURLs map[sectionItemImageKey]sectionItemImageURLs
+	var episodeMeta map[string]sections.SectionItemMeta
+	var mangaChapterMeta map[string]sections.SectionItemMeta
+
+	var wg sync.WaitGroup
+	run := func(fn func()) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fn()
+		}()
+	}
+
+	run(func() {
+		if len(contentIDs) == 0 || h.fetcher == nil {
+			return
+		}
+		summaries, err := h.fetcher.ListOverlaySummaries(r.Context(), contentIDs, requestAccessFilter(r))
+		if err != nil {
+			slog.ErrorContext(r.Context(), "loading overlay summaries", "component", "api", "error", err)
+			return
+		}
+		overlaySummaries = summaries
+	})
+
+	run(func() {
+		if h.playableTargets == nil {
+			return
+		}
 		inputs := make([]catalog.PlayableTargetInput, 0, len(allItems))
 		for _, item := range allItems {
 			if item == nil || item.ContentID == "" {
@@ -1314,14 +1397,21 @@ func (h *SectionHandler) buildSectionsResponse(r *http.Request, withItems []sect
 		})
 		if err != nil {
 			slog.WarnContext(r.Context(), "resolving section playable targets", "component", "api", "error", err)
-		} else {
-			playTargets = resolvedTargets
+			return
 		}
+		playTargets = resolvedTargets
+	})
+
+	run(func() { userStates = h.listSectionItemUserStates(r, allItems) })
+	run(func() { imageURLs = h.resolveSectionItemImageURLs(r.Context(), withItems, requestImageSize(r)) })
+	run(func() { episodeMeta = h.listSectionEpisodeItemMeta(r.Context(), withItems, requestAccessFilter(r)) })
+	run(func() { mangaChapterMeta = h.listSectionMangaChapterItemMeta(r.Context(), allItems) })
+
+	wg.Wait()
+
+	resp := homeSectionsResponse{
+		Sections: make([]resolvedSectionResponse, 0, len(withItems)),
 	}
-	userStates := h.listSectionItemUserStates(r, allItems)
-	imageURLs := h.resolveSectionItemImageURLs(r.Context(), withItems, requestImageSize(r))
-	episodeMeta := h.listSectionEpisodeItemMeta(r.Context(), withItems, requestAccessFilter(r))
-	mangaChapterMeta := h.listSectionMangaChapterItemMeta(r.Context(), allItems)
 	for _, s := range withItems {
 		items := make([]sectionItemResponse, 0, len(s.Items))
 		for _, item := range s.Items {

--- a/internal/catalog/access_filter.go
+++ b/internal/catalog/access_filter.go
@@ -229,12 +229,21 @@ func FilterMediaFilesByAccess(files []*models.MediaFile, filter AccessFilter) []
 	return filtered
 }
 
+// SQLTrimSpaceChars is a PostgreSQL E-string holding exactly the runes Go's
+// strings.TrimSpace strips: ASCII whitespace plus every rune with the Unicode
+// White_Space property. Pass it as BTRIM's second argument wherever SQL has to
+// trim a value the way Go would, so a resolution such as "\u00a02160p" ranks
+// the same on both sides instead of falling through to the ELSE branch.
+//
+// Use octal \013 for vertical tab; PostgreSQL treats \v as a literal v. The
+// \uXXXX escapes need a UTF-8 database, which Silo requires anyway.
+const SQLTrimSpaceChars = `E' \t\n\013\f\r\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004` +
+	`\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000'`
+
 // MediaFileQualityCeilingSQL renders the playback-quality ceiling as a SQL
 // condition over the given media_files alias, or "" when the filter sets no
-// ceiling. It mirrors access.QualityAllowed, trimming ASCII whitespace.
-// Use octal \013 for vertical tab; PostgreSQL treats \v as a literal v.
-// Go's TrimSpace also strips Unicode spaces (such as U+00A0); the scanner has
-// never been observed to write those.
+// ceiling. It mirrors access.QualityAllowed, trimming whitespace the way Go
+// does (see SQLTrimSpaceChars).
 func MediaFileQualityCeilingSQL(alias string, maxPlaybackQuality string) string {
 	quality := access.NormalizePlaybackQuality(maxPlaybackQuality)
 	if quality == "" {
@@ -244,9 +253,9 @@ func MediaFileQualityCeilingSQL(alias string, maxPlaybackQuality string) string 
 	if quality == access.PlaybackQuality4K {
 		maxRank = 4
 	}
-	return fmt.Sprintf(`CASE UPPER(BTRIM(COALESCE(%s.resolution, ''), E' \t\n\013\f\r'))
+	return fmt.Sprintf(`CASE UPPER(BTRIM(COALESCE(%s.resolution, ''), %s))
 		WHEN '480P' THEN 1 WHEN '720P' THEN 2 WHEN '1080P' THEN 3
-		WHEN '2160P' THEN 4 WHEN '4320P' THEN 5 ELSE 0 END <= %d`, alias, maxRank)
+		WHEN '2160P' THEN 4 WHEN '4320P' THEN 5 ELSE 0 END <= %d`, alias, SQLTrimSpaceChars, maxRank)
 }
 
 // MediaFileAccessSQL renders FileAllowedByAccess as SQL conditions over the

--- a/internal/catalog/access_filter.go
+++ b/internal/catalog/access_filter.go
@@ -228,3 +228,49 @@ func FilterMediaFilesByAccess(files []*models.MediaFile, filter AccessFilter) []
 	}
 	return filtered
 }
+
+// MediaFileQualityCeilingSQL renders the playback-quality ceiling as a SQL
+// condition over the given media_files alias, or "" when the filter sets no
+// ceiling. It mirrors access.QualityAllowed, trimming ASCII whitespace.
+// Use octal \013 for vertical tab; PostgreSQL treats \v as a literal v.
+// Go's TrimSpace also strips Unicode spaces (such as U+00A0); the scanner has
+// never been observed to write those.
+func MediaFileQualityCeilingSQL(alias string, maxPlaybackQuality string) string {
+	quality := access.NormalizePlaybackQuality(maxPlaybackQuality)
+	if quality == "" {
+		return ""
+	}
+	maxRank := 3
+	if quality == access.PlaybackQuality4K {
+		maxRank = 4
+	}
+	return fmt.Sprintf(`CASE UPPER(BTRIM(COALESCE(%s.resolution, ''), E' \t\n\013\f\r'))
+		WHEN '480P' THEN 1 WHEN '720P' THEN 2 WHEN '1080P' THEN 3
+		WHEN '2160P' THEN 4 WHEN '4320P' THEN 5 ELSE 0 END <= %d`, alias, maxRank)
+}
+
+// MediaFileAccessSQL renders FileAllowedByAccess as SQL conditions over the
+// given media_files alias, appending any bind values to args and numbering
+// placeholders from the resulting argument positions. Callers must append the
+// returned args in order.
+//
+// This is the SQL mirror of FileAllowedByAccess and must stay in step with it:
+// it exists so queries that would otherwise ship every candidate file to Go can
+// filter and reduce inside PostgreSQL instead.
+func MediaFileAccessSQL(alias string, filter AccessFilter, args []any) ([]string, []any) {
+	conditions := make([]string, 0, 3)
+
+	if filter.AllowedLibraryIDs != nil {
+		args = append(args, filter.AllowedLibraryIDs)
+		conditions = append(conditions, fmt.Sprintf("%s.media_folder_id = ANY($%d)", alias, len(args)))
+	}
+	if len(filter.DisabledLibraryIDs) > 0 {
+		args = append(args, filter.DisabledLibraryIDs)
+		conditions = append(conditions, fmt.Sprintf("NOT (%s.media_folder_id = ANY($%d))", alias, len(args)))
+	}
+	if ceiling := MediaFileQualityCeilingSQL(alias, filter.MaxPlaybackQuality); ceiling != "" {
+		conditions = append(conditions, ceiling)
+	}
+
+	return conditions, args
+}

--- a/internal/overlays/summary.go
+++ b/internal/overlays/summary.go
@@ -49,6 +49,31 @@ func BuildSummary(files []*models.MediaFile) *Summary {
 	return summary
 }
 
+// BestFile returns the file a summary is derived from: the highest resolution,
+// then the richest dynamic-range metadata, then the earliest file in the slice.
+//
+// It is exported because the same choice is also made in SQL, by
+// sections.overlaySummaryQuery, so that a card backed by thousands of files
+// (every episode of a series shares the series content_id) can be reduced to one
+// row inside PostgreSQL instead of being shipped here in full. The two rankings
+// must agree; TestOverlaySummarySQLRankingMatchesGo pins that.
+func BestFile(files []*models.MediaFile) *models.MediaFile {
+	return bestFile(files)
+}
+
+// ResolutionRank exposes the resolution ordering used by BestFile so the SQL
+// mirror can be tested against it.
+func ResolutionRank(value string) int { return resolutionRank(value) }
+
+// RangeRank exposes the dynamic-range ordering used by BestFile so the SQL
+// mirror can be tested against it.
+func RangeRank(file *models.MediaFile) int {
+	if file == nil {
+		return 0
+	}
+	return rangeRank(file)
+}
+
 func bestFile(files []*models.MediaFile) *models.MediaFile {
 	var best *models.MediaFile
 	bestRes := -1

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -16,6 +16,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/Silo-Server/silo-server/internal/access"
+	"github.com/Silo-Server/silo-server/internal/cache"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/overlays"
@@ -59,7 +61,12 @@ const editorialCandidateCacheTTL = 24 * time.Hour
 // load-testing pool contention.
 const fetchAllMaxConcurrency = 6
 const slowSectionFetchThreshold = 500 * time.Millisecond
-const slowAggregateFetchThreshold = time.Second
+
+// slowAggregateFetchThreshold sits below the typical aggregate duration on
+// purpose. At one second it matched the middle of the production distribution
+// and fired on well under one percent of requests, which read as "FetchAll is
+// fine" when it was simply never tripping.
+const slowAggregateFetchThreshold = 500 * time.Millisecond
 
 type recommendationReader interface {
 	GetForYouMain(ctx context.Context, userID int, profileID string, limit int, filter catalog.AccessFilter) (*recommendations.ForYouRow, error)
@@ -91,6 +98,9 @@ type Fetcher struct {
 	// Snapshots are produced out-of-band by TrendingRefresher, so the read path
 	// never calls the upstream provider.
 	TrendingSnapshots trendingSnapshotGetter
+
+	overlaySummaryCacheOnce sync.Once
+	overlaySummaryCache     *cache.TTLCache[*models.OverlaySummary]
 
 	candidateCacheMu sync.Mutex
 	candidateCache   *editorialCandidateCache
@@ -1096,33 +1106,180 @@ func (f *Fetcher) FetchEpisodesByContentIDs(ctx context.Context, contentIDs []st
 	return f.fetchEpisodeTargetsByContentIDs(ctx, contentIDs, nil, nil, filter)
 }
 
+// overlaySummaryCacheTTL bounds how stale a card's quality badges may be. A
+// summary only changes when the underlying files do — a rescan or a re-probe —
+// so this trades a few minutes of badge staleness for not re-deriving the same
+// answer for every profile that loads the same home screen. It matches
+// resolvedListRefreshAfter so the two caches age on the same cadence.
+const overlaySummaryCacheTTL = 5 * time.Minute
+
+func (f *Fetcher) overlaySummaries() *cache.TTLCache[*models.OverlaySummary] {
+	f.overlaySummaryCacheOnce.Do(func() {
+		f.overlaySummaryCache = cache.NewTTLCache[*models.OverlaySummary]()
+	})
+	return f.overlaySummaryCache
+}
+
+// overlaySummaryCacheScope fingerprints the parts of an access filter that can
+// change which file a card's summary is built from. MaxContentRating is absent
+// deliberately: it gates items, not files, and never reaches
+// catalog.FileAllowedByAccess.
+func overlaySummaryCacheScope(filter catalog.AccessFilter) string {
+	var b strings.Builder
+	if filter.AllowedLibraryIDs == nil {
+		// A nil allow-list means unrestricted, which is not the same as an empty
+		// one, so the two must not fingerprint alike.
+		b.WriteString("a:*")
+	} else {
+		allowed := append([]int(nil), filter.AllowedLibraryIDs...)
+		sort.Ints(allowed)
+		b.WriteString("a:")
+		for _, id := range allowed {
+			b.WriteString(strconv.Itoa(id))
+			b.WriteByte(',')
+		}
+	}
+	disabled := append([]int(nil), filter.DisabledLibraryIDs...)
+	sort.Ints(disabled)
+	b.WriteString("|d:")
+	for _, id := range disabled {
+		b.WriteString(strconv.Itoa(id))
+		b.WriteByte(',')
+	}
+	b.WriteString("|q:")
+	b.WriteString(access.NormalizePlaybackQuality(filter.MaxPlaybackQuality))
+	return b.String()
+}
+
+// overlaySummaryResolutionRankSQL mirrors overlays.ResolutionRank: "4k"/"uhd"
+// rank as 2160p, signed digits followed by "p" rank as their value, otherwise 0.
+// Use octal \013 for vertical tab; PostgreSQL treats \v as a literal v.
+// Trim ASCII whitespace as Go does. Go's TrimSpace also strips Unicode spaces
+// (such as U+00A0), which the scanner has never been observed to write.
+// Limit numeric matches to 18 digits so they fit in int64, as required by Atoi.
+const overlaySummaryResolutionRankSQL = `CASE
+				WHEN lower(btrim(coalesce(mf.resolution, ''), E' \t\n\013\f\r')) IN ('4k', 'uhd') THEN 2160
+				WHEN lower(btrim(coalesce(mf.resolution, ''), E' \t\n\013\f\r')) ~ '^[+-]?[0-9]{1,18}p$'
+					THEN substring(lower(btrim(mf.resolution, E' \t\n\013\f\r')) from '^([+-]?[0-9]{1,18})p$')::numeric
+				ELSE 0
+			END`
+
+// overlaySummaryRangeRankSQL mirrors overlays.RangeRank: Dolby Vision outranks a
+// typed HDR flavor, which outranks the bare hdr boolean. The two jsonpath
+// predicates mirror overlays.hasDolbyVision and overlays.hdrTypeFromTracks
+// respectively. Note the asymmetry those two carry: hasDolbyVision tests the
+// raw video_range_type while hdrTypeFromTracks trims it first, so only the
+// latter's patterns tolerate surrounding whitespace. \s is deliberately not used
+// — jsonpath's string lexer eats the backslash, silently turning the class into
+// a literal "s". jsonb_path_exists is used rather than expanding the
+// array with jsonb_array_elements: on a real library the expansion costs about
+// three times as much for the same answer.
+const overlaySummaryRangeRankSQL = `CASE
+				WHEN jsonb_path_exists(coalesce(mf.video_tracks, '[]'::jsonb),
+					'$[*] ? ((@.dolby_vision.type() == "string" && @.dolby_vision != "") || @.dv_profile > 0 || @.video_range_type like_regex "^DOVI")') THEN 3
+				WHEN jsonb_path_exists(coalesce(mf.video_tracks, '[]'::jsonb),
+					'$[*] ? (@.hdr10_plus == true || @.video_range_type like_regex "HDR10Plus" || @.video_range_type like_regex "^[[:space:]]*HDR10[[:space:]]*$" || @.video_range_type like_regex "WithHDR10[[:space:]]*$" || @.video_range_type like_regex "^[[:space:]]*HLG[[:space:]]*$" || @.video_range_type like_regex "WithHLG[[:space:]]*$" || @.color_transfer like_regex "smpte2084" flag "i" || @.color_transfer like_regex "arib-std-b67" flag "i")') THEN 2
+				WHEN coalesce(mf.hdr, false) THEN 1
+				ELSE 0
+			END`
+
 // ListOverlaySummaries batches file lookups for section cards and derives the
-// compact overlay summary per content ID.
+// compact overlay summary per content ID. Each requested ID independently gets
+// all accessible, non-missing files matching its content_id or episode_id.
+// A series therefore retains every episode file even when that episode is also
+// requested, making summaries independent of page composition and cache state.
+//
+// PostgreSQL reduces each card to the single file the summary is built from
+// rather than returning every candidate. That matters because episode files
+// carry their series' content_id: without the reduction one series card drags
+// back every episode file of the show (over 8,000 rows for the largest series
+// in a real library), so a home screen of series cards moved megabytes of
+// track JSON per request to render a handful of badges. The DISTINCT ON
+// ordering mirrors overlays.BestFile, and the access predicate mirrors
+// catalog.FileAllowedByAccess.
 func (f *Fetcher) ListOverlaySummaries(ctx context.Context, contentIDs []string, filter catalog.AccessFilter) (map[string]*models.OverlaySummary, error) {
+	summaries, _, err := f.listOverlaySummaries(ctx, contentIDs, filter)
+	return summaries, err
+}
+
+// listOverlaySummaries is ListOverlaySummaries plus the number of rows the
+// query actually read, which tests use to assert the reduction is happening.
+func (f *Fetcher) listOverlaySummaries(ctx context.Context, contentIDs []string, filter catalog.AccessFilter) (map[string]*models.OverlaySummary, int, error) {
 	summaries := make(map[string]*models.OverlaySummary, len(contentIDs))
 	if len(contentIDs) == 0 {
-		return summaries, nil
+		return summaries, 0, nil
 	}
 
-	rows, err := f.pool.Query(ctx, `
-		SELECT content_id, episode_id, file_path, resolution, codec_audio, audio_tracks, hdr, video_tracks,
-		       codec_video, audio_channels, container, subtitle_tracks, external_subtitles, edition_key
-		FROM media_files
-		WHERE (content_id = ANY($1) OR episode_id = ANY($1)) AND missing_since IS NULL
-		ORDER BY content_id ASC, episode_id ASC, id ASC
-	`, contentIDs)
+	// Cached summaries are shared across profiles and must never be mutated in
+	// place; nothing downstream does, the response only reads them.
+	summaryCache := f.overlaySummaries()
+	scope := overlaySummaryCacheScope(filter)
+	uncached := make([]string, 0, len(contentIDs))
+	for _, contentID := range contentIDs {
+		// A card with no usable file caches as a nil summary rather than as a
+		// miss, so it is not re-queried on every request.
+		if summary, ok := summaryCache.Get(scope + "\x00" + contentID); ok {
+			if summary != nil {
+				summaries[contentID] = summary
+			}
+			continue
+		}
+		uncached = append(uncached, contentID)
+	}
+	if len(uncached) == 0 {
+		return summaries, 0, nil
+	}
+
+	args := []any{uncached}
+	conditions := []string{
+		"(mf.content_id = ANY($1) OR mf.episode_id = ANY($1))",
+		"mf.missing_since IS NULL",
+		"g.group_key = ANY($1)",
+	}
+	accessConditions, args := catalog.MediaFileAccessSQL("mf", filter, args)
+	conditions = append(conditions, accessConditions...)
+
+	// Deliberately let a file contribute to both its series and episode cards:
+	// unlike the old exclusive grouping, a series always reports its best file
+	// regardless of which episodes are on the page. Keep the media_files OR
+	// predicate to drive index lookups before fanning out to requested groups.
+	// The ranking sorts narrow (group_key, id, rank) tuples, joining winners back
+	// for their columns afterwards, because sorting the wide rows themselves
+	// costs noticeably more.
+	query := fmt.Sprintf(`
+		WITH winners AS (
+			SELECT DISTINCT ON (group_key) group_key, id
+			FROM (
+				SELECT
+					g.group_key,
+					mf.id, mf.content_id, mf.episode_id,
+					%s AS resolution_rank,
+					%s AS range_rank
+				FROM media_files mf
+				CROSS JOIN LATERAL (VALUES (mf.content_id), (mf.episode_id)) AS g(group_key)
+				WHERE %s
+			) candidates
+			-- The final tiebreak repeats the legacy row order (content_id,
+			-- episode_id, id) rather than id alone, because overlays.BestFile keeps
+			-- the earliest file in the slice and that slice arrived in this order.
+			ORDER BY group_key, resolution_rank DESC, range_rank DESC, content_id ASC, episode_id ASC, id ASC
+		)
+		SELECT winners.group_key, mf.content_id, mf.episode_id, mf.file_path, mf.resolution, mf.codec_audio,
+			mf.audio_tracks, mf.hdr, mf.video_tracks, mf.codec_video, mf.audio_channels, mf.container,
+			mf.subtitle_tracks, mf.external_subtitles, mf.edition_key
+		FROM winners
+		JOIN media_files mf ON mf.id = winners.id
+	`, overlaySummaryResolutionRankSQL, overlaySummaryRangeRankSQL, strings.Join(conditions, " AND "))
+
+	rows, err := f.pool.Query(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("querying overlay summaries: %w", err)
+		return nil, 0, fmt.Errorf("querying overlay summaries: %w", err)
 	}
 	defer rows.Close()
 
-	requested := make(map[string]struct{}, len(contentIDs))
-	for _, contentID := range contentIDs {
-		requested[contentID] = struct{}{}
-	}
-
-	grouped := make(map[string][]*models.MediaFile, len(contentIDs))
+	rowCount := 0
 	for rows.Next() {
+		var groupKey string
 		var contentID string
 		var episodeID *string
 		var filePath string
@@ -1139,11 +1296,12 @@ func (f *Fetcher) ListOverlaySummaries(ctx context.Context, contentIDs []string,
 		var editionKey *string
 
 		if err := rows.Scan(
-			&contentID, &episodeID, &filePath, &resolution, &codecAudio, &audioTracksJSON, &hdr, &videoTracksJSON,
-			&codecVideo, &audioChannels, &container, &subtitleTracksJSON, &externalSubtitlesJSON, &editionKey,
+			&groupKey, &contentID, &episodeID, &filePath, &resolution, &codecAudio, &audioTracksJSON, &hdr,
+			&videoTracksJSON, &codecVideo, &audioChannels, &container, &subtitleTracksJSON, &externalSubtitlesJSON, &editionKey,
 		); err != nil {
-			return nil, fmt.Errorf("scanning overlay summary row: %w", err)
+			return nil, 0, fmt.Errorf("scanning overlay summary row: %w", err)
 		}
+		rowCount++
 
 		file := &models.MediaFile{
 			ContentID: contentID,
@@ -1173,45 +1331,38 @@ func (f *Fetcher) ListOverlaySummaries(ctx context.Context, contentIDs []string,
 		}
 		if len(audioTracksJSON) > 0 {
 			if err := json.Unmarshal(audioTracksJSON, &file.AudioTracks); err != nil {
-				return nil, fmt.Errorf("unmarshaling overlay audio tracks: %w", err)
+				return nil, 0, fmt.Errorf("unmarshaling overlay audio tracks: %w", err)
 			}
 		}
 		if len(videoTracksJSON) > 0 {
 			if err := json.Unmarshal(videoTracksJSON, &file.VideoTracks); err != nil {
-				return nil, fmt.Errorf("unmarshaling overlay video tracks: %w", err)
+				return nil, 0, fmt.Errorf("unmarshaling overlay video tracks: %w", err)
 			}
 		}
 		if len(subtitleTracksJSON) > 0 {
 			if err := json.Unmarshal(subtitleTracksJSON, &file.SubtitleTracks); err != nil {
-				return nil, fmt.Errorf("unmarshaling overlay subtitle tracks: %w", err)
+				return nil, 0, fmt.Errorf("unmarshaling overlay subtitle tracks: %w", err)
 			}
 		}
 		if len(externalSubtitlesJSON) > 0 {
 			if err := json.Unmarshal(externalSubtitlesJSON, &file.ExternalSubtitles); err != nil {
-				return nil, fmt.Errorf("unmarshaling overlay external subtitles: %w", err)
+				return nil, 0, fmt.Errorf("unmarshaling overlay external subtitles: %w", err)
 			}
 		}
 
-		groupKey := contentID
-		if episodeID != nil {
-			if _, ok := requested[*episodeID]; ok {
-				groupKey = *episodeID
-			}
+		if summary := overlays.BuildSummary([]*models.MediaFile{file}); summary != nil {
+			summaries[groupKey] = summary
 		}
-		grouped[groupKey] = append(grouped[groupKey], file)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating overlay summary rows: %w", err)
+		return nil, 0, fmt.Errorf("iterating overlay summary rows: %w", err)
 	}
 
-	for contentID, files := range grouped {
-		files = catalog.FilterMediaFilesByAccess(files, filter)
-		if summary := overlays.BuildSummary(files); summary != nil {
-			summaries[contentID] = summary
-		}
+	for _, contentID := range uncached {
+		summaryCache.Set(scope+"\x00"+contentID, summaries[contentID], overlaySummaryCacheTTL)
 	}
 
-	return summaries, nil
+	return summaries, rowCount, nil
 }
 
 // userAgnosticSectionFetch is the signature shared by every fetch helper whose

--- a/internal/sections/fetcher.go
+++ b/internal/sections/fetcher.go
@@ -1153,14 +1153,13 @@ func overlaySummaryCacheScope(filter catalog.AccessFilter) string {
 
 // overlaySummaryResolutionRankSQL mirrors overlays.ResolutionRank: "4k"/"uhd"
 // rank as 2160p, signed digits followed by "p" rank as their value, otherwise 0.
-// Use octal \013 for vertical tab; PostgreSQL treats \v as a literal v.
-// Trim ASCII whitespace as Go does. Go's TrimSpace also strips Unicode spaces
-// (such as U+00A0), which the scanner has never been observed to write.
+// Whitespace is trimmed with catalog.SQLTrimSpaceChars so the set matches Go's
+// strings.TrimSpace exactly, Unicode spaces included.
 // Limit numeric matches to 18 digits so they fit in int64, as required by Atoi.
 const overlaySummaryResolutionRankSQL = `CASE
-				WHEN lower(btrim(coalesce(mf.resolution, ''), E' \t\n\013\f\r')) IN ('4k', 'uhd') THEN 2160
-				WHEN lower(btrim(coalesce(mf.resolution, ''), E' \t\n\013\f\r')) ~ '^[+-]?[0-9]{1,18}p$'
-					THEN substring(lower(btrim(mf.resolution, E' \t\n\013\f\r')) from '^([+-]?[0-9]{1,18})p$')::numeric
+				WHEN lower(btrim(coalesce(mf.resolution, ''), ` + catalog.SQLTrimSpaceChars + `)) IN ('4k', 'uhd') THEN 2160
+				WHEN lower(btrim(coalesce(mf.resolution, ''), ` + catalog.SQLTrimSpaceChars + `)) ~ '^[+-]?[0-9]{1,18}p$'
+					THEN substring(lower(btrim(mf.resolution, ` + catalog.SQLTrimSpaceChars + `)) from '^([+-]?[0-9]{1,18})p$')::numeric
 				ELSE 0
 			END`
 

--- a/internal/sections/overlay_summary_cache_test.go
+++ b/internal/sections/overlay_summary_cache_test.go
@@ -1,0 +1,62 @@
+package sections
+
+import (
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+)
+
+func TestOverlaySummaryCacheScopeSeparatesAccess(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		filter catalog.AccessFilter
+	}{
+		{"unrestricted", catalog.AccessFilter{}},
+		{"empty allow list", catalog.AccessFilter{AllowedLibraryIDs: []int{}}},
+		{"one library", catalog.AccessFilter{AllowedLibraryIDs: []int{1}}},
+		{"two libraries", catalog.AccessFilter{AllowedLibraryIDs: []int{1, 2}}},
+		{"disabled library", catalog.AccessFilter{DisabledLibraryIDs: []int{1}}},
+		{"quality ceiling", catalog.AccessFilter{MaxPlaybackQuality: "1080p"}},
+		{"4k ceiling", catalog.AccessFilter{MaxPlaybackQuality: "2160p"}},
+	}
+
+	seen := make(map[string]string, len(cases))
+	for _, tc := range cases {
+		scope := overlaySummaryCacheScope(tc.filter)
+		if other, clash := seen[scope]; clash {
+			t.Errorf("%q and %q share cache scope %q; one profile would read the other's summaries", tc.name, other, scope)
+		}
+		seen[scope] = tc.name
+	}
+}
+
+func TestOverlaySummaryCacheScopeIgnoresOrderAndContentRating(t *testing.T) {
+	t.Parallel()
+
+	a := overlaySummaryCacheScope(catalog.AccessFilter{
+		AllowedLibraryIDs:  []int{3, 1, 2},
+		DisabledLibraryIDs: []int{9, 7},
+		MaxContentRating:   "PG",
+	})
+	b := overlaySummaryCacheScope(catalog.AccessFilter{
+		AllowedLibraryIDs:  []int{1, 2, 3},
+		DisabledLibraryIDs: []int{7, 9},
+		MaxContentRating:   "R",
+	})
+	if a != b {
+		t.Errorf("equivalent access filters produced different scopes:\n  %q\n  %q", a, b)
+	}
+}
+
+// A nil allow-list means "every library"; an empty one means "none". Collapsing
+// them would let an unrestricted profile's summaries serve a profile with no
+// library access at all.
+func TestOverlaySummaryCacheScopeNilAllowListIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	if overlaySummaryCacheScope(catalog.AccessFilter{}) == overlaySummaryCacheScope(catalog.AccessFilter{AllowedLibraryIDs: []int{}}) {
+		t.Error("nil and empty AllowedLibraryIDs share a cache scope")
+	}
+}

--- a/internal/sections/overlay_summary_grouping_sql_test.go
+++ b/internal/sections/overlay_summary_grouping_sql_test.go
@@ -1,0 +1,102 @@
+package sections
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestOverlaySummariesIndependentOfPageAndCache(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	ctx := t.Context()
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Each connection gets its own temporary fixture; no application schema is
+	// needed and no persistent tables are changed.
+	config.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, `
+			CREATE TEMP TABLE media_files (
+				id integer PRIMARY KEY, content_id text, episode_id text,
+				file_path text NOT NULL DEFAULT '', resolution text, codec_audio text,
+				audio_tracks jsonb, hdr boolean NOT NULL DEFAULT false, video_tracks jsonb,
+				codec_video text, audio_channels integer, container text,
+				subtitle_tracks jsonb, external_subtitles jsonb, edition_key text,
+				missing_since timestamptz
+			);
+			INSERT INTO media_files (id, content_id, episode_id, resolution, missing_since) VALUES
+				(1, 'series', 'episode-best', '2160p', NULL),
+				(2, 'series', 'episode-other', '1080p', NULL),
+				(3, 'series', 'episode-missing', '4320p', now()),
+				(4, 'movie', NULL, '720p', NULL);
+		`)
+		return err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	ids := []string{"series", "episode-best", "episode-other", "episode-missing", "movie"}
+	filter := catalog.AccessFilter{}
+	baseline := make(map[string]*models.OverlaySummary)
+	for _, id := range ids {
+		fetcher := &Fetcher{pool: pool}
+		summaries, err := fetcher.ListOverlaySummaries(ctx, []string{id}, filter)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if summary := summaries[id]; summary != nil {
+			baseline[id] = summary
+		}
+	}
+	if baseline["series"] == nil || baseline["series"].Resolution != "2160p" {
+		t.Fatalf("series alone must use its best non-missing episode file: %+v", baseline["series"])
+	}
+
+	for _, tc := range []struct {
+		name string
+		warm []string
+	}{
+		{name: "cold"},
+		{name: "episode cached", warm: []string{"episode-best"}},
+		{name: "series cached", warm: []string{"series"}},
+		{name: "missing cached", warm: []string{"episode-missing"}},
+		{name: "all cached", warm: ids},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fetcher := &Fetcher{pool: pool}
+			if _, err := fetcher.ListOverlaySummaries(ctx, tc.warm, filter); err != nil {
+				t.Fatal(err)
+			}
+			got, err := fetcher.ListOverlaySummaries(ctx, ids, filter)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, baseline) {
+				t.Errorf("combined page differs from individual cards: got %+v, want %+v", got, baseline)
+			}
+			for _, id := range ids {
+				single, rows, err := fetcher.listOverlaySummaries(ctx, []string{id}, filter)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if rows != 0 || !reflect.DeepEqual(single[id], baseline[id]) {
+					t.Errorf("cached card %s: got %+v (%d rows), want %+v", id, single[id], rows, baseline[id])
+				}
+			}
+		})
+	}
+}

--- a/internal/sections/overlay_summary_rank_sql_test.go
+++ b/internal/sections/overlay_summary_rank_sql_test.go
@@ -1,0 +1,119 @@
+package sections
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/models"
+	"github.com/Silo-Server/silo-server/internal/overlays"
+)
+
+// TestOverlaySummaryRankSQLMatchesGo pins the SQL mirror of overlays.BestFile.
+// ListOverlaySummaries reduces each card to one file inside PostgreSQL, so the
+// ordering encoded in overlaySummaryResolutionRankSQL and
+// overlaySummaryRangeRankSQL has to agree with overlays.ResolutionRank and
+// overlays.RangeRank. Drift here silently changes which file a card's badges
+// come from, which no other test would catch.
+//
+// The expressions are evaluated over a VALUES list aliased as mf, so the test
+// needs a PostgreSQL connection but no schema and no fixtures.
+func TestOverlaySummaryRankSQLMatchesGo(t *testing.T) {
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+
+	cases := []struct {
+		name      string
+		file      models.MediaFile
+		rawTracks string
+	}{
+		{"tab newline resolution", models.MediaFile{Resolution: "\t2160p\n"}, ""},
+		{"all ASCII whitespace", models.MediaFile{Resolution: " \t\n\v\f\r2160p \t\n\v\f\r"}, ""},
+		{"leading plus", models.MediaFile{Resolution: "+2160p"}, ""},
+		{"leading zeros", models.MediaFile{Resolution: "0000002160p"}, ""},
+		{"padded signed zeros", models.MediaFile{Resolution: "\t+002160p\t"}, ""},
+		{"negative", models.MediaFile{Resolution: "-2160p"}, ""},
+		{"18 digits", models.MediaFile{Resolution: "999999999999999999p"}, ""},
+		{"null dolby vision", models.MediaFile{Resolution: "1080p"}, `[{"dolby_vision":null}]`},
+		{"null dolby vision with HDR10", models.MediaFile{Resolution: "1080p"}, `[{"dolby_vision":null,"video_range_type":"HDR10"}]`},
+		{"absent dolby vision", models.MediaFile{Resolution: "1080p"}, `[{}]`},
+		{"empty", models.MediaFile{}, ""},
+		{"1080p", models.MediaFile{Resolution: "1080p"}, ""},
+		{"2160p", models.MediaFile{Resolution: "2160p"}, ""},
+		{"480p", models.MediaFile{Resolution: "480p"}, ""},
+		{"4k alias", models.MediaFile{Resolution: "4K"}, ""},
+		{"uhd alias", models.MediaFile{Resolution: "UHD"}, ""},
+		{"padded resolution", models.MediaFile{Resolution: "  1080P  "}, ""},
+		{"unparseable resolution", models.MediaFile{Resolution: "hd"}, ""},
+		{"numeric without p", models.MediaFile{Resolution: "1080"}, ""},
+		{"hdr bool only", models.MediaFile{Resolution: "1080p", HDR: true}, ""},
+		{"dolby vision string", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{DolbyVision: "profile 8"}}}, ""},
+		{"dv profile", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{DVProfile: 5}}}, ""},
+		{"dovi range type", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: "DOVIWithHDR10"}}}, ""},
+		{"dovi range type padded", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: " DOVIWithHLG"}}}, ""},
+		{"hdr10 plus flag", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{HDR10Plus: true}}}, ""},
+		{"hdr10 plus range", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: "HDR10Plus"}}}, ""},
+		{"hdr10 range", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: "HDR10"}}}, ""},
+		{"hdr10 range padded", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: " HDR10 "}}}, ""},
+		{"with hdr10 suffix", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: "SomethingWithHDR10"}}}, ""},
+		{"hlg range", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: "HLG"}}}, ""},
+		{"with hlg suffix", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: "SomethingWithHLG"}}}, ""},
+		{"smpte2084 transfer", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{ColorTransfer: "SMPTE2084"}}}, ""},
+		{"arib transfer", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{ColorTransfer: "ARIB-STD-B67"}}}, ""},
+		{"sdr tracks", models.MediaFile{Resolution: "1080p", VideoTracks: []models.VideoTrack{{VideoRangeType: "SDR"}}}, ""},
+		{"sdr tracks with hdr bool", models.MediaFile{Resolution: "1080p", HDR: true, VideoTracks: []models.VideoTrack{{VideoRangeType: "SDR"}}}, ""},
+		{"second track carries hdr", models.MediaFile{Resolution: "2160p", VideoTracks: []models.VideoTrack{{VideoRangeType: "SDR"}, {VideoRangeType: "HDR10"}}}, ""},
+	}
+
+	ctx := t.Context()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connecting to test database: %v", err)
+	}
+	defer func() { _ = conn.Close(context.Background()) }()
+
+	query := fmt.Sprintf(
+		"SELECT %s, %s, %s FROM (VALUES ($1::text, $2::boolean, $3::jsonb)) AS mf(resolution, hdr, video_tracks)",
+		overlaySummaryResolutionRankSQL, overlaySummaryRangeRankSQL, catalog.MediaFileQualityCeilingSQL("mf", "1080p"),
+	)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := tc.file
+			tracks, err := json.Marshal(file.VideoTracks)
+			if err != nil {
+				t.Fatalf("marshaling video tracks: %v", err)
+			}
+
+			if tc.rawTracks != "" {
+				tracks = []byte(tc.rawTracks)
+				if err := json.Unmarshal(tracks, &file.VideoTracks); err != nil {
+					t.Fatalf("decoding raw video tracks: %v", err)
+				}
+			}
+
+			var sqlAllowed bool
+			var sqlResolution, sqlRange int
+			if err := conn.QueryRow(ctx, query, file.Resolution, file.HDR, string(tracks)).Scan(&sqlResolution, &sqlRange, &sqlAllowed); err != nil {
+				t.Fatalf("evaluating rank SQL: %v", err)
+			}
+
+			if want := catalog.FileAllowedByAccess(&file, catalog.AccessFilter{MaxPlaybackQuality: "1080p"}); sqlAllowed != want {
+				t.Errorf("quality ceiling for %q: SQL %t, Go %t", file.Resolution, sqlAllowed, want)
+			}
+			if want := overlays.ResolutionRank(file.Resolution); sqlResolution != want {
+				t.Errorf("resolution rank for %q: SQL %d, Go %d", file.Resolution, sqlResolution, want)
+			}
+			if want := overlays.RangeRank(&file); sqlRange != want {
+				t.Errorf("range rank for %+v: SQL %d, Go %d", file.VideoTracks, sqlRange, want)
+			}
+		})
+	}
+}

--- a/internal/sections/overlay_summary_rank_sql_test.go
+++ b/internal/sections/overlay_summary_rank_sql_test.go
@@ -36,6 +36,12 @@ func TestOverlaySummaryRankSQLMatchesGo(t *testing.T) {
 	}{
 		{"tab newline resolution", models.MediaFile{Resolution: "\t2160p\n"}, ""},
 		{"all ASCII whitespace", models.MediaFile{Resolution: " \t\n\v\f\r2160p \t\n\v\f\r"}, ""},
+		{"non-breaking space", models.MediaFile{Resolution: "\u00a02160p\u00a0"}, ""},
+		{"all Unicode whitespace", models.MediaFile{
+			Resolution: "\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u30002160p" +
+				"\u0085\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000",
+		}, ""},
+		{"non-breaking space below ceiling", models.MediaFile{Resolution: "\u00a0720p\u00a0"}, ""},
 		{"leading plus", models.MediaFile{Resolution: "+2160p"}, ""},
 		{"leading zeros", models.MediaFile{Resolution: "0000002160p"}, ""},
 		{"padded signed zeros", models.MediaFile{Resolution: "\t+002160p\t"}, ""},


### PR DESCRIPTION
The home screen now returns in a fifth of the time it used to: production p50 fell from
1030ms to 195ms and the mean from 1074ms to 253ms, measured over 3,211 real requests in the
19.6 hours since deploy against 1,028 requests in the 8.3 hours before it. The change also fixes a
pre-existing bug that hid quality badges entirely from any profile with a library allow-list.

One commit: the fix plus the phase instrumentation that proves where the time went.

## Related work

Third in the sections performance series, after #984 (stored parent IDs for episode totals) and
#947 (Continue Watching stops re-reading watch history). It branches directly off #947's merge
commit.

It does not fix anything those two broke, and it does not touch their code — the diff against
`origin/main` leaves `internal/catalog/continue_watching_progress.go` untouched. They removed
per-section costs; this removes the fixed cost every request paid regardless of section, which is
what was left once theirs landed. The badge bug below is older than all three: it dates to
`c085b12f`, the initial migration.

One thing #947 introduced is still open and this PR does not address it: the
`continue-watching: superseded-episode walk hit page cap` WARN fires at a comparable rate before
and after (23/h and 26/h), so whatever it indicates is unchanged.

Related issue: N/A — no issue or epic exists for the sections latency work; #947 and #984 are
pull requests. Worth opening one if this series continues.

## Problem

**The home screen took about a second for everyone, every time.** Opening Silo on any client
meant waiting roughly a second before the first row of posters appeared. It was not a slow
network or a slow device — it was the server, and it was consistent: 96.6% of home-screen
requests took 900ms or more, and only 7 requests out of 1,028 came back in under 300ms. The
delay showed up identically on Android, on tvOS, and on iOS, so no client team could fix it on
their side.

**The cost scaled with the size of the library, not with what was on screen.** The home screen
shows about 30 rows of roughly 20 posters each. To draw the small quality badges on a poster
(4K, HDR, Atmos), the server was reading *every media file behind every card* — and for a TV
series card, that meant every episode file of the entire show. One series in this library has
8,302 files, all of them read to render a single badge. A row of 20 children's shows pulled
2,723 database rows and about 6 MB of data to draw 20 badges. All but 20 of those rows were
decoded and thrown away.

**Households with restricted libraries saw no quality badges at all.** Separately from the
speed problem, any profile limited to a subset of libraries — a kids' profile, a shared-account
guest — got posters with no 4K, HDR, or audio badges anywhere on the home screen. The badges
were not "sometimes wrong"; they were entirely absent for those profiles, and had been for as
long as the feature has existed. Nobody filed an issue for it, so it appears to have been read
as "this build just doesn't show badges" rather than as a bug.

**There was no way to tell which part of the request was slow.** The endpoint reported one
number — total duration — so every explanation for the second was a guess. Two plausible
guesses turned out to be wrong, and there was no evidence available to settle it either way.

## Solution

### perf(sections): cut the fixed cost out of the home sections response

**Reduce each card to one file inside PostgreSQL.** `listOverlaySummaries`
(`internal/sections/fetcher.go:1207`) now picks the single best file per card with
`DISTINCT ON (group_key)` (`internal/sections/fetcher.go:1251`) instead of returning every
candidate file and reducing in Go. Only the winner's wide columns — including the four JSON
track blobs — are fetched, via a join back on `winners.id`; the ranking sorts narrow
`(group_key, id, rank)` tuples first, because sorting the wide rows costs measurably more.

The ranking mirrors `overlays.BestFile` (`internal/overlays/summary.go:60`) exactly, down to
the final tiebreak `content_id ASC, episode_id ASC, id ASC` — the old Go path kept the first
file in the slice, and the slice arrived in that order. `overlays.ResolutionRank` and
`overlays.RangeRank` (`internal/overlays/summary.go:66,70`) were exported so a test can pin the
SQL against the Go implementation rather than against a second hand-written copy of the rules.

Measured against the production database: 580 mixed cards went from 4,578 rows / 357ms to
580 rows / 140ms; 300 series cards from 8,639 rows / 636ms to 300 rows / 150ms; the Kids Shows
row from 2,723 rows / ~372ms to 20 rows / 100ms.

**Push the access predicate into SQL, and fix the bug that surfaced.** The old query filtered
files in Go with `catalog.FilterMediaFilesByAccess` (old `fetcher.go:1208`), but its `SELECT`
list (old `fetcher.go:1108`) never included `media_folder_id`. Every `MediaFile` therefore
carried `MediaFolderID == 0`, and `FileAllowedByAccess`
(`internal/catalog/access_filter.go:189`) compares exactly that field against
`filter.AllowedLibraryIDs`. Folder 0 is in nobody's allow-list, so for any profile with a
non-nil allow-list *every* file was dropped, `BuildSummary` received an empty slice, and the
card got no summary at all.

The new path applies the same predicate as a SQL `WHERE` clause through
`catalog.MediaFileAccessSQL` (`internal/catalog/access_filter.go:260`), a new helper that
mirrors `FileAllowedByAccess` field for field — allow-list, disabled libraries, and the
quality ceiling. Because the filter is now applied against the real column instead of a
zero-valued struct field, restricted profiles get their badges. This is a user-visible change
in those households: badges appear where there were none.

**Cache summaries per access scope.** `overlaySummaryCacheScope`
(`internal/sections/fetcher.go:1127`) fingerprints only the parts of the access filter that can
change the answer, and summaries are cached under `scope\x00contentID` with a 5-minute TTL
(`internal/sections/fetcher.go:1114`). A card with no usable file caches as a nil summary
rather than as a miss, so it is not re-queried every request. In steady state the second and
later requests read zero rows.

Caching is only sound because of the behaviour change below.

**Run the six enrichment lookups concurrently.** `buildSectionsResponse`
(`internal/api/handlers/sections.go:1315`) issued six independent database round trips over
every card on the page — overlays, playable targets, user states, image URLs, episode meta,
manga chapter meta — one after another, and only combined them at the end. They now run
together under a `sync.WaitGroup`, so the phase costs the slowest lookup rather than their sum.
Fan-out stays at six, matching what `FetchAll` already takes, so peak pool usage per request is
unchanged — the two phases never overlap.

**Add phase timing, and lower the aggregate alarm.** `sectionPhaseTimer`
(`internal/api/handlers/sections.go:603`) records `resolve / next_up / fetch_all /
build_response / write` and emits the whole breakdown as one line from `HandleHomeSections`
(`internal/api/handlers/sections.go:635`): WARN past 500ms
(`slowHomeSectionsThreshold`, `internal/api/handlers/sections.go:598`), DEBUG below, so the
phases are always available without making a slow request indistinguishable from a fast one.
`slowAggregateFetchThreshold` (`internal/sections/fetcher.go:69`) dropped from 1s to 500ms for
the same reason: a threshold set at the middle of the distribution almost never fires and
reports nothing.

This instrumentation is what turned the diagnosis from argument into measurement, and it is
what produced the phase table below.

### Deliberate behaviour change

A series that shares a page with one of its own episodes now reports **the best file in the
whole show**. Previously the episode's file was removed from the series' candidate pool, so the
same series card showed different badges depending on which other cards happened to be on the
page with it. Page-dependent badges were the reason the result could not be cached; making the
answer page-independent is both more correct and what makes the cache sound. Verified against
production data across four card samples — the only differences are the 28 expected ones in the
series-plus-their-own-episodes sample.

## Results

Production, `GET /api/v1/home/sections`, status 200. Before: the container running the previous
build, 2026-09-06T04:00Z until the deploy. After: the current container, deployed
2026-09-06T12:21:11Z, read at 2026-09-07T07:58Z. Request rate was comparable across both
windows (123/h before, 164/h after), so this is not a traffic artifact. All "after" figures come
from a single frozen log snapshot, because the live container keeps appending.

| | n | min | p50 | p90 | p95 | p99 | max | mean |
|---|---|---|---|---|---|---|---|---|
| Before | 1028 | 65 | 1030 | 1275 | 1499 | 2299 | 2863 | 1074 |
| After | 3211 | 45 | **195** | **388** | **506** | **1075** | 5437 | **253** |
| Change | | −31% | **−81%** | **−70%** | **−66%** | **−53%** | see below | **−76%** |

The shape of the distribution changed, not just its percentiles. The old mode was a tall spike
in the 1000–1249ms bucket holding 54% of all requests; the new mode is the 0–249ms bucket
holding 74%.

| duration | before | after |
|---|---|---|
| 0–249ms | 0.7% | **73.5%** |
| 250–499ms | 0.8% | 21.4% |
| 500–749ms | 1.2% | 3.1% |
| 750–999ms | 32.1% | 0.9% |
| 1000–1249ms | 54.0% | 0.3% |
| ≥1250ms | 11.2% | 0.9% |

Requests at or above 900ms fell from 993 of 1028 (96.6%) to 43 of 3211 (1.3%). Requests under
300ms rose from 7 (0.7%) to 2,639 (82.2%).

### By client family

The win is not one platform. All three client families improved by roughly the same proportion.

| client | before mean | after mean | before p50 | after p50 | n after |
|---|---|---|---|---|---|
| ktor (Android) | 1082 | **252** | 1033 | **195** | 2826 |
| SiloTV (tvOS) | 977 | **186** | 986 | **164** | 195 |
| Silo iOS | 973 | **332** | 970 | **227** | 190 |

`ktor-client` is the Silo Android phone/TV client — it is the only non-Apple user agent that
reaches this endpoint at all. `SiloTV` covers tvOS including the Top Shelf extension, `Silo` is
iOS. No browser hit `/api/v1/home/sections` during either window, so the **web UI is unmeasured**
here; it runs the same server code, so it should see the same improvement, but that is inference
rather than a reading.

The iOS mean is inflated by three 5.2–5.4s outliers discussed below; excluding them it is
252ms (p50 224ms, p95 423ms, n=187), in line with the other two.

### Phase breakdown

159 of 3,211 requests (5.0%) crossed the 500ms WARN threshold. Across those 159 lines:

| phase | mean | p50 | p90 | max | share of total |
|---|---|---|---|---|---|
| `resolve_ms` | 2 | 2 | 4 | 12 | 0.2% |
| `next_up_ms` | 0 | 0 | 1 | 2 | 0.0% |
| `fetch_all_ms` | 231 | 159 | 644 | 1175 | 25% |
| `build_response_ms` | **679** | **525** | **861** | 5258 | **73%** |
| `write_ms` | 22 | 23 | 26 | 40 | 2.3% |
| `total_ms` | 936 | 713 | 1552 | 5432 | |

`build_response` exceeds `fetch_all` on 146 of the 159 slow requests and accounts for 73% of
their combined time. That settles the question the instrumentation was added to answer: **the
remaining cost is the enrichment pass, not `FetchAll`.** Two earlier hypotheses — that
`FetchAll` concurrency waves were the bottleneck, and that per-section costs measured on
`/home/sections/{id}/items` were section-fetch costs — are both disproven by this table and
should not be re-litigated. Typical pages carry 31 sections and ~550 items.

### Jellyfin clients

jellycompat does not touch this code. `ListOverlaySummaries` has exactly three callers —
`internal/api/handlers/sections.go:1364`, `internal/api/handlers/watch_tonight.go:355` and
`internal/api/handlers/recommendations.go:655` — all on the v1 surface, and nothing under
`internal/jellycompat/` references overlay summaries or `buildSectionsResponse` at all. Jellyfin
clients build their home screen from `/Items/Latest`, `/Shows/NextUp` and `/UserItems/Resume`,
which are a separate view over the catalog.

Measured anyway, to confirm nothing regressed. Per-route, status < 400, excluding streaming and
the 60s `/socket` long-poll:

| route | before p50 | after p50 | before p95 | after p95 | after n |
|---|---|---|---|---|---|
| `/Items/Latest` | 180 | **56** | 434 | 420 | 3588 |
| `/Users/{id}/Items/Latest` | 46 | **27** | 297 | 265 | 2687 |
| `/Items/{id}/Download` | 42 | **31** | 156 | 144 | 13286 |
| `/UserItems/Resume` | 110 | 106 | 433 | 437 | 1108 |
| `/Shows/NextUp` | 107 | 114 | 570 | 389 | 1148 |
| `/Shows/{id}/Episodes` | 42 | 42 | 74 | 83 | 5003 |
| `/Items` | 0 | 0 | 214 | 238 | 8117 |
| `/Sessions/Playing/Progress` | 5 | 5 | 9 | 9 | 37241 |

Nothing regressed. Several routes improved, most visibly `/Items/Latest`. I would not attribute
that to this change — the plausible mechanism is reduced connection-pool and buffer pressure now
that the sections endpoint no longer pulls millions of rows — but the traffic mix also differs
between the two windows, so treat it as "no regression, possibly a bonus" rather than a claim.

## Risk / follow-ups

- **Badges appear where they did not before.** Any profile with a library allow-list will
  suddenly see 4K/HDR/audio badges on the home screen. This is the bug fix landing, not a
  regression, but it is a visible change for those households and worth saying out loud in
  release notes. No issue was ever filed for the missing badges (searched open and closed), so
  nobody is expecting the change.
- **Badges can now be up to 5 minutes stale** because of the summary cache. A file replaced
  with a better version will keep showing the old badge until the TTL expires. Acceptable for
  decorative badges; not acceptable if anything load-bearing is ever derived from them.
- **The maximum got worse: three 5.2–5.4s requests, all from one user.** 14:33, 17:21 and
  21:29, every one of them the same account on the same iOS build, `fetch_all_ms` ~130ms and
  `build_response_ms` 5,071–5,258ms. That user's other 16 requests in the window are normal
  (p50 379ms), and no other request on the server stalled at those moments, so it is neither a
  server-wide event nor a permanently slow profile. There is no `context.WithTimeout` anywhere
  in the enrichment path, so despite how consistent the ceiling looks it is not a code deadline
  — the most likely candidate is the image resolver's ladder fallback
  (`internal/metadata/image_resolver.go:338`) taking a cold-cache walk with real storage HEADs
  behind it. Not a regression this change introduced, and it predates the change in kind; it was
  simply invisible before, when every request cost a second anyway. Worth a follow-up issue, not
  a blocker.
- **One cold-cache request per hour still costs ~1.5s.** Requests at :45–:52 past most hours
  land at 1.4–1.7s with both `fetch_all_ms` (~650ms vs ~150ms typical) and `build_response_ms`
  (~800–950ms) elevated — a cache-expiry cliff paid by whoever arrives first. Steady-state
  performance is unaffected; a background refresh would remove it.
- **Five enrichment stages are still individually unmeasured.** `build_response` is now the
  dominant remaining cost but is timed as a whole. The named suspects inside it are
  `catalog.PlayableTargetResolver.Resolve` (serial progress batches of 500),
  `resolveItemUserStatesWithOptions` (six *inner* serial round trips that this change did not
  parallelise), and `resolveSectionItemImageURLs` (presigns up to ~1,740 paths).
- **The structural question is untouched.** The server still builds ~31 sections when the
  client shows three or four above the fold. That is the largest remaining win, and it is a v1
  API shape change needing `silo-apple` and `silo-android` coordination — a product decision,
  not a patch.
- **Client-visible surface.** No API shape change, so no client work is required. jellycompat
  does not use this path and needs no parity change. No `docs/*-api.md` update is needed.
- **`internal/catalog/access_filter.go` gained `MediaFileAccessSQL`,** which duplicates
  `FileAllowedByAccess` in SQL. The two must stay in step; they are pinned by test, but a
  future field added to one and not the other would diverge silently.

## Verification

- `gofmt -l internal/` clean; `go build ./...` and `go vet` clean on the touched packages.
- `go test ./internal/sections/... ./internal/overlays/... ./internal/catalog/... ./internal/api/handlers/...`
  green (re-run against the deployed commit).
- `golangci-lint --new-from-merge-base=origin/main`: 0 issues.
- `TestOverlaySummaryRankSQLMatchesGo` pins the SQL ranking against `overlays.BestFile` over a
  VALUES list. It caught four real divergences during development: jsonpath eating the
  backslash in `\s`; `hasDolbyVision` reading the raw `video_range_type` where
  `hdrTypeFromTracks` trims it; `BTRIM` stripping only spaces where `strings.TrimSpace` strips
  the whole ASCII set; and jsonpath treating JSON `null` as `!= ""`.
- `TestOverlaySummariesIndependentOfPageAndCache` pins page- and cache-independence against a
  temporary `media_files` fixture.
- Old vs new overlay output compared against production data across four card samples
  (mixed 580, series 300, episodes 400, series-plus-their-own-episodes 360): zero unexpected
  differences. The 28 differences in the last sample are the intended page-independence change.
- `go test ./...` green; `go test -race` green on the section handler tests. Two
  `internal/playback` failures on one full-suite run are pre-existing and environment-dependent:
  one is flaky under load, and `TestResolveCopySeekAnchorMatchesRealLongGOPHEVC` fails
  identically on a clean `origin/main` worktree because it shells out to ffmpeg.
- Deployed to production and measured against 19.6 hours of real traffic, 3,211 home-screen
  requests, from a single frozen log snapshot. Numbers above.
- No new error classes in the deploy window. The 8 `loading overlay summaries` ERRORs present
  in the before window — client cancellations during the long row iteration — are gone
  entirely. Zero panics. The `plugin batch image resolution failed` ERRORs are pre-existing
  (172 in the before window) and are `context canceled` from the tvdb image plugin during a
  jellycompat request surge; they do not touch this path, whose requests during the largest
  burst ran 193–282ms.
- Running image confirmed identical to the built `silo:local`
  (`sha256:b410b937e34a6…`), so the measured window is this code.

## AI-use disclosure

Written with AI assistance: Claude Code (claude-opus-5) did the investigation, the
implementation, and the production before/after measurement. All numbers are from production
logs and the production database; the reasoning and conclusions were reviewed by the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved loading speed for home sections by processing content more efficiently.
  * Added caching for overlay summaries to improve repeat access times, including empty results.
  * Reduced the threshold for identifying slow section loading.

* **Access and Playback**
  * Overlay summaries now respect library access permissions and playback-quality limits.
  * Improved selection of the best available media file for each content group.
  * Improved consistency when media resolutions contain surrounding whitespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
