### PR TITLE
fix(audiobooks): return chapters from every audio file

### DIFF
--- a/internal/audiobooks/abs/handler.go
+++ b/internal/audiobooks/abs/handler.go
@@ -233,10 +233,10 @@ type Dependencies struct {
 	CredValidator  ProfileCredentialValidator
 	AccessResolver AccessResolver
 	// UsernameResolver returns the display username for an ABS principal
-	// (userID, profileID) without re-authenticating. Optional; GET /me falls
-	// back to the userID when this is nil or returns "". Login gets the
-	// display name from the credential validator, but /me only has the token
-	// claims, so it needs this to show the real username instead of the id.
+	// (userID, profileID) without re-authenticating. Optional; token-based
+	// endpoints fall back to the userID when this is nil or returns "". Login
+	// gets the display name from the credential validator, while /me,
+	// /authorize, and /auth/refresh only have the token claims.
 	UsernameResolver func(ctx context.Context, userID, profileID string) string
 	Config           ConfigProvider
 	Publisher        EventPublisher // may be nil

--- a/internal/audiobooks/abs/items_detail_test.go
+++ b/internal/audiobooks/abs/items_detail_test.go
@@ -85,3 +85,39 @@ func TestSiloItemToLibraryItemDetail_ExpandedShape(t *testing.T) {
 		t.Errorf("descriptionPlain = %q, want %q", dp, "Hello world")
 	}
 }
+
+// TestSiloItemToLibraryItemDetail_FlattensChaptersAcrossFiles verifies that
+// chapters from multiple audio files use contiguous IDs and absolute offsets.
+func TestSiloItemToLibraryItemDetail_FlattensChaptersAcrossFiles(t *testing.T) {
+	// Given an audiobook whose chapters are distributed across two audio files.
+	item := &models.MediaItem{ContentID: "book-multi"}
+	files := []*models.MediaFile{
+		{
+			FilePath: "/x/part1.mp3",
+			Duration: 120,
+			Chapters: []models.MediaChapter{{Index: 0, Title: "One", StartSeconds: 0, EndSeconds: 60}},
+		},
+		{
+			FilePath: "/x/part2.mp3",
+			Duration: 90,
+			Chapters: []models.MediaChapter{{Index: 0, Title: "Two", StartSeconds: 0, EndSeconds: 45}},
+		},
+	}
+
+	// When the ABS item-detail response is built.
+	detail := siloItemToLibraryItemDetail(item, files, AudiobookLibrary{ID: 1, Name: "Audiobooks"}, "http://x")
+
+	// Then every file chapter is present with an absolute offset and contiguous IDs.
+	if len(detail.Media.Chapters) != 2 {
+		t.Fatalf("chapters = %d, want 2", len(detail.Media.Chapters))
+	}
+	if detail.Media.Chapters[0].Title != "One" || detail.Media.Chapters[0].Start != 0 {
+		t.Fatalf("first chapter = %+v, want title One at 0", detail.Media.Chapters[0])
+	}
+	if detail.Media.Chapters[1].Title != "Two" || detail.Media.Chapters[1].Start != 120 || detail.Media.Chapters[1].End != 165 {
+		t.Fatalf("second chapter = %+v, want title Two at 120 ending at 165", detail.Media.Chapters[1])
+	}
+	if detail.Media.Chapters[0].ID != 0 || detail.Media.Chapters[1].ID != 1 {
+		t.Fatalf("chapter ids = (%d, %d), want (0, 1)", detail.Media.Chapters[0].ID, detail.Media.Chapters[1].ID)
+	}
+}

--- a/internal/audiobooks/abs/libraries_handler.go
+++ b/internal/audiobooks/abs/libraries_handler.go
@@ -894,20 +894,21 @@ func siloItemToLibraryItemDetail(item *models.MediaItem, files []*models.MediaFi
 		totalDuration = base.Media.Duration
 	}
 
-	// Chapters from the first file that has them.
+	// ABS expects chapters as one flat timeline spanning every audio file.
 	chapters := make([]ChapterABS, 0)
+	chapterOffset := float64(0)
+	chapterID := 0
 	for _, f := range files {
-		if len(f.Chapters) > 0 {
-			for i, c := range f.Chapters {
-				chapters = append(chapters, ChapterABS{
-					ID:    i,
-					Start: c.StartSeconds,
-					End:   c.EndSeconds,
-					Title: c.Title,
-				})
-			}
-			break
+		for _, c := range f.Chapters {
+			chapters = append(chapters, ChapterABS{
+				ID:    chapterID,
+				Start: chapterOffset + c.StartSeconds,
+				End:   chapterOffset + c.EndSeconds,
+				Title: c.Title,
+			})
+			chapterID++
 		}
+		chapterOffset += float64(f.Duration)
 	}
 
 	// libraryFiles + summed size mirror real ABS toOldJSONExpanded. Each entry

--- a/internal/audiobooks/abs/libraries_handler.go
+++ b/internal/audiobooks/abs/libraries_handler.go
@@ -894,22 +894,7 @@ func siloItemToLibraryItemDetail(item *models.MediaItem, files []*models.MediaFi
 		totalDuration = base.Media.Duration
 	}
 
-	// ABS expects chapters as one flat timeline spanning every audio file.
-	chapters := make([]ChapterABS, 0)
-	chapterOffset := float64(0)
-	chapterID := 0
-	for _, f := range files {
-		for _, c := range f.Chapters {
-			chapters = append(chapters, ChapterABS{
-				ID:    chapterID,
-				Start: chapterOffset + c.StartSeconds,
-				End:   chapterOffset + c.EndSeconds,
-				Title: c.Title,
-			})
-			chapterID++
-		}
-		chapterOffset += float64(f.Duration)
-	}
+	chapters := buildSiloChapters(files)
 
 	// libraryFiles + summed size mirror real ABS toOldJSONExpanded. Each entry
 	// is the real-ABS library file shape (ino + file metadata + fileType).

--- a/internal/audiobooks/abs/login.go
+++ b/internal/audiobooks/abs/login.go
@@ -440,7 +440,13 @@ func (h *Handler) handleABSAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 	// /authorize never issues a refresh token (the client already holds one),
 	// so there is nothing to return in the body.
-	writeJSON(w, http.StatusOK, h.loginEnvelope(r, time.Now(), a.UserID, a.UserID, access, "", false))
+	displayName := a.UserID
+	if h.deps.UsernameResolver != nil {
+		if resolved := h.deps.UsernameResolver(r.Context(), a.UserID, a.ProfileID); resolved != "" {
+			displayName = resolved
+		}
+	}
+	writeJSON(w, http.StatusOK, h.loginEnvelope(r, time.Now(), a.UserID, displayName, access, "", false))
 }
 
 // setRefreshCookie writes the ABS refresh_token cookie exactly as real ABS
@@ -590,13 +596,19 @@ func (h *Handler) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	// full envelope (not a thin token map) so a strict client can decode it
 	// with the same model it uses for login. The rotated refresh token goes
 	// in the body when the client sent x-refresh-token (mobile), otherwise as
-	// the refresh_token cookie. No displayName is available at refresh time —
-	// loginEnvelope falls back to the userID for username.
+	// the refresh_token cookie. Resolve the display name from the authenticated
+	// principal so clients show the username rather than the internal user ID.
 	returnRefreshInBody := strings.TrimSpace(r.Header.Get("x-refresh-token")) != ""
 	if !returnRefreshInBody {
 		setRefreshCookie(w, r, refresh, refreshTTL)
 	}
-	writeJSON(w, http.StatusOK, h.loginEnvelope(r, now, claims.UserID, "", access, refresh, returnRefreshInBody))
+	displayName := claims.UserID
+	if h.deps.UsernameResolver != nil {
+		if resolved := h.deps.UsernameResolver(r.Context(), claims.UserID, claims.ProfileID); resolved != "" {
+			displayName = resolved
+		}
+	}
+	writeJSON(w, http.StatusOK, h.loginEnvelope(r, now, claims.UserID, displayName, access, refresh, returnRefreshInBody))
 }
 
 // handleLogout — POST /logout (and /api/logout, /abs/api/logout, /abs/api/auth/logout)

--- a/internal/audiobooks/abs/login_envelope_test.go
+++ b/internal/audiobooks/abs/login_envelope_test.go
@@ -1,6 +1,7 @@
 package abs
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -147,5 +148,43 @@ func TestLoginEnvelope_DisplayNameFallsBackToUserID(t *testing.T) {
 	user, _ := env["user"].(map[string]any)
 	if user["username"] != "user-42" {
 		t.Errorf("username = %v, want user-42 (fallback)", user["username"])
+	}
+}
+
+// TestHandleABSAuthorize_ResolvesUsername verifies that authorize responses
+// expose the resolved username instead of the internal user ID.
+func TestHandleABSAuthorize_ResolvesUsername(t *testing.T) {
+	// Given
+	h, _, _ := newRefreshTestHandler(t)
+	h.deps.UsernameResolver = func(context.Context, string, string) string { return "sara" }
+
+	req := httptest.NewRequest(http.MethodPost, "/api/authorize", nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxKey{}, ctxAuth{
+		UserID:    "15",
+		ProfileID: "profile-1",
+		Token:     "access.jwt",
+	}))
+	rec := httptest.NewRecorder()
+
+	// When
+	h.handleABSAuthorize(rec, req)
+
+	// Then
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var env map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	user, ok := env["user"].(map[string]any)
+	if !ok {
+		t.Fatalf("user is not a map: %T", env["user"])
+	}
+	if user["username"] != "sara" {
+		t.Errorf("username = %v, want sara", user["username"])
+	}
+	if user["id"] != "15" {
+		t.Errorf("id = %v, want 15", user["id"])
 	}
 }

--- a/internal/audiobooks/abs/login_refresh_test.go
+++ b/internal/audiobooks/abs/login_refresh_test.go
@@ -240,6 +240,41 @@ func TestHandleRefresh_ReturnsFullLoginEnvelope(t *testing.T) {
 	}
 }
 
+// TestHandleRefresh_ResolvesUsername verifies that refresh responses expose
+// the resolved username instead of the internal user ID.
+func TestHandleRefresh_ResolvesUsername(t *testing.T) {
+	// Given
+	h, store, cfg := newRefreshTestHandler(t)
+	h.deps.UsernameResolver = func(context.Context, string, string) string { return "sara" }
+	refresh, _ := mintAndPersistRefresh(t, store, cfg, "15")
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/refresh", nil)
+	req.Header.Set("x-refresh-token", refresh)
+	rec := httptest.NewRecorder()
+
+	// When
+	h.handleRefresh(rec, req)
+
+	// Then
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	user, ok := resp["user"].(map[string]any)
+	if !ok {
+		t.Fatalf("user object missing")
+	}
+	if user["username"] != "sara" {
+		t.Errorf("username = %v, want sara", user["username"])
+	}
+	if user["id"] != "15" {
+		t.Errorf("id = %v, want 15", user["id"])
+	}
+}
+
 // TestHandleRefresh_NoHeader_SetsCookie: without x-refresh-token the rotated
 // refresh token is delivered as the refresh_token cookie and nulled in the body.
 func TestHandleRefresh_NoHeader_SetsCookie(t *testing.T) {

--- a/internal/audiobooks/abs/play_chapters_test.go
+++ b/internal/audiobooks/abs/play_chapters_test.go
@@ -1,0 +1,69 @@
+package abs
+
+import (
+	"encoding/json"
+	"net/http"
+	"slices"
+	"testing"
+
+	"github.com/Silo-Server/silo-server/internal/models"
+)
+
+func TestPlayStart_ChaptersMatchItemDetail(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []*models.MediaFile
+		want  []ChapterABS
+	}{
+		{name: "empty", want: []ChapterABS{}},
+		{name: "single file", files: []*models.MediaFile{
+			{FilePath: "book.m4b", Duration: 60, Chapters: []models.MediaChapter{{StartSeconds: 1.5, EndSeconds: 59.5, Title: "One"}}},
+		}, want: []ChapterABS{{ID: 0, Start: 1.5, End: 59.5, Title: "One"}}},
+		{name: "multiple files with chapterless gap", files: []*models.MediaFile{
+			{FilePath: "01.mp3", Duration: 120, Chapters: []models.MediaChapter{
+				{Index: 8, StartSeconds: 0, EndSeconds: 60, Title: "One"},
+				{Index: 9, StartSeconds: 60, EndSeconds: 120, Title: "Two"},
+			}},
+			{FilePath: "02.mp3", Duration: 30},
+			{FilePath: "03.mp3", Duration: 90, Chapters: []models.MediaChapter{{Index: 0, StartSeconds: 2.5, EndSeconds: 89.5, Title: "Three"}}},
+		}, want: []ChapterABS{
+			{ID: 0, Start: 0, End: 60, Title: "One"},
+			{ID: 1, Start: 60, End: 120, Title: "Two"},
+			{ID: 2, Start: 152.5, End: 239.5, Title: "Three"},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item := &models.MediaItem{ContentID: "book-1", Type: "audiobook"}
+			h := New(Dependencies{MediaStore: &playStartMediaStore{item: item, files: tc.files}})
+			detailRec := dispatchABSWithParams(http.MethodGet, "/api/items/book-1", map[string]string{"id": "book-1"}, nil, "1", "", h.handleItem)
+			if detailRec.Code != http.StatusOK {
+				t.Fatalf("detail status=%d: %s", detailRec.Code, detailRec.Body.String())
+			}
+			var detail LibraryItem
+			if err := json.Unmarshal(detailRec.Body.Bytes(), &detail); err != nil {
+				t.Fatal(err)
+			}
+			playRec := dispatchABSWithParams(http.MethodPost, "/api/items/book-1/play", map[string]string{"libraryItemId": "book-1"}, nil, "1", "", h.handlePlayStart)
+			if playRec.Code != http.StatusOK {
+				t.Fatalf("play status=%d: %s", playRec.Code, playRec.Body.String())
+			}
+			var play struct {
+				Chapters    []ChapterABS `json:"chapters"`
+				LibraryItem struct {
+					Media struct {
+						Chapters []ChapterABS `json:"chapters"`
+					} `json:"media"`
+				} `json:"libraryItem"`
+			}
+			if err := json.Unmarshal(playRec.Body.Bytes(), &play); err != nil {
+				t.Fatal(err)
+			}
+			for name, got := range map[string][]ChapterABS{"detail": detail.Media.Chapters, "session": play.Chapters, "session item": play.LibraryItem.Media.Chapters} {
+				if got == nil || !slices.Equal(got, tc.want) {
+					t.Errorf("%s chapters=%+v, want %+v (non-null)", name, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/audiobooks/abs/play_response.go
+++ b/internal/audiobooks/abs/play_response.go
@@ -270,27 +270,23 @@ func buildSiloAudioTracks(
 	return tracks
 }
 
-// buildSiloChapters extracts chapters from the first media file that has them.
-// ABS expects chapters as a flat list spanning the whole book; for multi-file
-// audiobooks we only use the first file's chapters (most single-file M4B
-// audiobooks have embedded chapters; multi-MP3 sets rarely do).
-func buildSiloChapters(files []*models.MediaFile) []map[string]any {
+// buildSiloChapters builds the shared item-detail and playback chapter timeline.
+// File-relative timestamps use the same cumulative durations as audio tracks.
+func buildSiloChapters(files []*models.MediaFile) []ChapterABS {
+	chapters := make([]ChapterABS, 0)
+	offset := float64(0)
 	for _, f := range files {
-		if len(f.Chapters) == 0 {
-			continue
-		}
-		chapters := make([]map[string]any, 0, len(f.Chapters))
-		for i, c := range f.Chapters {
-			chapters = append(chapters, map[string]any{
-				"id":    i,
-				"start": c.StartSeconds,
-				"end":   c.EndSeconds,
-				"title": c.Title,
+		for _, c := range f.Chapters {
+			chapters = append(chapters, ChapterABS{
+				ID:    len(chapters),
+				Start: offset + c.StartSeconds,
+				End:   offset + c.EndSeconds,
+				Title: c.Title,
 			})
 		}
-		return chapters
+		offset += float64(f.Duration)
 	}
-	return []map[string]any{}
+	return chapters
 }
 
 // buildSiloPlayMediaMetadata builds the playbackSession.mediaMetadata object
@@ -385,7 +381,7 @@ func buildSiloPlayLibraryItem(
 	contentID string,
 	mediaMetadata map[string]any,
 	audioTracks []AudioTrack,
-	chapters []map[string]any,
+	chapters []ChapterABS,
 	totalDuration float64,
 	baseURL string,
 ) map[string]any {

--- a/internal/audiobooks/cred_validator.go
+++ b/internal/audiobooks/cred_validator.go
@@ -101,18 +101,18 @@ func (v *SiloCredValidator) ResolveUsername(ctx context.Context, userID, profile
 	if v.Pool == nil {
 		return ""
 	}
+	uid, err := strconv.Atoi(userID)
+	if err != nil {
+		return ""
+	}
 	if strings.TrimSpace(profileID) != "" {
 		var name string
 		err := v.Pool.QueryRow(ctx,
-			`SELECT name FROM user_profiles WHERE id = $1`, profileID,
+			`SELECT name FROM user_profiles WHERE user_id = $1 AND id = $2`, uid, profileID,
 		).Scan(&name)
 		if err == nil && strings.TrimSpace(name) != "" {
 			return name
 		}
-	}
-	uid, err := strconv.Atoi(userID)
-	if err != nil {
-		return ""
 	}
 	var username string
 	if err := v.Pool.QueryRow(ctx,


### PR DESCRIPTION
Related issue: N/A — narrow fix

Multi-file audiobooks returned chapters from only the first audio file. Item details and playback responses now use one shared chapter builder, with sequential IDs and timestamps offset by the duration of preceding files. Both the playback session's chapters and its embedded library item include the full timeline.

Authorize and refresh responses also resolve the authenticated profile's display name, with an account-name/user-ID fallback. Profile lookup is scoped to the owning account. The chapter and username fixes are intentionally included together.

Validation:
- A handler regression test fails against the previous implementation because both playback chapter lists omit later chapters; it passes with the fix.
- The test checks item details and both playback chapter lists for empty books, single-file books, and multiple files with a chapterless gap, fractional timestamps, and sequential IDs.
- `go test ./internal/audiobooks/abs ./internal/audiobooks -count=1` passed.
- `go vet ./internal/audiobooks/abs ./internal/audiobooks` passed.
- `make embed-stub` and `go build ./...` passed.
- Formatting and `git diff --check` passed.

The changes are confined to the ABS compatibility layer. Response schemas and persistence are unchanged; no native Apple/Android client or Jellyfin changes are required. Physical-client chapter navigation has not been verified for the playback fix. The full Go test suite, repository-wide lint/vet, web checks, and generated-contract gates were not rerun for this focused update.

AI disclosure: Original implementation used `openai/gpt-5.6-luna` through OpenCode with OhMyOpenCode/Sisyphus. Playback implementation and regression validation used `gpt-6` through Codex, with shell and GitHub CLI tools. CodeRabbit supplied automated review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login and token refresh responses now display the resolved username while preserving the authenticated user ID.
  * Audiobook chapters now appear as a continuous timeline across multiple audio files, including accurate start and end positions.

* **Bug Fixes**
  * Chapter information is now consistent between audiobook details and playback responses.
  * Profile-based username resolution now selects the correct user profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->