### PR TITLE
fix(jellycompat): redact credentials from request and debug logs

### DIFF
--- a/internal/jellycompat/handlers_items.go
+++ b/internal/jellycompat/handlers_items.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Silo-Server/silo-server/internal/access"
 	"github.com/Silo-Server/silo-server/internal/catalog"
 	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/logredact"
 	"github.com/Silo-Server/silo-server/internal/models"
 	"github.com/Silo-Server/silo-server/internal/playback"
 	"github.com/Silo-Server/silo-server/internal/recommendations"
@@ -1457,7 +1458,7 @@ func (h *ItemsHandler) HandleSeasons(w http.ResponseWriter, r *http.Request) {
 			slog.ErrorContext(r.Context(), "jellycompat HandleSeasons panic", "component", "jellycompat",
 				"error", fmt.Sprint(rv),
 				"path", r.URL.Path,
-				"query", r.URL.RawQuery,
+				"query", logredact.SanitizeQuery(r.URL.RawQuery),
 				"stack", string(debug.Stack()),
 			)
 			writeError(w, http.StatusInternalServerError, "ServerError", "Internal error")

--- a/internal/jellycompat/logging.go
+++ b/internal/jellycompat/logging.go
@@ -233,6 +233,9 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 
 			if requestCapture != nil && requestCapture.body.Len() > 0 {
 				_, _ = fmt.Fprintf(logFile, "Request Body (%d bytes captured):\n", requestCapture.body.Len())
+				if requestCapture.truncated {
+					_, _ = fmt.Fprintf(logFile, "[truncated at %d bytes]\n", debugMaxBodyCapture)
+				}
 				writeIndentedJSON(logFile, requestCapture.body.Bytes())
 			}
 
@@ -257,12 +260,17 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 // changing the request's length, read errors or Close result.
 type debugRequestBody struct {
 	io.ReadCloser
-	body bytes.Buffer
+	body      bytes.Buffer
+	truncated bool
 }
 
 func (b *debugRequestBody) Read(p []byte) (int, error) {
 	n, err := b.ReadCloser.Read(p)
-	if remaining := debugMaxBodyCapture - b.body.Len(); remaining > 0 {
+	remaining := debugMaxBodyCapture - b.body.Len()
+	if n > remaining {
+		b.truncated = true
+	}
+	if remaining > 0 {
 		_, _ = b.body.Write(p[:min(n, remaining)])
 	}
 	return n, err

--- a/internal/jellycompat/logging.go
+++ b/internal/jellycompat/logging.go
@@ -3,7 +3,6 @@ package jellycompat
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -12,12 +11,12 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/Silo-Server/silo-server/internal/httpstream"
+	"github.com/Silo-Server/silo-server/internal/logredact"
 )
 
 type loggingResponseWriter struct {
@@ -81,7 +80,7 @@ func requestLoggerMiddleware(next http.Handler) http.Handler {
 			"method", r.Method,
 			"path", r.URL.Path,
 			"original_path", firstNonEmpty(originalPathFromContext(r.Context()), r.URL.Path),
-			"query", r.URL.RawQuery,
+			"query", logredact.SanitizeQuery(r.URL.RawQuery),
 			"route", routePattern,
 			"status", statusOrDefault(ww.status),
 			"duration_ms", time.Since(start).Milliseconds(),
@@ -191,8 +190,8 @@ func (w *debugResponseWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }
 
-// newDebugLogMiddleware creates a middleware that logs full request/response
-// pairs to the given file. Enable by setting JELLYCOMPAT_DEBUG_LOG=/path/to/file.
+// newDebugLogMiddleware logs request/response diagnostics with credentials
+// redacted. Non-JSON bodies are omitted. Enable with JELLYCOMPAT_DEBUG_LOG.
 // When userAgentFilter is non-empty, only requests whose User-Agent contains
 // the filter string (case-insensitive) are logged.
 func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.Handler) http.Handler {
@@ -205,10 +204,10 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 			}
 
 			// Capture request body for POST/PUT/PATCH.
-			var reqBody []byte
+			var requestCapture *debugRequestBody
 			if r.Body != nil && (r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch) {
-				reqBody, _ = io.ReadAll(io.LimitReader(r.Body, debugMaxBodyCapture))
-				r.Body = io.NopCloser(bytes.NewReader(reqBody))
+				requestCapture = &debugRequestBody{ReadCloser: r.Body}
+				r.Body = requestCapture
 			}
 
 			start := time.Now()
@@ -225,16 +224,16 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 			fmt.Fprintf(logFile, "=== %s %s %s [%s] %dms ===\n",
 				start.Format("2006/01/02 15:04:05"),
 				r.Method,
-				r.URL.String(),
+				logredact.SanitizeRequestURL(r.URL.String()),
 				reqID,
 				elapsed.Milliseconds(),
 			)
 			fmt.Fprintf(logFile, "Remote: %s  User-Agent: %s\n", r.RemoteAddr, r.UserAgent())
 			fmt.Fprintf(logFile, "Status: %d\n", status)
 
-			if len(reqBody) > 0 {
-				fmt.Fprintf(logFile, "Request Body (%d bytes):\n", len(reqBody))
-				writeIndentedJSON(logFile, reqBody)
+			if requestCapture != nil && requestCapture.body.Len() > 0 {
+				fmt.Fprintf(logFile, "Request Body (%d bytes captured):\n", requestCapture.body.Len())
+				writeIndentedJSON(logFile, requestCapture.body.Bytes())
 			}
 
 			switch {
@@ -254,22 +253,26 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 	}
 }
 
-// writeIndentedJSON pretty-prints b if it's valid JSON, otherwise writes it as
-// UTF-8 text. If b is not valid UTF-8 (e.g. a handler lied about Content-Type),
-// it is omitted so the log file stays readable.
+// debugRequestBody observes reads without consuming ahead of the handler or
+// changing the request's length, read errors or Close behaviour.
+type debugRequestBody struct {
+	io.ReadCloser
+	body bytes.Buffer
+}
+
+func (b *debugRequestBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if remaining := debugMaxBodyCapture - b.body.Len(); remaining > 0 {
+		_, _ = b.body.Write(p[:min(n, remaining)])
+	}
+	return n, err
+}
+
+// writeIndentedJSON writes only sanitised structured bodies, never a raw-text
+// fallback that could contain passwords, form credentials or stream URLs.
 func writeIndentedJSON(w io.Writer, b []byte) {
-	var buf bytes.Buffer
-	if json.Indent(&buf, b, "", "  ") == nil {
-		buf.WriteByte('\n')
-		w.Write(buf.Bytes())
-		return
-	}
-	if utf8.Valid(b) {
-		w.Write(b)
-		fmt.Fprintln(w)
-		return
-	}
-	fmt.Fprintf(w, "[non-UTF-8 payload, %d bytes omitted]\n", len(b))
+	_, _ = w.Write(logredact.SanitizeJSON(b))
+	_, _ = fmt.Fprintln(w)
 }
 
 // isTextualContentType reports whether a captured body with Content-Type ct is

--- a/internal/jellycompat/logging.go
+++ b/internal/jellycompat/logging.go
@@ -232,7 +232,7 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 			fmt.Fprintf(logFile, "Status: %d\n", status)
 
 			if requestCapture != nil && requestCapture.body.Len() > 0 {
-				fmt.Fprintf(logFile, "Request Body (%d bytes captured):\n", requestCapture.body.Len())
+				_, _ = fmt.Fprintf(logFile, "Request Body (%d bytes captured):\n", requestCapture.body.Len())
 				writeIndentedJSON(logFile, requestCapture.body.Bytes())
 			}
 
@@ -254,7 +254,7 @@ func newDebugLogMiddleware(logFile io.Writer, userAgentFilter string) func(http.
 }
 
 // debugRequestBody observes reads without consuming ahead of the handler or
-// changing the request's length, read errors or Close behaviour.
+// changing the request's length, read errors or Close result.
 type debugRequestBody struct {
 	io.ReadCloser
 	body bytes.Buffer
@@ -268,7 +268,7 @@ func (b *debugRequestBody) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// writeIndentedJSON writes only sanitised structured bodies, never a raw-text
+// writeIndentedJSON writes only redacted structured bodies, never a raw-text
 // fallback that could contain passwords, form credentials or stream URLs.
 func writeIndentedJSON(w io.Writer, b []byte) {
 	_, _ = w.Write(logredact.SanitizeJSON(b))

--- a/internal/jellycompat/logging_test.go
+++ b/internal/jellycompat/logging_test.go
@@ -90,7 +90,7 @@ func TestDebugLoggerOmitsUnsafeBodiesWithoutTruncatingRequests(t *testing.T) {
 		`Pw=form-secret`,
 		strings.Repeat(" ", debugMaxBodyCapture) + `{"Pw":"oversize-secret"}`,
 	} {
-		t.Run(string(body[:8]), func(t *testing.T) {
+		t.Run(body[:8], func(t *testing.T) {
 			var logs bytes.Buffer
 			h := newDebugLogMiddleware(&logs, "")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				got, err := io.ReadAll(r.Body)

--- a/internal/jellycompat/logging_test.go
+++ b/internal/jellycompat/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -157,5 +158,33 @@ func TestDebugLoggerFilterLeavesRequestUnread(t *testing.T) {
 	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/", original))
 	if logs.Len() != 0 {
 		t.Fatal("filtered request was logged")
+	}
+}
+
+func TestDebugLoggerReportsActualRequestTruncation(t *testing.T) {
+	for _, size := range []int{debugMaxBodyCapture - 1, debugMaxBodyCapture, debugMaxBodyCapture + 1} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			const prefix = `{"Pw":"capture-secret","data":"`
+			const suffix = `"}`
+			body := prefix + strings.Repeat("a", size-len(prefix)-len(suffix)) + suffix
+			var logs bytes.Buffer
+			h := newDebugLogMiddleware(&logs, "")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got, err := io.ReadAll(r.Body)
+				if err != nil || string(got) != body {
+					t.Fatal("request body changed")
+				}
+			}))
+			r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+			r.ContentLength = -1 // Verify observed reads, not a trusted length header.
+			h.ServeHTTP(httptest.NewRecorder(), r)
+			wantTruncated := size > debugMaxBodyCapture
+			if got := strings.Contains(logs.String(), "[truncated at"); got != wantTruncated {
+				t.Errorf("truncation notice = %t, want %t", got, wantTruncated)
+			}
+			if !wantTruncated && strings.Contains(logs.String(), "omitted") {
+				t.Error("complete JSON was omitted")
+			}
+			assertLogSecretsAbsent(t, logs.String(), "capture-secret")
+		})
 	}
 }

--- a/internal/jellycompat/logging_test.go
+++ b/internal/jellycompat/logging_test.go
@@ -1,0 +1,161 @@
+package jellycompat
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestRequestLoggerRedactsQueryCredentials(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	const target = "/Items?%41piKey=query-secret&API_KEY=legacy-secret&Limit=20"
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	h := requestLoggerMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RawQuery != strings.SplitN(target, "?", 2)[1] {
+			t.Fatal("logging changed the live query")
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	assertLogSecretsAbsent(t, logs.String(), "query-secret", "legacy-secret")
+	for _, want := range []string{"Limit=20", `"status":202`, `"path":"/Items"`, "duration_ms"} {
+		if !strings.Contains(logs.String(), want) {
+			t.Errorf("missing diagnostic %q: %s", want, logs.String())
+		}
+	}
+}
+
+func TestSeasonsPanicLoggerRedactsQueryCredentials(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	codec := NewResourceIDCodec()
+	h := &ItemsHandler{codec: codec} // nil content triggers the recovery path.
+	r := httptest.NewRequest(http.MethodGet, "/Shows/series/Seasons?ApiKey=panic-secret&Limit=20", nil)
+	ctx := chi.NewRouteContext()
+	ctx.URLParams.Add("id", codec.EncodeStringID(EncodedIDItem, "series"))
+	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, ctx))
+	r = r.WithContext(context.WithValue(r.Context(), compatSessionKey, &Session{}))
+	w := httptest.NewRecorder()
+	h.HandleSeasons(w, r)
+	if w.Code != http.StatusInternalServerError || !strings.Contains(logs.String(), "HandleSeasons panic") {
+		t.Fatalf("panic path not exercised: status=%d log=%s", w.Code, logs.String())
+	}
+	assertLogSecretsAbsent(t, logs.String(), "panic-secret")
+	if !strings.Contains(logs.String(), "Limit=20") {
+		t.Fatal("panic log lost harmless query")
+	}
+}
+
+func TestDebugLoggerRedactsCredentialsAndPreservesTraffic(t *testing.T) {
+	const requestBody = `{"Username":"example","Pw":"password-secret","nested":[{"PASSWORD":"nested-secret"}],"Limit":20}`
+	const responseBody = `{"AccessToken":"session-secret","Items":[{"Name":"Example","DirectStreamUrl":"/stream?api_key=stream-secret&Static=true"}]}`
+	var logs bytes.Buffer
+	h := newDebugLogMiddleware(&logs, "")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil || string(body) != requestBody || r.URL.Query().Get("ApiKey") != "query-secret" {
+			t.Fatal("debug logging changed the request")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, responseBody)
+	}))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/Users/AuthenticateByName?ApiKey=query-secret&Limit=20", strings.NewReader(requestBody)))
+	if w.Body.String() != responseBody {
+		t.Fatal("debug logging changed the response")
+	}
+	assertLogSecretsAbsent(t, logs.String(), "password-secret", "nested-secret", "session-secret", "stream-secret", "query-secret")
+	for _, want := range []string{"Example", `"Limit": 20`, "Limit=20", "Static=true", "Status: 200", "[REDACTED]"} {
+		if !strings.Contains(logs.String(), want) {
+			t.Errorf("missing diagnostic %q: %s", want, logs.String())
+		}
+	}
+}
+
+func TestDebugLoggerOmitsUnsafeBodiesWithoutTruncatingRequests(t *testing.T) {
+	for _, body := range []string{
+		`{"Pw":"malformed-secret"`,
+		`Pw=form-secret`,
+		strings.Repeat(" ", debugMaxBodyCapture) + `{"Pw":"oversize-secret"}`,
+	} {
+		t.Run(string(body[:8]), func(t *testing.T) {
+			var logs bytes.Buffer
+			h := newDebugLogMiddleware(&logs, "")(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got, err := io.ReadAll(r.Body)
+				if err != nil || string(got) != body {
+					t.Errorf("handler received %d bytes, want %d; error=%v", len(got), len(body), err)
+				}
+				w.Header().Set("Content-Type", "text/plain")
+				_, _ = io.WriteString(w, "response-secret")
+			}))
+			h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body)))
+			assertLogSecretsAbsent(t, logs.String(), "malformed-secret", "form-secret", "oversize-secret", "response-secret")
+			if !strings.Contains(logs.String(), "omitted") {
+				t.Fatal("missing body omission diagnostic")
+			}
+		})
+	}
+}
+
+func assertLogSecretsAbsent(t *testing.T, log string, secrets ...string) {
+	t.Helper()
+	for _, secret := range secrets {
+		if strings.Contains(log, secret) {
+			t.Errorf("log contains synthetic credential %q", secret)
+		}
+	}
+}
+
+type debugErrorBody struct {
+	err    error
+	closed bool
+}
+
+func (b *debugErrorBody) Read(p []byte) (int, error) {
+	return copy(p, "partial"), b.err
+}
+
+func (b *debugErrorBody) Close() error {
+	b.closed = true
+	return b.err
+}
+
+func TestDebugRequestBodyPreservesReadAndCloseErrors(t *testing.T) {
+	wantErr := errors.New("synthetic read error")
+	original := &debugErrorBody{err: wantErr}
+	body := &debugRequestBody{ReadCloser: original}
+	buf := make([]byte, 16)
+	n, err := body.Read(buf)
+	if !errors.Is(err, wantErr) || string(buf[:n]) != "partial" || body.body.String() != "partial" {
+		t.Fatalf("read changed: n=%d err=%v capture=%q", n, err, body.body.String())
+	}
+	if err := body.Close(); !errors.Is(err, wantErr) || !original.closed {
+		t.Fatalf("Close not forwarded: %v", err)
+	}
+}
+
+func TestDebugLoggerFilterLeavesRequestUnread(t *testing.T) {
+	var logs bytes.Buffer
+	original := io.NopCloser(strings.NewReader("unchanged"))
+	h := newDebugLogMiddleware(&logs, "selected-client")(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if r.Body != original {
+			t.Fatal("filtered request body was wrapped")
+		}
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/", original))
+	if logs.Len() != 0 {
+		t.Fatal("filtered request was logged")
+	}
+}

--- a/internal/logredact/diagnostic.go
+++ b/internal/logredact/diagnostic.go
@@ -89,9 +89,33 @@ func sanitizeDiagnosticValue(value any) any {
 	case string:
 		// Playback responses contain token-bearing relative and absolute URLs
 		// under ordinary keys such as DirectStreamUrl and MediaSources[].Path.
-		if strings.Contains(v, "?") || strings.Contains(v, "://") {
+		if looksLikeDiagnosticURL(v) {
 			return SanitizeRequestURL(v)
 		}
 	}
 	return value
+}
+
+// looksLikeDiagnosticURL matches rooted paths and scheme-prefixed URLs,
+// not a question mark or an embedded link in ordinary metadata. Spaces do not
+// disqualify a URL: its query can still contain a credential needing redaction.
+func looksLikeDiagnosticURL(value string) bool {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "/") {
+		return true
+	}
+	scheme, _, found := strings.Cut(value, "://")
+	if !found || scheme == "" {
+		return false
+	}
+	for i, c := range scheme {
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' {
+			continue
+		}
+		if i > 0 && (c >= '0' && c <= '9' || c == '+' || c == '-' || c == '.') {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/logredact/diagnostic.go
+++ b/internal/logredact/diagnostic.go
@@ -1,0 +1,97 @@
+package logredact
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"strings"
+)
+
+// SanitizeQuery preserves diagnostic parameters while masking credentials.
+// Parse errors omit the entire query: ParseQuery can otherwise return a partial
+// result and tempt callers to fall back to the unsafe original input.
+func SanitizeQuery(raw string) string {
+	query, err := url.ParseQuery(raw)
+	if err != nil {
+		return "[query omitted: invalid encoding]"
+	}
+	for key := range query {
+		if diagnosticSecretKey(key) {
+			query[key] = []string{Placeholder}
+		}
+	}
+	return query.Encode()
+}
+
+// SanitizeRequestURL accepts relative request targets as well as absolute URLs.
+// Unlike SanitizeURL (transport error diagnostics), it retains safe query fields.
+// The caller's URL and live request are never modified.
+func SanitizeRequestURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Opaque != "" {
+		return invalidURLPlaceholder
+	}
+	u.User = nil
+	u.RawQuery = SanitizeQuery(u.RawQuery)
+	u.Fragment = ""
+	u.RawFragment = ""
+	return u.String()
+}
+
+// SanitizeJSON keeps structured diagnostics, including exact JSON numbers, but
+// masks credential fields and credentials in URL strings. Invalid, truncated,
+// scalar and non-JSON bodies are omitted rather than logged as raw text.
+func SanitizeJSON(body []byte) []byte {
+	const omitted = "[body omitted: not a complete JSON object or array]"
+	if !json.Valid(body) {
+		return []byte(omitted)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return []byte(omitted)
+	}
+	switch value.(type) {
+	case map[string]any, []any:
+	default:
+		return []byte(omitted)
+	}
+	result, err := json.MarshalIndent(sanitizeDiagnosticValue(value), "", "  ")
+	if err != nil {
+		return []byte(omitted)
+	}
+	return result
+}
+
+func diagnosticSecretKey(key string) bool {
+	// Pw is the Jellyfin login alias. Normalisation covers the casing and
+	// separators used by compatibility clients without changing auth parsing.
+	key = strings.ToLower(strings.TrimSpace(key))
+	key = strings.ReplaceAll(strings.ReplaceAll(key, "_", ""), "-", "")
+	return key == "pw" || SecretKey(key)
+}
+
+func sanitizeDiagnosticValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			if diagnosticSecretKey(key) {
+				v[key] = Placeholder
+			} else {
+				v[key] = sanitizeDiagnosticValue(child)
+			}
+		}
+	case []any:
+		for i, child := range v {
+			v[i] = sanitizeDiagnosticValue(child)
+		}
+	case string:
+		// Playback responses contain token-bearing relative and absolute URLs
+		// under ordinary keys such as DirectStreamUrl and MediaSources[].Path.
+		if strings.Contains(v, "?") || strings.Contains(v, "://") {
+			return SanitizeRequestURL(v)
+		}
+	}
+	return value
+}

--- a/internal/logredact/diagnostic_test.go
+++ b/internal/logredact/diagnostic_test.go
@@ -81,3 +81,37 @@ func TestSanitizeJSONOmitsUnsafeRepresentations(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeJSONPreservesOrdinaryText(t *testing.T) {
+	for _, value := range []string{"Can he escape? Nobody knows", "Why?", "Read https://example.com for details?", "A story? Part #2", "Still here?\nYes."} {
+		body, err := json.Marshal(map[string]string{"Overview": value})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got map[string]string
+		if err := json.Unmarshal(SanitizeJSON(body), &got); err != nil {
+			t.Fatal(err)
+		}
+		if got["Overview"] != value {
+			t.Errorf("ordinary text changed: got %q, want %q", got["Overview"], value)
+		}
+	}
+}
+
+func TestSanitizeJSONRedactsURLFormsWithSpaces(t *testing.T) {
+	for _, value := range []string{
+		"/stream?ApiKey=url-secret&Name=Two Words",
+		"https://example.com/stream?api_key=url-secret&Name=Two Words",
+		"HTTPS://example.com/stream?API_KEY=url-secret",
+		"https://operator:url-secret@%invalid/stream",
+		" /stream?ApiKey=url-secret&Name=Two Words",
+	} {
+		body, err := json.Marshal(map[string]string{"DirectStreamUrl": value})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := string(SanitizeJSON(body)); strings.Contains(got, "url-secret") {
+			t.Errorf("URL credential escaped redaction: %s", got)
+		}
+	}
+}

--- a/internal/logredact/diagnostic_test.go
+++ b/internal/logredact/diagnostic_test.go
@@ -1,0 +1,83 @@
+package logredact
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeQueryCredentialAliases(t *testing.T) {
+	for _, key := range []string{"ApiKey", "api_key", "API_KEY", "%41piKey", "Api%5fKey", "AccessToken", "X-Emby-Token", "Pw", "PASSWORD", "Authorization", "Cookie"} {
+		t.Run(key, func(t *testing.T) {
+			got := SanitizeQuery(key + "=first-secret&" + key + "=second-secret&Limit=20&Tag=a&Tag=b")
+			if strings.Contains(got, "secret") {
+				t.Fatalf("credential leaked: %q", got)
+			}
+			query, err := url.ParseQuery(got)
+			if err != nil || query.Get("Limit") != "20" || strings.Join(query["Tag"], ",") != "a,b" {
+				t.Fatalf("lost harmless diagnostics: %q, %v", got, err)
+			}
+		})
+	}
+}
+
+func TestSanitizeQueryFailsClosed(t *testing.T) {
+	for _, raw := range []string{"ApiKey=secret%ZZ", "ApiKey=secret;Limit=20", "ApiKey=secret&bad=%"} {
+		if got := SanitizeQuery(raw); strings.Contains(got, "secret") || !strings.Contains(got, "omitted") {
+			t.Fatalf("invalid query not omitted: %q", got)
+		}
+	}
+	if got := SanitizeQuery(""); got != "" {
+		t.Fatalf("empty query = %q", got)
+	}
+}
+
+func TestSanitizeRequestURL(t *testing.T) {
+	for _, raw := range []string{
+		"/stream?ApiKey=query-secret&Static=true#fragment-secret",
+		"https://operator:user-secret@example.com/stream?api_key=query-secret&Static=true#fragment-secret",
+	} {
+		got := SanitizeRequestURL(raw)
+		if strings.Contains(got, "secret") || !strings.Contains(got, "/stream?") || !strings.Contains(got, "Static=true") {
+			t.Fatalf("unsafe or unhelpful URL: %q", got)
+		}
+	}
+	for _, raw := range []string{"http://%secret", "scheme:opaque-secret"} {
+		if got := SanitizeRequestURL(raw); got != invalidURLPlaceholder {
+			t.Fatalf("invalid/opaque URL not omitted: %q", got)
+		}
+	}
+}
+
+func TestSanitizeJSONNestedCredentialsAndExactNumbers(t *testing.T) {
+	const body = `{"Pw":"first-secret","Pw":"duplicate-secret","p\u0077":"escaped-secret","API_KEY":{"nested":"object-secret"},"Items":[{"AccessToken":"session-secret","Url":"/stream?%41piKey=url-secret&Static=true"}],"PositionTicks":9007199254740993,"Enabled":true,"Name":"Example","Optional":null}`
+	got := SanitizeJSON([]byte(body))
+	if strings.Contains(string(got), "secret") || !json.Valid(got) {
+		t.Fatalf("unsafe JSON: %s", got)
+	}
+	for _, want := range []string{"9007199254740993", `"Enabled": true`, `"Name": "Example"`, `"Optional": null`, "Static=true", Placeholder} {
+		if !strings.Contains(string(got), want) {
+			t.Errorf("lost diagnostic %q: %s", want, got)
+		}
+	}
+	if !strings.Contains(body, "first-secret") {
+		t.Fatal("input was modified")
+	}
+}
+
+func TestSanitizeJSONOmitsUnsafeRepresentations(t *testing.T) {
+	for _, body := range []string{
+		`{"Pw":"truncated-secret"`,
+		`{"Pw":"first-secret"} {"Pw":"second-secret"}`,
+		`Pw=form-secret`,
+		`<Password>xml-secret</Password>`,
+		`"scalar-secret"`,
+		"\xffbinary-secret",
+	} {
+		got := string(SanitizeJSON([]byte(body)))
+		if strings.Contains(got, "secret") || !strings.Contains(got, "omitted") {
+			t.Fatalf("unsafe body not omitted: %q", got)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: N/A, narrow security fix.

Jellyfin-compatible requests can put a session token or API key in `ApiKey` or `api_key`. The request logger writes `r.URL.RawQuery` under the ordinary `query` attribute, so the existing key-based log redactor does not mask it. The `HandleSeasons` panic logger has the same path. Rejected requests are logged too.

Optional `JELLYCOMPAT_DEBUG_LOG` capture also writes complete URLs and request/response bodies directly to its file. That can retain login `Pw`/`Password` fields, returned `AccessToken` values and tokens inside playback URLs. This file writer bypasses the slog redactor.

This is a CWE-532 credential-exposure fix. Someone who can read retained or exported logs could reuse a still-valid credential with its existing permissions. It does not establish unauthenticated access to logs, an administrator-level credential, or an actual account compromise. The normal request-log exposure was reproduced on a running deployment; debug-body exposure was reproduced in tests, not by enabling debug capture on production.

## Approach

I kept the fix at the logging boundary so clients can keep using the compatibility protocol without changes:

- Add shared query, request-URL and JSON helpers in `internal/logredact`.
- Use query redaction in both normal compatibility request logs and the seasons panic path. Match credential aliases case-insensitively after decoding, handle duplicate keys, and omit malformed queries instead of falling back to the original input.
- Remove URL userinfo and fragments, redact credential query parameters, and preserve ordinary parameters. Apply this to debug request URLs and URL strings in JSON, including relative stream URLs.
- Recursively mask credential-bearing JSON fields, including Jellyfin's `Pw` alias. Preserve exact JSON numbers. Omit incomplete, scalar and non-JSON bodies rather than writing an unsafe raw-text fallback.
- Capture request bytes as the handler reads them, up to the existing 256 KiB limit. The old debug middleware replaced the request body with that limited prefix, so a larger request was truncated before reaching its handler. The new wrapper forwards the full stream and its read/close results.

This changes diagnostic output, not live authentication, request parameters, response bodies, route registration or API schemas. The contribution is based on upstream `main` at `dc887b3c567303ca5554e3a1101d2dd6324345a4`; it contains no deployment settings or unrelated fork changes.

## Validation

### Maintainer review follow-up

Revision `868d856d` keeps on-disk file paths verbatim in debug JSON. Before this change, any string starting with `/` was re-rendered as a URL, so `Path` values gained percent-encoding or became `[invalid URL]`. Strings are now rewritten only when they contain `?`, `#` or `@`, the only places a credential can appear. Redaction coverage is unchanged. `TestSanitizeJSONPreservesFilePaths` covers the case, and upstream CI passed on this revision.

AI disclosure for this follow-up: written by Claude Opus 5.5 (`claude-opus-5-5`) in Claude Code during maintainer review.

### CodeRabbit follow-up

Current contribution revision: `ad4eb4df`.

I addressed the two diagnostic-quality findings from CodeRabbit:

- Ordinary metadata containing question marks or embedded links stays unchanged. URL detection requires a rooted path or a valid scheme prefix. I did not use the proposed whitespace exclusion, because a URL with spaces can still carry a credential. Regression cases cover plain text, embedded links, root-relative and absolute URLs with spaces, mixed-case schemes and malformed URLs.
- Request capture records whether reads actually exceeded the 256 KiB capture budget. Only then does it report truncation. Tests cover one byte below, exactly at and one byte above the limit with an unknown content length, and confirm the handler receives the complete request.

`TestSanitizeJSONPreservesOrdinaryText` and the oversized case of `TestDebugLoggerReportsActualRequestTruncation` failed on the previous PR revision and pass with this follow-up. The full focused redaction/debug test selection and targeted vet passed. Upstream CI for this new revision is pending.

The original deployment evidence below applies to the initial fix, not this follow-up. This follow-up has not been deployed or merged into the fork's production `main`. The docstring coverage warning is not being addressed with boilerplate comments on test functions; the new production helper has a contract comment.

### Before/after evidence

The initial four middleware regressions were run before implementation on `08691635c6c315f091e224603271036071ee97db`. They reproduced query leaks, panic-path leaks, debug URL/body leaks, unsafe raw-body fallback and request truncation. The affected logging implementation at that baseline matches the upstream base. These tests pass with the fix.

The same five changed files were deployed in fork revision `8d5b5c34ff050c1039ccead5e68c890e553b3dc1`. This is separate from the upstream contribution revision `88ca57e7afb6df86bd5a07af53adecbf9c670f79`; file comparisons confirmed they contained the same initial fix before the CodeRabbit follow-up.

Live verification used deliberately invalid synthetic tokens, never a real credential. A GET to `/Users/Me` returned 401 before and after deployment. The following are verifier counters, not reconstructed raw log lines. Private request logs are deliberately excluded.

To repeat the query check, replace the reserved example host with a test instance, send the request below, and inspect only the request-log entry carrying `codex_log_probe=redaction-check`. The expected response is 401 in both versions. The old logger retains the synthetic token; the patched logger replaces its value with `[REDACTED]` while keeping `Limit=20`. Repeat with the aliases listed below. The example token is deliberately non-functional.

```sh
curl -s -o /dev/null -w '%{http_code}\n' \
  'https://media.example.invalid/Users/Me?ApiKey=synthetic-only-not-a-real-token&Limit=20&codex_log_probe=redaction-check'
```

Before:

```json
{"phase":"before","http_status":401,"matching_log_lines":1,"synthetic_secret_logged":true}
```

After, using `ApiKey`, `API_KEY`, `%41piKey` and `Api%5fKey` (all four requests returned 401):

```json
{"phase":"after","matching_log_lines":4,"synthetic_secret_logged":false,"redaction_present":true,"safe_parameter_retained":true}
```

After deployment, both health checks returned 200 and the container was healthy with no restarts. Subsequent read-only checks found an active, unpaused playback session updated within four seconds and 30 successful `POST /Sessions/Playing/Progress` responses with status 204 in a five-minute sample. That demonstrates continuing server-side playback reporting, not a fresh-start, seek or client-rendering test.

### Regression coverage

- `TestRequestLoggerRedactsQueryCredentials` and `TestSeasonsPanicLoggerRedactsQueryCredentials`: secret removal at the actual sinks, retained safe parameters, and unchanged live requests/statuses.
- `TestDebugLoggerRedactsCredentialsAndPreservesTraffic`: passwords, nested credential fields, access tokens and stream URLs are masked while the handler and client receive unchanged bodies.
- `TestDebugLoggerOmitsUnsafeBodiesWithoutTruncatingRequests`: malformed/form bodies and oversized requests do not leak through the raw fallback or truncate the handler's input.
- `TestDebugRequestBodyPreservesReadAndCloseErrors` and `TestDebugLoggerFilterLeavesRequestUnread`: original I/O results and the user-agent filter remain intact.
- The `TestSanitize*` cases cover aliases, percent-encoded and duplicate query keys, invalid encodings, URL userinfo/fragments, escaped/duplicate JSON keys, arrays, exact large numbers and unsafe body representations.

### Commands and CI

Initial-fix evidence, before the CodeRabbit follow-up:

On contribution revision `88ca57e7afb6df86bd5a07af53adecbf9c670f79`:

```sh
git diff upstream/main HEAD --check
GOMAXPROCS=2 go test -p 1 ./internal/logredact ./internal/jellycompat -run 'Test(Sanitize|RequestLoggerRedacts|SeasonsPanicLoggerRedacts|Debug)' -count=1 -timeout=2m
GOMAXPROCS=2 go vet -p 1 ./internal/logredact ./internal/jellycompat
```

All three passed. [Full CI for this exact contribution revision](https://github.com/blurbery/silo-server/actions/runs/34295443197) also passed: Go, Web and Docs hygiene are green. Upstream-owned PR checks will run separately after publication; those are not being reported as passed in advance.

The full gate runs `make embed-stub`, `go build ./...`, `gofmt -l .`, `go vet ./...`, changed-line golangci-lint, `make test-go`, settings-binding and playback-fixture checks, plus web lint/format/build/tests and docs-path hygiene. The fork-hosted dispatch compares lint against its `origin/main`; the upstream PR check will compare against the upstream target. Neither is described as a full-tree lint cleanup.

Additional evidence for the deployed fork revision, not a substitute for this PR's revision checks: [Go/Web/docs and PostgreSQL integration passed](https://github.com/blurbery/silo-server/actions/runs/34292481849), and [both container architectures built successfully](https://github.com/blurbery/silo-server/actions/runs/34293561415). The earlier development revision failed four lint checks; those corrections are included in this PR. Debug logging stayed disabled on production, so its enabled-mode evidence is from regression tests.

### API v2 / Huma compatibility

I checked the Huma foundation and pilot work (#936 and #941), plus the recent playback work in #1002 and #1005. The [API v2 contract](https://github.com/Silo-Server/silo-server/blob/26661d76f451ed790cf74221538b1048a8d193d6/docs/architecture/api-contract.md#L1060) explicitly keeps Jellyfin compatibility outside the native v2 contract. Huma is mounted through `humachi` on the native API listener; this fix stays in compatibility logging and standard-library redaction helpers.

At `apiv2` revision `26661d76f451ed790cf74221538b1048a8d193d6`, the existing affected logging files and `internal/logredact` are identical to the upstream base. Applying the complete contribution diff to a temporary index populated from that revision passed `git apply --cached --check` without conflicts. The reviewed playback PRs did not change this patch's logging files.

The compatibility claim is therefore source and patch compatibility with the inspected v2 branch, not a claim that the full Huma runtime or migration suite was executed. No v2 operations, OpenAPI artifacts, client bindings or playback contracts change. Apple and Android changes are not required for this logging-only patch. Recheck integration when the v2 branch moves.

## Benchmarks

Not run. Query parsing and JSON redaction add work to the logging path; I am not claiming zero overhead or a performance improvement. The debug capture remains bounded at 256 KiB. Latency, throughput and allocation effects have not been measured.

## Risks

- Diagnostic query ordering/encoding and JSON field ordering can change. Non-JSON, malformed and incomplete body captures are intentionally replaced by omission markers; raw XML, forms and text will no longer be dumped verbatim.
- Redaction follows recognised credential fields and URL representations. This is not a general guarantee that arbitrary free-text messages or every other logger in the repository contain no sensitive information.
- Existing logs are not rewritten, and exposed credentials are not automatically revoked. Operators should identify and revoke affected sessions/keys separately and review log retention and access.
- No database migration, settings change, authentication change or production deployment is part of this upstream PR.

## Checklist

- [x] I read and can explain the complete diff. Agent review is complete; human maintainer review is requested.
- [x] This pull request addresses one concern: credential-safe compatibility diagnostics, including preserving requests while capturing them.

## AI Disclosure

AI-assisted with Astra. I directed the task and designed the work.

- Harness: OpenAI Codex desktop.
- Tool(s): Codex Security plugin, CodeRabbit (external review suggestions), Git, GitHub CLI, Go tooling and SSH for authorised deployment verification.
- Model(s): Astra (`gpt-6-astra`), confirmed for this task. CodeRabbit did not report its underlying model identifier.
- Involvement: AI-assisted implementation, tests, review, verification and PR drafting under my direction. No claim of independent human code review.
- Adversarial review: a same-agent review traced the query, panic, debug URL and body sinks; checked encoded/duplicate aliases, malformed input and nested JSON; and checked ordinary request/response bytes, request-length limits, I/O errors and filtering. The debug request-truncation defect was addressed and covered by regression tests. Separate workers were not used, so this is not an independent multi-agent review. All reported patch lint failures were corrected and revalidated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive credentials are now redacted from diagnostic logs, including request URLs, query strings, request bodies, response bodies, and panic-recovery messages.
  * Malformed, oversized, or unsafe diagnostic content is omitted rather than logged.
  * Truncated request-body captures are clearly marked.
  * Traffic remains unaffected while debug logging captures sanitized information.

* **Tests**
  * Added coverage for credential redaction, safe handling of malformed content, truncation notices, body-read errors, and filtered requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

