### PR TITLE
perf(literaryworks): use indexed candidate lookups for book matching

### DIFF
--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -208,3 +208,35 @@ would re-introduce a custom sink the OTLP + runtime split already covers.
   (DB connect, migrations, tuning) reach stderr only, matching existing `opslog` behavior.
 - **Per-subsystem trace propagation into plugins** is a follow-up owned by
   `silo-plugin-sdk`; this repo instruments only the host side.
+
+## Literary-work matching
+
+`internal/literaryworks` records candidate selection and automatic matching on
+Prometheus. The `origin` label is restricted to `scanner`, `ebook_enrichment`,
+`audiobook_enrichment`, and `other` (including interactive candidate requests).
+Media identifiers and titles are never labels.
+
+| Metric | Meaning |
+| --- | --- |
+| `silo_literary_match_candidate_duration_seconds` | Candidate-ID selection time, including pool wait and row reads; `outcome` is `success` or `error`. |
+| `silo_literary_match_candidates` | Candidate count for successful lookups, including zero matches. |
+| `silo_literary_match_active` | Automatic matching calls currently running on this replica. Sum across replicas to observe cluster concurrency. |
+| `silo_literary_match_attempts_total` | Completed automatic calls with `linked`, `already_linked`, `no_match`, or `error` outcomes. |
+
+Candidate selection unions independent title, provider-ID, and series index
+lookups before applying ignored decisions, global ordering, and the limit.
+Combining these criteria with cross-table `OR EXISTS` predicates can scan the
+entire book catalog despite the lookup indexes. Keep deduplication before the
+limit and hydrate metadata only for selected IDs. Sources without usable criteria
+retain the opposite-format fallback. Already-linked automatic calls skip candidate
+selection; unchanged unlinked books are still reconsidered so newly added
+counterparts can be found.
+
+The opt-in `TestCandidateLookupLargeCatalog` test compares the old and current
+queries with custom and generic prepared plans on a synthetic catalog. Set
+`SILO_TEST_DATABASE_URL` to a disposable PostgreSQL database and
+`SILO_TEST_LITERARY_PERF=1`, then run
+`go test ./internal/literaryworks -run TestCandidateLookupLargeCatalog -count=1 -v`.
+The fixture uses temporary tables and checks execution plans for catalog-wide
+work and unnecessary JIT. Treat reported timings as local test results rather
+than production latency guarantees.

--- a/internal/audiobooks/enrichment.go
+++ b/internal/audiobooks/enrichment.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/literaryworks"
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/scanner"
@@ -719,7 +720,7 @@ func (e *Enricher) autoLinkLiteraryWork(ctx context.Context, contentID string) {
 	if e == nil || e.workLinker == nil || strings.TrimSpace(contentID) == "" {
 		return
 	}
-	workID, linked, err := e.workLinker.AutoLinkContent(ctx, contentID)
+	workID, linked, err := e.workLinker.AutoLinkContent(literaryworks.WithMatchOrigin(ctx, "audiobook_enrichment"), contentID)
 	if err != nil {
 		slog.WarnContext(ctx, "audiobook enrichment: literary work auto-link failed", "component", "audiobooks", "content_id", contentID, "error", err)
 		return

--- a/internal/ebooks/enrichment.go
+++ b/internal/ebooks/enrichment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Silo-Server/silo-server/internal/catalog"
+	"github.com/Silo-Server/silo-server/internal/literaryworks"
 	"github.com/Silo-Server/silo-server/internal/metadata"
 	"github.com/Silo-Server/silo-server/internal/models"
 )
@@ -1107,7 +1108,7 @@ func (e *Enricher) autoLinkLiteraryWork(ctx context.Context, contentID string) {
 	if e == nil || e.workLinker == nil || strings.TrimSpace(contentID) == "" {
 		return
 	}
-	workID, linked, err := e.workLinker.AutoLinkContent(ctx, contentID)
+	workID, linked, err := e.workLinker.AutoLinkContent(literaryworks.WithMatchOrigin(ctx, "ebook_enrichment"), contentID)
 	if err != nil {
 		slog.WarnContext(ctx, "ebook enrichment: literary work auto-link failed", "component", "ebooks", "content_id", contentID, "error", err)
 		return

--- a/internal/literaryworks/candidates_performance_test.go
+++ b/internal/literaryworks/candidates_performance_test.go
@@ -1,0 +1,155 @@
+package literaryworks
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Run explicitly against a disposable database. Planner costs alone cannot
+// establish that the rewrite avoids catalog-wide work with prepared statements.
+func TestCandidateLookupLargeCatalog(t *testing.T) {
+	if os.Getenv("SILO_TEST_LITERARY_PERF") != "1" {
+		t.Skip("set SILO_TEST_LITERARY_PERF=1 for the large synthetic catalog comparison")
+	}
+	pool := candidateTestPool(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `
+ SET statement_timeout = '180s';
+ INSERT INTO media_items
+ SELECT 'book-'||g, CASE WHEN g%3=0 THEN 'movie' WHEN g%3=1 THEN 'ebook' ELSE 'audiobook' END,
+ CASE WHEN g%1000=0 THEN 'Common title' ELSE 'Title '||g END
+ FROM generate_series(1,620000) g;
+ INSERT INTO media_item_provider_ids SELECT content_id,'isbn',content_id,type FROM media_items;
+ INSERT INTO media_item_provider_ids SELECT content_id,'work',content_id,type FROM media_items LIMIT 247000;
+ INSERT INTO ebook_series SELECT content_id,'Series '||content_id,1 FROM media_items WHERE type='ebook';
+ INSERT INTO audiobook_series SELECT content_id,'Series '||content_id,1 FROM media_items WHERE type='audiobook';
+ ANALYZE media_items; ANALYZE media_item_provider_ids; ANALYZE ebook_series; ANALYZE audiobook_series; ANALYZE literary_work_match_decisions;
+ SET statement_timeout = '30s';
+ `)
+	if err != nil {
+		t.Fatal(err)
+	}
+	index := 1.0
+	for _, mode := range []string{"force_custom_plan", "force_generic_plan"} {
+		if _, err := pool.Exec(ctx, "SET plan_cache_mode = "+mode); err != nil {
+			t.Fatal(err)
+		}
+		for _, format := range []string{FormatEbook, FormatAudiobook} {
+			target := "book-2"
+			title := "Title 2"
+			if format == FormatAudiobook {
+				target = "book-1"
+				title = "Title 1"
+			}
+			cases := []struct {
+				name   string
+				source MatchItem
+			}{
+				{"title", MatchItem{Title: title}},
+				{"provider", MatchItem{ExternalIDs: map[string]string{"isbn": target}}},
+				{"series", MatchItem{SeriesName: "Series " + target, SeriesIndex: &index}},
+				{"combined", MatchItem{Title: title, ExternalIDs: map[string]string{"isbn": target, "work": target}, SeriesName: "Series " + target, SeriesIndex: &index}},
+				{"common", MatchItem{Title: "Common title", ExternalIDs: map[string]string{"isbn": target}}},
+				{"no_match", MatchItem{Title: "Missing", ExternalIDs: map[string]string{"isbn": "missing", "work": "missing"}, SeriesName: "Missing", SeriesIndex: &index}},
+			}
+			for _, tc := range cases {
+				t.Run(mode+"/"+format+"/"+tc.name, func(t *testing.T) {
+					source := tc.source
+					source.Type = format
+					source.ContentID = "source"
+					oldQuery, oldArgs := legacyCandidateQuery(source, 100)
+					newQuery, newArgs := matchCandidateIDsQuery(source, 100)
+					old := explainCandidate(t, pool, oldQuery, oldArgs)
+					next := explainCandidate(t, pool, newQuery, newArgs)
+					t.Logf("legacy %.3f ms; indexed %.3f ms", old.ExecutionTime, next.ExecutionTime)
+					checkCandidatePlan(t, next.Plan)
+					if next.JIT != nil {
+						t.Error("indexed candidate query unnecessarily triggers JIT")
+					}
+				})
+			}
+		}
+	}
+	source := MatchItem{ContentID: "source", Type: FormatEbook, Title: "Missing", ExternalIDs: map[string]string{"isbn": "missing"}}
+	query, args := matchCandidateIDsQuery(source, 100)
+	started := time.Now()
+	for i := 0; i < 1000; i++ {
+		candidateIDs(t, pool, query, args)
+	}
+	t.Logf("1000 repeated no-match lookups: %s", time.Since(started))
+}
+
+type candidatePlan struct {
+	NodeType   string          `json:"Node Type"`
+	Relation   string          `json:"Relation Name"`
+	ActualRows float64         `json:"Actual Rows"`
+	Loops      float64         `json:"Actual Loops"`
+	Removed    float64         `json:"Rows Removed by Filter"`
+	Plans      []candidatePlan `json:"Plans"`
+}
+type candidateExplain struct {
+	Plan          candidatePlan   `json:"Plan"`
+	ExecutionTime float64         `json:"Execution Time"`
+	JIT           json.RawMessage `json:"JIT"`
+}
+
+func explainCandidate(t *testing.T, pool *pgxpool.Pool, query string, args []any) candidateExplain {
+	t.Helper()
+	ctx := context.Background()
+	// EXPLAIN's own prepared statement does not exercise a cached SELECT plan.
+	// Prepare the SELECT explicitly and EXPLAIN EXECUTE it with bound literals.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
+	if _, err = conn.Conn().Prepare(ctx, "candidate_perf", query); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := conn.Conn().Deallocate(ctx, "candidate_perf"); err != nil {
+			t.Error(err)
+		}
+	}()
+	literals := make([]string, len(args))
+	for i, arg := range args {
+		literals[i] = candidateSQLLiteral(arg)
+	}
+	var raw []byte
+	if err := conn.QueryRow(ctx, "EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) EXECUTE candidate_perf("+strings.Join(literals, ",")+")").Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	var plans []candidateExplain
+	if err := json.Unmarshal(raw, &plans); err != nil {
+		t.Fatal(err)
+	}
+	return plans[0]
+}
+
+func checkCandidatePlan(t *testing.T, plan candidatePlan) {
+	t.Helper()
+	// Even an index scan can read the entire catalog and discard it via a filter.
+	// Common-title fixtures have hundreds of hits; catalog scans have hundreds of thousands.
+	if plan.Relation != "" && (plan.ActualRows+plan.Removed)*plan.Loops > 10000 {
+		t.Errorf("lookup scanned too many rows: %+v", plan)
+	}
+	for _, child := range plan.Plans {
+		checkCandidatePlan(t, child)
+	}
+}
+
+func candidateSQLLiteral(value any) string {
+	switch value := value.(type) {
+	case string:
+		return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+	default:
+		return fmt.Sprint(value)
+	}
+}

--- a/internal/literaryworks/candidates_test.go
+++ b/internal/literaryworks/candidates_test.go
@@ -1,0 +1,182 @@
+package literaryworks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// These temporary tables shadow catalog tables on a single test connection.
+// They let the same fixture exercise both the old predicate and the new lookup
+// without touching existing catalog rows in the configured test database.
+func candidateTestPool(t testing.TB) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("SILO_TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("SILO_TEST_DATABASE_URL is not set")
+	}
+	cfg, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.MaxConns = 1
+	cfg.MinConns = 0
+	cfg.MaxConnLifetime = time.Hour
+	cfg.ConnConfig.RuntimeParams["statement_timeout"] = "30000"
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	_, err = pool.Exec(context.Background(), `
+ CREATE TEMP TABLE media_items (content_id text PRIMARY KEY, type text NOT NULL, title text NOT NULL);
+ CREATE INDEX ON media_items (content_id, type);
+ CREATE INDEX ON media_items (type);
+ CREATE INDEX ON media_items (lower(title)) WHERE type IN ('ebook','audiobook');
+ CREATE TEMP TABLE media_item_provider_ids (content_id text, provider text, provider_id text, item_type text, PRIMARY KEY(content_id,provider), UNIQUE(provider,provider_id,item_type));
+ CREATE TEMP TABLE ebook_series (content_id text PRIMARY KEY, series_name text, series_index numeric);
+ CREATE INDEX ON ebook_series (lower(series_name),series_index);
+ CREATE TEMP TABLE audiobook_series (LIKE ebook_series INCLUDING ALL);
+ CREATE TEMP TABLE literary_work_match_decisions (source_content_id text, target_content_id text, decision text, PRIMARY KEY(source_content_id,target_content_id));
+ CREATE INDEX ON literary_work_match_decisions(target_content_id,decision);
+ `)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pool
+}
+
+// legacyCandidateQuery is the pre-rewrite predicate, retained as a result oracle
+// and performance baseline. It deliberately uses correlated OR predicates.
+func legacyCandidateQuery(source MatchItem, limit int) (string, []any) {
+	args := []any{source.ContentID, source.Type}
+	var criteria []string
+	if strings.TrimSpace(source.Title) != "" {
+		args = append(args, source.Title)
+		criteria = append(criteria, fmt.Sprintf("lower(mi.title)=lower($%d)", len(args)))
+	}
+	for provider, id := range source.ExternalIDs {
+		if provider == "" || provider == "asin" || id == "" {
+			continue
+		}
+		args = append(args, provider, id)
+		criteria = append(criteria, fmt.Sprintf("EXISTS (SELECT 1 FROM media_item_provider_ids p WHERE p.content_id=mi.content_id AND p.provider=$%d AND p.provider_id=$%d)", len(args)-1, len(args)))
+	}
+	if strings.TrimSpace(source.SeriesName) != "" && source.SeriesIndex != nil {
+		table := "ebook_series"
+		if source.Type == FormatEbook {
+			table = "audiobook_series"
+		}
+		args = append(args, source.SeriesName, *source.SeriesIndex)
+		criteria = append(criteria, fmt.Sprintf("EXISTS (SELECT 1 FROM %s s WHERE s.content_id=mi.content_id AND lower(s.series_name)=lower($%d) AND s.series_index=$%d)", table, len(args)-1, len(args)))
+	}
+	where := ""
+	if len(criteria) > 0 {
+		where = " AND (" + strings.Join(criteria, " OR ") + ")"
+	}
+	args = append(args, limit)
+	return `SELECT mi.content_id FROM media_items mi WHERE mi.content_id<>$1 AND mi.type IN ('ebook','audiobook') AND mi.type<>$2 AND NOT EXISTS (SELECT 1 FROM literary_work_match_decisions d WHERE d.decision='ignored' AND ((d.source_content_id=$1 AND d.target_content_id=mi.content_id) OR (d.source_content_id=mi.content_id AND d.target_content_id=$1)))` + where + ` ORDER BY mi.title,mi.content_id LIMIT $` + fmt.Sprint(len(args)), args
+}
+
+func candidateIDs(t testing.TB, pool *pgxpool.Pool, query string, args []any) []string {
+	t.Helper()
+	rows, err := pool.Query(context.Background(), query, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ids
+}
+
+func TestCandidateLookupMatchesLegacy(t *testing.T) {
+	pool := candidateTestPool(t)
+	ctx := context.Background()
+	_, err := pool.Exec(ctx, `
+ INSERT INTO media_items VALUES
+ ('source','ebook','Common'),('same-format','ebook','Common'),
+ ('title-a','audiobook','Common'),('title-b','audiobook','Common'),
+ ('provider','audiobook','A provider'),('series','audiobook','B series'),
+ ('ignored-forward','audiobook','Common'),('ignored-reverse','audiobook','Common'),
+ ('nonbook','movie','Common'),('asin-only','audiobook','ASIN match'),
+ ('ebook-provider','ebook','A ebook provider'),('ebook-series','ebook','B ebook series');
+ INSERT INTO media_item_provider_ids VALUES
+ ('provider','isbn','123','audiobook'),('ebook-provider','isbn','123','ebook'),
+ ('title-a','work','456','audiobook'),('asin-only','asin','789','audiobook'),
+ ('nonbook','isbn','123','movie');
+ INSERT INTO audiobook_series VALUES ('series','Sequence',1),('title-a','Sequence',1),('nonbook','Sequence',1);
+ INSERT INTO ebook_series VALUES ('ebook-series','Sequence',1);
+ INSERT INTO literary_work_match_decisions VALUES ('source','ignored-forward','ignored'),('ignored-reverse','source','ignored'),('source','title-b','confirmed');
+ `)
+	if err != nil {
+		t.Fatal(err)
+	}
+	index := 1.0
+	cases := []struct {
+		name   string
+		source MatchItem
+		limit  int
+		want   []string
+	}{
+		{"title", MatchItem{Title: "cOmMoN"}, 100, []string{"title-a", "title-b"}},
+		{"provider", MatchItem{ExternalIDs: map[string]string{"isbn": "123"}}, 100, []string{"provider"}},
+		{"series", MatchItem{SeriesName: "sEqUeNcE", SeriesIndex: &index}, 100, []string{"series", "title-a"}},
+		{"combined deduplicated", MatchItem{Title: "Common", ExternalIDs: map[string]string{"isbn": "123", "work": "456", "asin": "789"}, SeriesName: "Sequence", SeriesIndex: &index}, 100, []string{"provider", "series", "title-a", "title-b"}},
+		{"global limit", MatchItem{Title: "Common", ExternalIDs: map[string]string{"isbn": "123"}}, 2, []string{"provider", "title-a"}},
+		{"no match", MatchItem{Title: "Absent", ExternalIDs: map[string]string{"isbn": "missing"}}, 100, nil},
+		{"asin excluded", MatchItem{Title: "Absent", ExternalIDs: map[string]string{"asin": "789"}}, 100, nil},
+		{"empty criteria", MatchItem{}, 2, []string{"provider", "asin-only"}},
+		{"unusable criteria fallback", MatchItem{Title: "  ", ExternalIDs: map[string]string{"": "123", "isbn": "", "asin": "789"}, SeriesName: "Sequence"}, 2, []string{"provider", "asin-only"}},
+		{"reverse format", MatchItem{Type: FormatAudiobook, ExternalIDs: map[string]string{"isbn": "123"}, SeriesName: "Sequence", SeriesIndex: &index}, 100, []string{"ebook-provider", "ebook-series"}},
+		{"source excluded", MatchItem{ContentID: "title-a", Title: "Common"}, 100, []string{"ignored-forward", "ignored-reverse", "title-b"}},
+	}
+	for _, mode := range []string{"force_custom_plan", "force_generic_plan"} {
+		if _, err := pool.Exec(ctx, "SET plan_cache_mode = "+mode); err != nil {
+			t.Fatal(err)
+		}
+		for _, tc := range cases {
+			t.Run(mode+"/"+tc.name, func(t *testing.T) {
+				source := tc.source
+				if source.Type == "" {
+					source.Type = FormatEbook
+				}
+				if source.ContentID == "" {
+					source.ContentID = "source"
+				}
+				query, args := matchCandidateIDsQuery(source, tc.limit)
+				got := candidateIDs(t, pool, query, args)
+				oldQuery, oldArgs := legacyCandidateQuery(source, tc.limit)
+				old := candidateIDs(t, pool, oldQuery, oldArgs)
+				if !reflect.DeepEqual(got, old) {
+					t.Fatalf("new=%v legacy=%v", got, old)
+				}
+				if len(got) != len(tc.want) || (len(got) > 0 && !reflect.DeepEqual(got, tc.want)) {
+					t.Fatalf("got=%v want=%v", got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+func TestCandidateParametersStable(t *testing.T) {
+	source := MatchItem{ContentID: "source", Type: FormatEbook, ExternalIDs: map[string]string{"z": "last", "a": "first", "asin": "skip"}}
+	query, args := matchCandidateIDsQuery(source, 100)
+	for i := 0; i < 50; i++ {
+		next, nextArgs := matchCandidateIDsQuery(source, 100)
+		if query != next || !reflect.DeepEqual(args, nextArgs) {
+			t.Fatal("query parameters depend on map iteration order")
+		}
+	}
+	if !reflect.DeepEqual(args, []any{"source", FormatEbook, "a", "first", "z", "last", 100}) {
+		t.Fatalf("args=%v", args)
+	}
+}

--- a/internal/literaryworks/metrics.go
+++ b/internal/literaryworks/metrics.go
@@ -1,0 +1,61 @@
+package literaryworks
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type matchOriginKey struct{}
+
+// WithMatchOrigin attributes matching work to a bounded set of callers. Unknown
+// origins are folded into "other" so labels cannot grow with request data.
+func WithMatchOrigin(ctx context.Context, origin string) context.Context {
+	switch origin {
+	case "scanner", "ebook_enrichment", "audiobook_enrichment":
+	default:
+		origin = "other"
+	}
+	return context.WithValue(ctx, matchOriginKey{}, origin)
+}
+
+func matchOrigin(ctx context.Context) string {
+	if origin, ok := ctx.Value(matchOriginKey{}).(string); ok {
+		return origin
+	}
+	return "other"
+}
+
+var (
+	candidateDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "silo_literary_match_candidate_duration_seconds",
+		Help:    "Time to select literary-work candidate IDs, including pool wait and row reads.",
+		Buckets: []float64{0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	}, []string{"origin", "outcome"})
+	candidateCount = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "silo_literary_match_candidates",
+		Help:    "Candidate IDs returned by successful literary-work lookups.",
+		Buckets: []float64{0, 1, 5, 20, 50, 100, 250, 500},
+	}, []string{"origin"})
+	autoMatchActive = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "silo_literary_match_active",
+		Help: "Automatic literary-work matching calls currently running on this replica.",
+	}, []string{"origin"})
+	autoMatchTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "silo_literary_match_attempts_total",
+		Help: "Completed automatic literary-work matching calls by caller and outcome.",
+	}, []string{"origin", "outcome"})
+)
+
+func observeCandidateQuery(ctx context.Context, started time.Time, count int, err error) {
+	origin := matchOrigin(ctx)
+	outcome := "success"
+	if err != nil {
+		outcome = "error"
+	} else {
+		candidateCount.WithLabelValues(origin).Observe(float64(count))
+	}
+	candidateDuration.WithLabelValues(origin, outcome).Observe(time.Since(started).Seconds())
+}

--- a/internal/literaryworks/metrics_test.go
+++ b/internal/literaryworks/metrics_test.go
@@ -1,0 +1,75 @@
+package literaryworks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestMatchOriginIsBounded(t *testing.T) {
+	for _, origin := range []string{"scanner", "ebook_enrichment", "audiobook_enrichment", "other", "untrusted-value"} {
+		want := origin
+		if origin == "untrusted-value" {
+			want = "other"
+		}
+		if got := matchOrigin(WithMatchOrigin(context.Background(), origin)); got != want {
+			t.Fatalf("origin=%q got=%q want=%q", origin, got, want)
+		}
+	}
+	if got := matchOrigin(context.Background()); got != "other" {
+		t.Fatalf("default=%q", got)
+	}
+}
+
+func TestAutoMatchErrorReleasesActiveGauge(t *testing.T) {
+	ctx := WithMatchOrigin(context.Background(), "ebook_enrichment")
+	active := autoMatchActive.WithLabelValues("ebook_enrichment")
+	failures := autoMatchTotal.WithLabelValues("ebook_enrichment", "error")
+	beforeActive, beforeErrors := metricValue(t, active), metricValue(t, failures)
+	var service *Service
+	if _, _, err := service.AutoLinkContent(ctx, "missing"); !errors.Is(err, ErrWorkNotFound) {
+		t.Fatalf("error=%v", err)
+	}
+	if got := metricValue(t, active); got != beforeActive {
+		t.Fatalf("active gauge leaked: %v", got)
+	}
+	if got := metricValue(t, failures); got != beforeErrors+1 {
+		t.Fatalf("error counter=%v", got)
+	}
+}
+
+func TestAutoMatchAlreadyLinkedSkipsCandidateQuery(t *testing.T) {
+	pool := candidateTestPool(t)
+	ctx := WithMatchOrigin(context.Background(), "scanner")
+	_, err := pool.Exec(ctx, `CREATE TEMP TABLE literary_work_items (content_id text, work_id text, updated_at timestamptz);
+ INSERT INTO literary_work_items VALUES ('linked','existing-work',now());`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The minimal media_items fixture cannot satisfy GetMatchItem's hydration
+	// query, so any regression past the linked-item guard would fail this call.
+	counter := autoMatchTotal.WithLabelValues("scanner", "already_linked")
+	before := metricValue(t, counter)
+	workID, linked, err := NewService(NewRepository(pool)).AutoLinkContent(ctx, "linked")
+	if err != nil || linked || workID != "existing-work" {
+		t.Fatalf("work=%q linked=%v err=%v", workID, linked, err)
+	}
+	if got := metricValue(t, counter); got != before+1 {
+		t.Fatalf("already-linked counter=%v", got)
+	}
+}
+
+func metricValue(t *testing.T, metric prometheus.Metric) float64 {
+	t.Helper()
+	var value dto.Metric
+	if err := metric.Write(&value); err != nil {
+		t.Fatal(err)
+	}
+	if value.Gauge != nil {
+		return value.Gauge.GetValue()
+	}
+	return value.Counter.GetValue()
+}

--- a/internal/literaryworks/repository.go
+++ b/internal/literaryworks/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -189,54 +190,79 @@ func (r *Repository) ListMatchCandidates(ctx context.Context, source MatchItem, 
 	return items, rows.Err()
 }
 
-// listMatchCandidateIDs selects opposite-format candidate content IDs using only
-// predicates that can ride base-table indexes (title on media_items, provider IDs
-// on media_item_provider_ids, series on the format-specific series table) instead
-// of filtering on lateral aggregate output. The opposite format is fixed by the
-// source type, so the series lookup targets a single concrete table.
-func (r *Repository) listMatchCandidateIDs(ctx context.Context, source MatchItem, limit int) ([]string, error) {
+// listMatchCandidateIDs selects IDs before candidate metadata is hydrated.
+func (r *Repository) listMatchCandidateIDs(ctx context.Context, source MatchItem, limit int) (ids []string, err error) {
+	started := time.Now()
+	defer func() { observeCandidateQuery(ctx, started, len(ids), err) }()
 	if r == nil || r.pool == nil {
 		return nil, fmt.Errorf("literary works repository requires a database pool")
 	}
-	// Candidates are the opposite format of the source; match their own series table.
+	query, args := matchCandidateIDsQuery(source, limit)
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// matchCandidateIDsQuery keeps each criterion in an independent index lookup.
+// Combining title and correlated provider/series EXISTS predicates with OR makes
+// PostgreSQL scan the book catalog even when each lookup matches very few rows.
+func matchCandidateIDsQuery(source MatchItem, limit int) (string, []any) {
 	seriesTable := "ebook_series"
 	if source.Type == "ebook" {
 		seriesTable = "audiobook_series"
 	}
 	args := []any{source.ContentID, source.Type}
-	matchFilters := make([]string, 0, 3)
+	lookups := make([]string, 0, 3)
 	if strings.TrimSpace(source.Title) != "" {
 		args = append(args, source.Title)
-		matchFilters = append(matchFilters, fmt.Sprintf("LOWER(mi.title) = LOWER($%d)", len(args)))
+		lookups = append(lookups, fmt.Sprintf(`
+			SELECT content_id FROM media_items
+			WHERE type IN ('ebook', 'audiobook') AND type <> $2
+			  AND LOWER(title) = LOWER($%d)`, len(args)))
 	}
+	// Stable parameter ordering lets the prepared-statement cache reuse queries
+	// regardless of Go map iteration order.
+	providers := make([]string, 0, len(source.ExternalIDs))
 	for provider, providerID := range source.ExternalIDs {
-		if provider == "" || provider == "asin" || providerID == "" {
-			continue
+		if provider != "" && provider != "asin" && providerID != "" {
+			providers = append(providers, provider)
 		}
-		args = append(args, provider, providerID)
-		matchFilters = append(matchFilters, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM media_item_provider_ids mip WHERE mip.content_id = mi.content_id AND mip.provider = $%d AND mip.provider_id = $%d)",
-			len(args)-1,
-			len(args),
-		))
+	}
+	sort.Strings(providers)
+	for _, provider := range providers {
+		args = append(args, provider, source.ExternalIDs[provider])
+		lookups = append(lookups, fmt.Sprintf(`
+			SELECT content_id FROM media_item_provider_ids
+			WHERE provider = $%d AND provider_id = $%d`, len(args)-1, len(args)))
 	}
 	if strings.TrimSpace(source.SeriesName) != "" && source.SeriesIndex != nil {
 		args = append(args, source.SeriesName, *source.SeriesIndex)
-		matchFilters = append(matchFilters, fmt.Sprintf(
-			"EXISTS (SELECT 1 FROM %s bs WHERE bs.content_id = mi.content_id AND LOWER(bs.series_name) = LOWER($%d) AND bs.series_index = $%d)",
-			seriesTable,
-			len(args)-1,
-			len(args),
-		))
+		lookups = append(lookups, fmt.Sprintf(`
+			SELECT content_id FROM %s
+			WHERE LOWER(series_name) = LOWER($%d) AND series_index = $%d`,
+			seriesTable, len(args)-1, len(args)))
 	}
-	matchWhere := ""
-	if len(matchFilters) > 0 {
-		matchWhere = " AND (" + strings.Join(matchFilters, " OR ") + ")"
+	candidateJoin := ""
+	if len(lookups) > 0 {
+		// UNION deduplicates across criteria before the global ordering and limit.
+		candidateJoin = " JOIN (" + strings.Join(lookups, " UNION ") + ") candidates ON candidates.content_id = mi.content_id"
 	}
+	// Preserve the existing opposite-format fallback when there are no usable
+	// criteria. In particular, an ASIN-only source still uses that fallback.
 	args = append(args, limit)
-	rows, err := r.pool.Query(ctx, `
+	return `
 		SELECT mi.content_id
-		FROM media_items mi
+		FROM media_items mi` + candidateJoin + `
 		WHERE mi.content_id <> $1
 		  AND mi.type IN ('ebook', 'audiobook')
 		  AND mi.type <> $2
@@ -247,23 +273,9 @@ func (r *Repository) listMatchCandidateIDs(ctx context.Context, source MatchItem
 				(d.source_content_id = $1 AND d.target_content_id = mi.content_id)
 				OR (d.source_content_id = mi.content_id AND d.target_content_id = $1)
 			  )
-		  )`+matchWhere+`
+		  )
 		ORDER BY mi.title ASC, mi.content_id ASC
-		LIMIT $`+fmt.Sprint(len(args))+`
-	`, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
-	}
-	return ids, rows.Err()
+		LIMIT $` + fmt.Sprint(len(args)), args
 }
 
 func (r *Repository) queryMatchItems(ctx context.Context, suffix string, args ...any) (pgx.Rows, error) {

--- a/internal/literaryworks/service.go
+++ b/internal/literaryworks/service.go
@@ -135,7 +135,23 @@ func (s *Service) LinkItems(ctx context.Context, workID string, contentIDs []str
 	return workID, nil
 }
 
-func (s *Service) AutoLinkContent(ctx context.Context, contentID string) (string, bool, error) {
+func (s *Service) AutoLinkContent(ctx context.Context, contentID string) (workID string, linked bool, err error) {
+	origin := matchOrigin(ctx)
+	active := autoMatchActive.WithLabelValues(origin)
+	active.Inc()
+	defer func() {
+		active.Dec()
+		outcome := "no_match"
+		switch {
+		case err != nil:
+			outcome = "error"
+		case linked:
+			outcome = "linked"
+		case workID != "":
+			outcome = "already_linked"
+		}
+		autoMatchTotal.WithLabelValues(origin, outcome).Inc()
+	}()
 	if s == nil || s.repo == nil {
 		return "", false, ErrWorkNotFound
 	}
@@ -171,7 +187,7 @@ func (s *Service) AutoLinkContent(ctx context.Context, contentID string) (string
 	if best.Score < AutoLinkThreshold || best.TargetContentID == "" {
 		return "", false, nil
 	}
-	workID := strings.TrimSpace(bestTarget.WorkID)
+	workID = strings.TrimSpace(bestTarget.WorkID)
 	if workID == "" {
 		workID = generatedWorkID(source.MatchItem)
 		if _, err := s.repo.CreateWork(ctx, CreateWorkParams{

--- a/internal/scanner/ebook_scan.go
+++ b/internal/scanner/ebook_scan.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Silo-Server/silo-server/internal/idgen"
 	"github.com/Silo-Server/silo-server/internal/imageutil"
+	"github.com/Silo-Server/silo-server/internal/literaryworks"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/rootcheck"
 	"github.com/Silo-Server/silo-server/internal/titleutil"
@@ -635,7 +636,7 @@ func (s *Scanner) autoLinkLiteraryWork(ctx context.Context, contentID string) {
 	if s == nil || s.literaryWorkLinker == nil || strings.TrimSpace(contentID) == "" {
 		return
 	}
-	workID, linked, err := s.literaryWorkLinker.AutoLinkContent(ctx, contentID)
+	workID, linked, err := s.literaryWorkLinker.AutoLinkContent(literaryworks.WithMatchOrigin(ctx, "scanner"), contentID)
 	if err != nil {
 		slog.WarnContext(ctx, "literary work auto-link failed", "component", "scanner", "content_id", contentID, "error", err)
 		return


### PR DESCRIPTION
DOING what I want on my own fork

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved literary-work matching performance for large catalogs.
  - Matching now combines multiple lookup criteria more efficiently while preserving existing fallback and filtering behavior.
  - Added clearer tracking of matching activity, outcomes, duration, and candidate counts.
  - Matching activity is now categorized by source, including scanning, ebook enrichment, and audiobook enrichment.

- **Documentation**
  - Added observability guidance for literary-work matching metrics and candidate-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->