### PR TITLE
fix(playback): reconcile failed starts and retry retained requests

### DIFF
--- a/cmd/playback-synthetic/main.go
+++ b/cmd/playback-synthetic/main.go
@@ -189,7 +189,7 @@ func run(ctx context.Context, opts options) (result error) {
 	}
 	defer func() { _ = listener.Close() }()
 	manager := playback.NewSessionManager(0, 0)
-	handler := api.NewRouter(api.Dependencies{Config: cfg, AppContext: ctx, DB: pool, SecretCipher: cipher, UserStoreProvider: provider, RedisClient: redisClient, SessionMgr: manager, FileRepo: scanner.NewFileRepository(pool), FolderRepo: catalog.NewFolderRepository(pool), ClientIPResolver: clientip.NewResolver(nil), NodeID: "synthetic-playback", InitialPlayback: flow, InitialPlaybackReconcileAccounts: []int{source.AccountID}})
+	handler := api.NewRouter(api.Dependencies{Config: cfg, AppContext: ctx, DB: pool, SecretCipher: cipher, UserStoreProvider: provider, RedisClient: redisClient, SessionMgr: manager, FileRepo: scanner.NewFileRepository(pool), FolderRepo: catalog.NewFolderRepository(pool), ClientIPResolver: clientip.NewResolver(nil), NodeID: "synthetic-playback", InitialPlayback: flow})
 	server := &http.Server{Handler: handler, ReadHeaderTimeout: 10 * time.Second}
 	finished := make(chan error, 1)
 	go func() { finished <- server.Serve(listener) }()

--- a/cmd/silo/playback_initial.go
+++ b/cmd/silo/playback_initial.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/api"
@@ -62,6 +61,5 @@ func configureInitialPlaybackStartup(bootstrap *config.BootstrapConfig, deps *ap
 	flow.AuxiliaryEnabled = bootstrap.InitialPlaybackAPIOrigin != ""
 	flow.TimelineResolver = catalog.NewClientPlaybackManifestResolver(deps.DB)
 	deps.InitialPlayback = flow
-	deps.InitialPlaybackReconcileAccounts = slices.Clone(bootstrap.InitialPlaybackReconcileAccounts)
 	return nil
 }

--- a/cmd/silo/playback_initial_test.go
+++ b/cmd/silo/playback_initial_test.go
@@ -21,7 +21,7 @@ type initialUnsupportedProvider struct{ userstore.UserStoreProvider }
 
 func TestInitialPlaybackStartupDefaultOff(t *testing.T) {
 	// OFF must not inspect, replace or initialize any existing dependency.
-	deps := api.Dependencies{InitialPlaybackReconcileAccounts: []int{72}}
+	deps := api.Dependencies{}
 	before := deps
 	if err := configureInitialPlaybackStartup(&config.BootstrapConfig{}, &deps); err != nil {
 		t.Fatal(err)
@@ -35,7 +35,7 @@ func TestInitialPlaybackStartupDefaultOff(t *testing.T) {
 }
 
 func TestInitialPlaybackStartupRefusesIncompleteAssembly(t *testing.T) {
-	on := &config.BootstrapConfig{InitialPlaybackEnabled: true, Mode: "integrated", InitialPlaybackReconcileAccounts: []int{1}}
+	on := &config.BootstrapConfig{InitialPlaybackEnabled: true, Mode: "integrated"}
 	if err := configureInitialPlaybackStartup(on, nil); err == nil {
 		t.Fatal("missing dependencies accepted")
 	}

--- a/docs/architecture/initial-playback-runtime.md
+++ b/docs/architecture/initial-playback-runtime.md
@@ -85,3 +85,24 @@ Shutdown waits under the application's existing graceful-shutdown deadline.
 Cancellation is lease loss, not a fabricated stop receipt. If a dependency fails
 to honor cancellation and cleanup exceeds the deadline, the application reports
 that cleanup did not finish; it must not report a clean terminal receipt.
+
+## Failed starts and recovery
+
+Each configured runtime reconciles retained work across all accounts in bounded
+pages. Multiple replicas use the existing compare-and-set transitions and exact
+source receipts; the runner needs no account list and joins application shutdown.
+A slow source cannot keep the scan from reaching later attempts. When idle cleanup
+removes a local session, it closes that session's exact retained owner so the lease
+can expire and recovery can finish; an absent player never keeps an owner alive
+indefinitely.
+
+A server-owned startup abort waits briefly for its source receipt and database
+drain deadline, then returns the retained terminal decision when complete.
+Otherwise reconciliation finishes it independently of the browser. Workers get
+the same 30-second manifest readiness budget as local execution.
+
+The web client retries the exact saved START automatically. If a previous response
+never reached the player, recovery closes that captured session before another
+Play. Once the durable session mapping exists, recovery resumes its exact STOP
+directly, including after a lost response or reload. The original START remains
+saved until cleanup completes. Identity changes quarantine the old recovery task.

--- a/docs/architecture/playback-attempt-authority.md
+++ b/docs/architecture/playback-attempt-authority.md
@@ -381,8 +381,7 @@ new execution or progress rights. See [the wire contract](../playback-api.md).
 
 PostgreSQL first admission is an explicit operation, separate from runtime
 enablement. SQLite provisioning, retirement/cutover, restore, takeover and replacement
-remain inactive. Explicit router configuration can run bounded reconciliation for
-selected accounts. It retries initial aborts and completes normal stops with an
+remain inactive. Every configured runtime runs bounded reconciliation across accounts. It retries initial aborts and completes normal stops with an
 existing matching source receipt; a stop without that receipt still requires the
-original client body. Normal application startup does not enable the runner. The
-initial protocol does not supply the later retirement-before-seal workflow.
+original client body. Each scan advances past visited rows even if a source exhausts the page deadline.
+The runner joins application shutdown. The initial protocol does not supply the later retirement-before-seal workflow.

--- a/docs/playback-api.md
+++ b/docs/playback-api.md
@@ -191,23 +191,40 @@ The web client persists the exact start request before dispatch, then persists
 sequence allocation, pending progress and stop bodies in browser storage.
 Web Locks serialize mutations across tabs. Records bind the installation,
 account, profile, origin and session; credentials are not stored. Identity changes
-quarantine old requests. Reload exposes an explicit Retry action: recovering an
-uncertain start confirms the original attempt and offers to stop it, without
-autoplay. An unresolved start blocks a different attempt and legacy fallback.
+quarantine old requests. Reload automatically replays an uncertain START with its
+original bytes. If it recovers a session that never reached the player, it stops
+that exact session through the durable STOP path. A new Play resolves the retained
+attempt before dispatching its new request. Transport failures, server errors and
+draining receipts retry within a 60-second budget; recovery never mints an attempt
+or falls back to legacy playback. Video and audiobook hosts share the recovery
+task and display one Retry notification only if automatic recovery cannot finish.
 A validation rejection, including `422 validation_failed`, retains its journal:
 it cannot prove that an earlier dispatch never allocated a session. The current
 API has no authoritative no-allocation receipt. Storage
 or Web Locks unavailability fails configured playback before dispatch. Clearing
 or evicting browser storage loses recovery state; unload cannot guarantee polling.
 
-Runtime wiring is explicit through `NewInitialPlaybackRuntime` and the router's
-`InitialPlayback` dependency. Normal application startup does not enable it.
-The constructor verifies the persisted installation identity and requires source,
-owner and media-grant policies. Ordinary starts only read source admission.
+Normal application startup wires `NewInitialPlaybackRuntime` through the router's
+`InitialPlayback` dependency. The constructor verifies the persisted installation
+identity and requires source, owner and media-grant policies. Ordinary starts may
+perform first admission through the retained PostgreSQL admission protocol; they
+never bypass source markers or authority checks.
 `internal/playback/testfixture.ProvisionPostgres` enrolls a newly created synthetic
 account transactionally; it cannot enroll an existing account.
 
-An explicit `InitialPlaybackReconcileAccounts` list enables bounded account scans.
+Every configured playback runtime runs bounded reconciliation across accounts;
+no account list or operator opt-in is required. Database compare-and-set transitions
+and exact source receipts allow multiple API replicas to complete the same work
+safely. The scan advances past visited rows even when a slow source exhausts a
+page deadline, and the runner joins application shutdown.
+A failed START performs its own durable abort and waits briefly for the source
+receipt and database drain deadline. Once both complete, it returns the existing
+`201 adaptation_unavailable` decision with terminal reason `playback_start_aborted`.
+If completion is still uncertain, retained state remains available for automatic
+reconciliation and exact START replay. Remote transcode startup uses the same
+30-second manifest readiness budget as local startup; a running process alone
+does not count as ready.
+
 Expired activated attempts move through owner-loss terminal recovery.
 Expired or withdrawn pending/installed starts move through durable abort intents;
 aborting intents retry their exact source operation. A stopping intent completes

--- a/internal/api/handlers/onboarding_service.go
+++ b/internal/api/handlers/onboarding_service.go
@@ -28,7 +28,7 @@ func (h *OnboardingHandler) progressStore(ctx context.Context, userID int) (user
 	if err != nil {
 		return nil, err
 	}
-	progress, ok := store.(userstore.OnboardingProgressStore)
+	progress, ok := userstore.Capability[userstore.OnboardingProgressStore](store)
 	if !ok {
 		return nil, apiError(http.StatusServiceUnavailable, "unavailable", "Onboarding progress is unavailable")
 	}

--- a/internal/api/handlers/playback.go
+++ b/internal/api/handlers/playback.go
@@ -1412,7 +1412,17 @@ func (h *PlaybackHandler) finalizeSessionAbort(ctx context.Context, session *pla
 }
 
 func (h *PlaybackHandler) handleExpiredSession(session *playback.Session) {
-	if h == nil || session == nil || nativeSessionExecutorBound(h.tm, session) {
+	if h == nil || session == nil {
+		return
+	}
+	if binding, ok := session.InitialActivationBinding(); ok && h.initialFlow != nil {
+		// The local session has already expired. Stop renewing its exact owner;
+		// retained owner-loss recovery must finish the durable source lifecycle.
+		// Keeping that owner alive would make every lost START replay fail forever.
+		h.closeInitialRuntimeV3(binding)
+		return
+	}
+	if nativeSessionExecutorBound(h.tm, session) {
 		return
 	}
 	sessionCopy := *session

--- a/internal/api/handlers/playback_initial_abort_recovery.go
+++ b/internal/api/handlers/playback_initial_abort_recovery.go
@@ -52,6 +52,11 @@ func (h *PlaybackHandler) recoverOrdinaryInitialAbortV3(ctx context.Context, sta
 			return fail(errors.Join(stopErr, err))
 		}
 	}
+	return ordinaryInitialAbortResponseV3(state)
+}
+
+func ordinaryInitialAbortResponseV3(state playback.InitialActivationV3) (playback.DecisionResponseV3, error) {
+	fail := func(err error) (playback.DecisionResponseV3, error) { return playback.DecisionResponseV3{}, err }
 	if state.Phase != playback.InitialActivationAbortedV3 || state.Terminal == nil {
 		return fail(playback.ErrInitialActivationConflictV3)
 	}

--- a/internal/api/handlers/playback_initial_distributed_test.go
+++ b/internal/api/handlers/playback_initial_distributed_test.go
@@ -12,12 +12,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
 	"github.com/Silo-Server/silo-server/internal/auth"
 	"github.com/Silo-Server/silo-server/internal/clientip"
 	"github.com/Silo-Server/silo-server/internal/config"
@@ -268,22 +270,31 @@ func TestInitialPlaybackHTTPDistributed(t *testing.T) {
 			}
 			status, data := f.call(t, http.MethodPost, "/start", f.request)
 			if loseReadyReply {
-				if status != http.StatusServiceUnavailable || starts.Load() != 1 {
+				if status != http.StatusCreated || starts.Load() != 1 {
 					t.Fatalf("uncertain start status=%d starts=%d body=%s", status, starts.Load(), data)
+				}
+				var terminal playback.DecisionResponseV3
+				if err := json.Unmarshal(data, &terminal); err != nil || terminal.Terminal == nil || terminal.Terminal.Reason != "playback_start_aborted" || terminal.SessionID != "" || terminal.PlaybackPlan != nil {
+					t.Fatalf("failed worker start lacked definitive terminal: %s %v", data, err)
 				}
 				var phase, sessionID string
 				if err := f.pool.QueryRow(t.Context(), `SELECT control_activation->>'phase',session_id::text FROM playback_v3_attempts WHERE playback_attempt_id=$1`, f.request.PlaybackAttemptID).Scan(&phase, &sessionID); err != nil {
 					t.Fatal(err)
 				}
-				if phase != "aborting" && phase != "aborted" {
+				if phase != "aborted" {
 					t.Fatalf("uncertain executor became %s", phase)
 				}
 				if _, err := f.manager.GetSession(sessionID); !errors.Is(err, playback.ErrSessionNotFound) {
 					t.Fatal("uncertain start published session", err)
 				}
-				status, data = f.call(t, http.MethodPost, "/start", f.request)
-				if status != http.StatusServiceUnavailable || starts.Load() != 1 {
-					t.Fatalf("uncertain start replay status=%d starts=%d body=%s", status, starts.Load(), data)
+				// This fixture enters the transport handler directly. Replay through
+				// the same retained-recovery boundary used by the v2 adapter.
+				f.flow.InstallationID = uuid.NewString()
+				replayCtx := apimw.SetClaims(t.Context(), &auth.Claims{UserID: f.userID, Role: "user", TokenType: auth.TokenTypeAccess})
+				replayCtx = apimw.SetProfileID(replayCtx, f.request.ProfileID)
+				status, recovered, handled, err := f.handler.RecoverInitialPlaybackStart(replayCtx, PlaybackCaller{UserID: f.userID, ProfileID: f.request.ProfileID, InstallationID: f.flow.InstallationID}, f.request)
+				if err != nil || !handled || status != http.StatusCreated || starts.Load() != 1 || !reflect.DeepEqual(recovered, terminal) {
+					t.Fatalf("uncertain start replay status=%d handled=%v starts=%d result=%+v err=%v", status, handled, starts.Load(), recovered, err)
 				}
 				return
 			}

--- a/internal/api/handlers/playback_initial_flow.go
+++ b/internal/api/handlers/playback_initial_flow.go
@@ -247,9 +247,22 @@ func (h *PlaybackHandler) startInitialPlaybackV3(r *http.Request, userID int, pr
 		cleanup, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), 5*time.Second)
 		defer cancel()
 		state, cancelErr := flow.Control.CancelInitialActivation(cleanup, binding, abortID)
-		if cancelErr == nil && state.Phase == playback.InitialActivationAbortingV3 {
-			_ = h.reconcileInitialAbortV3(cleanup, binding, abortID)
+		if cancelErr == nil && (state.Phase == playback.InitialActivationAbortingV3 || state.Phase == playback.InitialActivationAbortedV3) {
+			// Drain is judged by PostgreSQL, never by the API host's wall clock.
+			// The bounded cleanup owns this cancellation even after HTTP disconnect.
+			cancelErr = h.finishInitialAbortV3(cleanup, binding, abortID)
+			if cancelErr == nil {
+				state, cancelErr = flow.Control.ReadInitialActivation(cleanup, binding)
+				if cancelErr == nil {
+					response, responseErr := ordinaryInitialAbortResponseV3(state)
+					if responseErr == nil {
+						return response, nil
+					}
+					cancelErr = responseErr
+				}
+			}
 		}
+		logInitialAbortV3(cleanup, "abort_completion", req.PlaybackAttemptID, stage.ID, cancelErr)
 		return fail(cause)
 	}
 	sink, err := flow.Sources.OpenPlaybackSink(r.Context(), binding.Source)
@@ -455,6 +468,24 @@ func (h *PlaybackHandler) startInitialPlaybackV3(r *http.Request, userID int, pr
 	}
 	published = true
 	return response, nil
+}
+
+// finishInitialAbortV3 waits only for the captured drain, within its caller's
+// cleanup budget. Other failures stay durable for the normal reconciler.
+func (h *PlaybackHandler) finishInitialAbortV3(ctx context.Context, binding playback.InitialActivationBindingV3, abortID string) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		err := h.reconcileInitialAbortV3(ctx, binding, abortID)
+		if !errors.Is(err, playback.ErrPlaybackRecoveryDrainingV3) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
 }
 
 func (h *PlaybackHandler) reconcileInitialAbortV3(ctx context.Context, binding playback.InitialActivationBindingV3, abortID string) error {

--- a/internal/api/handlers/playback_initial_reconcile.go
+++ b/internal/api/handlers/playback_initial_reconcile.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/playback"
@@ -14,9 +15,9 @@ type InitialPlaybackReconciliation struct {
 	NextAttemptID               string
 }
 
-// ReconcileInitialPlayback processes one explicit account's retained intents.
+// ReconcileInitialPlayback processes a bounded page of retained intents across accounts.
 // It never enrolls sources, adopts active owners, or invents a final stop sample.
-func (h *PlaybackHandler) ReconcileInitialPlayback(ctx context.Context, accountID int, afterAttemptID string, limit int) (InitialPlaybackReconciliation, error) {
+func (h *PlaybackHandler) ReconcileInitialPlayback(ctx context.Context, afterAttemptID string, limit int) (InitialPlaybackReconciliation, error) {
 	var result InitialPlaybackReconciliation
 	if h.initialFlow == nil {
 		return result, playback.ErrInitialActivationUnavailableV3
@@ -25,7 +26,7 @@ func (h *PlaybackHandler) ReconcileInitialPlayback(ctx context.Context, accountI
 	if !ok {
 		return result, playback.ErrInitialActivationUnavailableV3
 	}
-	states, err := inventory.ListInitialReconciliation(ctx, accountID, afterAttemptID, limit)
+	states, err := inventory.ListInitialReconciliation(ctx, afterAttemptID, limit)
 	if err != nil {
 		return result, err
 	}
@@ -99,29 +100,29 @@ func (h *PlaybackHandler) reconcileInitialStopReceipt(ctx context.Context, state
 	return nil
 }
 
-// RunInitialPlaybackReconciliation is explicitly scoped by the embedding test
-// instance. Every tick visits at most one page per configured account. Failed
-// intents remain durable and recur on the next sweep; no new authority is minted.
-func (h *PlaybackHandler) RunInitialPlaybackReconciliation(ctx context.Context, accounts []int, interval time.Duration) {
-	if ctx == nil || interval <= 0 || len(accounts) == 0 {
+// RunInitialPlaybackReconciliation closes durable orphaned work without client
+// participation. Multiple API replicas may visit a row; the existing per-attempt
+// CAS transitions and exact receipts serialize completion without new authority.
+func (h *PlaybackHandler) RunInitialPlaybackReconciliation(ctx context.Context, interval time.Duration) {
+	if ctx == nil || interval <= 0 {
 		return
 	}
-	cursors := make(map[int]string, len(accounts))
-	for _, accountID := range accounts {
-		if accountID > 0 {
-			cursors[accountID] = ""
-		}
-	}
+	cursor := ""
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
-		for accountID, cursor := range cursors {
-			result, _ := h.ReconcileInitialPlayback(ctx, accountID, cursor, 100)
-			if result.Visited < 100 {
-				cursors[accountID] = ""
-			} else {
-				cursors[accountID] = result.NextAttemptID
-			}
+		pageCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		result, err := h.ReconcileInitialPlayback(pageCtx, cursor, 100)
+		cancel()
+		if err != nil && ctx.Err() == nil && result.Visited == 0 {
+			slog.WarnContext(ctx, "playback reconciliation inventory unavailable", "component", "playback")
+		}
+		// A deadline can interrupt a full inventory page after only a prefix.
+		// Advance past every visited row so a slow source cannot starve later accounts.
+		if result.Visited == 0 {
+			cursor = ""
+		} else {
+			cursor = result.NextAttemptID
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/api/handlers/playback_initial_reconcile_test.go
+++ b/internal/api/handlers/playback_initial_reconcile_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -76,7 +77,7 @@ func TestInitialPlaybackReconcileExpiredIntent(t *testing.T) {
 			if _, err := f.pool.Exec(ctx, `UPDATE playback_v3_attempts SET control_lease_expires_at=clock_timestamp()-interval '2 minutes',expires_at=clock_timestamp()-interval '1 minute' WHERE playback_attempt_id=$1`, f.request.PlaybackAttemptID); err != nil {
 				t.Fatal(err)
 			}
-			result, err := f.handler.ReconcileInitialPlayback(ctx, f.userID, "", 10)
+			result, err := f.handler.ReconcileInitialPlayback(ctx, "", 10)
 			if scenario == "source unavailable" || scenario == "different terminal" {
 				if err == nil || result.Pending != 1 || result.Completed != 0 {
 					t.Fatalf("unavailable source: %+v %v", result, err)
@@ -150,7 +151,7 @@ func TestInitialPlaybackReconcileNormalStopRequiresReceipt(t *testing.T) {
 				}
 				before = result.State
 			}
-			result, err := f.handler.ReconcileInitialPlayback(ctx, f.userID, "", 10)
+			result, err := f.handler.ReconcileInitialPlayback(ctx, "", 10)
 			after, readErr := f.source.ReadPlaybackProgress(ctx, active.Binding.Scope)
 			if readErr != nil || !reflect.DeepEqual(before, after) {
 				t.Fatalf("reconciler mutated source: before=%+v after=%+v err=%v", before, after, readErr)
@@ -226,7 +227,7 @@ func TestInitialPlaybackReconcileClosesMatchingTranscode(t *testing.T) {
 	}
 	deadline := time.Now().Add(5 * time.Second)
 	for {
-		result, err := f.handler.ReconcileInitialPlayback(ctx, f.userID, "", 10)
+		result, err := f.handler.ReconcileInitialPlayback(ctx, "", 10)
 		if err == nil && result.Completed == 1 {
 			break
 		}
@@ -338,5 +339,143 @@ func TestInitialPlaybackAutomaticallyAdmitsOrdinaryAccount(t *testing.T) {
 				t.Fatalf("first admission receipt: %d %v", receipts, err)
 			}
 		})
+	}
+}
+
+// No account list and no browser request is needed after an API dies mid-start.
+func TestInitialPlaybackBackgroundReconcilesAccountsAfterRestart(t *testing.T) {
+	first, second := newInitialHTTPFixture(t), newInitialHTTPFixture(t)
+	bindings := []playback.InitialActivationBindingV3{
+		initialReconciliationBinding(t, first), initialReconciliationBinding(t, second),
+	}
+	for _, b := range bindings {
+		if _, err := first.pool.Exec(t.Context(), `UPDATE playback_v3_attempts SET control_lease_expires_at=clock_timestamp()-interval '1 minute' WHERE playback_attempt_id=$1`, b.Fence.AttemptID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() { defer close(done); first.handler.RunInitialPlaybackReconciliation(ctx, 10*time.Millisecond) }()
+	defer func() { cancel(); <-done }()
+	deadline, stop := context.WithTimeout(t.Context(), 5*time.Second)
+	defer stop()
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		var completed int
+		if err := first.pool.QueryRow(t.Context(), `SELECT count(*) FROM playback_v3_attempts WHERE playback_attempt_id=ANY($1) AND control_state='stopped' AND control_activation->>'phase'='aborted' AND control_activation->'terminal' IS NOT NULL`, []string{bindings[0].Fence.AttemptID, bindings[1].Fence.AttemptID}).Scan(&completed); err != nil {
+			t.Fatal(err)
+		}
+		if completed == 2 {
+			return
+		}
+		select {
+		case <-deadline.Done():
+			t.Fatal("background recovery did not finish both accounts")
+		case <-tick.C:
+		}
+	}
+}
+
+type deadlineReconciliationControl struct {
+	InitialPlaybackControlV3
+	cursors chan string
+}
+
+func (s deadlineReconciliationControl) ListInitialReconciliation(_ context.Context, after string, _ int) ([]playback.InitialActivationV3, error) {
+	s.cursors <- after
+	if after != "" {
+		return nil, nil
+	}
+	return []playback.InitialActivationV3{
+		{Phase: playback.InitialActivationPendingV3, Binding: playback.InitialActivationBindingV3{Fence: userstore.PlaybackProgressFence{AttemptID: "first"}}},
+		{Phase: playback.InitialActivationPendingV3, Binding: playback.InitialActivationBindingV3{Fence: userstore.PlaybackProgressFence{AttemptID: "second"}}},
+	}, nil
+}
+
+func (s deadlineReconciliationControl) AbortInitialActivation(ctx context.Context, _ playback.InitialActivationBindingV3, _ string) (playback.InitialActivationV3, error) {
+	<-ctx.Done()
+	return playback.InitialActivationV3{}, ctx.Err()
+}
+
+func TestInitialPlaybackReconciliationAdvancesAfterPageDeadline(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	control := deadlineReconciliationControl{cursors: make(chan string, 2)}
+	h := &PlaybackHandler{initialFlow: &InitialPlaybackFlowV3{Control: control}}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.RunInitialPlaybackReconciliation(ctx, time.Millisecond)
+	}()
+	for _, want := range []string{"", "first"} {
+		select {
+		case got := <-control.cursors:
+			if got != want {
+				t.Fatalf("cursor = %q, want %q; timed-out source starved later attempts", got, want)
+			}
+		case <-time.After(12 * time.Second):
+			t.Fatal("reconciliation did not advance after its page deadline")
+		}
+	}
+	cancel()
+	<-done
+}
+
+func TestInitialPlaybackExpiredUndisplayedStartReleasesOwner(t *testing.T) {
+	f := newInitialHTTPFixture(t)
+	f.flow.InstallationID = uuid.NewString()
+	f.flow.Policy = playback.RuntimeGrantPolicyV3{MaxDuration: 3 * time.Second, SafetyMargin: 100 * time.Millisecond, RenewBefore: time.Second, PollInterval: 10 * time.Millisecond}
+	status, data := f.call(t, http.MethodPost, "/start", f.request)
+	if status != http.StatusCreated {
+		t.Fatalf("start: %d %s", status, data)
+	}
+	var decision playback.DecisionResponseV3
+	if err := json.Unmarshal(data, &decision); err != nil {
+		t.Fatal(err)
+	}
+	value, ok := f.flow.owners.Load(decision.SessionID)
+	if !ok {
+		t.Fatal("missing owner")
+	}
+	owner := value.(*playback.RuntimeOwnerLeaseV3)
+	// A successful response can be lost before the browser ever opens media or
+	// sends progress. Exercise the real idle cleanup hook without a fixed sleep.
+	if expired := f.manager.CleanInactive(time.Nanosecond, time.Nanosecond); len(expired) != 1 {
+		t.Fatalf("expired sessions = %d, want 1", len(expired))
+	}
+	select {
+	case <-owner.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("expired session kept renewing its owner and blocked START recovery")
+	}
+	if _, ok := f.flow.pending.Load(decision.SessionID); ok {
+		t.Fatal("expired publication remains boot-local")
+	}
+	ctx := apimw.SetClaims(t.Context(), &auth.Claims{UserID: f.userID, Role: "user", TokenType: auth.TokenTypeAccess})
+	ctx = apimw.SetProfileID(ctx, f.request.ProfileID)
+	caller := PlaybackCaller{UserID: f.userID, ProfileID: f.request.ProfileID, InstallationID: f.flow.InstallationID}
+	deadline := time.NewTimer(6 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(10 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		// Replay itself can finish owner-loss once the retained lease expires.
+		status, recovered, handled, err := f.handler.RecoverInitialPlaybackStart(ctx, caller, f.request)
+		if err == nil && handled && status == http.StatusCreated {
+			terminal, ok := recovered.(PlaybackOwnerLossStart)
+			if !ok || terminal.Terminal == nil || terminal.Terminal.Reason != "playback_owner_lost" || terminal.Recovery.PlaybackAttemptID != f.request.PlaybackAttemptID || terminal.Recovery.SessionID != decision.SessionID || terminal.Recovery.State != "aborted" || terminal.Recovery.Accepted != nil {
+				t.Fatalf("recovery replaced the original attempt or invented progress: %+v", recovered)
+			}
+			if _, err := f.manager.GetSession(decision.SessionID); !errors.Is(err, playback.ErrSessionNotFound) {
+				t.Fatalf("recovery reconstructed expired session: %v", err)
+			}
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("expired START did not reach terminal: status=%d handled=%v err=%v body=%+v", status, handled, err, recovered)
+		case <-tick.C:
+		}
 	}
 }

--- a/internal/api/handlers/playback_transport.go
+++ b/internal/api/handlers/playback_transport.go
@@ -89,7 +89,7 @@ func (h *PlaybackHandler) startRemotePlaybackTransport(ctx context.Context, node
 
 func (h *PlaybackHandler) remotePlaybackTransportTimeout(nodeURL string, request transcodenode.TranscodeStartRequest) time.Duration {
 	if request.ToneMapMode == "" {
-		return 20 * time.Second
+		return playback.ManifestStartupTimeout + 5*time.Second
 	}
 	timeout := h.remoteToneMapProbeTimeoutV3(nodeURL) + playback.ManifestStartupTimeout
 	if request.ToneMapPreflightRequired {

--- a/internal/api/playback_initial_shutdown_test.go
+++ b/internal/api/playback_initial_shutdown_test.go
@@ -31,7 +31,7 @@ type initialRouterShutdownControl struct {
 	release chan struct{}
 }
 
-func (s initialRouterShutdownControl) ListInitialReconciliation(ctx context.Context, _ int, _ string, _ int) ([]playback.InitialActivationV3, error) {
+func (s initialRouterShutdownControl) ListInitialReconciliation(ctx context.Context, _ string, _ int) ([]playback.InitialActivationV3, error) {
 	close(s.entered)
 	<-ctx.Done()
 	<-s.release
@@ -63,7 +63,7 @@ func TestInitialPlaybackRouterJoinsReconciliation(t *testing.T) {
 		t.Fatal(err)
 	}
 	var work []<-chan struct{}
-	_ = NewRouter(Dependencies{Config: cfg, AppContext: ctx, SessionMgr: playback.NewSessionManager(0, 0), InitialPlayback: flow, InitialPlaybackReconcileAccounts: []int{1}, RegisterShutdownWork: func(done <-chan struct{}) { work = append(work, done) }})
+	_ = NewRouter(Dependencies{Config: cfg, AppContext: ctx, SessionMgr: playback.NewSessionManager(0, 0), InitialPlayback: flow, RegisterShutdownWork: func(done <-chan struct{}) { work = append(work, done) }})
 	select {
 	case <-control.entered:
 	case <-time.After(3 * time.Second):

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -88,10 +88,8 @@ import (
 
 // Dependencies holds all shared dependencies that handlers need.
 type Dependencies struct {
-	// InitialPlayback is explicit opt-in dependency wiring for admitted sources.
-	// Default startup leaves it nil; ordinary starts never enroll an account.
-	InitialPlayback                  *handlers.InitialPlaybackFlowV3
-	InitialPlaybackReconcileAccounts []int
+	// InitialPlayback supplies the default durable runtime and its recovery worker.
+	InitialPlayback *handlers.InitialPlaybackFlowV3
 
 	Config *config.Config
 	// LiveConfig returns the current hot-reloaded config. May be nil (tests,
@@ -1078,15 +1076,13 @@ func newChiRouter(deps Dependencies) chi.Router {
 			if deps.RegisterShutdownWork != nil {
 				deps.RegisterShutdownWork(playbackHandler.InitialPlaybackShutdownDone())
 			}
-			if len(deps.InitialPlaybackReconcileAccounts) > 0 {
-				done := make(chan struct{})
-				go func() {
-					defer close(done)
-					playbackHandler.RunInitialPlaybackReconciliation(deps.InitialPlayback.Context, deps.InitialPlaybackReconcileAccounts, time.Second)
-				}()
-				if deps.RegisterShutdownWork != nil {
-					deps.RegisterShutdownWork(done)
-				}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				playbackHandler.RunInitialPlaybackReconciliation(deps.InitialPlayback.Context, time.Second)
+			}()
+			if deps.RegisterShutdownWork != nil {
+				deps.RegisterShutdownWork(done)
 			}
 		}
 		// Maintenance also bounds the in-memory fallback store: without it a

--- a/internal/apiv2/onboarding_test.go
+++ b/internal/apiv2/onboarding_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/Silo-Server/silo-server/internal/api/handlers"
+	"github.com/Silo-Server/silo-server/internal/notifications"
 	"github.com/Silo-Server/silo-server/internal/onboarding"
 	"github.com/Silo-Server/silo-server/internal/userdb"
 	"github.com/Silo-Server/silo-server/internal/userstore"
@@ -107,7 +108,7 @@ func TestOnboardingSQLiteAndTransport(t *testing.T) {
 	store := userdb.NewSQLiteUserStore(db.DB)
 	testOnboardingStore(t, store)
 	deps := pilotDeps(nil, nil)
-	deps.Onboarding = handlers.NewOnboardingHandler(collectionGuardHTTPProvider{stores: map[int]userstore.UserStore{1: store}}, onboarding.Gates{})
+	deps.Onboarding = handlers.NewOnboardingHandler(notifications.WrapUserStoreProvider(collectionGuardHTTPProvider{stores: map[int]userstore.UserStore{1: store}}, &notifications.System{}), onboarding.Gates{})
 	h := newTestHandler(t, deps)
 	read := do(t, h, "GET", Prefix+"/onboarding/state", "", profileOwner())
 	if read.Code != 200 {
@@ -189,6 +190,19 @@ func TestOnboardingPostgresDB(t *testing.T) {
 		t.Fatal(err)
 	}
 	testOnboardingStore(t, store)
+	deps := pilotDeps(nil, nil)
+	provider := notifications.WrapUserStoreProvider(collectionGuardHTTPProvider{stores: map[int]userstore.UserStore{1: store}}, &notifications.System{})
+	deps.Onboarding = handlers.NewOnboardingHandler(provider, onboarding.Gates{})
+	h := newTestHandler(t, deps)
+	read := do(t, h, "GET", Prefix+"/onboarding/state", "", profileOwner())
+	if read.Code != 200 {
+		t.Fatalf("wrapped PostgreSQL onboarding: %d %s", read.Code, read.Body)
+	}
+	write := do(t, h, "PUT", Prefix+"/onboarding/progress", `{"tour_id":"`+onboarding.TourID+`","last_step":"playback"}`, with(profileOwner(), "If-Match", read.Header().Get("ETag")))
+	if write.Code != 200 {
+		t.Fatalf("wrapped PostgreSQL progress: %d %s", write.Code, write.Body)
+	}
+
 	other, err := pgstore.NewPostgresProvider(fixture).ForUser(t.Context(), 2)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/apiv2/playback_recovery_test.go
+++ b/internal/apiv2/playback_recovery_test.go
@@ -357,7 +357,7 @@ func TestPlaybackOwnerLossHTTPDrainAndOriginalStop(t *testing.T) {
 			}
 			f.expire(t)
 			f.restart(t)
-			reconciled, err := f.application.ReconcileInitialPlayback(t.Context(), f.user, "", 10)
+			reconciled, err := f.application.ReconcileInitialPlayback(t.Context(), "", 10)
 			if err == nil || reconciled.Pending != 1 {
 				t.Fatalf("missing ordinary receipt was synthesized: %+v %v", reconciled, err)
 			}
@@ -507,12 +507,12 @@ func TestPlaybackOwnerLossReconcileRetentionExpiry(t *testing.T) {
 			if _, err := f.pool.Exec(t.Context(), `UPDATE playback_v3_attempts SET expires_at=clock_timestamp()-interval '1 second' WHERE playback_attempt_id=$1`, f.binding.Fence.AttemptID); err != nil {
 				t.Fatal(err)
 			}
-			result, err := f.application.ReconcileInitialPlayback(t.Context(), f.user, "", 10)
+			result, err := f.application.ReconcileInitialPlayback(t.Context(), "", 10)
 			if err != nil || result.Visited != 1 || result.Completed != 1 || result.Pending != 0 {
 				t.Fatalf("expiry reconciliation: %+v %v", result, err)
 			}
 			assertRecovery(t, f.call(t, "POST", "/start", f.body), 201, f.binding, false)
-			again, err := f.application.ReconcileInitialPlayback(t.Context(), f.user, "", 10)
+			again, err := f.application.ReconcileInitialPlayback(t.Context(), "", 10)
 			if err != nil || again.Visited != 0 {
 				t.Fatalf("terminal re-inventoried: %+v %v", again, err)
 			}

--- a/internal/config/bootstrap.go
+++ b/internal/config/bootstrap.go
@@ -16,14 +16,13 @@ const minSecretKeyLen = 32
 
 // BootstrapConfig holds the minimal config needed before database connection.
 type BootstrapConfig struct {
-	InitialPlaybackAPIOrigin         string
-	InitialPlaybackEnabled           bool
-	InitialPlaybackReconcileAccounts []int
-	DatabaseURL                      string
-	RedisURL                         string // optional override; empty means use DB setting
-	Listen                           string
-	JFListen                         string
-	Mode                             string
+	InitialPlaybackAPIOrigin string
+	InitialPlaybackEnabled   bool
+	DatabaseURL              string
+	RedisURL                 string // optional override; empty means use DB setting
+	Listen                   string
+	JFListen                 string
+	Mode                     string
 	// SecretKey is the master key (raw SECRET_KEY env value) from which the
 	// at-rest credential cipher derives its data key. It lives outside Postgres
 	// so encrypted secrets survive a full database compromise/dump.
@@ -76,15 +75,14 @@ func LoadBootstrap(envFile string) (*BootstrapConfig, error) {
 	redisURL := os.Getenv("REDIS_URL")
 
 	return &BootstrapConfig{
-		InitialPlaybackAPIOrigin:         initialAPIOrigin,
-		InitialPlaybackEnabled:           initialEnabled,
-		InitialPlaybackReconcileAccounts: nil,
-		DatabaseURL:                      dbURL,
-		RedisURL:                         redisURL,
-		Listen:                           ":" + port,
-		JFListen:                         ":" + jfPort,
-		Mode:                             mode,
-		SecretKey:                        []byte(secretKey),
+		InitialPlaybackAPIOrigin: initialAPIOrigin,
+		InitialPlaybackEnabled:   initialEnabled,
+		DatabaseURL:              dbURL,
+		RedisURL:                 redisURL,
+		Listen:                   ":" + port,
+		JFListen:                 ":" + jfPort,
+		Mode:                     mode,
+		SecretKey:                []byte(secretKey),
 	}, nil
 }
 

--- a/internal/notifications/interest_hooks.go
+++ b/internal/notifications/interest_hooks.go
@@ -122,6 +122,10 @@ type interestTrackingStore struct {
 	updater *InterestUpdater
 }
 
+// Optional capabilities not intercepted here retain the backing store's support.
+// Capability lookup checks this decorator first, preserving its mutation hooks.
+func (s *interestTrackingStore) UnwrapUserStore() userstore.UserStore { return s.UserStore }
+
 type interestTrackingStoreWithDevices struct {
 	*interestTrackingStore
 	userstore.DeviceRegistry

--- a/internal/notifications/interest_hooks_test.go
+++ b/internal/notifications/interest_hooks_test.go
@@ -579,3 +579,26 @@ func TestInterestTrackingStoreConditionalCapabilities(t *testing.T) {
 		})
 	}
 }
+
+func TestInterestTrackingOptionalCapabilityResolution(t *testing.T) {
+	inner := &struct {
+		userstore.UserStore
+		userstore.OnboardingProgressStore
+	}{}
+	provider := WrapUserStoreProvider(preferenceTransactionTestProvider{store: inner}, &System{})
+	wrapped, err := provider.ForUser(t.Context(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	progress, ok := userstore.Capability[userstore.OnboardingProgressStore](wrapped)
+	if !ok || progress != inner {
+		t.Fatal("lost underlying onboarding capability")
+	}
+	writer, ok := userstore.Capability[userstore.WatchedBatchWriter](wrapped)
+	if !ok || any(writer) != any(wrapped) {
+		t.Fatal("capability lookup bypassed notification mutation hooks")
+	}
+	if _, ok := userstore.Capability[userstore.SeriesEpisodeRollupStore](wrapped); ok {
+		t.Fatal("capability lookup invented backend support")
+	}
+}

--- a/internal/playback/initial_reconciliation_v3.go
+++ b/internal/playback/initial_reconciliation_v3.go
@@ -2,9 +2,9 @@ package playback
 
 import "context"
 
-// InitialReconciliationStoreV3 returns a bounded account inventory, not authority.
+// InitialReconciliationStoreV3 returns a bounded global inventory, not authority.
 // Use the final binding's attempt ID as the exclusive next key. Restart at an
 // empty key for each sweep; eligibility may change between pages.
 type InitialReconciliationStoreV3 interface {
-	ListInitialReconciliation(context.Context, int, string, int) ([]InitialActivationV3, error)
+	ListInitialReconciliation(context.Context, string, int) ([]InitialActivationV3, error)
 }

--- a/internal/playback/planstore/initial_activation.go
+++ b/internal/playback/planstore/initial_activation.go
@@ -257,7 +257,7 @@ func (s *Postgres) CompleteInitialAbort(ctx context.Context, binding playback.In
 		if state.AbortReason == playback.InitialAbortOwnerLostV3 && !row.admitting {
 			return zero, playback.ErrInitialActivationConflictV3
 		}
-		if state.AbortReason == playback.InitialAbortOwnerLostV3 && state.AbortID == abortID && state.DrainNotBefore.After(row.now) {
+		if state.AbortID == abortID && state.DrainNotBefore.After(row.now) {
 			return zero, playback.ErrPlaybackRecoveryDrainingV3
 		}
 		if state.AbortID != abortID || (state.Phase != playback.InitialActivationAbortingV3 && state.Phase != playback.InitialActivationAbortedV3) || state.DrainNotBefore.After(row.now) {

--- a/internal/playback/planstore/initial_reconciliation.go
+++ b/internal/playback/planstore/initial_reconciliation.go
@@ -15,13 +15,13 @@ var _ playback.InitialReconciliationStoreV3 = (*Postgres)(nil)
 // each binding using the existing CAS methods outside this read transaction.
 // afterAttemptID is exclusive; pass the final returned attempt ID for the next
 // page. A new sweep starts with an empty key so newly eligible older rows recur.
-func (s *Postgres) ListInitialReconciliation(ctx context.Context, accountID int, afterAttemptID string, limit int) ([]playback.InitialActivationV3, error) {
-	if accountID <= 0 || limit < 1 || limit > 100 {
+func (s *Postgres) ListInitialReconciliation(ctx context.Context, afterAttemptID string, limit int) ([]playback.InitialActivationV3, error) {
+	if limit < 1 || limit > 100 {
 		return nil, playback.ErrInitialActivationInvalidV3
 	}
-	rows, err := s.db.Query(ctx, `SELECT a.control_activation FROM playback_v3_attempts a
+	rows, err := s.db.Query(ctx, `SELECT a.user_id,a.control_activation FROM playback_v3_attempts a
  LEFT JOIN playback_source_registrations r ON r.user_id=a.user_id
- WHERE a.user_id=$1 AND a.playback_attempt_id>$2 AND a.control_activation IS NOT NULL
+ WHERE a.playback_attempt_id>$1 AND a.control_activation IS NOT NULL
  AND (a.control_activation->>'phase' IN ('aborting','stopping') OR
  (a.control_activation->>'phase' IN ('pending','installed','activated') AND
  (a.control_lease_expires_at<=clock_timestamp() OR a.expires_at<=clock_timestamp() OR r.user_id IS NULL OR r.admission_state<>'admitting'
@@ -29,7 +29,7 @@ func (s *Postgres) ListInitialReconciliation(ctx context.Context, accountID int,
  OR r.backend IS DISTINCT FROM a.control_activation->'binding'->'source'->>'Backend'
  OR r.source_id::text IS DISTINCT FROM a.control_activation->'binding'->'source'->>'SourceID'
  OR r.selection_generation::text IS DISTINCT FROM a.control_activation->'binding'->'source'->>'SelectionGeneration')))
- ORDER BY a.playback_attempt_id ASC LIMIT $3`, accountID, afterAttemptID, limit)
+ ORDER BY a.playback_attempt_id ASC LIMIT $2`, afterAttemptID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list initial reconciliation: %w", err)
 	}
@@ -37,7 +37,8 @@ func (s *Postgres) ListInitialReconciliation(ctx context.Context, accountID int,
 	result := make([]playback.InitialActivationV3, 0, limit)
 	for rows.Next() {
 		var data []byte
-		if err := rows.Scan(&data); err != nil {
+		var accountID int
+		if err := rows.Scan(&accountID, &data); err != nil {
 			return nil, err
 		}
 		if len(data) > initialActivationDocumentLimit {

--- a/internal/playback/planstore/initial_reconciliation_test.go
+++ b/internal/playback/planstore/initial_reconciliation_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/google/uuid"
 )
 
-func TestInitialReconciliationAccountPagesAndEligibility(t *testing.T) {
+func TestInitialReconciliationGlobalPagesAndEligibility(t *testing.T) {
 	f := newInitialActivationFixture(t)
 	f.begin(t)
-	rows, err := f.store.ListInitialReconciliation(t.Context(), f.userID, "", 1)
+	rows, err := f.store.ListInitialReconciliation(t.Context(), "", 1)
 	if err != nil || len(rows) != 0 {
 		t.Fatalf("live pending included: %v %v", rows, err)
 	}
@@ -41,7 +41,7 @@ func TestInitialReconciliationAccountPagesAndEligibility(t *testing.T) {
 	seen := map[string]bool{}
 	after := ""
 	for {
-		page, err := f.store.ListInitialReconciliation(t.Context(), f.userID, after, 1)
+		page, err := f.store.ListInitialReconciliation(t.Context(), after, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -60,8 +60,8 @@ func TestInitialReconciliationAccountPagesAndEligibility(t *testing.T) {
 	}
 	other := newInitialActivationFixture(t)
 	other.begin(t)
-	if rows, err := f.store.ListInitialReconciliation(t.Context(), other.userID, "", 100); err != nil || len(rows) != 0 {
-		t.Fatalf("account isolation: %v %v", rows, err)
+	if rows, err := f.store.ListInitialReconciliation(t.Context(), "", 100); err != nil || len(rows) != 3 {
+		t.Fatalf("live second account must stay excluded: %v %v", rows, err)
 	}
 	if _, err := f.pool.Exec(t.Context(), `UPDATE playback_source_registrations SET admission_state='admitting' WHERE user_id=$1`, f.userID); err != nil {
 		t.Fatal(err)
@@ -69,7 +69,7 @@ func TestInitialReconciliationAccountPagesAndEligibility(t *testing.T) {
 	if _, err := f.pool.Exec(t.Context(), `UPDATE playback_v3_attempts SET control_lease_expires_at=clock_timestamp()-interval '1 hour',expires_at=clock_timestamp()-interval '1 minute' WHERE user_id=$1`, f.userID); err != nil {
 		t.Fatal(err)
 	}
-	rows, err = f.store.ListInitialReconciliation(t.Context(), f.userID, "", 100)
+	rows, err = f.store.ListInitialReconciliation(t.Context(), "", 100)
 	if err != nil || len(rows) != 3 {
 		t.Fatalf("expired retention omitted: %d %v", len(rows), err)
 	}
@@ -77,19 +77,19 @@ func TestInitialReconciliationAccountPagesAndEligibility(t *testing.T) {
 	if _, err := f.store.AbortInitialActivation(t.Context(), f.binding, abortID); err != nil {
 		t.Fatal(err)
 	}
-	rows, err = f.store.ListInitialReconciliation(t.Context(), f.userID, "", 100)
+	rows, err = f.store.ListInitialReconciliation(t.Context(), "", 100)
 	if err != nil || len(rows) != 3 {
 		t.Fatalf("aborting omitted: %d %v", len(rows), err)
 	}
 	if _, err := f.store.CompleteInitialAbort(t.Context(), f.binding, abortID, f.receipt(t, terminalInitialReceipt(t, f, abortID))); err != nil {
 		t.Fatal(err)
 	}
-	rows, err = f.store.ListInitialReconciliation(t.Context(), f.userID, "", 100)
+	rows, err = f.store.ListInitialReconciliation(t.Context(), "", 100)
 	if err != nil || len(rows) != 2 {
 		t.Fatalf("terminal included: %d %v", len(rows), err)
 	}
 	for _, limit := range []int{0, 101} {
-		if _, err := f.store.ListInitialReconciliation(t.Context(), f.userID, "", limit); err == nil {
+		if _, err := f.store.ListInitialReconciliation(t.Context(), "", limit); err == nil {
 			t.Fatal("invalid limit")
 		}
 	}
@@ -97,7 +97,7 @@ func TestInitialReconciliationAccountPagesAndEligibility(t *testing.T) {
 
 func TestInitialReconciliationIncludesStoppingNotActivated(t *testing.T) {
 	f := activatedLifecycleFixture(t)
-	rows, err := f.store.ListInitialReconciliation(t.Context(), f.userID, "", 10)
+	rows, err := f.store.ListInitialReconciliation(t.Context(), "", 10)
 	if err != nil || len(rows) != 0 {
 		t.Fatalf("activated included: %v %v", rows, err)
 	}
@@ -110,7 +110,7 @@ func TestInitialReconciliationIncludesStoppingNotActivated(t *testing.T) {
 	if _, err := f.store.CleanupExpired(t.Context(), time.Now()); err != nil {
 		t.Fatal(err)
 	}
-	rows, err = f.store.ListInitialReconciliation(t.Context(), f.userID, "", 10)
+	rows, err = f.store.ListInitialReconciliation(t.Context(), "", 10)
 	if err != nil || len(rows) != 1 || rows[0].Phase != playback.InitialActivationStoppingV3 {
 		t.Fatalf("stopping missing: %v %v", rows, err)
 	}

--- a/internal/transcodenode/server.go
+++ b/internal/transcodenode/server.go
@@ -208,7 +208,7 @@ const sessionReapInterval = time.Minute
 const sessionTrackingOperationTimeout = 2 * time.Second
 
 // TranscodeStartReadinessTimeout is the node-side RequireReady manifest budget.
-const TranscodeStartReadinessTimeout = 8 * time.Second
+const TranscodeStartReadinessTimeout = playback.ManifestStartupTimeout
 
 // progressiveRemuxShutdownTimeout bounds a destructive reload when a canceled
 // FFmpeg process does not exit. A timed-out reload must fail rather than report

--- a/internal/userstore/capability.go
+++ b/internal/userstore/capability.go
@@ -1,0 +1,19 @@
+package userstore
+
+// Capability finds an optional store interface without losing it at a decorator.
+// The outermost implementation wins so mutation hooks still intercept writes.
+// Only transparent decorators should expose UnwrapUserStore.
+func Capability[T any](store UserStore) (T, bool) {
+	for store != nil {
+		if capability, ok := any(store).(T); ok {
+			return capability, true
+		}
+		wrapper, ok := store.(interface{ UnwrapUserStore() UserStore })
+		if !ok {
+			break
+		}
+		store = wrapper.UnwrapUserStore()
+	}
+	var zero T
+	return zero, false
+}

--- a/web/src/pages/audiobooks/player/audiobookPlaybackContext.tsx
+++ b/web/src/pages/audiobooks/player/audiobookPlaybackContext.tsx
@@ -101,9 +101,11 @@ export function AudiobookPlaybackProvider({ children }: { children: ReactNode })
           isCurrent: () => isCapturedProfileAuthorityActive(captured),
         };
       },
+      onPlaybackStartResolved: () => toast.dismiss("playback-start-pending"),
       onPlaybackStartError: (error, retry) =>
-        toast.error("Audiobook start unconfirmed", {
-          id: "audiobook-start-pending",
+        toast.error("Playback unavailable", {
+          id: "playback-start-pending",
+          duration: Infinity,
           description: error.message,
           action: { label: "Retry", onClick: retry },
         }),
@@ -127,9 +129,10 @@ export function AudiobookPlaybackProvider({ children }: { children: ReactNode })
     if (accountId == null || !profileId) return;
     let disposed = false;
     void initialPlaybackCapabilities(playerConfig)
-      .then((cap) => {
+      .then(async (cap) => {
         if (disposed || !cap.installation_id) return;
-        offerPendingInitialStart(playerConfig, cap);
+        await offerPendingInitialStart(playerConfig, cap);
+        if (disposed) return;
         offerPendingPlaybackStops(playerConfig, cap.installation_id);
       })
       .catch(() => {

--- a/web/src/pages/audiobooks/player/audiobookPlaybackContext.v2.test.tsx
+++ b/web/src/pages/audiobooks/player/audiobookPlaybackContext.v2.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "./audiobookPlaybackContext";
 
 const identity = vi.hoisted(() => ({ account: 1, toast: vi.fn() }));
-vi.mock("sonner", () => ({ toast: { error: identity.toast } }));
+vi.mock("sonner", () => ({ toast: { error: identity.toast, dismiss: vi.fn() } }));
 vi.mock("@/hooks/useAuth", () => ({ useAuth: () => ({ user: { id: identity.account } }) }));
 vi.mock("@/hooks/useCurrentProfile", () => ({
   useCurrentProfile: () => ({ profile: { id: "profile" } }),

--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -508,9 +508,11 @@ export function WatchPlaybackHost() {
       getProfileId: () => storage.get(storage.KEYS.PROFILE_ID),
       getProfileToken: () => getProfileToken(),
       getDeviceId: () => getOrCreateDeviceId(),
+      onPlaybackStartResolved: () => toast.dismiss("playback-start-pending"),
       onPlaybackStartError: (error, retry) => {
-        toast.error("Playback start unconfirmed", {
+        toast.error("Playback unavailable", {
           id: "playback-start-pending",
+          duration: Infinity,
           description: error.message,
           action: { label: "Retry", onClick: retry },
         });
@@ -532,9 +534,10 @@ export function WatchPlaybackHost() {
     if (accountId == null || !profileId) return;
     let disposed = false;
     void initialPlaybackCapabilities(playerConfig)
-      .then((cap) => {
+      .then(async (cap) => {
         if (!disposed && cap?.installation_id && cap.state !== "not_configured") {
-          offerPendingInitialStart(playerConfig, cap);
+          await offerPendingInitialStart(playerConfig, cap);
+          if (disposed) return;
           offerPendingPlaybackStops(playerConfig, cap.installation_id);
         }
       })

--- a/web/src/player/context/PlayerConfigContext.tsx
+++ b/web/src/player/context/PlayerConfigContext.tsx
@@ -15,6 +15,7 @@ export interface PlaybackMutationContext {
 }
 
 export interface PlayerConfig {
+  onPlaybackStartResolved?: () => void;
   onPlaybackStartError?: (error: Error, retry: () => void) => void;
   capturePlaybackMutationContext?: () => PlaybackMutationContext | null;
   /** Base URL for API calls, e.g. "/api/v1" */

--- a/web/src/player/durable-session-mutations.ts
+++ b/web/src/player/durable-session-mutations.ts
@@ -406,10 +406,7 @@ export function durableStop(
 }
 
 // Restore only exact current ownership. Other identities remain untouched.
-export function pendingDurableSessions(
-  config: PlayerConfig,
-  installationId: string,
-): DurableSession[] {
+function storedDurableSessions(config: PlayerConfig, installationId: string): DurableSession[] {
   const context = config.capturePlaybackMutationContext?.();
   if (!context || !context.isCurrent()) return [];
   const pending: DurableSession[] = [];
@@ -435,8 +432,29 @@ export function pendingDurableSessions(
         ? { timeline: readProgressTimeline(timeline, timeline.media_item_id, timeline.file_id) }
         : {}),
     };
-    const record = read(binding);
-    if (!record.stopped && !hasDurableTermination(binding)) pending.push(binding);
+    read(binding); // Validate even completed records before exposing their binding.
+    pending.push(binding);
   }
   return pending;
+}
+
+export function pendingDurableSessions(
+  config: PlayerConfig,
+  installationId: string,
+): DurableSession[] {
+  return storedDurableSessions(config, installationId).filter(
+    (binding) => !read(binding).stopped && !hasDurableTermination(binding),
+  );
+}
+
+// A START retained through cleanup may outlive its STOP receipt. Recover the
+// original mapping even when that STOP has already completed locally.
+export function retainedStartSession(
+  config: PlayerConfig,
+  installationId: string,
+  attemptId: string,
+): DurableSession | undefined {
+  return storedDurableSessions(config, installationId).find(
+    (binding) => binding.attemptId === attemptId,
+  );
 }

--- a/web/src/player/initial-v2.test.ts
+++ b/web/src/player/initial-v2.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, expect, it, vi } from "vitest";
-import { initialPlaybackCapabilities, startInitialPlayback } from "./initial-v2";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  initialPlaybackCapabilities,
+  startInitialPlayback as dispatchStart,
+  offerPendingInitialStart,
+} from "./initial-v2";
 import type { PlayerConfig } from "./context/PlayerConfigContext";
 import { buildStartRequestV3 } from "./playback-session-wire-v3";
 import {
@@ -39,8 +43,35 @@ const cap = {
   features: ["sequenced_progress_v1"],
   deliveries: ["direct"],
 };
+const startAborted = {
+  protocol_version: 3,
+  server_features: ["sequenced_progress_v1"],
+  outcome: "adaptation_unavailable",
+  terminal: {
+    reason: "playback_start_aborted",
+    message: "Playback could not start.",
+    retryable: false,
+  },
+};
 const reply = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status });
+beforeEach(() => vi.useFakeTimers());
+// Advance bounded retry backoff without waiting on wall-clock time. Attach both
+// outcomes before advancing so rejected requests never become unhandled promises.
+async function settle<T>(promise: Promise<T>): Promise<T> {
+  const outcome = promise.then(
+    (value) => ({ value }),
+    (error: unknown) => ({ error }),
+  );
+  await vi.runAllTimersAsync();
+  const result = await outcome;
+  if ("error" in result) throw result.error;
+  return result.value;
+}
+function startInitialPlayback(...args: Parameters<typeof dispatchStart>) {
+  return settle(dispatchStart(...args));
+}
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   localStorage.clear();
 });
@@ -109,49 +140,49 @@ it("refuses configured start before effects when browser locking is unavailable"
   await expect(startInitialPlayback(config, body)).rejects.toThrow("storage locking");
   expect(fetcher).toHaveBeenCalledTimes(1);
 });
-it("keeps an uncertain start body through reload and blocks a newly minted attempt", async () => {
-  vi.stubGlobal("navigator", {
-    locks: {
-      request: (_key: string, _options: unknown, action: () => Promise<unknown>) => action(),
-    },
-  });
-  const fetcher = vi.fn().mockImplementation(async (url: string) => {
-    if (url.endsWith("capabilities")) return reply(cap);
+it("automatically resolves an uncertain start after reload and never replaces its bytes", async () => {
+  const fetcher = boundTransport(async () => {
     throw new TypeError("lost successful reply");
   });
-  vi.stubGlobal("fetch", fetcher);
-  await expect(startInitialPlayback(config, body)).rejects.toThrow("lost successful reply");
-  const original = fetcher.mock.calls.find((c) => c[0].endsWith("/start"))![1].body;
+  const onPlaybackStartError = vi.fn();
+  const scoped = { ...config, onPlaybackStartError };
+  await expect(startInitialPlayback(scoped, body)).rejects.toThrow("lost successful reply");
+  const starts = () => fetcher.mock.calls.filter(([url]) => url.endsWith("/start"));
+  const original = starts()[0]![1]?.body;
   expect(localStorage.getItem(localStorage.key(0)!)).toBe(original);
+  expect(onPlaybackStartError).toHaveBeenCalledTimes(1);
   await expect(
     startInitialPlayback(config, { ...body, playback_attempt_id: "different-attempt" }),
-  ).rejects.toThrow("earlier playback start");
-  expect(fetcher.mock.calls.filter((c) => c[0].endsWith("/start"))).toHaveLength(1);
+  ).rejects.toThrow("lost successful reply");
+  expect(starts().length).toBeGreaterThan(2);
+  expect(starts().every((call) => call[1]?.body === original)).toBe(true);
   vi.resetModules();
   const reloaded = await import("./initial-v2");
   fetcher.mockImplementation(async (url: string) =>
-    url.endsWith("capabilities")
-      ? reply(cap)
-      : reply({
-          protocol_version: 3,
-          server_features: [],
-          outcome: "terminal",
-          terminal: { code: "unavailable" },
-        }),
+    url.endsWith("capabilities") ? reply(cap) : reply(startAborted, 201),
   );
-  await reloaded.startInitialPlayback(config, body);
-  expect(fetcher.mock.calls.filter((c) => c[0].endsWith("/start"))[1]![1].body).toBe(original);
+  const resolved = vi.fn();
+  await settle(
+    reloaded.offerPendingInitialStart({ ...config, onPlaybackStartResolved: resolved }, cap),
+  );
+  expect(starts().slice(-1)[0]![1]?.body).toBe(original);
   expect(localStorage.length).toBe(0);
+  expect(resolved).toHaveBeenCalledTimes(1);
 });
 it("quarantines an old start recovery action after identity changes", async () => {
-  let current = true;
+  let profile = "profile";
   let retry: (() => void) | undefined;
   const scoped = {
     ...config,
-    capturePlaybackMutationContext: () => ({
-      ...config.capturePlaybackMutationContext!()!,
-      isCurrent: () => current,
-    }),
+    getProfileId: () => profile,
+    capturePlaybackMutationContext: () => {
+      const capturedProfile = profile;
+      return {
+        ...config.capturePlaybackMutationContext!()!,
+        profileId: capturedProfile,
+        isCurrent: () => profile === capturedProfile,
+      };
+    },
     onPlaybackStartError: (_error: Error, action: () => void) => {
       retry = action;
     },
@@ -168,13 +199,22 @@ it("quarantines an old start recovery action after identity changes", async () =
   vi.stubGlobal("fetch", fetcher);
   await expect(startInitialPlayback(scoped, body)).rejects.toThrow("lost");
   expect(retry).toBeTypeOf("function");
-  current = false;
+  const oldKey = Object.keys(localStorage)[0]!;
+  profile = "other-profile";
+  const newKey = oldKey.replace(
+    encodeURIComponent('"profile"'),
+    encodeURIComponent('"other-profile"'),
+  );
+  localStorage.setItem(
+    newKey,
+    localStorage.getItem(oldKey)!.replace('"profile"', '"other-profile"'),
+  );
   fetcher.mockClear();
   retry!();
   await Promise.resolve();
   await Promise.resolve();
   expect(fetcher).not.toHaveBeenCalled();
-  expect(localStorage.length).toBe(1);
+  expect(localStorage.length).toBe(2);
 });
 it("does not fall back to legacy while an earlier start remains uncertain", async () => {
   vi.stubGlobal("navigator", {
@@ -196,44 +236,27 @@ it("does not fall back to legacy while an earlier start remains uncertain", asyn
   );
   expect(localStorage.length).toBe(1);
 });
-it("retains the same attempt after a lost start reply followed by validation_failed", async () => {
-  vi.stubGlobal("navigator", {
-    locks: {
-      request: (_key: string, _options: unknown, action: () => Promise<unknown>) => action(),
-    },
-  });
+it("retains the same attempt after a lost response followed by validation_failed", async () => {
+  let reject = true;
   let starts = 0;
-  const fetcher = vi.fn(async (url: string, _options?: RequestInit) => {
-    if (url.endsWith("capabilities")) return reply(cap);
+  const fetcher = boundTransport(async () => {
     starts++;
-    if (starts === 1) throw new Error("lost successful reply");
-    if (starts === 2) {
-      return reply(
-        { type: "https://siloserver.org/docs/api/v2/problems/validation_failed", status: 422 },
-        422,
-      );
-    }
-    return reply({
-      protocol_version: 3,
-      server_features: [],
-      outcome: "adaptation_unavailable",
-      terminal: { code: "unavailable" },
-    });
+    if (starts === 1) throw new TypeError("lost successful reply");
+    return reject ? reply({ status: 422 }, 422) : reply(startAborted, 201);
   });
-  vi.stubGlobal("fetch", fetcher);
-  await expect(startInitialPlayback(config, body)).rejects.toThrow("lost successful reply");
-  const stored = localStorage.getItem(localStorage.key(0)!);
   await expect(startInitialPlayback(config, body)).rejects.toThrow("Failed to start playback");
-  expect(localStorage.getItem(localStorage.key(0)!)).toBe(stored);
+  const stored = localStorage.getItem(localStorage.key(0)!);
   await expect(
     startInitialPlayback(config, { ...body, playback_attempt_id: "different-attempt" }),
-  ).rejects.toThrow("earlier playback start");
-  expect(starts).toBe(2);
+  ).rejects.toThrow("Failed to start playback");
+  expect(localStorage.getItem(localStorage.key(0)!)).toBe(stored);
+  expect(starts).toBe(3);
+  reject = false;
   await startInitialPlayback(config, body);
   expect(localStorage.length).toBe(0);
-  const requests = fetcher.mock.calls.filter((c) => c[0].endsWith("/start"));
-  expect(requests).toHaveLength(3);
-  for (const request of requests) expect((request[1] as RequestInit).body).toBe(stored);
+  const requests = fetcher.mock.calls.filter(([url]) => url.endsWith("/start"));
+  expect(requests).toHaveLength(4);
+  for (const request of requests) expect(request[1]?.body).toBe(stored);
 });
 it.each([
   {
@@ -267,8 +290,10 @@ it.each([
     expect(localStorage.length).toBe(1);
     await expect(
       startInitialPlayback(config, { ...body, playback_attempt_id: "new-attempt" }),
-    ).rejects.toThrow("earlier playback start");
-    expect(fetcher.mock.calls.filter((c) => c[0].endsWith("/start"))).toHaveLength(1);
+    ).rejects.toThrow();
+    expect(
+      new Set(fetcher.mock.calls.filter((c) => c[0].endsWith("/start")).map((c) => c[1].body)).size,
+    ).toBe(1);
   },
 );
 
@@ -343,7 +368,8 @@ it("retires only the exact retained201 timeline terminal, then permits a new exp
     await reloaded.startInitialPlayback(config, boundBody, "installation", timeline),
   ).toMatchObject(timelineTerminal);
   const starts = () => fetcher.mock.calls.filter(([url]) => url.endsWith("/start"));
-  expect(starts()).toHaveLength(2);
+  const retainedCount = starts().length;
+  expect(retainedCount).toBeGreaterThan(2);
   expect(starts()[1]![1]?.body).toBe(original);
   expect(localStorage.length).toBe(0);
   const fresh = { ...timeline, timeline_id: "b".repeat(64) };
@@ -353,8 +379,8 @@ it("retires only the exact retained201 timeline terminal, then permits a new exp
     "installation",
     fresh,
   );
-  expect(starts()).toHaveLength(3);
-  expect(JSON.parse(String(starts()[2]![1]?.body))).toMatchObject({
+  expect(starts()).toHaveLength(retainedCount + 1);
+  expect(JSON.parse(String(starts().slice(-1)[0]![1]?.body))).toMatchObject({
     playback_attempt_id: "new-explicit-intent",
     timeline_id: fresh.timeline_id,
   });
@@ -395,9 +421,13 @@ it.each([
         "installation",
         timeline,
       ),
-    ).rejects.toThrow("earlier playback start");
+    ).rejects.toThrow();
     expect(localStorage.getItem(key)).toBe(original);
-    expect(fetcher.mock.calls.filter(([url]) => url.endsWith("/start"))).toHaveLength(1);
+    expect(
+      new Set(
+        fetcher.mock.calls.filter(([url]) => url.endsWith("/start")).map((call) => call[1]?.body),
+      ).size,
+    ).toBe(1);
     expect(
       Object.keys(localStorage).some((key) => key.startsWith("silo-playback-mutation-v1:")),
     ).toBe(false);
@@ -442,7 +472,7 @@ const ownerTerminal = {
   },
   recovery: { ...ownerRecovery, state: "aborted" },
 };
-it("retains exact lost START bytes through draining reload, then durably records abandonment", async () => {
+it("automatically retries a lost START through draining and records terminal abandonment", async () => {
   let phase = 0;
   const fetcher = boundTransport(async () => {
     if (phase++ === 0) throw new TypeError("lost response");
@@ -450,18 +480,18 @@ it("retains exact lost START bytes through draining reload, then durably records
       ? reply({ outcome: "draining", recovery: ownerRecovery }, 202)
       : reply(ownerTerminal, 201);
   });
-  await expect(startInitialPlayback(config, body)).rejects.toThrow("lost response");
-  const key = Object.keys(localStorage).find((key) => key.startsWith("silo-playback-start-v1:"))!;
-  const original = localStorage.getItem(key);
-  await expect(startInitialPlayback(config, body)).rejects.toThrow("still draining");
-  expect(localStorage.getItem(key)).toBe(original);
-  vi.resetModules();
-  const restored = await import("./initial-v2");
-  expect(await restored.startInitialPlayback(config, body)).toEqual(ownerTerminal);
+  const onPlaybackStartError = vi.fn();
+  expect(await startInitialPlayback({ ...config, onPlaybackStartError }, body)).toEqual(
+    ownerTerminal,
+  );
   const starts = fetcher.mock.calls.filter(([url]) => url.endsWith("/start"));
+  const original = starts[0]![1]?.body;
   expect(starts).toHaveLength(3);
   expect(starts.every((call) => call[1]?.body === original)).toBe(true);
-  expect(localStorage.getItem(key)).toBeNull();
+  expect(onPlaybackStartError).not.toHaveBeenCalled();
+  expect(Object.keys(localStorage).some((key) => key.startsWith("silo-playback-start-v1:"))).toBe(
+    false,
+  );
   const recoveryKey = Object.keys(localStorage).find((key) =>
     key.startsWith("silo-playback-start-recovery-v1:"),
   )!;
@@ -512,7 +542,7 @@ it("refuses a changed recovery identity after observing the original pending STA
   let receipt: unknown = { outcome: "draining", recovery: ownerRecovery };
   let status = 202;
   boundTransport(async () => reply(receipt, status));
-  await expect(startInitialPlayback(config, body)).rejects.toThrow("still draining");
+  await expect(startInitialPlayback(config, body)).rejects.toThrow("still stopping");
   const snapshot = { ...localStorage };
   receipt = {
     ...ownerTerminal,
@@ -594,8 +624,187 @@ it.each([false, true])(
         "installation",
         mapping,
       ),
-    ).rejects.toThrow("earlier playback start");
+    ).rejects.toThrow();
     expect({ ...localStorage }).toEqual(saved);
-    expect(fetcher.mock.calls.filter(([url]) => url.endsWith("/start"))).toHaveLength(1);
+    expect(
+      new Set(
+        fetcher.mock.calls.filter(([url]) => url.endsWith("/start")).map((call) => call[1]?.body),
+      ).size,
+    ).toBe(1);
   },
 );
+
+it.each(["success", "stop_failure", "owner_loss", "cleanup_crash"])(
+  "finishes the exact undisplayed session before a new Play: %s",
+  async (mode) => {
+    const fetcher = boundTransport(async () => {
+      throw new TypeError("lost response");
+    });
+    await expect(startInitialPlayback(config, body)).rejects.toThrow("lost response");
+    const retained = fetcher.mock.calls.find(([url]) => url.endsWith("/start"))![1]?.body;
+    fetcher.mockClear();
+    const plan = fixturePlanV3();
+    let stopFails = mode === "stop_failure";
+    let stopAttempted = false;
+    fetcher.mockImplementation(async (url: string, options?: RequestInit) => {
+      if (url.endsWith("capabilities")) return reply(cap);
+      if (options?.method === "DELETE") {
+        expect(url).toContain("undisplayed-session");
+        stopAttempted = true;
+        if (stopFails) return reply({}, 503);
+        if (mode === "owner_loss")
+          return reply({
+            outcome: "aborted",
+            recovery: { ...ownerTerminal.recovery, session_id: "undisplayed-session" },
+          });
+        return reply({ outcome: "stopped", stop_id: JSON.parse(String(options.body)).stop_id });
+      }
+      const request = JSON.parse(String(options?.body));
+      if (request.playback_attempt_id !== "attempt") return reply(startAborted, 201);
+      if (stopAttempted) return reply({}, 503); // STOP may already have committed on the server.
+      return reply(
+        {
+          protocol_version: 3,
+          server_features: ["sequenced_progress_v1"],
+          outcome: "play",
+          session_id: "undisplayed-session",
+          playback_plan: {
+            ...plan,
+            requested_media_file_id: "42",
+            effective_media_file_id: "42",
+            source: { ...plan.source, media_file_id: "42" },
+          },
+        },
+        201,
+      );
+    });
+    if (stopFails) {
+      for (let tries = 0; tries < 2; tries++) {
+        await expect(
+          startInitialPlayback(config, { ...body, playback_attempt_id: "new-intent" }),
+        ).rejects.toThrow("stop is still pending");
+        const key = Object.keys(localStorage).find((key) =>
+          key.startsWith("silo-playback-start-v1:"),
+        )!;
+        expect(localStorage.getItem(key)).toBe(retained);
+        const starts = fetcher.mock.calls.filter(([url]) => url.endsWith("/start"));
+        expect(starts).toHaveLength(1);
+        expect(starts.every((call) => call[1]?.body === retained)).toBe(true);
+      }
+      const stops = fetcher.mock.calls.filter((call) => call[1]?.method === "DELETE");
+      expect(new Set(stops.map((call) => call[1]?.body)).size).toBe(1);
+      stopFails = false;
+      // Reload resumes both original operations, including the saved STOP ID.
+      vi.resetModules();
+      const reloaded = await import("./initial-v2");
+      await settle(reloaded.offerPendingInitialStart(config, cap));
+      expect(
+        fetcher.mock.calls.filter((call) => call[1]?.method === "DELETE").slice(-1)[0]![1]?.body,
+      ).toBe(stops[0]![1]?.body);
+      fetcher.mockClear();
+    }
+    if (mode === "cleanup_crash") {
+      const remove = Storage.prototype.removeItem;
+      const spy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(function (
+        this: Storage,
+        key,
+      ) {
+        if (key.startsWith("silo-playback-start-v1:")) throw new Error("cleanup interrupted");
+        return remove.call(this, key);
+      });
+      try {
+        await expect(
+          startInitialPlayback(config, { ...body, playback_attempt_id: "new-intent" }),
+        ).rejects.toThrow("cleanup interrupted");
+      } finally {
+        spy.mockRestore();
+      }
+    }
+    await startInitialPlayback(config, { ...body, playback_attempt_id: "new-intent" });
+    const effects = fetcher.mock.calls.filter(([url]) => !url.endsWith("capabilities"));
+    if (mode === "stop_failure") {
+      expect(effects).toHaveLength(1);
+      expect(JSON.parse(String(effects[0]![1]?.body))).toMatchObject({
+        playback_attempt_id: "new-intent",
+      });
+      return;
+    }
+    expect(effects.map((call) => call[1]?.method)).toEqual(["POST", "DELETE", "POST"]);
+    expect(effects[0]![1]?.body).toBe(retained);
+    expect(JSON.parse(String(effects[1]![1]?.body))).toMatchObject({
+      installation_id: "installation",
+      stop_id: expect.any(String),
+    });
+    expect(JSON.parse(String(effects[2]![1]?.body))).toMatchObject({
+      playback_attempt_id: "new-intent",
+    });
+    expect(Object.keys(localStorage).some((key) => key.startsWith("silo-playback-start-v1:"))).toBe(
+      false,
+    );
+  },
+);
+
+it("shares one automatic recovery task between video and audiobook hosts", async () => {
+  const fetcher = boundTransport(async () => {
+    throw new TypeError("lost response");
+  });
+  await expect(startInitialPlayback(config, body)).rejects.toThrow("lost response");
+  fetcher.mockClear();
+  fetcher.mockImplementation(async (url: string) =>
+    url.endsWith("capabilities") ? reply(cap) : reply(startAborted, 201),
+  );
+  const resolved = vi.fn();
+  const failed = vi.fn();
+  const scoped = { ...config, onPlaybackStartResolved: resolved, onPlaybackStartError: failed };
+  const video = offerPendingInitialStart(scoped, cap);
+  const audiobook = offerPendingInitialStart(scoped, cap);
+  expect(video).toBe(audiobook);
+  await settle(video);
+  expect(fetcher.mock.calls.filter(([url]) => url.endsWith("/start"))).toHaveLength(1);
+  expect(resolved).toHaveBeenCalledTimes(1);
+  expect(failed).not.toHaveBeenCalled();
+});
+
+it("bounds the whole START recovery, including the final network request", async () => {
+  const originalTimeout = vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new DOMException("timed out", "TimeoutError")), ms);
+    return controller.signal;
+  });
+  let requests = 0;
+  const startAt = Date.now();
+  boundTransport(async () => {
+    throw new Error("unused");
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string, options?: RequestInit) => {
+      if (url.endsWith("capabilities")) return reply(cap);
+      if (++requests === 1) {
+        await new Promise((resolve) => setTimeout(resolve, 44000));
+        return reply({}, 503);
+      }
+      return new Promise<Response>((_resolve, reject) =>
+        options!.signal!.addEventListener("abort", () => reject(options!.signal!.reason), {
+          once: true,
+        }),
+      );
+    }),
+  );
+  let finishedAt = 0;
+  const result = dispatchStart(config, body).catch((error) => {
+    finishedAt = Date.now();
+    return error;
+  });
+  try {
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(await result).toBeInstanceOf(DOMException);
+    expect(finishedAt - startAt).toBe(60000);
+    expect(requests).toBe(2);
+    expect(Object.keys(localStorage).some((key) => key.startsWith("silo-playback-start-v1:"))).toBe(
+      true,
+    );
+  } finally {
+    originalTimeout.mockRestore();
+  }
+});

--- a/web/src/player/initial-v2.ts
+++ b/web/src/player/initial-v2.ts
@@ -1,12 +1,20 @@
-import { pendingDurableSessions } from "./durable-session-mutations";
-import { readOwnerLossRecovery, type OwnerLossRecovery } from "./owner-loss-recovery";
+import { pendingDurableSessions, retainedStartSession } from "./durable-session-mutations";
+import {
+  readOwnerLossRecovery,
+  PlaybackOwnerLostError,
+  type OwnerLossRecovery,
+} from "./owner-loss-recovery";
 import { readProgressTimeline, type ProgressTimeline } from "./bound-client-timeline";
 import type { components } from "@/api/v2/schema";
 import type { PlaybackMutationContext, PlayerConfig } from "./context/PlayerConfigContext";
 import { playerRequestHeaders, PlayerFetchError } from "./player-fetch";
 import { playerV2Origin } from "./player-v2";
 import type { DecisionResponseV3, StartRequestV3 } from "./protocol-v3";
-import { offerPendingPlaybackStops, registerDurableSessionMutations } from "./session-mutations";
+import {
+  offerPendingPlaybackStops,
+  registerDurableSessionMutations,
+  stopSequencedSession,
+} from "./session-mutations";
 
 export type InitialPlaybackCapabilities = components["schemas"]["PlaybackCapabilities"];
 export async function initialPlaybackCapabilities(
@@ -102,9 +110,13 @@ export async function startInitialPlayback(
     file_id: String(body.file_id),
     installation_id: cap.installation_id,
   } satisfies components["schemas"]["PlaybackStartBody"]);
-  return await navigator.locks.request(key, { signal: AbortSignal.timeout(30000) }, async () => {
+  return await navigator.locks.request(key, { signal: AbortSignal.timeout(90000) }, async () => {
     if (!authority.isCurrent()) throw new Error("Playback identity changed");
-    const pending = localStorage.getItem(key);
+    let pending = localStorage.getItem(key);
+    if (pending && pending !== payload) {
+      await resolveRetainedStart(config, authority, cap.installation_id!, key, pending);
+      pending = localStorage.getItem(key);
+    }
     if (
       !pending &&
       body.progress_persistence === "client_bound" &&
@@ -112,12 +124,6 @@ export async function startInitialPlayback(
     ) {
       offerPendingPlaybackStops(config, cap.installation_id!, true);
       throw new Error("A previous audiobook part still needs its terminal stop receipt");
-    }
-    if (pending && pending !== payload) {
-      offerPendingInitialStart(config, cap);
-      throw new Error(
-        "An earlier playback start is still unconfirmed. Resolve it before starting another session.",
-      );
     }
     if (expectedTimeline) {
       const expected = JSON.stringify(expectedTimeline);
@@ -132,9 +138,17 @@ export async function startInitialPlayback(
     if (localStorage.getItem(key) !== payload)
       throw new Error("Playback retry storage unavailable");
     try {
-      return await dispatchInitialStart(config, authority, cap.installation_id!, key, payload);
+      const response = await dispatchInitialStartWithRetry(
+        config,
+        authority,
+        cap.installation_id!,
+        key,
+        payload,
+      );
+      config.onPlaybackStartResolved?.();
+      return response;
     } catch (error) {
-      offerPendingInitialStart(config, cap);
+      if (authority.isCurrent()) reportStartRecoveryFailure(config, cap, authority);
       throw error;
     }
   });
@@ -175,14 +189,11 @@ function startKey(context: PlaybackMutationContext, installationId: string): str
     )
   );
 }
-async function dispatchInitialStart(
-  config: PlayerConfig,
+function readSavedInitialStart(
+  payload: string,
   authority: PlaybackMutationContext,
   installationId: string,
-  key: string,
-  payload: string,
-): Promise<DecisionResponseV3> {
-  if (!authority.isCurrent()) throw new Error("Playback identity changed");
+) {
   const saved = JSON.parse(payload) as {
     installation_id?: string;
     playback_attempt_id?: string;
@@ -198,6 +209,19 @@ async function dispatchInitialStart(
     !saved.playback_attempt_id
   )
     throw new Error("Invalid saved playback start identity");
+  return { ...saved, playback_attempt_id: saved.playback_attempt_id };
+}
+async function dispatchInitialStart(
+  config: PlayerConfig,
+  authority: PlaybackMutationContext,
+  installationId: string,
+  key: string,
+  payload: string,
+  timeout: number,
+  retainUntilStopped: boolean,
+): Promise<DecisionResponseV3> {
+  if (!authority.isCurrent()) throw new Error("Playback identity changed");
+  const saved = readSavedInitialStart(payload, authority, installationId);
   let expectedTimeline;
   if (saved.progress_persistence === "client_bound") {
     const value = JSON.parse(
@@ -211,7 +235,7 @@ async function dispatchInitialStart(
     method: "POST",
     headers: playerRequestHeaders(config, undefined, true),
     body: payload,
-    signal: AbortSignal.timeout(15000),
+    signal: AbortSignal.timeout(timeout),
   });
   if (!authority.isCurrent()) throw new Error("Playback identity changed while starting");
   if (!response.ok) {
@@ -249,7 +273,7 @@ async function dispatchInitialStart(
     if (localStorage.getItem(recoveryKey) !== recorded)
       throw new Error("Playback recovery receipt could not be saved");
     if (recovery.state === "draining")
-      throw new Error("Playback owner recovery is still draining. Retry the original request.");
+      throw new PlaybackStartDrainingError("Playback is still stopping on the server");
     // Persist terminal abandonment before releasing the old START. Its original bytes
     // and the server's accepted Last remain in the per-attempt recovery record.
     localStorage.removeItem(key);
@@ -309,51 +333,157 @@ async function dispatchInitialStart(
     );
   else if (!wire.terminal)
     throw new Error("Playback start returned no durable session or terminal decision");
-  localStorage.removeItem(key);
-  localStorage.removeItem(timelineKey(key));
+  if (!retainUntilStopped || !wire.session_id) {
+    localStorage.removeItem(key);
+    localStorage.removeItem(timelineKey(key));
+  }
   return { ...wire, playback_plan: converted } as DecisionResponseV3;
 }
 
+class PlaybackStartDrainingError extends Error {}
+
+// Retrying this operation never changes the attempt or launches a replacement.
+// A successful replay or retained terminal decision is the only journal release.
+async function dispatchInitialStartWithRetry(
+  config: PlayerConfig,
+  authority: PlaybackMutationContext,
+  installationId: string,
+  key: string,
+  payload: string,
+  retainUntilStopped = false,
+): Promise<DecisionResponseV3> {
+  const deadline = Date.now() + 60000;
+  let delay = 250;
+  for (;;) {
+    try {
+      return await dispatchInitialStart(
+        config,
+        authority,
+        installationId,
+        key,
+        payload,
+        Math.min(45000, deadline - Date.now()),
+        retainUntilStopped,
+      );
+    } catch (error) {
+      const transient =
+        error instanceof TypeError ||
+        (error instanceof DOMException &&
+          (error.name === "TimeoutError" || error.name === "AbortError")) ||
+        (error instanceof PlayerFetchError && error.status >= 500) ||
+        error instanceof PlaybackStartDrainingError;
+      if (!transient || !authority.isCurrent() || Date.now() + delay >= deadline) throw error;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      if (!authority.isCurrent()) throw new Error("Playback identity changed");
+      delay = Math.min(delay * 2, 2000);
+    }
+  }
+}
+
+async function resolveRetainedStart(
+  config: PlayerConfig,
+  authority: PlaybackMutationContext,
+  installationId: string,
+  key: string,
+  payload: string,
+): Promise<void> {
+  const saved = readSavedInitialStart(payload, authority, installationId);
+  const retained = retainedStartSession(config, installationId, saved.playback_attempt_id!);
+  let sessionId: string | undefined;
+  if (retained) {
+    // Once START registered the session, STOP may have committed despite a lost
+    // reply. Resume that captured STOP directly; a stopped session need not have
+    // a replayable START decision anymore.
+    sessionId = retained.identity.sessionId;
+    await registerDurableSessionMutations(
+      config,
+      sessionId,
+      installationId,
+      retained.timeline,
+      authority,
+      saved.playback_attempt_id,
+    );
+  } else {
+    const response = await dispatchInitialStartWithRetry(
+      config,
+      authority,
+      installationId,
+      key,
+      payload,
+      true,
+    );
+    sessionId = response.session_id;
+  }
+  // This response belongs to an earlier, undisplayed start. Close that exact
+  // session through its normal durable STOP before returning to the new Play.
+  if (sessionId) {
+    try {
+      await stopSequencedSession(config, sessionId);
+    } catch (error) {
+      // This exception follows a durably validated terminal receipt. No old
+      // executor remains to stop, so the user's new Play may continue.
+      if (!(error instanceof PlaybackOwnerLostError)) throw error;
+    }
+    if (!authority.isCurrent()) throw new Error("Playback identity changed");
+    if (localStorage.getItem(key) !== payload)
+      throw new Error("The pending playback start changed while stopping its session");
+    localStorage.removeItem(key);
+    localStorage.removeItem(timelineKey(key));
+  }
+  config.onPlaybackStartResolved?.();
+}
+
+const recoveringStarts = new Map<string, Promise<void>>();
+
+// The video and audiobook hosts share the same durable START namespace. One
+// recovery task per key avoids duplicate requests and notifications in this tab;
+// the existing Web Lock serializes recovery against starts in other tabs.
 export function offerPendingInitialStart(
   config: PlayerConfig,
   cap: InitialPlaybackCapabilities,
-): void {
+): Promise<void> {
   const authority = config.capturePlaybackMutationContext?.();
-  if (!authority?.isCurrent() || !cap.installation_id) return;
+  if (!authority?.isCurrent() || !cap.installation_id) return Promise.resolve();
   const installationId = cap.installation_id;
   const key = startKey(authority, installationId);
-  const payload = localStorage.getItem(key);
-  if (!payload) return;
-  const retry = () => {
-    void (async () => {
-      if (!authority.isCurrent())
-        throw new Error("Return to the original playback identity before retrying.");
+  if (!localStorage.getItem(key)) return Promise.resolve();
+  const running = recoveringStarts.get(key);
+  if (running) return running;
+  const recovery = (async () => {
+    try {
       const current = await initialPlaybackCapabilities(config);
+      if (!authority.isCurrent()) return;
       if (
-        !current?.allowed ||
+        !current.allowed ||
         current.state !== "available" ||
         current.installation_id !== installationId
       )
-        throw new Error("The original playback installation is not currently admitted.");
-      if (!navigator.locks?.request)
-        throw new Error("Durable playback requires browser storage locking");
-      await navigator.locks.request(key, { signal: AbortSignal.timeout(30000) }, async () => {
-        if (localStorage.getItem(key) !== payload)
-          throw new Error("The pending playback start has already changed.");
-        await dispatchInitialStart(config, authority, installationId, key, payload);
+        throw new Error("Playback is currently unavailable on this server");
+      if (!navigator.locks?.request) throw new Error("Playback storage locking is unavailable");
+      await navigator.locks.request(key, { signal: AbortSignal.timeout(90000) }, async () => {
+        if (!authority.isCurrent()) return;
+        const payload = localStorage.getItem(key);
+        if (payload) await resolveRetainedStart(config, authority, installationId, key, payload);
       });
-      offerPendingPlaybackStops(config, installationId, true);
-    })().catch((error) =>
-      config.onPlaybackStartError?.(
-        error instanceof Error ? error : new Error("Playback start is unconfirmed"),
-        retry,
-      ),
-    );
-  };
+    } catch {
+      if (authority.isCurrent()) reportStartRecoveryFailure(config, cap, authority);
+    } finally {
+      recoveringStarts.delete(key);
+    }
+  })();
+  recoveringStarts.set(key, recovery);
+  return recovery;
+}
+
+function reportStartRecoveryFailure(
+  config: PlayerConfig,
+  cap: InitialPlaybackCapabilities,
+  authority: PlaybackMutationContext,
+): void {
   config.onPlaybackStartError?.(
-    new Error(
-      "A previous playback start is unconfirmed. Retry to resolve it before starting another session.",
-    ),
-    retry,
+    new Error("Unable to finish starting playback. Check your connection and try again."),
+    () => {
+      if (authority.isCurrent()) void offerPendingInitialStart(config, cap);
+    },
   );
 }


### PR DESCRIPTION
Playback starts could remain unconfirmed after worker startup failure or a lost response, and onboarding progress became unavailable behind the notification store wrapper. This draft adds global retained-attempt reconciliation, aligns worker manifest startup timing, releases owners when idle sessions expire, preserves optional store capabilities, and automatically retries the browser's exact saved START and STOP requests.

Related issue: #135

### Known blockers and handoff

- **Do not merge yet:** a confirmed missing-file START rejection remains saved in the browser. Later Play actions replay that old request before sending the newly selected file, so unrelated items all appear unavailable. Reproduce by starting a missing catalog file, then selecting a different item: the new page refers to the new file while POST START still contains the previous file and attempt IDs. Distinguish a confirmed pre-start rejection from an uncertain response without weakening the existing identity and ownership fences.
- `verify-route-inventory` rejects the generic type assertion in `internal/userstore/capability.go`. Resolve this interaction with the route verifier.
- Full web tests expose an audiobook retained-start assertion failure and a subtitle-font import failure; focused tests alone missed them.
- Deployment follow-up remains outside this patch: the audiobook media root is absent from the running development container's mounts. The video media root is mounted. Verify and restore the expected deployment override mounts separately.
- Apple and Android wire behavior remains unchanged; their existing terminal handling was inspected. Jellyfin compatibility keeps its legacy finalization path.

### Validation

Earlier focused verification passed 90 web tests, TypeScript checking, database-backed reconciliation/onboarding tests, and focused race tests for idle owner release and recovery. Live validation exercised a lost successful START response, automatic exact-request replay, rendered playback, and sequenced STOP completion. It did not cover the confirmed missing-file rejection described above.

Pre-PR checks passed: Go build and vet, formatting of Go files under cmd/internal, settings bindings, playback fixtures, offline routes, v2 OpenAPI, v2 contract compatibility against origin/apiv2, v2 fixtures, committed router artifact test, local-path checks, and production web build.

Required checks that failed or could not complete:
- Frozen dependency install refused noninteractive replacement of the existing modules directory.
- `golangci-lint` is not installed.
- Full web lint: constant-condition errors in adminImages.ts and adminSplit.ts, plus warnings.
- Web format check: 34 files reported.
- Full web tests: 4,365 tests passed, one audiobook recovery assertion failed, and the ASS subtitle test suite could not import a font asset.
- Route inventory: generic capability assertion rejected.
- Migration ledger and scenario catalog verification: ledger/inventory consistency failures.
- Full Go suite: stopped after the 120-second validation time limit; no full-suite pass is claimed.

A prior transcode-node test run also failed `TestMediaRouteManifest`; that snapshot failure was reproduced at the unchanged base commit.

### AI disclosure

Implementation, diagnosis, tests, and PR preparation used OpenAI GPT-6 through the Codex desktop agent harness (the exact serving variant is not exposed in this task). A Codex subagent reviewed recovery behavior; its exact serving variant is likewise not exposed. Architecture advice used Claude Advisor with `claude-fable-5-1`. Review covered retained request identity, distributed cleanup, cursor progress, STOP recovery, and idle owner expiry. The known failures above remain unresolved; this is a draft handoff, not a claim of merge readiness.
