### PR TITLE
fix(tonemap): probe hardware decoders with a real Main 10 fixture (apiv2 backport)

### DIFF
--- a/internal/tonemap/probe.go
+++ b/internal/tonemap/probe.go
@@ -37,16 +37,24 @@ const (
 	probeRequestSlack  = 5 * time.Second
 )
 
-// One deterministic 256x256 Main 10 HEVC frame. Keeping the compressed fixture
+// One deterministic 256x256 HEVC Main 10 frame. Keeping the compressed fixture
 // in the binary lets production probes exercise the real decoder without
 // depending on a media mount or generating source files with an encoder whose
 // availability is itself under test. The dimensions deliberately exceed the
-// 144x144 minimum reported by Pascal-generation NVIDIA NVDEC; the old 64x64
-// fixture produced a false negative on otherwise capable GPUs such as the
-// GeForce GTX 1050 Ti.
+// 144x144 minimum reported by Pascal-generation NVIDIA NVDEC; a 64x64 fixture
+// produced a false negative on otherwise capable GPUs such as the GeForce GTX
+// 1050 Ti.
+//
+// The SPS must signal general_profile_idc 2 (Main 10). The 256x256 fixture
+// that replaced the 64x64 one was encoded as profile_idc 4 (Rext, format
+// range extensions) even though its pixel format was yuv420p10le, and every
+// Intel VAAPI/QSV hardware decoder refused it with "No support for codec hevc
+// profile 4", so no Intel node advertised hardware tone mapping. Software
+// decoding accepts Rext and hid the regression from the software smoke.
+// TestDecodeProbeFixtureIsMain10 pins the profile.
 const decodeProbeFixtureBitDepth = 10
 
-const decodeProbeFixtureBase64 = "AAAAAUABDAH//wQIAAADAJ2oAAADAAD/ugJAAAAAAUIBAQQIAAADAJ2oAAADAAD/oAgIBATZbpKTC8BaAgAAAwACAAADAAIQAAAAAUQBwHGJEgAAASgBrBbgS3G0f////Pv////tVP2ox2hZslSupK6krqSupK7frt+u367frt+u367frszYCj///9yP+45+4B9sj2WPZY9lj2WPZf9l/2X/Zf9l/2X/Zf9lkAQv///uR/3HP3APtkeyx7LHsseyx7L/sv+y/7L/sv+y/7L/ssgjv///WO/rDXqy3UjtJ+0n7SftJ+0p/Sn9Kf0p/Sn9Kf0p/SgZv///Eg/iKnhzHCIL8wvzC/ML8wv1+/X79fv1+/X79fv1+/Md5///rbv1r11jtqm6mXqZepl6mXqafpp+mn6afpp+mn6afpmJf///pN/0kv0bvoTect5y3nLect5z/nP+c/5z/nP+c/5z/nM6P//9VI+qTmpQFOSEXYRdhF2EXYRl9GX0ZfRl9GX0ZfRl9GBz///piP0u50mBooieGJ4YnhieGJ5fnl+eX55fnl+eX55fniHX//+u//XX/W3+rv6e/p7+nv6e/p/+n/6f/p/+n/6f/p/+n13///yyj5X+ZSwSQoGbgZuBm4GbgaXxpfGl8aXxpfGl8aXxn3n//9oH+z0+y49iB1qHWodah1qHWv9a/1r/Wv9a/1r/Wv9anf///kJ/yCPx3PjCeGp4anhqeGp4b/hv+G/4b/hv+G/4b/hrwf//5od8zmsxFpYHEP8Q/xD/EP8RT5FPkU+RT5FPkU+RT5EQH//+r1fVybVRKodSRNJE0kTSRNJI+kj6SPpI+kj6SPpI+kVZ////y3n5ag5VUyV5GxkbGRsZGxkbvxu/G78bvxu/G78bvxtmA7EMv/IDBiETjInjAOXAAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAAADAKOA"
+const decodeProbeFixtureBase64 = "AAAAAUABDAH//wIgAAADALAAAAMAAAMAPAjAkAAAAAFCAQECIAAAAwCwAAADAAADADygCAgEBNiAjuRZFL/y5/E/rAWoEBAQBAAAAAFEAcBy8FMkAAAAAU4BBTJHVkrcXExDP5TvxRE80UOoAQAAAwABAwAAAwABAgADX/8LAAADAAADAAErEAwDkSsBDf////+AAAAAASgBrxAgmwzKq+iGPv/9kz4R2XADPFSQkYVLvPxAuVCAAuhvgvlhUQRRzuAARkAHHgAADpgAAAMAATcAAAMADvgAAAMAY0A="
 
 // CommandRunner executes a bounded external command and returns its combined
 // output. Tests inject it to model individual FFmpeg capabilities and failures.

--- a/internal/tonemap/probe_test.go
+++ b/internal/tonemap/probe_test.go
@@ -2,6 +2,7 @@ package tonemap
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"os"
@@ -62,6 +63,42 @@ func TestDecodeProbeFixtureCoversPascalNVDECMinimum(t *testing.T) {
 	if stream.PixFmt != "yuv420p10le" {
 		t.Fatalf("fixture pixel format = %q, want yuv420p10le", stream.PixFmt)
 	}
+}
+
+// TestDecodeProbeFixtureIsMain10 pins the fixture's HEVC profile by reading
+// the SPS profile_tier_level directly, so it holds without ffprobe. Intel
+// VAAPI/QSV decoders accept general_profile_idc 2 (Main 10) and refuse 4
+// (Rext); a Rext fixture makes every hardware tone-map smoke fail while the
+// software smoke, which decodes Rext, still passes.
+func TestDecodeProbeFixtureIsMain10(t *testing.T) {
+	data, err := base64.StdEncoding.DecodeString(decodeProbeFixtureBase64)
+	if err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	const (
+		nalSPS         = 33
+		hevcMain10IDC  = 2
+		nalHeaderBytes = 2
+		spsPrefixBytes = 1 // sps_video_parameter_set_id, max_sub_layers_minus1, temporal_id_nesting
+	)
+	for i := 0; i+3 < len(data); i++ {
+		if data[i] != 0 || data[i+1] != 0 || data[i+2] != 1 {
+			continue
+		}
+		header := i + 3
+		if (data[header]>>1)&0x3f != nalSPS {
+			continue
+		}
+		ptl := header + nalHeaderBytes + spsPrefixBytes
+		if ptl >= len(data) {
+			t.Fatal("fixture SPS is truncated")
+		}
+		if got := data[ptl] & 0x1f; got != hevcMain10IDC {
+			t.Fatalf("fixture general_profile_idc = %d, want %d (Main 10)", got, hevcMain10IDC)
+		}
+		return
+	}
+	t.Fatal("fixture has no SPS NAL unit")
 }
 
 // TestHardwareSmokeFilterNVENCPreservesSourceBitDepth verifies that the CUDA


### PR DESCRIPTION
## Problem

Related issue: #610

Backport of #1006 to `apiv2`. Every Intel transcode node advertised only software HDR tone mapping because the tone-map capability probe's embedded decoder fixture was encoded as HEVC profile 4 (Rext) rather than Main 10, which Intel VAAPI/QSV decoders refuse. HDR sources were therefore CPU-transcoded on GPU-capable nodes. `apiv2` carries the same fixture as `main` did.

## Approach

Clean cherry-pick of the squash-merged commit `dc887b3c5` from `main`: a 256x256 HEVC Main 10 fixture plus `TestDecodeProbeFixtureIsMain10`, which parses the SPS profile byte and fails against the old fixture. No conflicts; `internal/tonemap` is identical between `main` and `apiv2` at this point.

## Validation

- `go test ./internal/tonemap` passes on this branch.
- The same change was validated on shared-dev Intel nodes under #1006: both nodes advertise `hardware/qsv/tonemap_opencl` after deploy, and a 4K Dolby Vision source ran `tonemap_opencl` + `h264_qsv` where it ran `libx264` + `tonemapx` before.
- Not verified on NVIDIA (no node available); the fixture keeps the Pascal dimensions and pixel format from #843.

## Risks

None identified beyond the NVIDIA gap. Nodes pick up the fixture at their next capability snapshot.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Claude Code
- Tool(s): Claude Code
- Model(s): claude-fable-5-1
- Involvement: Fully AI-generated, human verified
- Adversarial review: n/a for the backport itself; the change was reviewed and hardware-validated under #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
