### PR TITLE
fix(web): copy API keys on insecure origins

### DIFF
--- a/web/src/pages/AdminApiKeys.test.tsx
+++ b/web/src/pages/AdminApiKeys.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AdminApiKeys from "./AdminApiKeys";
+
+const mocks = vi.hoisted(() => ({
+  copyTextToClipboard: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  createKey: vi.fn(),
+}));
+
+vi.mock("@/lib/clipboard", () => ({
+  copyTextToClipboard: (...args: unknown[]) => mocks.copyTextToClipboard(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess },
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ user: { id: 1 } }),
+}));
+
+vi.mock("@/hooks/queries/admin/users", () => ({
+  useAdminUsers: () => ({ data: [{ id: 1, username: "admin" }] }),
+}));
+
+vi.mock("@/hooks/queries/admin/apiKeys", () => ({
+  useAdminApiKeys: () => ({
+    data: [
+      {
+        id: 7,
+        user_id: 1,
+        username: "admin",
+        label: "CI",
+        key: "silo_listed_key_0123456789",
+        rate_tier: "standard",
+        created_at: "2026-09-01T00:00:00Z",
+      },
+    ],
+    isLoading: false,
+  }),
+  useAdminCreateApiKey: () => ({ mutate: mocks.createKey, isPending: false }),
+  useAdminDeleteApiKey: () => ({ mutate: vi.fn() }),
+  useAdminUpdateApiKeyTier: () => ({ mutate: vi.fn() }),
+}));
+
+const CREATED_KEY = "silo_created_key_9876543210";
+
+async function createKey() {
+  await userEvent.click(screen.getByRole("button", { name: /Create Key/ }));
+  await userEvent.type(screen.getByPlaceholderText(/CI\/CD Pipeline/), "Deploy bot");
+  await userEvent.click(screen.getByRole("button", { name: "Create" }));
+  await screen.findByText(CREATED_KEY);
+}
+
+describe("AdminApiKeys", () => {
+  beforeEach(() => {
+    mocks.copyTextToClipboard.mockReset();
+    mocks.copyTextToClipboard.mockResolvedValue(undefined);
+    mocks.toastError.mockReset();
+    mocks.toastSuccess.mockReset();
+    mocks.createKey.mockReset();
+    mocks.createKey.mockImplementation((_body, options) => {
+      options.onSuccess({ key: CREATED_KEY });
+    });
+  });
+
+  it("copies a listed key through the shared clipboard helper", async () => {
+    render(<AdminApiKeys />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy API key CI" }));
+
+    await waitFor(() =>
+      expect(mocks.copyTextToClipboard).toHaveBeenCalledWith("silo_listed_key_0123456789"),
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Copied to clipboard");
+  });
+
+  it("closes the create dialog once the new key is copied", async () => {
+    render(<AdminApiKeys />);
+    await createKey();
+
+    await userEvent.click(screen.getByRole("button", { name: /Copy & Close/ }));
+
+    await waitFor(() => expect(mocks.copyTextToClipboard).toHaveBeenCalledWith(CREATED_KEY));
+    await waitFor(() => expect(screen.queryByText(CREATED_KEY)).not.toBeInTheDocument());
+  });
+
+  it("keeps the new key on screen when the copy fails", async () => {
+    // The key is only ever shown once, so a failed copy must not close the dialog.
+    mocks.copyTextToClipboard.mockRejectedValue(new Error("clipboard blocked"));
+    render(<AdminApiKeys />);
+    await createKey();
+
+    await userEvent.click(screen.getByRole("button", { name: /Copy & Close/ }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Couldn't copy — select the key and copy it manually",
+      ),
+    );
+    expect(mocks.toastSuccess).not.toHaveBeenCalledWith("Copied to clipboard");
+    expect(screen.getByText(CREATED_KEY)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AdminApiKeys.tsx
+++ b/web/src/pages/AdminApiKeys.tsx
@@ -39,10 +39,22 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { formatDate } from "@/lib/datetime";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 function maskKey(key: string): string {
   if (key.length <= 10) return key;
   return key.slice(0, 6) + "..." + key.slice(-4);
+}
+
+async function copyKey(key: string): Promise<boolean> {
+  try {
+    await copyTextToClipboard(key);
+    toast.success("Copied to clipboard");
+    return true;
+  } catch {
+    toast.error("Couldn't copy — select the key and copy it manually");
+    return false;
+  }
 }
 
 const PAGE_SIZE_OPTIONS = ["25", "50", "100"] as const;
@@ -60,11 +72,6 @@ export default function AdminApiKeys() {
 
   function handleRevoke(key: AdminAPIKey) {
     setConfirmRevokeKey(key);
-  }
-
-  function handleCopy(text: string) {
-    navigator.clipboard.writeText(text);
-    toast.success("Copied to clipboard");
   }
 
   if (isLoading)
@@ -150,7 +157,7 @@ export default function AdminApiKeys() {
                       size="icon"
                       className="h-6 w-6"
                       aria-label={`Copy API key ${key.label}`}
-                      onClick={() => handleCopy(key.key)}
+                      onClick={() => void copyKey(key.key)}
                     >
                       <Copy className="h-3 w-3" aria-hidden="true" />
                     </Button>
@@ -264,11 +271,9 @@ function CreateApiKeyForm({ onClose }: { onClose: () => void }) {
     });
   }
 
-  function handleCopyAndClose() {
-    if (createdKey) {
-      navigator.clipboard.writeText(createdKey);
-      toast.success("Copied to clipboard");
-    }
+  async function handleCopyAndClose() {
+    // The key is shown once; keep the dialog open if the copy didn't land.
+    if (createdKey && !(await copyKey(createdKey))) return;
     onClose();
   }
 


### PR DESCRIPTION
## Problem

Related issue: #985

Both copy buttons on the admin API keys page call `navigator.clipboard.writeText` directly. On an insecure origin (a self-hosted server reached over plain HTTP on the LAN, as in the report) `navigator.clipboard` is undefined, so the click throws `TypeError: can't access property "writeText", navigator.clipboard is undefined` and nothing is copied. The page still showed "Copied to clipboard", and "Copy & Close" closed the dialog anyway, discarding a key that is only shown once.

Fixes #985

## Approach

Route both buttons through the existing `copyTextToClipboard` helper in `web/src/lib/clipboard.ts`, which already falls back to a hidden textarea plus `execCommand("copy")` when the async Clipboard API is missing. That is the same path `ConnectAppsSettings` and `NotificationsAdminSettings` use. A small `copyKey` helper handles the shared toast-on-success / toast-on-failure so both handlers stay one line, and `handleCopyAndClose` now keeps the dialog open when the copy fails.

Ten other files still call `navigator.clipboard.writeText` directly (invitations, invite codes, webhook URLs, media paths, signing secret, and others) and will fail the same way over HTTP. I left them out to keep this PR on the reported issue; happy to sweep them in a follow-up if that is wanted.

## Validation

- `pnpm exec vitest run src/pages/AdminApiKeys.test.tsx`: 3 passed. With the source change stashed, all 3 fail on the same `TypeError` as the report (jsdom does not define `navigator.clipboard`, matching an insecure origin).
- `pnpm exec eslint` on the two touched files: clean. `pnpm run lint` over the tree: 0 errors, 174 pre-existing warnings, none in the touched files.
- `pnpm run format:check` on the touched files: clean.
- `pnpm exec tsc -b`: clean.
- Not run: `vite build`, the Go gate, and `make verify-*` targets (no Go or generated-contract changes). Not exercised in a running deployment.

## Risks

None identified. The helper's `execCommand` fallback is already in production use elsewhere in the web app.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code (Claude Agent SDK)
- Tool(s): Claude Code
- Model(s): claude-fable-5-1
- Involvement: Fully AI-generated. Opened autonomously under the submitter's standing authorization; the submitter reviews after posting and owns the change. Not yet verified by a human in a running deployment.
- Adversarial review: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key copying with clearer success and error notifications.
  * The create-key dialog now remains open when copying fails, preventing users from losing access to the newly generated key.
  * Standardized copying behavior across existing and newly created API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->