### PR TITLE
fix(web): keep TV detail controls and navigation visible

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -2665,3 +2665,498 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     box-shadow: 0 12px 40px rgb(0 0 0 / 0.4);
   }
 }
+
+@layer utilities {
+  /* Episode navigation owns its viewport space; variable-length copy scrolls
+     independently instead of growing the hero and displacing the episode rail.
+     Layout measures the shell header, including text-size customization. */
+  .episode-detail-viewport {
+    height: calc(
+      100dvh - var(--detail-header-height, calc(4.75rem + 2px)) -
+        max(var(--watch-bar-height, 0px), var(--audiobook-bar-height, 0px))
+    );
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) min(var(--detail-navigation-height, 18rem), 40%);
+    container-type: size;
+    container-name: detail-viewport;
+  }
+
+  .episode-detail-navigation {
+    min-height: 0;
+    overflow-y: auto;
+    min-width: 0;
+    padding-block: 12px;
+  }
+
+  .episode-detail-navigation h2 {
+    margin-bottom: 4px;
+  }
+
+  .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout {
+    height: 100%;
+    min-height: 0;
+    padding-top: 64px;
+    padding-bottom: 16px;
+  }
+
+  .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout > .grid,
+  .item-detail-hero[data-viewport-bounded="true"] .detail-hero-primary-content {
+    height: 100%;
+    min-height: 0;
+  }
+
+  .item-detail-hero[data-viewport-bounded="true"] .detail-hero-copy {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    width: 100%;
+  }
+
+  .item-detail-hero[data-viewport-bounded="true"] .detail-hero-copy {
+    padding: 4px;
+  }
+
+  /* Copy flows naturally above the controls. Only overflowing information
+     scrolls, so Play remains visible even with a logo or a long overview. */
+  .detail-hero-information {
+    flex: 0 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+    margin-top: auto;
+    overflow-wrap: anywhere;
+  }
+
+  .detail-hero-information h1:not(.sr-only) {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: var(--detail-title-lines, 2);
+    line-height: 1.15;
+    overflow: hidden;
+  }
+
+  .item-detail-hero[data-viewport-bounded="true"] .detail-hero-copy > .detail-action-bar {
+    flex-shrink: 0;
+    margin-bottom: 4px;
+    max-height: 65%;
+    overflow-y: auto;
+  }
+
+  @media (min-width: 1024px) {
+    .episode-detail-viewport {
+      height: calc(
+        100dvh - var(--detail-header-height, 0px) -
+          max(var(--watch-bar-height, 0px), var(--audiobook-bar-height, 0px))
+      );
+    }
+  }
+
+  /* Keep the rail usable on short screens without reducing touch targets. */
+  @media (max-height: 650px) {
+    .episode-detail-viewport {
+      --detail-navigation-height: 16rem;
+    }
+
+    .episode-detail-navigation .media-card-longpress {
+      width: 180px;
+    }
+
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout {
+      padding-top: 52px;
+      padding-bottom: 8px;
+    }
+  }
+}
+
+@layer utilities {
+  @media (max-height: 650px) and (orientation: landscape) {
+    .episode-detail-viewport {
+      grid-template-columns: minmax(0, 1fr) minmax(160px, 35%);
+      grid-template-rows: minmax(0, 1fr);
+    }
+
+    .episode-detail-navigation {
+      align-self: end;
+      width: 100%;
+      padding-inline: 12px;
+    }
+  }
+}
+
+@layer utilities {
+  .series-detail-viewport {
+    --detail-navigation-height: 22rem;
+  }
+
+  .series-detail-navigation {
+    height: 100%;
+    min-height: 0;
+    overflow-y: auto;
+    min-width: 0;
+    padding-block: 12px;
+  }
+
+  .series-detail-navigation > section {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .series-detail-navigation > section > .overlay-scroll {
+    flex: 1;
+    min-height: 0;
+    align-content: start;
+  }
+
+  .series-detail-navigation .group\/season {
+    width: 140px;
+  }
+
+  .item-detail-hero:is([data-variant="series"], [data-variant="season"])
+    .detail-hero-primary-content {
+    flex-direction: row;
+    align-items: end;
+    gap: 16px;
+  }
+
+  .item-detail-hero:is([data-variant="series"], [data-variant="season"])
+    .detail-hero-primary-content
+    > .media-card-image {
+    flex-shrink: 0;
+    width: auto;
+    height: min(330px, 100%);
+    aspect-ratio: 2 / 3;
+  }
+
+  .item-detail-hero:is([data-variant="series"], [data-variant="season"])
+    .detail-hero-primary-content
+    > .media-card-image
+    img {
+    height: 100%;
+  }
+
+  .item-detail-hero:is([data-variant="series"], [data-variant="season"]) .detail-hero-copy {
+    min-width: 0;
+  }
+
+  @media (max-width: 1023px) {
+    .item-detail-hero:is([data-variant="series"], [data-variant="season"])
+      .detail-hero-primary-content
+      > .media-card-image {
+      height: min(150px, 50%);
+    }
+  }
+
+  @media (max-height: 650px) {
+    .series-detail-viewport {
+      --detail-navigation-height: 16rem;
+    }
+
+    .series-detail-navigation .group\/season {
+      width: 80px;
+    }
+  }
+
+  @media (max-height: 650px) and (orientation: landscape) {
+    .series-detail-navigation {
+      align-self: end;
+      width: 100%;
+      padding-inline: 12px;
+    }
+  }
+}
+
+@layer utilities {
+  @media (max-height: 650px) and (orientation: landscape) {
+    .series-detail-navigation .overlay-scroll {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+}
+
+@layer utilities {
+  @media (max-height: 650px) and (orientation: landscape) {
+    .episode-detail-navigation {
+      min-height: 0;
+      max-height: 100%;
+    }
+
+    .series-detail-navigation {
+      height: min(16rem, 100%);
+    }
+
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout {
+      padding-inline: 16px;
+    }
+  }
+
+  @media (max-height: 450px) and (orientation: landscape) {
+    .episode-detail-navigation .media-card-longpress {
+      width: 140px;
+    }
+  }
+}
+
+@layer utilities {
+  /* Use the remaining space after shell/player chrome, not device height. */
+  @container detail-viewport (max-height: 600px) {
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout {
+      padding-top: 52px;
+      padding-bottom: 8px;
+    }
+
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-copy > .detail-action-bar {
+      max-height: 45%;
+      margin-top: 12px;
+    }
+  }
+}
+
+@layer utilities {
+  .detail-short-label,
+  .detail-mobile-menu-actions,
+  .detail-mobile-synopsis {
+    display: none;
+  }
+
+  @media (max-width: 1023px) {
+    .episode-detail-viewport {
+      height: auto;
+      min-height: calc(
+        100dvh - var(--detail-header-height, 78px) -
+          max(var(--watch-bar-height, 0px), var(--audiobook-bar-height, 0px))
+      );
+      display: flex;
+      flex-direction: column;
+      container-type: normal;
+    }
+    .episode-detail-viewport .item-detail-hero {
+      flex: 1 0 auto;
+      overflow: visible;
+    }
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout {
+      height: auto;
+      min-height: 0;
+      padding: 52px 16px 16px;
+    }
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout > .grid,
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-primary-content,
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-copy {
+      height: auto;
+    }
+    .item-detail-hero[data-viewport-bounded="true"]
+      .detail-hero-primary-content
+      > .media-card-image {
+      display: none;
+    }
+    .detail-hero-information {
+      overflow: visible;
+      margin-top: 0;
+      flex: none;
+    }
+    .detail-hero-information .detail-hero-context {
+      margin-bottom: 8px;
+      font-size: 0.75rem;
+    }
+    .detail-hero-information .detail-hero-studio,
+    .detail-hero-information .detail-hero-description {
+      display: none;
+    }
+    .detail-hero-information h1:not(.sr-only) {
+      font-size: clamp(1.25rem, 6vw, 1.875rem);
+      margin-bottom: 12px;
+    }
+    .detail-hero-information > img {
+      height: 72px;
+      max-width: 320px;
+      margin-bottom: 12px;
+    }
+    .detail-hero-facts {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px 12px;
+    }
+    .detail-hero-facts > div {
+      margin: 0;
+    }
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-copy > .detail-action-bar {
+      overflow: visible;
+      max-height: none;
+      margin-top: 16px;
+      margin-bottom: 0;
+    }
+    [data-compact-mobile] .detail-full-label,
+    [data-compact-mobile] .detail-secondary-action {
+      display: none;
+    }
+    [data-compact-mobile] .detail-short-label {
+      display: inline;
+    }
+    [data-compact-mobile] .detail-primary-actions {
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    [data-compact-mobile] .detail-primary-actions > button {
+      min-width: 44px;
+      height: 44px;
+      padding-inline: 14px;
+      font-size: 0.875rem;
+      gap: 8px;
+    }
+    [data-compact-mobile] .detail-primary-actions > button[aria-haspopup="menu"] {
+      width: 44px;
+      padding-inline: 0;
+    }
+    [data-compact-mobile] button[aria-pressed="true"] {
+      border-color: var(--primary);
+    }
+    [data-compact-mobile] .detail-stream-actions {
+      gap: 8px;
+    }
+    [data-compact-mobile] .detail-stream-actions button {
+      min-height: 44px;
+    }
+    [data-compact-mobile] .detail-stream-actions button > span {
+      max-width: 5rem;
+    }
+    .detail-mobile-menu-actions,
+    .detail-mobile-synopsis {
+      display: block;
+    }
+    .episode-detail-navigation,
+    .series-detail-navigation {
+      flex: none;
+      height: auto;
+      min-height: 0;
+      max-height: none;
+      padding: 12px 16px 16px;
+      overflow: visible;
+    }
+    .series-detail-navigation > section {
+      height: auto;
+    }
+    .series-detail-navigation > section > div:first-child {
+      margin-bottom: 12px;
+    }
+    .series-detail-navigation .overlay-scroll {
+      display: grid;
+      grid-template-columns: none;
+      grid-auto-flow: column;
+      grid-auto-columns: 160px;
+      gap: 12px;
+      overflow-x: auto;
+      overflow-y: hidden;
+      max-height: none !important;
+      padding-bottom: 8px;
+      align-content: start;
+    }
+    .series-detail-navigation .media-card-longpress > a > .mt-1\.5 {
+      display: none;
+    }
+    .series-detail-navigation .group\/season {
+      width: 100px;
+    }
+    .episode-detail-navigation .media-card-longpress {
+      width: 180px;
+    }
+  }
+}
+
+@layer utilities {
+  @media (max-width: 1023px) {
+    [data-compact-mobile] .detail-stream-actions button > span {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .episode-detail-navigation .media-card-longpress {
+      width: 160px;
+    }
+    .episode-detail-navigation .embla__viewport {
+      padding-top: 4px;
+      padding-bottom: 4px;
+    }
+  }
+}
+
+@layer utilities {
+  @media (max-width: 1023px) {
+    .detail-hero-facts {
+      gap: 8px;
+    }
+    .detail-hero-facts .metadata-badge {
+      padding-inline: 6px;
+      font-size: 0.75rem;
+    }
+    .detail-hero-facts > div > .flex {
+      gap: 6px;
+    }
+    .series-detail-navigation .group\/season {
+      width: 80px;
+    }
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout {
+      padding-bottom: 8px;
+    }
+  }
+}
+
+@layer utilities {
+  @media (max-width: 1023px) {
+    .detail-hero-context nav > div > span {
+      min-width: 0;
+      flex-shrink: 0;
+    }
+    .detail-hero-context nav > div > span:first-child {
+      flex-shrink: 1;
+    }
+    .detail-hero-context nav a {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .detail-hero-context nav [aria-current] {
+      white-space: nowrap;
+    }
+    .detail-hero-context nav svg {
+      flex-shrink: 0;
+    }
+  }
+}
+
+@layer utilities {
+  @media (max-width: 1023px) {
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout > .grid {
+      grid-template-columns: minmax(0, 1fr);
+      min-width: 0;
+    }
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-primary-content {
+      min-width: 0;
+      width: 100%;
+    }
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-copy {
+      min-width: 0;
+      max-width: 100%;
+    }
+  }
+  @media (min-width: 1024px) and (max-height: 800px) {
+    .episode-detail-viewport {
+      grid-template-rows: minmax(0, 1fr) min(var(--detail-navigation-height, 18rem), 45%);
+    }
+    .item-detail-hero[data-viewport-bounded="true"] .detail-hero-layout {
+      padding-top: 52px;
+      padding-bottom: 8px;
+    }
+    .detail-hero-information h1:not(.sr-only) {
+      font-size: 3rem;
+    }
+  }
+}

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -2671,9 +2671,9 @@ html[data-navigation-direction]::view-transition-new(main-content) {
      independently instead of growing the hero and displacing the episode rail.
      Layout measures the shell header, including text-size customization. */
   .episode-detail-viewport {
+    --detail-player-height: max(var(--watch-bar-height, 0px), var(--audiobook-bar-height, 0px));
     height: calc(
-      100dvh - var(--detail-header-height, calc(4.75rem + 2px)) -
-        max(var(--watch-bar-height, 0px), var(--audiobook-bar-height, 0px))
+      100dvh - var(--detail-header-height, calc(4.75rem + 2px)) - var(--detail-player-height)
     );
     display: grid;
     grid-template-rows: minmax(0, 1fr) min(var(--detail-navigation-height, 18rem), 40%);
@@ -2745,10 +2745,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
 
   @media (min-width: 1024px) {
     .episode-detail-viewport {
-      height: calc(
-        100dvh - var(--detail-header-height, 0px) -
-          max(var(--watch-bar-height, 0px), var(--audiobook-bar-height, 0px))
-      );
+      height: calc(100dvh - var(--detail-header-height, 0px) - var(--detail-player-height));
     }
   }
 
@@ -2924,10 +2921,7 @@ html[data-navigation-direction]::view-transition-new(main-content) {
   @media (max-width: 1023px) {
     .episode-detail-viewport {
       height: auto;
-      min-height: calc(
-        100dvh - var(--detail-header-height, 78px) -
-          max(var(--watch-bar-height, 0px), var(--audiobook-bar-height, 0px))
-      );
+      min-height: calc(100dvh - var(--detail-header-height, 78px) - var(--detail-player-height));
       display: flex;
       flex-direction: column;
       container-type: normal;
@@ -3019,9 +3013,6 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     [data-compact-mobile] .detail-stream-actions button {
       min-height: 44px;
     }
-    [data-compact-mobile] .detail-stream-actions button > span {
-      max-width: 5rem;
-    }
     .detail-mobile-menu-actions,
     .detail-mobile-synopsis {
       display: block;
@@ -3055,12 +3046,6 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     }
     .series-detail-navigation .media-card-longpress > a > .mt-1\.5 {
       display: none;
-    }
-    .series-detail-navigation .group\/season {
-      width: 100px;
-    }
-    .episode-detail-navigation .media-card-longpress {
-      width: 180px;
     }
   }
 }
@@ -3158,5 +3143,11 @@ html[data-navigation-direction]::view-transition-new(main-content) {
     .detail-hero-information h1:not(.sr-only) {
       font-size: 3rem;
     }
+  }
+}
+
+@layer utilities {
+  .episode-detail-viewport:not(:has(> .episode-detail-navigation, > .series-detail-navigation)) {
+    grid-template-rows: minmax(0, 1fr);
   }
 }

--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -136,7 +136,21 @@ function setRoute(pathname: string, key: string, search = "") {
   mocks.location = { pathname, search, key };
 }
 
+let onHeaderResize: ResizeObserverCallback;
+const disconnectHeaderObserver = vi.fn();
+
 beforeEach(() => {
+  disconnectHeaderObserver.mockReset();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: ResizeObserverCallback) {
+        onHeaderResize = callback;
+      }
+      observe = vi.fn();
+      disconnect = disconnectHeaderObserver;
+    },
+  );
   vi.useFakeTimers();
   mocks.location = { pathname: "/", search: "", key: "home" };
   mocks.navigate.mockReset();
@@ -171,6 +185,23 @@ afterEach(() => {
 });
 
 describe("Layout mobile profile", () => {
+  it("updates the viewport offset when the mobile header resizes or disappears", () => {
+    const view = renderLayout();
+    const header = view.container.querySelector<HTMLElement>(".mobile-header")!;
+    const shell = header.parentElement!;
+    header.style.marginTop = "15px";
+    const bounds = vi.spyOn(header, "getBoundingClientRect");
+    bounds.mockReturnValue({ height: 82 } as DOMRect);
+    act(() => onHeaderResize([], {} as ResizeObserver));
+    expect(shell.style.getPropertyValue("--detail-header-height")).toBe("97px");
+
+    bounds.mockReturnValue({ height: 0 } as DOMRect);
+    act(() => onHeaderResize([], {} as ResizeObserver));
+    expect(shell.style.getPropertyValue("--detail-header-height")).toBe("0px");
+    view.unmount();
+    expect(disconnectHeaderObserver).toHaveBeenCalledOnce();
+  });
+
   it("renders the current profile avatar in the settings link", () => {
     renderLayout();
 

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { startTransition, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { Menu, Search } from "lucide-react";
@@ -38,6 +38,26 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
+  const shellRef = useRef<HTMLDivElement>(null);
+  const mobileHeaderRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const shell = shellRef.current;
+    const header = mobileHeaderRef.current;
+    if (!shell || !header) return;
+    const measureHeader = () => {
+      const height = header.getBoundingClientRect().height;
+      const margin = height ? parseFloat(getComputedStyle(header).marginTop) || 0 : 0;
+      shell.style.setProperty("--detail-header-height", `${height + margin}px`);
+    };
+    const observer = new ResizeObserver(measureHeader);
+    observer.observe(header);
+    window.addEventListener("resize", measureHeader);
+    measureHeader();
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measureHeader);
+    };
+  }, []);
   const location = useLocation();
   const navigate = useViewTransitionNavigate();
   const queryClient = useQueryClient();
@@ -305,7 +325,7 @@ export default function Layout({ children }: LayoutProps) {
       itemDetailsReady={itemDetailsReady}
       enteredItemFromHome={enteredItemFromHome}
     >
-      <div className="bg-background relative min-h-[100dvh] overflow-x-clip">
+      <div ref={shellRef} className="bg-background relative min-h-[100dvh] overflow-x-clip">
         <a
           href="#main-content"
           className="focus:bg-background focus:text-foreground focus:ring-ring sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:ring-2 focus:outline-none"
@@ -324,6 +344,7 @@ export default function Layout({ children }: LayoutProps) {
         {/* Mobile header — visible below lg. Slides up on scroll-down within
           the Calendar route to free vertical space; pulling up reveals it. */}
         <div
+          ref={mobileHeaderRef}
           className={`mobile-header glass-dark border-border/70 sticky top-0 z-30 mx-3 mt-3 flex items-center justify-between rounded-2xl border px-4 py-3 transition-transform duration-200 ease-out lg:hidden ${
             mobileHeaderHidden ? "-translate-y-[140%]" : "translate-y-0"
           }`}

--- a/web/src/hooks/usePlaybackBarHeight.test.tsx
+++ b/web/src/hooks/usePlaybackBarHeight.test.tsx
@@ -1,0 +1,41 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { usePlaybackBarHeight } from "./usePlaybackBarHeight";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it("tracks bar resizing and releases the reservation when hidden", () => {
+  let resize = () => {};
+  const disconnect = vi.fn();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: () => void) {
+        resize = callback;
+      }
+      observe() {}
+      disconnect = disconnect;
+    },
+  );
+  let height = 100;
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    () => ({ height }) as DOMRect,
+  );
+  function Bar({ visible }: { visible: boolean }) {
+    const ref = usePlaybackBarHeight("watch");
+    return visible ? <div ref={ref} style={{ bottom: 12 }} /> : null;
+  }
+  const view = render(<Bar visible />);
+  const reserved = () => document.documentElement.style.getPropertyValue("--watch-bar-height");
+  expect(reserved()).toBe("112px");
+  height = 160;
+  act(() => resize());
+  expect(reserved()).toBe("172px");
+  view.rerender(<Bar visible={false} />);
+  expect(reserved()).toBe("");
+  expect(disconnect).toHaveBeenCalledOnce();
+});

--- a/web/src/hooks/usePlaybackBarHeight.ts
+++ b/web/src/hooks/usePlaybackBarHeight.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+
+/** Reserve the visible fixed player's footprint, including its bottom inset. */
+export function usePlaybackBarHeight(kind: "watch" | "audiobook") {
+  return useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element) return;
+      const property = `--${kind}-bar-height`;
+      const root = document.documentElement;
+      const measure = () => {
+        const { height } = element.getBoundingClientRect();
+        const bottom = parseFloat(getComputedStyle(element).bottom) || 0;
+        root.style.setProperty(property, `${height + bottom}px`);
+      };
+      const observer = new ResizeObserver(measure);
+      observer.observe(element);
+      window.addEventListener("resize", measure);
+      measure();
+      return () => {
+        observer.disconnect();
+        window.removeEventListener("resize", measure);
+        root.style.removeProperty(property);
+      };
+    },
+    [kind],
+  );
+}

--- a/web/src/pages/ItemDetail/DetailHero.tsx
+++ b/web/src/pages/ItemDetail/DetailHero.tsx
@@ -3,6 +3,8 @@ import { Languages } from "lucide-react";
 import { decodeThumbhash } from "@/lib/thumbhash";
 import { useImageLoaded } from "@/hooks/useImageLoaded";
 
+import DetailTitle from "./DetailTitle";
+
 interface DetailHeroProps {
   title: string;
   subtitle?: ReactNode;
@@ -33,7 +35,7 @@ interface DetailHeroProps {
   tagline?: string;
   scoreRow?: ReactNode;
   crewLine?: ReactNode;
-  variant?: "full" | "compact";
+  variant?: "full" | "compact" | "episode" | "series" | "season";
   topNav?: ReactNode;
 }
 
@@ -68,6 +70,7 @@ export default function DetailHero({
   const backdropPlaceholder = backdropThumbhash ? decodeThumbhash(backdropThumbhash) : "";
   const posterPlaceholder = posterThumbhash ? decodeThumbhash(posterThumbhash) : "";
   const isCompact = variant === "compact";
+  const isViewportBounded = variant === "episode" || variant === "series" || variant === "season";
 
   const posterSizeClass = (() => {
     switch (posterOrientation) {
@@ -97,7 +100,11 @@ export default function DetailHero({
   })();
 
   return (
-    <section className="item-detail-hero border-border/10 relative isolate overflow-hidden border-b">
+    <section
+      className="item-detail-hero border-border/10 relative isolate overflow-hidden border-b"
+      data-variant={variant}
+      data-viewport-bounded={isViewportBounded || undefined}
+    >
       {topNav}
       {(backdropUrl || backdropPlaceholder) && (
         <div
@@ -134,7 +141,7 @@ export default function DetailHero({
       <div className="detail-hero-scrim detail-hero-scrim-over" />
 
       <div
-        className={`page-shell-wide relative flex flex-col justify-end pb-8 ${
+        className={`detail-hero-layout page-shell-wide relative flex flex-col justify-end pb-8 ${
           isCompact
             ? // min-height (not fixed height) below lg: bottom-justified content
               // taller than the hero would otherwise overflow out the top, under
@@ -192,108 +199,119 @@ export default function DetailHero({
 
             {/* Info column */}
             <div
+              key={isViewportBounded ? title : undefined}
               className="detail-hero-copy max-w-3xl"
               style={{ textShadow: "var(--hero-text-shadow, 0 1px 3px rgb(0 0 0 / 40%))" }}
             >
-              {context && (
-                <div className="text-muted-foreground mb-4 text-sm font-medium">{context}</div>
-              )}
+              <div
+                className={isViewportBounded ? "detail-hero-information" : "contents"}
+                tabIndex={isViewportBounded ? 0 : undefined}
+                role={isViewportBounded ? "region" : undefined}
+                aria-label={isViewportBounded ? "Media details" : undefined}
+              >
+                {context && (
+                  <div className="detail-hero-context text-muted-foreground mb-4 text-sm font-medium">
+                    {context}
+                  </div>
+                )}
 
-              {studioLabel && (
-                <div className="text-muted-foreground mb-2 text-xs font-semibold tracking-[0.16em] uppercase">
-                  {studioLabel}
-                </div>
-              )}
+                {studioLabel && (
+                  <div className="detail-hero-studio text-muted-foreground mb-2 text-xs font-semibold tracking-[0.16em] uppercase">
+                    {studioLabel}
+                  </div>
+                )}
 
-              {logoUrl ? (
-                <>
-                  <h1 className="sr-only">{title}</h1>
-                  <img
-                    src={logoUrl}
-                    alt=""
-                    decoding="async"
-                    className="mb-4 h-20 w-full max-w-[420px] object-contain object-left lg:h-28 lg:max-w-[480px]"
+                {logoUrl ? (
+                  <>
+                    <h1 className="sr-only">{title}</h1>
+                    <img
+                      src={logoUrl}
+                      alt=""
+                      decoding="async"
+                      className="mb-4 h-20 w-full max-w-[420px] object-contain object-left lg:h-28 lg:max-w-[480px]"
+                    />
+                  </>
+                ) : (
+                  <DetailTitle
+                    title={title}
+                    bounded={isViewportBounded}
+                    className={`text-foreground mb-3 font-extrabold tracking-tight ${
+                      isCompact
+                        ? "font-display text-3xl leading-[1.1] sm:text-4xl"
+                        : "font-display text-4xl leading-[0.98] tracking-[-0.05em] sm:text-5xl lg:text-7xl"
+                    }`}
                   />
-                </>
-              ) : (
-                <h1
-                  className={`text-foreground mb-3 font-extrabold tracking-tight ${
-                    isCompact
-                      ? "font-display text-3xl leading-[1.1] sm:text-4xl"
-                      : "font-display text-4xl leading-[0.98] tracking-[-0.05em] sm:text-5xl lg:text-7xl"
-                  }`}
-                >
-                  {title}
-                </h1>
-              )}
+                )}
 
-              {/* Tagline (italic) — falls back to subtitle */}
-              {(tagline || subtitle) && (
-                <div
-                  className={`text-muted-foreground mb-4 text-[13px] ${
-                    tagline
-                      ? "text-foreground/72 italic"
-                      : "text-muted-foreground text-base font-medium not-italic"
-                  }`}
-                >
-                  {tagline || subtitle}
-                </div>
-              )}
-
-              {metadata && <div className="mb-4">{metadata}</div>}
-
-              {scoreRow && <div className="mb-4">{scoreRow}</div>}
-
-              {overview && (
-                <div className="max-w-2xl">
-                  <p
-                    className={`text-muted-foreground leading-7 ${
-                      isCompact ? "text-sm" : "text-foreground/72 text-sm sm:text-[15px]"
-                    } ${overviewTranslating ? "animate-pulse opacity-50" : ""}`}
+                {/* Tagline (italic) — falls back to subtitle */}
+                {(tagline || subtitle) && (
+                  <div
+                    className={`text-muted-foreground mb-4 text-[13px] ${
+                      tagline
+                        ? "text-foreground/72 italic"
+                        : "text-muted-foreground text-base font-medium not-italic"
+                    }`}
                   >
-                    {overview}
-                  </p>
-                  {overviewTranslating && (
-                    <span className="text-muted-foreground/70 mt-1 inline-flex items-center gap-1.5 text-xs">
-                      <Languages className="h-3 w-3 animate-pulse" />
-                      Translating…
-                    </span>
-                  )}
-                  {!overviewTranslating && onTranslateOverview && (
-                    <button
-                      type="button"
-                      onClick={onTranslateOverview}
-                      className="text-muted-foreground hover:text-foreground border-border/60 mt-1.5 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors"
-                    >
-                      <Languages className="h-3 w-3" />
-                      Translate
-                    </button>
-                  )}
-                </div>
-              )}
+                    {tagline || subtitle}
+                  </div>
+                )}
 
-              {/* Crew line and genre chips render independently: pages that
-                  fold genres into their crew line simply omit the genres prop. */}
-              {crewLine && <div className="mt-3">{crewLine}</div>}
-              {genres && genres.length > 0 && (
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {genres.map((genre) =>
-                    genreHref ? (
-                      <a
-                        key={genre}
-                        href={genreHref(genre)}
-                        className="metadata-badge hover:bg-foreground/10 transition-colors"
-                      >
-                        {genre}
-                      </a>
-                    ) : (
-                      <span key={genre} className="metadata-badge">
-                        {genre}
-                      </span>
-                    ),
-                  )}
+                <div className="detail-hero-facts">
+                  {metadata && <div className="mb-4">{metadata}</div>}
+                  {scoreRow && <div className="mb-4">{scoreRow}</div>}
                 </div>
-              )}
+
+                {overview && (
+                  <div className="detail-hero-description max-w-2xl">
+                    <p
+                      className={`text-muted-foreground leading-7 ${
+                        isCompact ? "text-sm" : "text-foreground/72 text-sm sm:text-[15px]"
+                      } ${overviewTranslating ? "animate-pulse opacity-50" : ""}`}
+                    >
+                      {overview}
+                    </p>
+                    {overviewTranslating && (
+                      <span className="text-muted-foreground/70 mt-1 inline-flex items-center gap-1.5 text-xs">
+                        <Languages className="h-3 w-3 animate-pulse" />
+                        Translating…
+                      </span>
+                    )}
+                    {!overviewTranslating && onTranslateOverview && (
+                      <button
+                        type="button"
+                        onClick={onTranslateOverview}
+                        className="text-muted-foreground hover:text-foreground border-border/60 mt-1.5 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors"
+                      >
+                        <Languages className="h-3 w-3" />
+                        Translate
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Crew line and genre chips render independently: pages that
+                  fold genres into their crew line simply omit the genres prop. */}
+                {crewLine && <div className="detail-hero-description mt-3">{crewLine}</div>}
+                {genres && genres.length > 0 && (
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {genres.map((genre) =>
+                      genreHref ? (
+                        <a
+                          key={genre}
+                          href={genreHref(genre)}
+                          className="metadata-badge hover:bg-foreground/10 transition-colors"
+                        >
+                          {genre}
+                        </a>
+                      ) : (
+                        <span key={genre} className="metadata-badge">
+                          {genre}
+                        </span>
+                      ),
+                    )}
+                  </div>
+                )}
+              </div>
 
               {actions && (
                 <div className="detail-action-bar mt-6" style={{ textShadow: "none" }}>

--- a/web/src/pages/ItemDetail/DetailTitle.test.tsx
+++ b/web/src/pages/ItemDetail/DetailTitle.test.tsx
@@ -1,0 +1,46 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import DetailTitle from "./DetailTitle";
+
+afterEach(() => {
+  cleanup();
+  delete document.documentElement.dataset.textScale;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+it("refits when text scaling changes without a viewport resize", async () => {
+  vi.useFakeTimers();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  );
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) =>
+    setTimeout(() => callback(0), 0),
+  );
+  vi.stubGlobal("cancelAnimationFrame", clearTimeout);
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(350);
+  const computedStyle = window.getComputedStyle;
+  vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+    if (element.tagName !== "H1") return computedStyle(element);
+    return {
+      fontSize: document.documentElement.dataset.textScale === "x-large" ? "25px" : "22.5px",
+      letterSpacing: "0px",
+      fontFamily: "sans-serif",
+      fontWeight: "800",
+      fontStyle: "normal",
+    } as CSSStyleDeclaration;
+  });
+  render(<DetailTitle title="Light" className="" bounded />);
+  expect(screen.getByRole("heading").style.fontSize).toBe("22.5px");
+  await act(async () => {
+    document.documentElement.dataset.textScale = "x-large";
+    await Promise.resolve();
+    vi.runOnlyPendingTimers();
+  });
+  expect(screen.getByRole("heading").style.fontSize).toBe("25px");
+});

--- a/web/src/pages/ItemDetail/DetailTitle.tsx
+++ b/web/src/pages/ItemDetail/DetailTitle.tsx
@@ -1,0 +1,108 @@
+import { useLayoutEffect, useRef } from "react";
+
+/** Keep mobile titles readable; fit desktop titles into a bounded line budget. */
+export default function DetailTitle({
+  title,
+  className,
+  bounded,
+}: {
+  title: string;
+  className: string;
+  bounded: boolean;
+}) {
+  const titleRef = useRef<HTMLHeadingElement>(null);
+
+  useLayoutEffect(() => {
+    const heading = titleRef.current;
+    if (!bounded || !heading) return;
+    const measure = document.createElement("span");
+    measure.setAttribute("aria-hidden", "true");
+    Object.assign(measure.style, {
+      position: "fixed",
+      visibility: "hidden",
+      pointerEvents: "none",
+      display: "block",
+      overflowWrap: "anywhere",
+    });
+    measure.textContent = title;
+    document.body.append(measure);
+    let frame = 0;
+    let disposed = false;
+    let observedWidth = -1;
+
+    const fit = () => {
+      if (disposed) return;
+      heading.style.removeProperty("font-size");
+      heading.style.removeProperty("letter-spacing");
+      const style = getComputedStyle(heading);
+      const baseSize = parseFloat(style.fontSize);
+      const baseSpacing = parseFloat(style.letterSpacing) || 0;
+      const width = heading.clientWidth;
+      if (!width || !Number.isFinite(baseSize)) return;
+      Object.assign(measure.style, {
+        width: `${width}px`,
+        fontFamily: style.fontFamily,
+        fontWeight: style.fontWeight,
+        fontStyle: style.fontStyle,
+      });
+
+      // Descenders need a real line box, not the old 0.98 display leading.
+      // The smallest step adds a third line without increasing the budget.
+      const steps: ReadonlyArray<readonly [number, number]> =
+        window.innerWidth < 1024
+          ? [[1, 3]]
+          : [
+              [1, 2],
+              [5 / 6, 2],
+              [2 / 3, 3],
+            ];
+      for (const [scale, lines] of steps) {
+        const size = baseSize * scale;
+        measure.style.fontSize = `${size}px`;
+        measure.style.letterSpacing = `${baseSpacing * scale}px`;
+        measure.style.lineHeight = "1.15";
+        heading.style.fontSize = `${size}px`;
+        heading.style.letterSpacing = `${baseSpacing * scale}px`;
+        heading.style.setProperty("--detail-title-lines", String(lines));
+        if (measure.getBoundingClientRect().height <= size * 1.15 * lines + 1) break;
+      }
+    };
+    const scheduleFit = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(fit);
+    };
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry || entry.contentRect.width === observedWidth) return;
+      observedWidth = entry.contentRect.width;
+      scheduleFit();
+    });
+    observer.observe(heading);
+    // Theme preferences can change the rem-based font without changing width.
+    const typographyObserver = new MutationObserver(scheduleFit);
+    typographyObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-text-scale", "data-text-weight"],
+    });
+    window.addEventListener("resize", scheduleFit);
+    document.fonts?.addEventListener("loadingdone", scheduleFit);
+    void document.fonts?.ready.then(() => {
+      if (!disposed) scheduleFit();
+    });
+    fit();
+    return () => {
+      disposed = true;
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      typographyObserver.disconnect();
+      window.removeEventListener("resize", scheduleFit);
+      document.fonts?.removeEventListener("loadingdone", scheduleFit);
+      measure.remove();
+    };
+  }, [bounded, title, className]);
+
+  return (
+    <h1 ref={titleRef} title={bounded ? title : undefined} className={className}>
+      {title}
+    </h1>
+  );
+}

--- a/web/src/pages/ItemDetail/EpisodeContent.test.tsx
+++ b/web/src/pages/ItemDetail/EpisodeContent.test.tsx
@@ -478,6 +478,7 @@ describe("EpisodeContent", () => {
     );
 
     expect(markup).not.toContain("More Episodes");
+    expect(markup).not.toContain("episode-detail-navigation");
     expect(markup).not.toContain("episode-carousel");
   });
 

--- a/web/src/pages/ItemDetail/EpisodeContent.tsx
+++ b/web/src/pages/ItemDetail/EpisodeContent.tsx
@@ -1,3 +1,4 @@
+import DetailSynopsis from "./components/DetailSynopsis";
 import { useCallback, useMemo, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import type { FileVersion, ItemDetail } from "@/api/types";
@@ -259,167 +260,169 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
     breadcrumbSegments.push({ label: `Episode ${episodeNum}` });
   }
 
-  const contextLabel =
-    seasonNum != null && episodeNum != null ? `S${seasonNum} \u00B7 E${episodeNum}` : undefined;
-
   return (
     <div>
-      <DetailHero
-        title={title}
-        topNav={<PageBack />}
-        context={
-          <div className="space-y-3">
-            <DetailBreadcrumb segments={breadcrumbSegments} />
-            {contextLabel && (
-              <div className="text-muted-foreground text-xs font-medium">{contextLabel}</div>
-            )}
-          </div>
-        }
-        backdropUrl={item.backdrop_url}
-        backdropThumbhash={item.backdrop_thumbhash}
-        hidePoster
-        logoUrl={item.logo_url}
-        metadata={
-          <div className="flex flex-wrap items-center gap-2">
-            <MetadataBadges
-              duration={formatRuntimeMinutes(selectedMediaSummary.durationMinutes) || undefined}
+      <div className="episode-detail-viewport">
+        <DetailHero
+          variant="episode"
+          title={title}
+          topNav={<PageBack />}
+          context={<DetailBreadcrumb segments={breadcrumbSegments} />}
+          backdropUrl={item.backdrop_url}
+          backdropThumbhash={item.backdrop_thumbhash}
+          hidePoster
+          logoUrl={item.logo_url}
+          metadata={
+            <div className="flex flex-wrap items-center gap-2">
+              <MetadataBadges
+                duration={formatRuntimeMinutes(selectedMediaSummary.durationMinutes) || undefined}
+              />
+              {item.air_date && (
+                <span className="metadata-badge">
+                  {(() => {
+                    const d = new Date(item.air_date);
+                    return Number.isNaN(d.getTime())
+                      ? item.air_date
+                      : new Intl.DateTimeFormat(undefined, {
+                          year: "numeric",
+                          month: "short",
+                          day: "numeric",
+                        }).format(d);
+                  })()}
+                </span>
+              )}
+              <QualityBadges summary={selectedMediaSummary} />
+            </div>
+          }
+          scoreRow={
+            <ScoreRow
+              ratingImdb={effectiveRating}
+              ratingRtCritic={item.rating_rt_critic}
+              ratingRtAudience={item.rating_rt_audience}
             />
-            {item.air_date && (
-              <span className="metadata-badge">
-                {(() => {
-                  const d = new Date(item.air_date);
-                  return Number.isNaN(d.getTime())
-                    ? item.air_date
-                    : new Intl.DateTimeFormat(undefined, {
-                        year: "numeric",
-                        month: "short",
-                        day: "numeric",
-                      }).format(d);
-                })()}
-              </span>
-            )}
-            <QualityBadges summary={selectedMediaSummary} />
-          </div>
-        }
-        scoreRow={
-          <ScoreRow
-            ratingImdb={effectiveRating}
-            ratingRtCritic={item.rating_rt_critic}
-            ratingRtAudience={item.rating_rt_audience}
-          />
-        }
-        overview={item.overview}
-        overviewTranslating={overviewTranslating}
-        onTranslateOverview={onTranslateOverview}
-        crewLine={<HeroCrewLine crew={item.crew ?? []} />}
-        actions={
-          <WatchedActionBar
-            item={item}
-            contentId={item.content_id}
-            playHref={
-              item.versions && item.versions.length > 0 ? `/watch/${item.content_id}` : undefined
-            }
-            playLabel={primaryAction.label}
-            playProgress={primaryAction.progress}
-            restartHref={restartHref}
-            resumePositionSeconds={
-              item.user_data && "position_seconds" in item.user_data
-                ? item.user_data.position_seconds
-                : undefined
-            }
-            resumeDurationSeconds={
-              item.user_data && "duration_seconds" in item.user_data
-                ? item.user_data.duration_seconds
-                : undefined
-            }
-            resumeResolution={
-              item.user_data && "last_resolution" in item.user_data
-                ? item.user_data.last_resolution
-                : undefined
-            }
-            resumeHdr={
-              item.user_data && "last_hdr" in item.user_data ? item.user_data.last_hdr : undefined
-            }
-            effectiveVersionResolution={item.effective_version_resolution}
-            effectiveVersionHdr={item.effective_version_hdr}
-            onRefresh={
-              canCurateMetadata
-                ? (mode) =>
-                    refreshMetadataMutation.mutate({
-                      item,
-                      mode,
-                      onReplaced: (contentID) => navigate(`/item/${contentID}`, { replace: true }),
-                    })
-                : undefined
-            }
-            isRefreshing={refreshMetadataMutation.isPending}
-            onRedetectIntro={
-              isAdmin ? () => redetectIntroMutation.mutate(item.content_id) : undefined
-            }
-            isRedetectingIntro={redetectIntroMutation.isPending}
-            isAdmin={isAdmin}
-            canCurateMetadata={canCurateMetadata}
-            canEditMarkers={canEditMarkers}
-            onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
-            onShowMediaInfo={
-              canCurateMetadata && (item.versions?.length ?? 0) > 0
-                ? () => openMediaInfo()
-                : undefined
-            }
-            versions={item.versions ?? []}
-            playbackVariants={item.playback_variants}
-            selectedVersion={selectedVersion}
-            onSelectVersion={handleSelectVersion}
-            onDownload={
-              user?.download_allowed && (item.versions ?? []).length > 0
-                ? () => setDownloadOpen(true)
-                : undefined
-            }
-            onSearchSubtitles={
-              (item.versions?.length ?? 0) > 0 ? () => setSubtitleSearchOpen(true) : undefined
-            }
-            qualityPreference={qualityPreference}
-            audioSelectionMode={audioSelectionMode}
-            explicitAudioTrackIndex={explicitAudioTrackIndex}
-            onSelectAudioTrack={handleSelectAudioTrack}
-            onResetAudioSelection={handleResetAudioSelection}
-            prePlaySubtitleMode={subtitleSelectionMode}
-            explicitSubtitleSelection={explicitSubtitleSelection}
-            onSelectSubtitle={handleSelectSubtitle}
-            onSelectSubtitleOff={handleSelectSubtitleOff}
-            onResetSubtitleSelection={handleResetSubtitleSelection}
-            preferredSubtitleLanguage={item.effective_subtitle_language}
-            preferredSubtitleTrackSignature={preferredSubtitleTrackSignature}
-            subtitleMode={item.effective_subtitle_mode as "off" | "auto" | "always" | undefined}
-            showForcedSubtitles={item.effective_show_forced_subtitles}
-            profileLanguage={currentProfile?.language}
-          />
-        }
-      />
+          }
+          overview={item.overview}
+          overviewTranslating={overviewTranslating}
+          onTranslateOverview={onTranslateOverview}
+          crewLine={<HeroCrewLine crew={item.crew ?? []} />}
+          actions={
+            <WatchedActionBar
+              compactMobile
+              item={item}
+              contentId={item.content_id}
+              playHref={
+                item.versions && item.versions.length > 0 ? `/watch/${item.content_id}` : undefined
+              }
+              playLabel={primaryAction.label}
+              playProgress={primaryAction.progress}
+              restartHref={restartHref}
+              resumePositionSeconds={
+                item.user_data && "position_seconds" in item.user_data
+                  ? item.user_data.position_seconds
+                  : undefined
+              }
+              resumeDurationSeconds={
+                item.user_data && "duration_seconds" in item.user_data
+                  ? item.user_data.duration_seconds
+                  : undefined
+              }
+              resumeResolution={
+                item.user_data && "last_resolution" in item.user_data
+                  ? item.user_data.last_resolution
+                  : undefined
+              }
+              resumeHdr={
+                item.user_data && "last_hdr" in item.user_data ? item.user_data.last_hdr : undefined
+              }
+              effectiveVersionResolution={item.effective_version_resolution}
+              effectiveVersionHdr={item.effective_version_hdr}
+              onRefresh={
+                canCurateMetadata
+                  ? (mode) =>
+                      refreshMetadataMutation.mutate({
+                        item,
+                        mode,
+                        onReplaced: (contentID) =>
+                          navigate(`/item/${contentID}`, { replace: true }),
+                      })
+                  : undefined
+              }
+              isRefreshing={refreshMetadataMutation.isPending}
+              onRedetectIntro={
+                isAdmin ? () => redetectIntroMutation.mutate(item.content_id) : undefined
+              }
+              isRedetectingIntro={redetectIntroMutation.isPending}
+              isAdmin={isAdmin}
+              canCurateMetadata={canCurateMetadata}
+              canEditMarkers={canEditMarkers}
+              onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
+              onShowMediaInfo={
+                canCurateMetadata && (item.versions?.length ?? 0) > 0
+                  ? () => openMediaInfo()
+                  : undefined
+              }
+              versions={item.versions ?? []}
+              playbackVariants={item.playback_variants}
+              selectedVersion={selectedVersion}
+              onSelectVersion={handleSelectVersion}
+              onDownload={
+                user?.download_allowed && (item.versions ?? []).length > 0
+                  ? () => setDownloadOpen(true)
+                  : undefined
+              }
+              onSearchSubtitles={
+                (item.versions?.length ?? 0) > 0 ? () => setSubtitleSearchOpen(true) : undefined
+              }
+              qualityPreference={qualityPreference}
+              audioSelectionMode={audioSelectionMode}
+              explicitAudioTrackIndex={explicitAudioTrackIndex}
+              onSelectAudioTrack={handleSelectAudioTrack}
+              onResetAudioSelection={handleResetAudioSelection}
+              prePlaySubtitleMode={subtitleSelectionMode}
+              explicitSubtitleSelection={explicitSubtitleSelection}
+              onSelectSubtitle={handleSelectSubtitle}
+              onSelectSubtitleOff={handleSelectSubtitleOff}
+              onResetSubtitleSelection={handleResetSubtitleSelection}
+              preferredSubtitleLanguage={item.effective_subtitle_language}
+              preferredSubtitleTrackSignature={preferredSubtitleTrackSignature}
+              subtitleMode={item.effective_subtitle_mode as "off" | "auto" | "always" | undefined}
+              showForcedSubtitles={item.effective_show_forced_subtitles}
+              profileLanguage={currentProfile?.language}
+            />
+          }
+        />
+
+        <section className="page-shell episode-detail-navigation" aria-label="More episodes">
+          {/* More Episodes carousel — most useful, so show first */}
+          {siblingsLoading ? (
+            <EpisodeCarouselSkeleton />
+          ) : (
+            siblingEpisodes.length > 1 && (
+              <div>
+                <h2 className="mb-5 text-xl font-semibold tracking-tight">More Episodes</h2>
+                <EpisodeCarousel
+                  episodes={siblingEpisodes}
+                  currentEpisodeNumber={episodeNum ?? -1}
+                  episodeLinkState={episodeLinkState}
+                />
+              </div>
+            )
+          )}
+        </section>
+      </div>
 
       <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
+        <DetailSynopsis
+          overview={item.overview}
+          translating={overviewTranslating}
+          onTranslate={onTranslateOverview}
+        />
         {canCurateMetadata && (
           <MediaLocations
             title="Media locations"
             versions={item.versions}
             onShowMediaInfo={openMediaInfo}
           />
-        )}
-
-        {/* More Episodes carousel — most useful, so show first */}
-        {siblingsLoading ? (
-          <EpisodeCarouselSkeleton />
-        ) : (
-          siblingEpisodes.length > 1 && (
-            <div>
-              <h2 className="mb-5 text-xl font-semibold tracking-tight">More Episodes</h2>
-              <EpisodeCarousel
-                episodes={siblingEpisodes}
-                currentEpisodeNumber={episodeNum ?? -1}
-                episodeLinkState={episodeLinkState}
-              />
-            </div>
-          )
         )}
 
         {item.cast && item.cast.length > 0 && (

--- a/web/src/pages/ItemDetail/EpisodeContent.tsx
+++ b/web/src/pages/ItemDetail/EpisodeContent.tsx
@@ -392,12 +392,12 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
           }
         />
 
-        <section className="page-shell episode-detail-navigation" aria-label="More episodes">
-          {/* More Episodes carousel — most useful, so show first */}
-          {siblingsLoading ? (
-            <EpisodeCarouselSkeleton />
-          ) : (
-            siblingEpisodes.length > 1 && (
+        {(siblingsLoading || siblingEpisodes.length > 1) && (
+          <section className="page-shell episode-detail-navigation" aria-label="More episodes">
+            {/* More Episodes carousel — most useful, so show first */}
+            {siblingsLoading ? (
+              <EpisodeCarouselSkeleton />
+            ) : (
               <div>
                 <h2 className="mb-5 text-xl font-semibold tracking-tight">More Episodes</h2>
                 <EpisodeCarousel
@@ -406,9 +406,9 @@ export default function EpisodeContent({ item }: { item: ItemDetail & { type: "e
                   episodeLinkState={episodeLinkState}
                 />
               </div>
-            )
-          )}
-        </section>
+            )}
+          </section>
+        )}
       </div>
 
       <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">

--- a/web/src/pages/ItemDetail/SeasonContent.tsx
+++ b/web/src/pages/ItemDetail/SeasonContent.tsx
@@ -1,3 +1,4 @@
+import DetailSynopsis from "./components/DetailSynopsis";
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import type { ItemDetail } from "@/api/types";
@@ -56,13 +57,14 @@ export default function SeasonContent({ item }: { item: ItemDetail & { type: "se
     parentSeasonLabel: label,
   };
 
-  const displayTitle = `${seriesTitle}: ${label}`;
+  const seasonIndicator =
+    item.is_specials || seasonNumber === 0 ? "Specials" : `Season ${seasonNumber}`;
 
   const breadcrumb = (
     <DetailBreadcrumb
       segments={[
         { label: seriesTitle, href: seriesId ? `/item/${seriesId}` : "/" },
-        { label: label },
+        { label: seasonIndicator },
       ]}
     />
   );
@@ -88,63 +90,77 @@ export default function SeasonContent({ item }: { item: ItemDetail & { type: "se
 
   return (
     <div>
-      <DetailHero
-        variant="compact"
-        title={displayTitle}
-        topNav={<PageBack />}
-        context={breadcrumb}
-        backdropUrl={item.backdrop_url}
-        backdropThumbhash={item.backdrop_thumbhash}
-        posterUrl={item.poster_url}
-        posterThumbhash={item.poster_thumbhash}
-        logoUrl={item.logo_url}
-        metadata={
-          <MetadataBadges
-            year={yearStr || undefined}
-            episodeCount={item.episode_count ?? episodes.length}
-          />
-        }
-        overview={item.overview}
-        overviewTranslating={overviewTranslating}
-        onTranslateOverview={onTranslateOverview}
-        actions={
-          <WatchedActionBar
-            item={item}
-            contentId={item.content_id}
-            playHref={firstEpisode ? `/watch/${firstEpisode.content_id}` : undefined}
-            playLabel="Play First Episode"
-            onRefresh={
-              canCurateMetadata
-                ? (mode) =>
-                    refreshMetadataMutation.mutate({
-                      item,
-                      mode,
-                      onReplaced: (contentID) => navigate(`/item/${contentID}`, { replace: true }),
-                    })
-                : undefined
-            }
-            isRefreshing={refreshMetadataMutation.isPending}
-            isAdmin={isAdmin}
-            canCurateMetadata={canCurateMetadata}
-            onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
-          />
-        }
-      />
-
-      <div className="page-shell detail-supporting-content py-8 sm:py-10">
-        <div className="mb-5 flex items-center justify-between gap-3">
-          <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>
-          <span className="text-muted-foreground text-sm">
-            {item.episode_count ?? episodes.length} total
-          </span>
-        </div>
-
-        <SeasonEpisodeGrid
-          episodes={episodes}
-          isLoading={episodesLoading}
-          episodeLinkState={episodeLinkState}
+      <div className="episode-detail-viewport series-detail-viewport">
+        <DetailHero
+          variant="season"
+          title={seriesTitle}
+          subtitle={label !== seasonIndicator ? label : undefined}
+          topNav={<PageBack />}
+          context={breadcrumb}
+          backdropUrl={item.backdrop_url}
+          backdropThumbhash={item.backdrop_thumbhash}
+          posterUrl={item.poster_url}
+          posterThumbhash={item.poster_thumbhash}
+          logoUrl={item.logo_url}
+          metadata={
+            <MetadataBadges
+              year={yearStr || undefined}
+              seasonLabel={seasonIndicator}
+              episodeCount={item.episode_count ?? episodes.length}
+            />
+          }
+          overview={item.overview}
+          overviewTranslating={overviewTranslating}
+          onTranslateOverview={onTranslateOverview}
+          actions={
+            <WatchedActionBar
+              compactMobile
+              item={item}
+              contentId={item.content_id}
+              playHref={firstEpisode ? `/watch/${firstEpisode.content_id}` : undefined}
+              playLabel="Play First Episode"
+              onRefresh={
+                canCurateMetadata
+                  ? (mode) =>
+                      refreshMetadataMutation.mutate({
+                        item,
+                        mode,
+                        onReplaced: (contentID) =>
+                          navigate(`/item/${contentID}`, { replace: true }),
+                      })
+                  : undefined
+              }
+              isRefreshing={refreshMetadataMutation.isPending}
+              isAdmin={isAdmin}
+              canCurateMetadata={canCurateMetadata}
+              onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
+            />
+          }
         />
 
+        <div className="page-shell series-detail-navigation" aria-label="Season episodes">
+          <section>
+            <div className="mb-5 flex items-center justify-between gap-3">
+              <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>
+              <span className="text-muted-foreground text-sm">
+                {item.episode_count ?? episodes.length} total
+              </span>
+            </div>
+
+            <SeasonEpisodeGrid
+              episodes={episodes}
+              isLoading={episodesLoading}
+              episodeLinkState={episodeLinkState}
+            />
+          </section>
+        </div>
+      </div>
+      <div className="page-shell detail-supporting-content py-8 sm:py-10">
+        <DetailSynopsis
+          overview={item.overview}
+          translating={overviewTranslating}
+          onTranslate={onTranslateOverview}
+        />
         {item.cast && item.cast.length > 0 && (
           <div className="mt-10">
             <h2 className="mb-4 text-xl font-semibold tracking-tight">Cast</h2>

--- a/web/src/pages/ItemDetail/SeasonContent.tsx
+++ b/web/src/pages/ItemDetail/SeasonContent.tsx
@@ -138,7 +138,11 @@ export default function SeasonContent({ item }: { item: ItemDetail & { type: "se
           }
         />
 
-        <div className="page-shell series-detail-navigation" aria-label="Season episodes">
+        <div
+          className="page-shell series-detail-navigation"
+          role="region"
+          aria-label="Season episodes"
+        >
           <section>
             <div className="mb-5 flex items-center justify-between gap-3">
               <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>

--- a/web/src/pages/ItemDetail/SeriesContent.test.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.test.tsx
@@ -201,6 +201,22 @@ describe("SeriesContent", () => {
     mocks.useDeleteRating.mockReturnValue({ mutate: mocks.deleteRatingMutate });
   });
 
+  it.each([false, true])(
+    "only reserves empty season navigation while loading (%s)",
+    (isLoading) => {
+      mocks.useSeasons.mockReturnValue({ data: { seasons: [] }, isLoading });
+      const markup = renderToStaticMarkup(
+        <QueryClientProvider client={new QueryClient()}>
+          <MemoryRouter>
+            <SeriesContent item={makeSeriesItem()} />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      expect(markup.includes("series-detail-navigation")).toBe(isLoading);
+      expect(markup.includes('role="region" aria-label="Seasons and episodes"')).toBe(isLoading);
+    },
+  );
+
   it("passes rating state and change handler to ActionBar", () => {
     renderToStaticMarkup(
       <QueryClientProvider client={new QueryClient()}>

--- a/web/src/pages/ItemDetail/SeriesContent.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.tsx
@@ -1,3 +1,4 @@
+import DetailSynopsis from "./components/DetailSynopsis";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import type { ItemDetail } from "@/api/types";
@@ -108,85 +109,97 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
 
   return (
     <div>
-      <DetailHero
-        title={title}
-        topNav={<PageBack />}
-        context="Series"
-        studioLabel={firstNetwork}
-        backdropUrl={item.backdrop_url}
-        backdropThumbhash={item.backdrop_thumbhash}
-        posterUrl={item.poster_url}
-        posterThumbhash={item.poster_thumbhash}
-        logoUrl={item.logo_url}
-        tagline={item.tagline || undefined}
-        metadata={
-          <MetadataBadges
-            year={yearDisplay || undefined}
-            contentRating={item.content_rating || undefined}
-            seasonCount={seasons.length || undefined}
-            episodeCount={episodeCount || undefined}
-          />
-        }
-        scoreRow={
-          <ScoreRow
-            ratingImdb={item.rating_imdb}
-            ratingRtCritic={item.rating_rt_critic}
-            ratingRtAudience={item.rating_rt_audience}
-          />
-        }
-        overview={item.overview}
-        overviewTranslating={overviewTranslating}
-        onTranslateOverview={onTranslateOverview}
-        crewLine={
-          <HeroCrewLine crew={item.crew ?? []} genres={item.genres} jobLabel="Created by" />
-        }
-        actions={
-          <MediaUserActionBar
-            item={item}
-            contentId={item.content_id}
-            playHref={resolvedPrimaryHref}
-            playLabel={primaryAction.label}
-            playLoading={primaryActionLoading}
-            onRefresh={
-              canCurateMetadata
-                ? (mode) =>
-                    refreshMetadataMutation.mutate({
-                      item,
-                      mode,
-                      onReplaced: (contentID) => navigate(`/item/${contentID}`, { replace: true }),
-                    })
-                : undefined
-            }
-            isRefreshing={refreshMetadataMutation.isPending}
-            isAdmin={isAdmin}
-            canCurateMetadata={canCurateMetadata}
-            onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
-            onMatchItem={canCurateMetadata ? () => setMatchOpen(true) : undefined}
-            onSplitItem={canCurateMetadata ? () => setSplitOpen(true) : undefined}
-          />
-        }
-      />
-
-      <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
-        {seasonsLoading ? (
-          <SeasonCarouselSkeleton />
-        ) : singleSeason ? (
-          <section>
-            <div className="mb-5 flex items-center justify-between gap-3">
-              <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>
-              <span className="text-muted-foreground text-sm">
-                {singleSeason.episode_count} total
-              </span>
-            </div>
-            <SeasonEpisodeGrid
-              episodes={singleSeasonEpisodesQuery.data?.episodes ?? []}
-              isLoading={singleSeasonEpisodesQuery.isLoading}
-              episodeLinkState={singleSeasonEpisodeLinkState}
+      <div className="episode-detail-viewport series-detail-viewport">
+        <DetailHero
+          variant="series"
+          title={title}
+          topNav={<PageBack />}
+          context="Series"
+          studioLabel={firstNetwork}
+          backdropUrl={item.backdrop_url}
+          backdropThumbhash={item.backdrop_thumbhash}
+          posterUrl={item.poster_url}
+          posterThumbhash={item.poster_thumbhash}
+          logoUrl={item.logo_url}
+          tagline={item.tagline || undefined}
+          metadata={
+            <MetadataBadges
+              year={yearDisplay || undefined}
+              contentRating={item.content_rating || undefined}
+              seasonCount={seasons.length || undefined}
+              episodeCount={episodeCount || undefined}
             />
-          </section>
-        ) : (
-          seasons.length > 0 && <SeasonCarousel seasons={seasons} />
-        )}
+          }
+          scoreRow={
+            <ScoreRow
+              ratingImdb={item.rating_imdb}
+              ratingRtCritic={item.rating_rt_critic}
+              ratingRtAudience={item.rating_rt_audience}
+            />
+          }
+          overview={item.overview}
+          overviewTranslating={overviewTranslating}
+          onTranslateOverview={onTranslateOverview}
+          crewLine={
+            <HeroCrewLine crew={item.crew ?? []} genres={item.genres} jobLabel="Created by" />
+          }
+          actions={
+            <MediaUserActionBar
+              compactMobile
+              item={item}
+              contentId={item.content_id}
+              playHref={resolvedPrimaryHref}
+              playLabel={primaryAction.label}
+              playLoading={primaryActionLoading}
+              onRefresh={
+                canCurateMetadata
+                  ? (mode) =>
+                      refreshMetadataMutation.mutate({
+                        item,
+                        mode,
+                        onReplaced: (contentID) =>
+                          navigate(`/item/${contentID}`, { replace: true }),
+                      })
+                  : undefined
+              }
+              isRefreshing={refreshMetadataMutation.isPending}
+              isAdmin={isAdmin}
+              canCurateMetadata={canCurateMetadata}
+              onEditMetadata={canCurateMetadata ? () => setEditOpen(true) : undefined}
+              onMatchItem={canCurateMetadata ? () => setMatchOpen(true) : undefined}
+              onSplitItem={canCurateMetadata ? () => setSplitOpen(true) : undefined}
+            />
+          }
+        />
+
+        <div className="page-shell series-detail-navigation" aria-label="Seasons and episodes">
+          {seasonsLoading ? (
+            <SeasonCarouselSkeleton />
+          ) : singleSeason ? (
+            <section>
+              <div className="mb-5 flex items-center justify-between gap-3">
+                <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>
+                <span className="text-muted-foreground text-sm">
+                  {singleSeason.episode_count} total
+                </span>
+              </div>
+              <SeasonEpisodeGrid
+                episodes={singleSeasonEpisodesQuery.data?.episodes ?? []}
+                isLoading={singleSeasonEpisodesQuery.isLoading}
+                episodeLinkState={singleSeasonEpisodeLinkState}
+              />
+            </section>
+          ) : (
+            seasons.length > 0 && <SeasonCarousel seasons={seasons} />
+          )}
+        </div>
+      </div>
+      <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
+        <DetailSynopsis
+          overview={item.overview}
+          translating={overviewTranslating}
+          onTranslate={onTranslateOverview}
+        />
         {item.videos && item.videos.length > 0 && <TrailersSection videos={item.videos} />}
 
         {item.extras && item.extras.length > 0 && <ExtrasSection extras={item.extras} />}

--- a/web/src/pages/ItemDetail/SeriesContent.tsx
+++ b/web/src/pages/ItemDetail/SeriesContent.tsx
@@ -172,27 +172,33 @@ export default function SeriesContent({ item }: { item: ItemDetail & { type: "se
           }
         />
 
-        <div className="page-shell series-detail-navigation" aria-label="Seasons and episodes">
-          {seasonsLoading ? (
-            <SeasonCarouselSkeleton />
-          ) : singleSeason ? (
-            <section>
-              <div className="mb-5 flex items-center justify-between gap-3">
-                <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>
-                <span className="text-muted-foreground text-sm">
-                  {singleSeason.episode_count} total
-                </span>
-              </div>
-              <SeasonEpisodeGrid
-                episodes={singleSeasonEpisodesQuery.data?.episodes ?? []}
-                isLoading={singleSeasonEpisodesQuery.isLoading}
-                episodeLinkState={singleSeasonEpisodeLinkState}
-              />
-            </section>
-          ) : (
-            seasons.length > 0 && <SeasonCarousel seasons={seasons} />
-          )}
-        </div>
+        {(seasonsLoading || seasons.length > 0) && (
+          <div
+            className="page-shell series-detail-navigation"
+            role="region"
+            aria-label="Seasons and episodes"
+          >
+            {seasonsLoading ? (
+              <SeasonCarouselSkeleton />
+            ) : singleSeason ? (
+              <section>
+                <div className="mb-5 flex items-center justify-between gap-3">
+                  <h2 className="text-xl font-semibold tracking-tight">Episodes</h2>
+                  <span className="text-muted-foreground text-sm">
+                    {singleSeason.episode_count} total
+                  </span>
+                </div>
+                <SeasonEpisodeGrid
+                  episodes={singleSeasonEpisodesQuery.data?.episodes ?? []}
+                  isLoading={singleSeasonEpisodesQuery.isLoading}
+                  episodeLinkState={singleSeasonEpisodeLinkState}
+                />
+              </section>
+            ) : (
+              <SeasonCarousel seasons={seasons} />
+            )}
+          </div>
+        )}
       </div>
       <div className="page-shell detail-supporting-content space-y-12 py-10 sm:space-y-14">
         <DetailSynopsis

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -170,3 +170,30 @@ it("skips desktop-hidden actions when focusing and navigating the menu", () => {
     rects.mockRestore();
   }
 });
+
+it.each([null, 3])("focuses the active star in a rating-only menu (rating %s)", (rating) => {
+  const rects = vi
+    .spyOn(HTMLElement.prototype, "getClientRects")
+    .mockReturnValue([new DOMRect(0, 0, 100, 30)] as unknown as DOMRectList);
+  try {
+    const onRatingChange = vi.fn();
+    renderActionBar({ compactMobile: true, rating, onRatingChange });
+    const trigger = screen.getByRole("button", { name: "More actions" });
+    fireEvent.click(trigger);
+    const menu = screen.getByRole("menu");
+    const star = within(menu).getByRole("radio", { name: rating === 3 ? "3 stars" : "1 star" });
+    expect(star).toHaveFocus();
+    for (const key of ["ArrowDown", "ArrowUp", "Home", "End"]) {
+      trigger.focus();
+      fireEvent.keyDown(menu, { key });
+      expect(star).toHaveFocus();
+    }
+    fireEvent.keyDown(star, { key: "ArrowRight" });
+    expect(onRatingChange).toHaveBeenCalledWith((rating ?? 0) + 1);
+    fireEvent.keyDown(star, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  } finally {
+    rects.mockRestore();
+  }
+});

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -42,6 +42,22 @@ function renderActionBar(overrides: Partial<ActionBarProps> = {}) {
 }
 
 describe("ActionBar", () => {
+  it.each([true, false])(
+    "announces watched state %s independently of label wording",
+    (isWatched) => {
+      renderActionBar({
+        compactMobile: true,
+        isWatched,
+        watchedLabel: "Change watch status",
+        onToggleWatched: vi.fn(),
+      });
+      expect(screen.getByRole("button", { name: "Change watch status" })).toHaveAttribute(
+        "aria-pressed",
+        String(isWatched),
+      );
+    },
+  );
+
   it.each(playBranches)(
     "keeps the %s Play action on a compositor-only hover path",
     (_, overrides) => {

--- a/web/src/pages/ItemDetail/components/ActionBar.test.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.test.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 import type { FileVersion } from "@/api/types";
@@ -105,4 +105,52 @@ describe("ActionBar", () => {
     expect(watchedAction).toHaveClass("enabled:cursor-pointer");
     expect(watchedAction).not.toHaveClass("cursor-pointer");
   });
+});
+
+it("keeps compact secondary actions available in the overflow menu", () => {
+  const onToggleFavorite = vi.fn();
+  const onRatingChange = vi.fn();
+  renderActionBar({ compactMobile: true, onToggleFavorite, onRatingChange });
+  fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+  const menu = screen.getByRole("menu");
+  fireEvent.keyDown(within(menu).getByRole("radio", { name: "1 star" }), { key: "ArrowRight" });
+  expect(onRatingChange).toHaveBeenCalledWith(1);
+  fireEvent.click(within(menu).getByRole("menuitem", { name: "Add to favorites" }));
+  expect(onToggleFavorite).toHaveBeenCalledOnce();
+  expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+});
+
+it("skips desktop-hidden actions when focusing and navigating the menu", () => {
+  const rects = vi.spyOn(HTMLElement.prototype, "getClientRects").mockImplementation(function (
+    this: HTMLElement,
+  ) {
+    return (this.closest(".detail-mobile-menu-actions")
+      ? []
+      : [new DOMRect(0, 0, 100, 30)]) as unknown as DOMRectList;
+  });
+  try {
+    renderActionBar({
+      compactMobile: true,
+      onToggleFavorite: vi.fn(),
+      onToggleWatchlist: vi.fn(),
+      canCurateMetadata: true,
+      onEditMetadata: vi.fn(),
+    });
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    const first = screen.getByRole("menuitem", { name: "Add to Watchlist" });
+    const last = screen.getByRole("menuitem", { name: "Edit Metadata" });
+    expect(first).toHaveFocus();
+    fireEvent.keyDown(first, { key: "ArrowUp" });
+    expect(last).toHaveFocus();
+    fireEvent.keyDown(last, { key: "ArrowDown" });
+    expect(first).toHaveFocus();
+    fireEvent.keyDown(first, { key: "End" });
+    expect(last).toHaveFocus();
+    fireEvent.keyDown(last, { key: "Home" });
+    expect(first).toHaveFocus();
+    fireEvent.keyDown(first, { key: "e" });
+    expect(last).toHaveFocus();
+  } finally {
+    rects.mockRestore();
+  }
 });

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -107,6 +107,7 @@ export interface ActionBarProps {
   effectiveVersionResolution?: string;
   effectiveVersionHdr?: boolean;
   watchedLabel?: string;
+  isWatched?: boolean;
   onToggleWatched?: () => void;
   isUpdatingWatched?: boolean;
   onToggleFavorite?: () => void;
@@ -161,6 +162,7 @@ export default function ActionBar({
   resumePositionSeconds,
   resumeDurationSeconds,
   watchedLabel,
+  isWatched,
   onToggleWatched,
   isUpdatingWatched = false,
   onToggleFavorite,
@@ -552,7 +554,7 @@ export default function ActionBar({
           <Button
             variant="glass"
             aria-label={watchedLabel}
-            aria-pressed={compactMobile ? watchedLabel?.includes("Unwatched") : undefined}
+            aria-pressed={compactMobile ? isWatched : undefined}
             onClick={onToggleWatched}
             disabled={isUpdatingWatched}
             className={`${responsivePrimaryActionClass} h-11 min-w-[161px] rounded-full px-5 text-[14px] font-semibold enabled:cursor-pointer`}

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -63,7 +63,9 @@ const staticGlassActionClass = "transition-none";
 function visibleOverflowItems(menu: HTMLElement | null): HTMLButtonElement[] {
   if (!menu) return [];
   return Array.from(
-    menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)'),
+    menu.querySelectorAll<HTMLButtonElement>(
+      '[role="menuitem"]:not(:disabled), [role="radio"][tabindex="0"]:not(:disabled)',
+    ),
   ).filter(
     (item) => item.getClientRects().length > 0 && getComputedStyle(item).visibility === "visible",
   );

--- a/web/src/pages/ItemDetail/components/ActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/ActionBar.tsx
@@ -60,6 +60,15 @@ const responsivePrimaryActionClass =
 const responsivePlayActionClass = `${responsivePrimaryActionClass} hover:bg-primary motion-reduce:hover:bg-primary/90`;
 const staticGlassActionClass = "transition-none";
 
+function visibleOverflowItems(menu: HTMLElement | null): HTMLButtonElement[] {
+  if (!menu) return [];
+  return Array.from(
+    menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)'),
+  ).filter(
+    (item) => item.getClientRects().length > 0 && getComputedStyle(item).visibility === "visible",
+  );
+}
+
 function DetailOverflowMenuItem({
   className,
   closeMenu,
@@ -84,6 +93,7 @@ function DetailOverflowMenuItem({
 }
 
 export interface ActionBarProps {
+  compactMobile?: boolean;
   contentId?: string;
   playHref?: string;
   playLabel?: string;
@@ -141,6 +151,7 @@ export interface ActionBarProps {
 }
 
 export default function ActionBar({
+  compactMobile = false,
   contentId,
   playHref,
   playLabel = "Play",
@@ -211,6 +222,16 @@ export default function ActionBar({
   const showPlayChoiceDialog =
     !hasMultipleVersions && playLabel === "Resume" && !!playHref && !!restartHref;
   const displayedPlayLabel = showPlayChoiceDialog ? "Play" : playLabel;
+  const playText = compactMobile ? (
+    <>
+      <span className="detail-full-label">{displayedPlayLabel}</span>
+      <span className="detail-short-label">
+        {displayedPlayLabel === "Resume" ? "Resume" : "Play"}
+      </span>
+    </>
+  ) : (
+    displayedPlayLabel
+  );
 
   const progressOverlay =
     playProgress != null && playProgress > 0 && playProgress < 100 ? (
@@ -311,9 +332,6 @@ export default function ActionBar({
 
     const triggerElement = overflowTriggerRef.current;
     positionOverflowMenu();
-    overflowMenuRef.current
-      ?.querySelector<HTMLButtonElement>('[role="menuitem"]:not(:disabled)')
-      ?.focus({ preventScroll: true });
 
     window.addEventListener("resize", positionOverflowMenu);
     return () => {
@@ -326,6 +344,14 @@ export default function ActionBar({
       triggerElement?.focus({ preventScroll: true });
     };
   }, [overflowOpen, positionOverflowMenu]);
+
+  // The portal starts hidden until its position is measured. Focus only once
+  // it is painted, and skip actions hidden by the responsive layout.
+  const overflowPositioned = overflowPosition !== null;
+  useLayoutEffect(() => {
+    if (!overflowOpen || !overflowPositioned) return;
+    visibleOverflowItems(overflowMenuRef.current)[0]?.focus({ preventScroll: true });
+  }, [overflowOpen, overflowPositioned]);
 
   useEffect(() => {
     if (!overflowOpen) return;
@@ -394,9 +420,7 @@ export default function ActionBar({
       event.key !== " ";
     if (!isNavigationKey && !isTypeahead) return;
 
-    const items = Array.from(
-      event.currentTarget.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)'),
-    );
+    const items = visibleOverflowItems(event.currentTarget);
     if (items.length === 0) return;
 
     event.preventDefault();
@@ -438,7 +462,11 @@ export default function ActionBar({
     showMarkerEditor,
   );
   const hasOverflowMenuItems =
-    hasOverflowActions || hasAdminActions || hasMetadataActions || Boolean(contentId);
+    hasOverflowActions ||
+    hasAdminActions ||
+    hasMetadataActions ||
+    Boolean(contentId) ||
+    (compactMobile && Boolean(onToggleFavorite || onRatingChange));
 
   const formattedResumeTime = formatPlaybackTime(resumePositionSeconds ?? 0);
   const percentComplete =
@@ -472,9 +500,9 @@ export default function ActionBar({
   const hasStreamControls = Boolean(selectedVersion);
 
   return (
-    <div className="detail-action-bar space-y-2.5">
+    <div className="detail-action-bar space-y-2.5" data-compact-mobile={compactMobile || undefined}>
       {/* ── Primary actions ──────────────────────────────────── */}
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="detail-primary-actions flex flex-wrap items-center gap-3">
         {/* ── Play button ────────────────────────────────────── */}
         {playHref ? (
           showPlayChoiceDialog ? (
@@ -483,7 +511,7 @@ export default function ActionBar({
               className={`${responsivePlayActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
-              {displayedPlayLabel}
+              {playText}
               {progressOverlay}
             </Button>
           ) : selectedVersion ? (
@@ -492,7 +520,7 @@ export default function ActionBar({
               className={`${responsivePlayActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
-              {displayedPlayLabel}
+              {playText}
               {progressOverlay}
             </Button>
           ) : (
@@ -501,7 +529,7 @@ export default function ActionBar({
               className={`${responsivePlayActionClass} relative h-11 cursor-pointer gap-2.5 overflow-hidden rounded-full px-8 text-[15px] font-bold tracking-wide shadow-md`}
             >
               <Play className="size-[18px] fill-current" />
-              {displayedPlayLabel}
+              {playText}
               {progressOverlay}
             </Button>
           )
@@ -523,12 +551,21 @@ export default function ActionBar({
         {watchedLabel && onToggleWatched && (
           <Button
             variant="glass"
+            aria-label={watchedLabel}
+            aria-pressed={compactMobile ? watchedLabel?.includes("Unwatched") : undefined}
             onClick={onToggleWatched}
             disabled={isUpdatingWatched}
             className={`${responsivePrimaryActionClass} h-11 min-w-[161px] rounded-full px-5 text-[14px] font-semibold enabled:cursor-pointer`}
           >
             <Check className="size-[18px]" />
-            {watchedLabel}
+            {compactMobile ? (
+              <>
+                <span className="detail-full-label">{watchedLabel}</span>
+                <span className="detail-short-label">Watched</span>
+              </>
+            ) : (
+              watchedLabel
+            )}
           </Button>
         )}
 
@@ -540,7 +577,7 @@ export default function ActionBar({
             onClick={onToggleFavorite}
             title={isFavorite ? "Unfavorite" : "Favorite"}
             aria-label={isFavorite ? "Remove from favorites" : "Add to favorites"}
-            className={`${staticGlassActionClass} size-11 cursor-pointer rounded-full`}
+            className={`${staticGlassActionClass} detail-secondary-action size-11 cursor-pointer rounded-full`}
           >
             <Heart
               className={`size-[18px] transition-colors ${isFavorite ? "fill-current text-red-400" : ""}`}
@@ -549,7 +586,9 @@ export default function ActionBar({
         )}
 
         {onRatingChange && (
-          <StarRating value={rating ?? null} onChange={onRatingChange} size={18} />
+          <div className="detail-secondary-action">
+            <StarRating value={rating ?? null} onChange={onRatingChange} size={18} />
+          </div>
         )}
 
         {hasOverflowMenuItems && (
@@ -583,6 +622,32 @@ export default function ActionBar({
               role="menu"
               onKeyDown={handleOverflowKeyDown}
             >
+              {compactMobile && (
+                <div className="detail-mobile-menu-actions">
+                  {onToggleFavorite && (
+                    <DetailOverflowMenuItem
+                      closeMenu={closeOverflowMenu}
+                      onAction={onToggleFavorite}
+                    >
+                      <Heart className="size-4" />
+                      {isFavorite ? "Remove from favorites" : "Add to favorites"}
+                    </DetailOverflowMenuItem>
+                  )}
+                  {onRatingChange && (
+                    <div
+                      className="px-2 py-2"
+                      role="group"
+                      aria-label="Your rating"
+                      onKeyDown={(event) => {
+                        if (event.key !== "Escape" && event.key !== "Tab") event.stopPropagation();
+                      }}
+                    >
+                      <span className="mb-2 block text-sm">Your rating</span>
+                      <StarRating value={rating ?? null} onChange={onRatingChange} size={18} />
+                    </div>
+                  )}
+                </div>
+              )}
               {restartHref && (
                 <DetailOverflowMenuItem
                   closeMenu={closeOverflowMenu}
@@ -752,7 +817,7 @@ export default function ActionBar({
           three nowrap trigger buttons) inflates the auto-sized hero column
           past narrow viewports, clipping the whole info column. */}
       {hasStreamControls && (
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <div className="detail-stream-actions flex min-w-0 flex-wrap items-center gap-2">
           {versions && hasMultipleVersions && selectedVersion && onSelectVersion && (
             <VersionDropdown
               versions={versions}

--- a/web/src/pages/ItemDetail/components/DetailSynopsis.tsx
+++ b/web/src/pages/ItemDetail/components/DetailSynopsis.tsx
@@ -1,0 +1,30 @@
+export default function DetailSynopsis({
+  overview,
+  translating,
+  onTranslate,
+}: {
+  overview?: string | null;
+  translating?: boolean;
+  onTranslate?: () => void;
+}) {
+  if (!overview) return null;
+  return (
+    <section className="detail-mobile-synopsis">
+      <h2 className="mb-3 text-xl font-semibold">Synopsis</h2>
+      <p className="text-muted-foreground max-w-2xl leading-relaxed">{overview}</p>
+      {translating ? (
+        <p role="status">Translating…</p>
+      ) : (
+        onTranslate && (
+          <button
+            type="button"
+            onClick={onTranslate}
+            className="mt-3 rounded-full border px-3 py-2 text-sm"
+          >
+            Translate
+          </button>
+        )
+      )}
+    </section>
+  );
+}

--- a/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/MediaUserActionBar.tsx
@@ -8,6 +8,7 @@ import { getWatchedActionLabel } from "../watchedState";
 import ActionBar, { type ActionBarProps } from "./ActionBar";
 
 type UserActionProps =
+  | "isWatched"
   | "watchedLabel"
   | "onToggleWatched"
   | "isUpdatingWatched"
@@ -63,6 +64,7 @@ export default function MediaUserActionBar({ item, ...props }: MediaUserActionBa
     <ActionBar
       {...props}
       watchedLabel={getWatchedActionLabel(item)}
+      isWatched={item.user_data?.played ?? false}
       onToggleWatched={handleToggleWatched}
       isUpdatingWatched={isUpdatingWatched}
       onToggleFavorite={handleToggleFavorite}

--- a/web/src/pages/ItemDetail/components/MetadataBadges.tsx
+++ b/web/src/pages/ItemDetail/components/MetadataBadges.tsx
@@ -3,6 +3,7 @@ interface MetadataBadgesProps {
   contentRating?: string;
   duration?: string;
   seasonCount?: number;
+  seasonLabel?: string;
   episodeCount?: number;
   volumeCount?: number;
   chapterCount?: number;
@@ -14,6 +15,7 @@ export default function MetadataBadges({
   contentRating,
   duration,
   seasonCount,
+  seasonLabel,
   episodeCount,
   volumeCount,
   chapterCount,
@@ -29,6 +31,7 @@ export default function MetadataBadges({
           {seasonCount} {seasonCount === 1 ? "Season" : "Seasons"}
         </span>
       )}
+      {seasonLabel && <span className="metadata-badge">{seasonLabel}</span>}
       {episodeCount != null && (
         <span className="metadata-badge">
           {episodeCount} {episodeCount === 1 ? "Episode" : "Episodes"}

--- a/web/src/pages/ItemDetail/components/WatchedActionBar.tsx
+++ b/web/src/pages/ItemDetail/components/WatchedActionBar.tsx
@@ -4,7 +4,7 @@ import { useWatchedStateMutation } from "@/hooks/queries/items";
 import { getWatchedActionLabel } from "../watchedState";
 import ActionBar, { type ActionBarProps } from "./ActionBar";
 
-type WatchedActionProps = "watchedLabel" | "onToggleWatched" | "isUpdatingWatched";
+type WatchedActionProps = "isWatched" | "watchedLabel" | "onToggleWatched" | "isUpdatingWatched";
 
 interface WatchedActionBarProps extends Omit<ActionBarProps, WatchedActionProps> {
   item: ItemDetail;
@@ -22,6 +22,7 @@ export default function WatchedActionBar({ item, ...props }: WatchedActionBarPro
     <ActionBar
       {...props}
       watchedLabel={getWatchedActionLabel(item)}
+      isWatched={item.user_data?.played ?? false}
       onToggleWatched={handleToggleWatched}
       isUpdatingWatched={isUpdatingWatched}
     />

--- a/web/src/pages/audiobooks/player/MiniBar.test.tsx
+++ b/web/src/pages/audiobooks/player/MiniBar.test.tsx
@@ -1,10 +1,24 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MiniBar } from "./MiniBar";
 import { makeChapters, makePlayback, makePrefs } from "./playerTestUtils";
 
 describe("MiniBar", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+  });
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
   it("renders the title", () => {
     render(
       <MiniBar

--- a/web/src/pages/audiobooks/player/MiniBar.tsx
+++ b/web/src/pages/audiobooks/player/MiniBar.tsx
@@ -1,3 +1,4 @@
+import { usePlaybackBarHeight } from "@/hooks/usePlaybackBarHeight";
 import { X, Pause, Play, SkipBack, SkipForward } from "lucide-react";
 import { SeekBar, formatTime } from "@/player/components/SeekBar";
 import { ChaptersMenu } from "@/player/components/ChaptersMenu";
@@ -30,12 +31,14 @@ export function MiniBar({
   onClose,
   onExpand,
 }: MiniBarProps) {
+  const barRef = usePlaybackBarHeight("audiobook");
   const hasChapters = playback.chapters.length > 0;
   const hasNextChapter =
     playback.currentChapter != null && playback.currentChapter.index + 1 < playback.chapters.length;
 
   return (
     <div
+      ref={barRef}
       className="bg-background fixed right-0 bottom-0 z-40 border-t px-3 pt-2 pb-2 shadow-lg sm:px-6"
       style={{ left: "var(--app-sidebar-offset, 0px)" }}
     >

--- a/web/src/playback/WatchPlaybackChrome.tsx
+++ b/web/src/playback/WatchPlaybackChrome.tsx
@@ -1,3 +1,4 @@
+import { usePlaybackBarHeight } from "@/hooks/usePlaybackBarHeight";
 import {
   lazy,
   Suspense,
@@ -994,6 +995,7 @@ export function WatchPlaybackHost() {
 }
 
 export function WatchPlaybackBar() {
+  const barRef = usePlaybackBarHeight("watch");
   const controller = useContext(WatchPlaybackControllerContext);
   if (!controller) {
     throw new Error("Watch playback bar is unavailable outside WatchPlaybackProvider");
@@ -1015,7 +1017,10 @@ export function WatchPlaybackBar() {
   const displayedTime = scrubValue ?? snapshot?.currentTime ?? 0;
 
   return (
-    <div className="pointer-events-none fixed inset-x-3 bottom-3 z-40 flex justify-center">
+    <div
+      ref={barRef}
+      className="pointer-events-none fixed inset-x-3 bottom-3 z-40 flex justify-center"
+    >
       <div className="glass-dark border-border/70 pointer-events-auto w-full max-w-4xl rounded-2xl border px-4 py-3 shadow-[0_24px_80px_-32px_rgba(0,0,0,0.7)] backdrop-blur-xl">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Problem

Long TV titles and audio/subtitle controls could push episode navigation below the viewport. Show and season pages had similar problems, especially on small screens and with larger text.

Related issue: #804

## Approach

Reserve desktop navigation space using the measured header and background-player heights. Fit and truncate long titles with enough line height for descenders, and refit them when text preferences change.

On mobile, give the title and controls the full width, move the synopsis below navigation, and use compact horizontal cards. Keep secondary actions in the overflow menu and show the season as a chip before the episode count. Very short landscape screens use normal page scrolling instead of clipping content into small internal scroll areas. Keyboard menu navigation skips hidden actions.

## Validation

- Passed: Go build, vet, and merge-base lint (zero issues); frontend frozen install, lint, formatting, and production build; settings bindings, playback fixtures, and local-path checks.
- Frontend suite passed under CI's Node 22: 364 files, 3,117 tests. The initial Node 25 run exposed Web Storage compatibility failures; the rerun used the supported runtime. Updated the mini-bar tests with a ResizeObserver stub.
- `make test-go` failed in unchanged `internal/jellycompat`, `internal/playback`, `internal/proxy`, and `internal/transcodenode` packages. Failures include hardware-probe subprocesses reporting `signal: killed` and transcode-session assertions.
- Tracked Go files are gofmt-clean. The recursive `gofmt -l .` command also reported an ignored local scratch file.

Chromium checks covered show, season, and episode routes, short and long titles, title artwork, 1/2/12 seasons, extra-large text, navigation, track selectors, and menu keyboard behavior. The final targeted portrait cases and the 1366×768 desktop regression cases passed. Exceptionally short landscape layouts use the scrolling fallback.

## Risks

Frontend layout and accessibility changes only; no API, database, native-client, or Jellyfin contract changes. Browser validation used Chromium; Safari and Firefox were not exercised.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop.
- Tools: Codex coding tools, Playwright/Chromium, and `image_gen.imagegen` for local QA artwork only.
- Models: `gpt-6-astra`; the image-generation tool did not expose a model identifier.
- Involvement: AI-assisted. Codex implemented the changes, added tests, ran browser checks, and drafted this PR; the user directed the design and reviewed screenshots.
- Adversarial review: Same-agent source review and browser checks examined viewport clipping, title fitting, text scaling, player offsets, keyboard focus, and nested navigation. Findings included hidden controls, clipped titles/ratings, incorrect viewport offsets, hidden menu items intercepting keyboard navigation, and titles not responding to text-size changes. These were corrected and rechecked. No independent reviewer was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned episode, series, and season detail pages with responsive layouts and improved navigation.
  - Added mobile synopsis sections, translation actions, season metadata, and compact playback controls.
  - Added automatic title sizing to keep long detail titles readable.
  - Improved overflow menus, focus management, and keyboard navigation.
- **Bug Fixes**
  - Improved spacing around mobile headers and playback bars across screen sizes.
  - Playback controls now reserve space accurately to prevent content overlap.
  - Empty episode and season navigation sections no longer appear when there is no content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->