### PR TITLE
fix(web): render neutral empty state and loading placeholder for ambiguous roots

### DIFF
--- a/web/src/components/admin/CollapsibleDiagnosticsSection.test.tsx
+++ b/web/src/components/admin/CollapsibleDiagnosticsSection.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { CollapsibleDiagnosticsSection } from "./CollapsibleDiagnosticsSection";
+
+describe("CollapsibleDiagnosticsSection", () => {
+  it("renders collapsed with title, description, and count", () => {
+    render(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={5}
+        icon={<span>Icon</span>}
+        open={false}
+        onOpenChange={vi.fn()}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    expect(screen.getByText("Test Diagnostics")).toBeInTheDocument();
+    expect(screen.getByText("A test section description")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.queryByText("Child content")).not.toBeInTheDocument();
+  });
+
+  it("renders a loading indicator when isLoading is true", () => {
+    render(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={0}
+        isLoading={true}
+        icon={<span>Icon</span>}
+        open={false}
+        onOpenChange={vi.fn()}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    expect(screen.getByLabelText("Loading count")).toHaveTextContent("—");
+  });
+
+  it("applies neutral text styling to zero count", () => {
+    render(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={0}
+        icon={<span>Icon</span>}
+        open={false}
+        onOpenChange={vi.fn()}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    const countElem = screen.getByText("0");
+    expect(countElem.className).toContain("text-muted-foreground");
+  });
+
+  it("toggles and renders child content when open", async () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={3}
+        icon={<span>Icon</span>}
+        open={false}
+        onOpenChange={onOpenChange}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    await userEvent.click(screen.getByRole("button"));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={3}
+        icon={<span>Icon</span>}
+        open={true}
+        onOpenChange={onOpenChange}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/admin/CollapsibleDiagnosticsSection.test.tsx
+++ b/web/src/components/admin/CollapsibleDiagnosticsSection.test.tsx
@@ -61,6 +61,24 @@ describe("CollapsibleDiagnosticsSection", () => {
     expect(countElem.className).toContain("text-muted-foreground");
   });
 
+  it("renders an error indicator when isError is true", () => {
+    render(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={0}
+        isError={true}
+        icon={<span>Icon</span>}
+        open={false}
+        onOpenChange={vi.fn()}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    expect(screen.getByLabelText("Error loading count")).toHaveTextContent("!");
+  });
+
   it("toggles and renders child content when open", async () => {
     const onOpenChange = vi.fn();
     const { rerender } = render(

--- a/web/src/components/admin/CollapsibleDiagnosticsSection.test.tsx
+++ b/web/src/components/admin/CollapsibleDiagnosticsSection.test.tsx
@@ -25,8 +25,8 @@ describe("CollapsibleDiagnosticsSection", () => {
     expect(screen.queryByText("Child content")).not.toBeInTheDocument();
   });
 
-  it("renders a loading indicator when isLoading is true", () => {
-    render(
+  it("renders an accessible loading indicator when isLoading is true in both states", () => {
+    const { rerender } = render(
       <CollapsibleDiagnosticsSection
         title="Test Diagnostics"
         description="A test section description"
@@ -40,7 +40,25 @@ describe("CollapsibleDiagnosticsSection", () => {
       </CollapsibleDiagnosticsSection>,
     );
 
-    expect(screen.getByLabelText("Loading count")).toHaveTextContent("—");
+    expect(screen.getByText("Loading count")).toBeInTheDocument();
+    expect(screen.getByText("—")).toHaveAttribute("aria-hidden", "true");
+
+    rerender(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={0}
+        isLoading={true}
+        icon={<span>Icon</span>}
+        open={true}
+        onOpenChange={vi.fn()}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    expect(screen.getByText("Loading count")).toBeInTheDocument();
+    expect(screen.getByText("—")).toHaveAttribute("aria-hidden", "true");
   });
 
   it("applies neutral text styling to zero count", () => {
@@ -61,8 +79,8 @@ describe("CollapsibleDiagnosticsSection", () => {
     expect(countElem.className).toContain("text-muted-foreground");
   });
 
-  it("renders an error indicator when isError is true", () => {
-    render(
+  it("renders an accessible error indicator when isError is true in both states", () => {
+    const { rerender } = render(
       <CollapsibleDiagnosticsSection
         title="Test Diagnostics"
         description="A test section description"
@@ -76,7 +94,25 @@ describe("CollapsibleDiagnosticsSection", () => {
       </CollapsibleDiagnosticsSection>,
     );
 
-    expect(screen.getByLabelText("Error loading count")).toHaveTextContent("!");
+    expect(screen.getByText("Error loading count")).toBeInTheDocument();
+    expect(screen.getByText("!")).toHaveAttribute("aria-hidden", "true");
+
+    rerender(
+      <CollapsibleDiagnosticsSection
+        title="Test Diagnostics"
+        description="A test section description"
+        count={0}
+        isError={true}
+        icon={<span>Icon</span>}
+        open={true}
+        onOpenChange={vi.fn()}
+      >
+        <div>Child content</div>
+      </CollapsibleDiagnosticsSection>,
+    );
+
+    expect(screen.getByText("Error loading count")).toBeInTheDocument();
+    expect(screen.getByText("!")).toHaveAttribute("aria-hidden", "true");
   });
 
   it("toggles and renders child content when open", async () => {

--- a/web/src/components/admin/CollapsibleDiagnosticsSection.tsx
+++ b/web/src/components/admin/CollapsibleDiagnosticsSection.tsx
@@ -54,27 +54,25 @@ export function CollapsibleDiagnosticsSection({
         {isLoading ? (
           open ? (
             <Badge variant="secondary" className="text-[11px] tabular-nums">
-              &mdash;
+              <span className="sr-only">Loading count</span>
+              <span aria-hidden="true">&mdash;</span>
             </Badge>
           ) : (
-            <div
-              className="text-muted-foreground text-2xl leading-none font-bold tabular-nums"
-              aria-label="Loading count"
-            >
-              &mdash;
+            <div className="text-muted-foreground text-2xl leading-none font-bold tabular-nums">
+              <span className="sr-only">Loading count</span>
+              <span aria-hidden="true">&mdash;</span>
             </div>
           )
         ) : isError ? (
           open ? (
             <Badge variant="destructive" className="text-[11px] tabular-nums">
-              !
+              <span className="sr-only">Error loading count</span>
+              <span aria-hidden="true">!</span>
             </Badge>
           ) : (
-            <div
-              className="text-destructive text-2xl leading-none font-bold tabular-nums"
-              aria-label="Error loading count"
-            >
-              !
+            <div className="text-destructive text-2xl leading-none font-bold tabular-nums">
+              <span className="sr-only">Error loading count</span>
+              <span aria-hidden="true">!</span>
             </div>
           )
         ) : open ? (

--- a/web/src/components/admin/CollapsibleDiagnosticsSection.tsx
+++ b/web/src/components/admin/CollapsibleDiagnosticsSection.tsx
@@ -4,11 +4,16 @@ import { ChevronDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
+/**
+ * CollapsibleDiagnosticsSection renders an expandable administrative diagnostics panel
+ * displaying a severity icon, title, description, and status count, error indicator, or loading placeholder.
+ */
 export function CollapsibleDiagnosticsSection({
   title,
   description,
   count,
   isLoading,
+  isError,
   icon,
   iconClassName,
   open,
@@ -19,6 +24,7 @@ export function CollapsibleDiagnosticsSection({
   description: string;
   count: number;
   isLoading?: boolean;
+  isError?: boolean;
   icon: ReactNode;
   iconClassName?: string;
   open: boolean;
@@ -56,6 +62,19 @@ export function CollapsibleDiagnosticsSection({
               aria-label="Loading count"
             >
               &mdash;
+            </div>
+          )
+        ) : isError ? (
+          open ? (
+            <Badge variant="destructive" className="text-[11px] tabular-nums">
+              !
+            </Badge>
+          ) : (
+            <div
+              className="text-destructive text-2xl leading-none font-bold tabular-nums"
+              aria-label="Error loading count"
+            >
+              !
             </div>
           )
         ) : open ? (

--- a/web/src/components/admin/CollapsibleDiagnosticsSection.tsx
+++ b/web/src/components/admin/CollapsibleDiagnosticsSection.tsx
@@ -8,6 +8,7 @@ export function CollapsibleDiagnosticsSection({
   title,
   description,
   count,
+  isLoading,
   icon,
   iconClassName,
   open,
@@ -17,6 +18,7 @@ export function CollapsibleDiagnosticsSection({
   title: string;
   description: string;
   count: number;
+  isLoading?: boolean;
   icon: ReactNode;
   iconClassName?: string;
   open: boolean;
@@ -43,12 +45,32 @@ export function CollapsibleDiagnosticsSection({
           <h2 className="text-sm font-semibold tracking-wide">{title}</h2>
           <p className="text-muted-foreground text-xs leading-relaxed">{description}</p>
         </div>
-        {open ? (
+        {isLoading ? (
+          open ? (
+            <Badge variant="secondary" className="text-[11px] tabular-nums">
+              &mdash;
+            </Badge>
+          ) : (
+            <div
+              className="text-muted-foreground text-2xl leading-none font-bold tabular-nums"
+              aria-label="Loading count"
+            >
+              &mdash;
+            </div>
+          )
+        ) : open ? (
           <Badge variant="secondary" className="text-[11px] tabular-nums">
             {count}
           </Badge>
         ) : (
-          <div className="text-2xl leading-none font-bold tabular-nums">{count}</div>
+          <div
+            className={cn(
+              "text-2xl leading-none font-bold tabular-nums",
+              count === 0 && "text-muted-foreground",
+            )}
+          >
+            {count}
+          </div>
         )}
         <ChevronDown
           className={cn(

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -359,6 +359,20 @@ describe("AdminLibraries", () => {
     expect(mocks.useLibraryRoots).toHaveBeenCalledWith(42, "ambiguous");
   });
 
+  it("renders an error indicator for Ambiguous Roots when query fails", () => {
+    mocks.useLibraryRoots.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+    });
+
+    const markup = renderPage();
+
+    expect(markup).toContain("Ambiguous Roots");
+    expect(markup).toContain('aria-label="Error loading count"');
+    expect(markup).toContain("bg-destructive/10");
+  });
+
   it("renders Stale External IDs collapsed by default", () => {
     mocks.useStaleMediaIDs.mockReturnValue({
       data: [

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -332,7 +332,7 @@ describe("AdminLibraries", () => {
 
     expect(markup).toContain("Ambiguous Roots");
     expect(markup).toContain("Scanner roots that stay visible");
-    expect(markup).toContain('aria-label="Loading count"');
+    expect(markup).toContain("Loading count");
     expect(markup).toContain("bg-muted/50");
   });
 
@@ -369,7 +369,7 @@ describe("AdminLibraries", () => {
     const markup = renderPage();
 
     expect(markup).toContain("Ambiguous Roots");
-    expect(markup).toContain('aria-label="Error loading count"');
+    expect(markup).toContain("Error loading count");
     expect(markup).toContain("bg-destructive/10");
   });
 

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -336,6 +336,29 @@ describe("AdminLibraries", () => {
     expect(markup).toContain("bg-muted/50");
   });
 
+  it("queries ambiguous roots for the effective selected library", () => {
+    mocks.useAdminLibraries.mockReturnValue({
+      data: [
+        {
+          id: 42,
+          name: "Television",
+          paths: ["/media/tv"],
+          type: "tv",
+          enabled: true,
+          last_scanned_at: null,
+          scan_warning_code: null,
+          scan_warning_at: null,
+          scan_warning_message: null,
+        },
+      ],
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(mocks.useLibraryRoots).toHaveBeenCalledWith(42, "ambiguous");
+  });
+
   it("renders Stale External IDs collapsed by default", () => {
     mocks.useStaleMediaIDs.mockReturnValue({
       data: [

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -1,4 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -89,6 +91,17 @@ import AdminLibraries from "./AdminLibraries";
 const renderPage = () => {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <AdminLibraries />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const renderInteractivePage = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
     <QueryClientProvider client={client}>
       <MemoryRouter>
         <AdminLibraries />
@@ -371,6 +384,37 @@ describe("AdminLibraries", () => {
     expect(markup).toContain("Ambiguous Roots");
     expect(markup).toContain("Error loading count");
     expect(markup).toContain("bg-destructive/10");
+  });
+
+  it("renders a loading table row when Ambiguous Roots is expanded while loading", async () => {
+    mocks.useLibraryRoots.mockReturnValue({
+      data: [],
+      isLoading: true,
+    });
+
+    renderInteractivePage();
+
+    const trigger = screen.getByRole("button", { name: /ambiguous roots/i });
+    await userEvent.click(trigger);
+
+    expect(screen.getByText("Loading ambiguous roots for this library.")).toBeInTheDocument();
+  });
+
+  it("renders an error table row when Ambiguous Roots is expanded on query failure", async () => {
+    mocks.useLibraryRoots.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: true,
+    });
+
+    renderInteractivePage();
+
+    const trigger = screen.getByRole("button", { name: /ambiguous roots/i });
+    await userEvent.click(trigger);
+
+    expect(
+      screen.getByText("Failed to load ambiguous roots for this library."),
+    ).toBeInTheDocument();
   });
 
   it("renders Stale External IDs collapsed by default", () => {

--- a/web/src/pages/AdminLibraries.test.tsx
+++ b/web/src/pages/AdminLibraries.test.tsx
@@ -241,6 +241,8 @@ describe("AdminLibraries", () => {
 
     expect(markup).toContain("Ambiguous Roots");
     expect(markup).toContain("Scanner roots that stay visible");
+    expect(markup).toContain("text-amber-500");
+    expect(markup).toContain("bg-amber-500/10");
   });
 
   it("shows metadata matcher pending and parked counts", () => {
@@ -310,11 +312,28 @@ describe("AdminLibraries", () => {
 
   it("renders the collapsed Ambiguous Roots section when no roots exist", () => {
     // Default useLibraryRoots mock returns { data: [], isLoading: false }. The
-    // section itself still renders because it is gated on libraries.length.
+    // section itself still renders because it is gated on libraries.length, but
+    // uses neutral styling instead of an amber warning when count is 0.
     const markup = renderPage();
 
     expect(markup).toContain("Ambiguous Roots");
     expect(markup).toContain("Scanner roots that stay visible");
+    expect(markup).toContain("text-muted-foreground");
+    expect(markup).toContain("bg-muted/50");
+  });
+
+  it("renders a loading placeholder for Ambiguous Roots while loading", () => {
+    mocks.useLibraryRoots.mockReturnValue({
+      data: [],
+      isLoading: true,
+    });
+
+    const markup = renderPage();
+
+    expect(markup).toContain("Ambiguous Roots");
+    expect(markup).toContain("Scanner roots that stay visible");
+    expect(markup).toContain('aria-label="Loading count"');
+    expect(markup).toContain("bg-muted/50");
   });
 
   it("renders Stale External IDs collapsed by default", () => {

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -1412,7 +1412,7 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
   const [search, setSearch] = useState("");
   const [editingRoot, setEditingRoot] = useState<LibraryRoot | null>(null);
   const effectiveSelectedLibraryId = selectedLibraryId ?? libraries[0]?.id;
-  const { data: roots = [] } = useLibraryRoots(effectiveSelectedLibraryId, "ambiguous");
+  const { data: roots = [], isLoading } = useLibraryRoots(effectiveSelectedLibraryId, "ambiguous");
 
   const filteredRoots = useMemo(() => {
     if (!search) return roots;
@@ -1431,12 +1431,20 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
     return null;
   }
 
+  const isWarning = !isLoading && roots.length > 0;
+
   return (
     <CollapsibleDiagnosticsSection
       title="Ambiguous Roots"
       description="Scanner roots that stay visible but do not enter unattended metadata matching."
       count={roots.length}
-      icon={<FolderOpen className="h-4 w-4 text-amber-500" />}
+      isLoading={isLoading}
+      icon={
+        <FolderOpen
+          className={cn("h-4 w-4", isWarning ? "text-amber-500" : "text-muted-foreground")}
+        />
+      }
+      iconClassName={isWarning ? "bg-amber-500/10" : "bg-muted/50"}
       open={open}
       onOpenChange={setOpen}
     >
@@ -1490,7 +1498,9 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
             {filteredRoots.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={5} className="text-muted-foreground text-center text-sm">
-                  No ambiguous roots for this library.
+                  {search
+                    ? "No ambiguous roots match your filter."
+                    : "No ambiguous roots for this library."}
                 </TableCell>
               </TableRow>
             ) : (

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -1406,13 +1406,21 @@ function useSort<K extends string>(defaultField: K, defaultDir: SortDir = "desc"
 
 /* ─── Skipped Roots (Troubleshooting) ───────────────────────────── */
 
+/**
+ * AmbiguousRootsSection displays scanner roots that require manual resolution,
+ * handling loading, confirmed empty, populated warning, and error states.
+ */
 function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
   const [open, setOpen] = useState(false);
   const [selectedLibraryId, setSelectedLibraryId] = useState<number | undefined>(libraries[0]?.id);
   const [search, setSearch] = useState("");
   const [editingRoot, setEditingRoot] = useState<LibraryRoot | null>(null);
   const effectiveSelectedLibraryId = selectedLibraryId ?? libraries[0]?.id;
-  const { data: roots = [], isLoading } = useLibraryRoots(effectiveSelectedLibraryId, "ambiguous");
+  const {
+    data: roots = [],
+    isLoading,
+    isError,
+  } = useLibraryRoots(effectiveSelectedLibraryId, "ambiguous");
 
   const filteredRoots = useMemo(() => {
     if (!search) return roots;
@@ -1431,7 +1439,7 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
     return null;
   }
 
-  const isWarning = !isLoading && roots.length > 0;
+  const isWarning = !isLoading && !isError && roots.length > 0;
 
   return (
     <CollapsibleDiagnosticsSection
@@ -1439,12 +1447,17 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
       description="Scanner roots that stay visible but do not enter unattended metadata matching."
       count={roots.length}
       isLoading={isLoading}
+      isError={isError}
       icon={
-        <FolderOpen
-          className={cn("h-4 w-4", isWarning ? "text-amber-500" : "text-muted-foreground")}
-        />
+        isError ? (
+          <AlertTriangle className="text-destructive h-4 w-4" />
+        ) : (
+          <FolderOpen
+            className={cn("h-4 w-4", isWarning ? "text-amber-500" : "text-muted-foreground")}
+          />
+        )
       }
-      iconClassName={isWarning ? "bg-amber-500/10" : "bg-muted/50"}
+      iconClassName={isError ? "bg-destructive/10" : isWarning ? "bg-amber-500/10" : "bg-muted/50"}
       open={open}
       onOpenChange={setOpen}
     >
@@ -1495,7 +1508,13 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {filteredRoots.length === 0 ? (
+            {isError ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-destructive text-center text-sm">
+                  Failed to load ambiguous roots for this library.
+                </TableCell>
+              </TableRow>
+            ) : filteredRoots.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={5} className="text-muted-foreground text-center text-sm">
                   {search

--- a/web/src/pages/AdminLibraries.tsx
+++ b/web/src/pages/AdminLibraries.tsx
@@ -1514,6 +1514,12 @@ function AmbiguousRootsSection({ libraries }: { libraries: Library[] }) {
                   Failed to load ambiguous roots for this library.
                 </TableCell>
               </TableRow>
+            ) : isLoading ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-muted-foreground text-center text-sm">
+                  Loading ambiguous roots for this library.
+                </TableCell>
+              </TableRow>
             ) : filteredRoots.length === 0 ? (
               <TableRow>
                 <TableCell colSpan={5} className="text-muted-foreground text-center text-sm">


### PR DESCRIPTION
## Summary

Fixes #1000.

Resolves an issue where `AmbiguousRootsSection` in `AdminLibraries.tsx` displayed an amber warning badge with count `0` on healthy libraries and treated in-flight or unloaded query data as a premature zero.

---

### Background & Problem

1. **False-Positive Warning Styling:**
   - In `AdminLibraries.tsx`, `AmbiguousRootsSection` wrapped its contents in `<CollapsibleDiagnosticsSection>` with hardcoded warning styling (`<FolderOpen className="h-4 w-4 text-amber-500" />` and default `bg-amber-500/10`).
   - On healthy servers where no ambiguous roots exist (count is `0`), the section still presented as an active, amber diagnostic warning. This caused administrators to believe there was an unresolved scanner problem when the library was in fact completely healthy.

2. **Premature Zero During Loading:**
   - `const { data: roots = [] } = useLibraryRoots(...)` defaulted missing or in-flight data to `[]`.
   - On initial mount or library switch, the header immediately flashed an amber `0` before the network request resolved, conflating an unloaded query with a confirmed zero.

3. **Why the Section Cannot Be Conditionally Hidden on Zero:**
   - The library selector dropdown (`<Select>`) lives inside `AmbiguousRootsSection`. If library A has 0 ambiguous roots but library B has 3, hiding the section on count 0 would permanently lock out the administrator from switching to library B.
   - The section must remain accessible while reflecting the correct severity state.

---

### Solution Details

#### 1. `CollapsibleDiagnosticsSection.tsx`
- **Added `isLoading?: boolean` Support:**
  - When `isLoading` is true, renders a subtle placeholder dash (`—` with `aria-label="Loading count"`) in both open and collapsed badge/counter positions instead of a bold `0`.
- **Neutral Styling for Zero Counts:**
  - Applied `text-muted-foreground` to `count === 0` in the collapsed count view, visually distinguishing confirmed zero/healthy states from actionable non-zero counts.

#### 2. `AdminLibraries.tsx` (`AmbiguousRootsSection`)
- **Destructured Query State:**
  - Extracted `{ data: roots = [], isLoading }` from `useLibraryRoots(effectiveSelectedLibraryId, "ambiguous")`.
  - Derived `isWarning = !isLoading && roots.length > 0`.
- **Dynamic Icon & Container Styling:**
  - When confirmed zero (`!isLoading && roots.length === 0`): Renders neutral icon styling (`<FolderOpen className="h-4 w-4 text-muted-foreground" />` with `iconClassName="bg-muted/50"`).
  - When populated (`roots.length > 0`): Renders the amber warning styling (`<FolderOpen className="h-4 w-4 text-amber-500" />` with `iconClassName="bg-amber-500/10"`).
  - While loading: Passes `isLoading={isLoading}` to display the placeholder dash.
- **Contextual Table Empty Message:**
  - When `filteredRoots.length === 0`:
    - With active search: *"No ambiguous roots match your filter."*
    - Without active search: *"No ambiguous roots for this library."*

#### 3. Tests
- **`CollapsibleDiagnosticsSection.test.tsx` (New):**
  - Verified rendering collapsed title, description, and count.
  - Verified loading indicator (`aria-label="Loading count"`) when `isLoading` is true.
  - Verified neutral text styling on zero count.
  - Verified toggle interaction and child content visibility.
- **`AdminLibraries.test.tsx`:**
  - Updated empty-state test to verify neutral styling (`text-muted-foreground`, `bg-muted/50`) when count is 0.
  - Added test verifying loading placeholder state during in-flight queries.
  - Updated populated test to verify amber warning classes (`text-amber-500`, `bg-amber-500/10`) when roots exist.

---

### Test Plan

- [x] Ran unit tests for `CollapsibleDiagnosticsSection.test.tsx` and `AdminLibraries.test.tsx` via Vitest (`15 passed`).
- [x] Verified full TypeScript compilation with `pnpm tsc -b` (`0 errors`).
- [x] Verified ESLint checks with `pnpm lint` (`0 errors`).
- [x] Verified code formatting with Prettier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added loading and error indicators for diagnostic counts and ambiguous library roots.
  - Error states now include clear messaging and destructive styling when results cannot be loaded.
  - Updated empty states to distinguish between no ambiguous roots and no matches for an active search filter.
  - Warning colors appear only when ambiguous roots are successfully found; empty states use neutral styling.
  - Diagnostic counts display an em dash while loading and use neutral styling when the count is zero.
  - Collapsible diagnostic sections now support clearer loading, error, and accessible status messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->