### PR TITLE
refactor(apiv2): move shared request validation

### DIFF
--- a/internal/apiv2/profiles.go
+++ b/internal/apiv2/profiles.go
@@ -1,13 +1,10 @@
 package apiv2
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
 	"strconv"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -101,26 +98,6 @@ const memberAvatar = "avatar"
 var profileUpdateNullable = map[string]bool{
 	memberAvatar: true, "pin": true, "max_content_rating": true, "language": true,
 	"preferred_metadata_language": true, "subtitle_language": true, fieldMaxPlaybackQuality: true,
-}
-
-// rejectNonNullableNulls is the contract's omitted-versus-null rule for the
-// members that do not admit clearing.
-func rejectNonNullableNulls(raw []byte, nullable map[string]bool) *Problem {
-	// The framework already judged the syntax and shape; a document that
-	// does not decode here has no members to judge.
-	var members map[string]json.RawMessage
-	_ = json.Unmarshal(raw, &members)
-	var errs []ProblemError
-	for name, v := range members {
-		if bytes.Equal(bytes.TrimSpace(v), jsonNull) && !nullable[name] {
-			errs = append(errs, ProblemError{Location: locationBody + "." + name, Code: codeInvalidType, Detail: "null is not a value for this member; omit it to leave it unchanged"})
-		}
-	}
-	if len(errs) == 0 {
-		return nil
-	}
-	sort.Slice(errs, func(i, j int) bool { return errs[i].Location < errs[j].Location })
-	return NewProblem(TypeValidationFailed, "The request did not pass validation; see errors.").WithErrors(errs...)
 }
 
 // ProfileOutput is a single-profile response.

--- a/internal/apiv2/validation.go
+++ b/internal/apiv2/validation.go
@@ -1,0 +1,29 @@
+package apiv2
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/json"
+	"slices"
+)
+
+// rejectNonNullableNulls enforces the shared omitted-versus-null rule for
+// request members. Huma validates syntax and shape; this pass preserves the
+// API contract's distinction between an omitted member and an explicit null.
+func rejectNonNullableNulls(raw []byte, nullable map[string]bool) *Problem {
+	// The framework already judged the syntax and shape; a document that does
+	// not decode here has no members to judge.
+	var members map[string]json.RawMessage
+	_ = json.Unmarshal(raw, &members)
+	var errs []ProblemError
+	for name, value := range members {
+		if bytes.Equal(bytes.TrimSpace(value), jsonNull) && !nullable[name] {
+			errs = append(errs, ProblemError{Location: locationBody + "." + name, Code: codeInvalidType, Detail: "null is not a value for this member; omit it to leave it unchanged"})
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	slices.SortFunc(errs, func(a, b ProblemError) int { return cmp.Compare(a.Location, b.Location) })
+	return NewProblem(TypeValidationFailed, "The request did not pass validation; see errors.").WithErrors(errs...)
+}


### PR DESCRIPTION
## Problem

The shared `rejectNonNullableNulls` request validator was defined in `internal/apiv2/profiles.go` even though auth, account, settings, admin, and other API-v2 domains call it. That placement obscured ownership and made unrelated handlers depend on a profile file.

## Change

- Move the helper to `internal/apiv2/validation.go`, the package owner for shared request validation.
- Keep its signature, explicit-null versus omission rules, deterministic problem ordering, and all response contracts unchanged.
- Use the Go 1.26 `slices.SortFunc` and `cmp.Compare` form for the existing ordering.

No other high-confidence cleanup was found without changing Area 1 behavior or broadening the scope.

## Preserved invariants

- Account and household-profile semantics remain separate; admin role and primary-profile status remain distinct.
- Authentication, authorization, status codes, machine-readable problem types, headers, response shapes, and v1 bridge behavior are unchanged.
- Setup transaction and locking boundaries, retry/replay behavior, encrypted settings key binding, and nil-versus-empty collection semantics are untouched.
- API-key secrets remain one-time and owner-filtered revocation remains enforced.

## Area 1 endpoint and workflow audit

Inventory was built from mounted Huma registrations, `contracts/api/v2/openapi.json`, route fixtures, and router tests. It covers 92 operations:

| Area | Operations | Router contract | Durable state |
| --- | ---: | --- | --- |
| Account and password | 3 | tested | partial: service seams |
| Auth, sessions, setup, signup, OAuth, device login | 25 | tested | partial: service seams |
| Accounts and admin account projections | 17 | tested | partial: service seams |
| Profiles, PINs, avatars, household sessions | 10 | tested | partial: service seams; object storage not exercised |
| Personal and admin API keys | 9 | tested | partial: service seams; PostgreSQL metadata test present |
| User, profile, device, plugin, and effective settings | 28 | tested | partial: service seams |

The router tests cover initial setup and repeated setup, login/logout/refresh/session revocation, account/profile separation and wrong-account/profile authorization, profile lifecycle and primary-profile checks, PIN and avatar paths, settings scopes and merges, API-key creation/listing/secret redaction/revocation, capability states, malformed and missing resources, invalid transitions, pagination/cursors, headers, body schemas, and nil-versus-empty collections.

The isolated PostgreSQL competing-setup test exists and exercises both v1 and v2 through real routers, but it is skipped when `SILO_INITIAL_SETUP_ATOMIC_DSN` is unset. Therefore cross-replica durable setup locking and real object-storage avatar effects remain partial in this run.

## Validation

- `go test ./internal/apiv2`
- `go test -race ./internal/apiv2 -run 'Test(Setup|Auth|Login|Logout|Sessions|Profile|PersonalAPIKeys|.*Settings|Onboarding|AdminAccount|AdminAPIKey)'`
- `go test -v ./internal/auth -run TestInitialSetupCompetingCallersDB -count=1` (skipped: required isolated DSN unset)
- `make verify-apiv2-openapi`
- `make verify-route-inventory`
- `make verify-apiv2-fixtures`
- `make verify-apiv2-web-types`
- `make verify-apiv2-contract`
- `go build ./cmd/silo/`
- `cd web && pnpm exec tsc --noEmit`
- `make test-web` (4,217 tests passed)
- `make dev-deploy` invoked; source sync and remote image build started, but final deployment completion was not captured, so no deployed acceptance claim is made.
- `cd web && pnpm run lint` remains blocked by two pre-existing errors in generated API files and existing warnings.

Related issue: N/A — narrow fix

## AI use disclosure

- Model: `gpt-6-astra` (xhigh reasoning)
- Harness and tools: Codex agent harness with shell, Git, Go, Node, and GitHub CLI tooling
- Involvement: inspected the branch, route inventory, OpenAPI, fixtures, handlers, tests, and repository guidance; performed the cleanup; ran focused, race, contract, generation, build, and web validation; prepared this audit matrix.
- Independent/adversarial review: self review using contract, defect, and context passes over the complete diff; no additional findings.
