### PR TITLE
fix(trakt): restore complete movie and TV watched imports

### DIFF
--- a/internal/watchsync/providers/trakt/provider.go
+++ b/internal/watchsync/providers/trakt/provider.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +20,8 @@ import (
 )
 
 const defaultBaseURL = "https://api.trakt.tv"
+
+const traktMediaShows = "shows"
 
 type Provider struct {
 	client  *http.Client
@@ -209,12 +212,12 @@ func (p *Provider) FetchWatched(
 	cfg watchsync.ServerConfig,
 	conn watchsync.Connection,
 ) ([]watchsync.RemoteWatch, error) {
-	var movies []traktWatchedMovie
-	if err := p.do(ctx, http.MethodGet, "/sync/watched/movies", cfg, conn.AccessToken, nil, &movies); err != nil {
+	movies, err := fetchWatchedPages[traktWatchedMovie](ctx, p, cfg, conn, "movies")
+	if err != nil {
 		return nil, err
 	}
-	var shows []traktWatchedShow
-	if err := p.do(ctx, http.MethodGet, "/sync/watched/shows", cfg, conn.AccessToken, nil, &shows); err != nil {
+	shows, err := fetchWatchedPages[traktWatchedShow](ctx, p, cfg, conn, traktMediaShows)
+	if err != nil {
 		return nil, err
 	}
 
@@ -256,6 +259,29 @@ func (p *Provider) FetchWatched(
 		}
 	}
 	return rows, nil
+}
+
+// fetchWatchedPages requests explicit pagination for Trakt's watched endpoints.
+// Stop on an empty page: Trakt may apply a smaller limit than requested,
+// particularly for shows with season progress, so a short page is not the end.
+func fetchWatchedPages[T any](ctx context.Context, p *Provider, cfg watchsync.ServerConfig, conn watchsync.Connection, kind string) ([]T, error) {
+	query := url.Values{"limit": {"250"}}
+	if kind == traktMediaShows {
+		// Season and episode watched data is no longer included by default.
+		query.Set("extended", "progress")
+	}
+	var rows []T
+	for page := 1; ; page++ {
+		query.Set("page", strconv.Itoa(page))
+		var batch []T
+		if err := p.do(ctx, http.MethodGet, "/sync/watched/"+kind+"?"+query.Encode(), cfg, conn.AccessToken, nil, &batch); err != nil {
+			return nil, err
+		}
+		if len(batch) == 0 {
+			return rows, nil
+		}
+		rows = append(rows, batch...)
+	}
 }
 
 func (p *Provider) FetchProgress(

--- a/internal/watchsync/providers/trakt/watched_test.go
+++ b/internal/watchsync/providers/trakt/watched_test.go
@@ -1,0 +1,120 @@
+package trakt
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Silo-Server/silo-server/internal/historyimport"
+	"github.com/Silo-Server/silo-server/internal/watchsync"
+)
+
+func TestFetchWatchedImportsEveryPageAndEpisodeProgress(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kind := strings.TrimPrefix(r.URL.Path, "/sync/watched/")
+		page := r.URL.Query().Get("page")
+		requests = append(requests, kind+":"+page)
+		if r.URL.Query().Get("limit") != "250" {
+			t.Errorf("limit = %q, want 250", r.URL.Query().Get("limit"))
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("missing authorization")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Deliberately return short pages without pagination headers. Neither
+		// condition should prevent fetching the remaining watched records.
+		switch page {
+		case "1", "2":
+			switch kind {
+			case "movies":
+				writeWatchedFixture(t, w, `[{"plays":2,"last_watched_at":"2026-09-01T12:00:00Z","movie":{"title":"Movie %s","year":2020,"ids":{"tmdb":10%s}}}]`, page, page)
+			case "shows":
+				if r.URL.Query().Get("extended") != "progress" {
+					// Current Trakt default: no seasons or episodes without progress.
+					writeWatchedFixture(t, w, `[{"show":{"title":"Show","ids":{"tmdb":200}}}]`)
+					return
+				}
+				writeWatchedFixture(t, w, `[{"show":{"title":"Show %s","year":2021,"ids":{"tmdb":20%s,"tvdb":30%s,"imdb":"tt40%s"}},"seasons":[{"number":0,"episodes":[{"number":1,"plays":3,"last_watched_at":"2026-09-02T12:00:00Z"}]},{"number":2,"episodes":[{"number":5,"plays":1,"last_watched_at":"2026-09-03T12:00:00Z"}]}]}]`, page, page, page, page)
+			default:
+				t.Errorf("unexpected path %s", r.URL.Path)
+				http.NotFound(w, r)
+			}
+		case "3":
+			writeWatchedFixture(t, w, `[]`)
+		default:
+			t.Errorf("unexpected page %q", page)
+			http.Error(w, "unexpected page", 500)
+		}
+	}))
+	defer server.Close()
+	rows, err := NewProvider(server.Client(), server.URL).FetchWatched(context.Background(), watchsync.ServerConfig{}, watchsync.Connection{AccessToken: "test-token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRequests := []string{"movies:1", "movies:2", "movies:3", "shows:1", "shows:2", "shows:3"}
+	if !reflect.DeepEqual(requests, wantRequests) {
+		t.Fatalf("requests = %v, want %v", requests, wantRequests)
+	}
+	if len(rows) != 6 {
+		t.Fatalf("got %d records, want 2 movies and 4 episodes", len(rows))
+	}
+	for i, row := range rows[:2] {
+		if row.Kind != historyimport.KindMovie || row.TMDBID != fmt.Sprintf("10%d", i+1) || row.PlayCount != 2 {
+			t.Errorf("movie %d = %#v", i, row)
+		}
+	}
+	for i, row := range rows[2:] {
+		show := i/2 + 1
+		season, episode, plays, day := 0, 1, 3, 2
+		if i%2 == 1 {
+			season, episode, plays, day = 2, 5, 1, 3
+		}
+		watchedAt := time.Date(2026, 9, day, 12, 0, 0, 0, time.UTC)
+		if row.Kind != historyimport.KindEpisode || row.SeriesTMDBID != fmt.Sprintf("20%d", show) || row.SeriesTVDBID != fmt.Sprintf("30%d", show) || row.SeriesIMDbID != fmt.Sprintf("tt40%d", show) || row.SeasonNumber != season || row.EpisodeNumber != episode || row.PlayCount != plays || row.LastWatchedAt == nil || !row.LastWatchedAt.Equal(watchedAt) {
+			t.Errorf("episode %d = %#v", i, row)
+		}
+	}
+}
+
+func TestFetchWatchedDoesNotReturnPartialHistoryOnLaterPageFailure(t *testing.T) {
+	for _, kind := range []string{"movies", "shows"} {
+		for _, failure := range []string{"http", "json"} {
+			t.Run(kind+"/"+failure, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					if r.URL.Query().Get("page") == "1" {
+						writeWatchedFixture(t, w, `[{"plays":1,"last_watched_at":"2026-09-01T12:00:00Z","movie":{"ids":{"tmdb":123}},"show":{"ids":{"tmdb":456}},"seasons":[{"number":1,"episodes":[{"number":1,"plays":1,"last_watched_at":"2026-09-01T12:00:00Z"}]}]}]`)
+						return
+					}
+					if r.URL.Path == "/sync/watched/"+kind {
+						if failure == "http" {
+							http.Error(w, "unavailable", http.StatusServiceUnavailable)
+						} else {
+							writeWatchedFixture(t, w, `[{`)
+						}
+						return
+					}
+					writeWatchedFixture(t, w, `[]`)
+				}))
+				defer server.Close()
+				rows, err := NewProvider(server.Client(), server.URL).FetchWatched(context.Background(), watchsync.ServerConfig{}, watchsync.Connection{})
+				if err == nil || rows != nil {
+					t.Fatalf("got rows=%#v, err=%v; want no partial history and an error", rows, err)
+				}
+			})
+		}
+	}
+}
+
+func writeWatchedFixture(t *testing.T, w http.ResponseWriter, format string, args ...any) {
+	t.Helper()
+	if _, err := fmt.Fprintf(w, format, args...); err != nil {
+		t.Errorf("write watched fixture: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Trakt TV watched imports silently produce no episode records because Silo does not request season progress. Movie imports stop after the first page. Trakt changed both defaults in its [watched-endpoint API update](https://github.com/trakt/trakt-api/discussions/775).

## Approach

Request `extended=progress` for watched shows and paginate both watched endpoints with explicit `page` and `limit` parameters. Continue until an empty page, since Trakt can return fewer items than requested. A failed later page returns an error without handing partial history to the importer.

Regression tests cover multiple short pages, episode identifiers and watched timestamps, specials, and HTTP/JSON failures on later pages. The pagination regression test fails against the original implementation.

## Validation

Passed:
- Go build, gofmt, go vet, and golangci-lint against the main merge base.
- Watch-sync and history-import package tests, plus Trakt tests with the race detector.
- Frozen frontend dependency install, lint, formatting, and production build.
- Web suite: 362 files / 3,112 tests passed with `NODE_OPTIONS=--no-experimental-webstorage`. The initial Node 25 run failed with localStorage errors; CI uses Node 22.
- Settings bindings, playback fixtures, local-path hygiene, and diff whitespace checks.

`make test-go` ran but failed in unchanged `internal/api/handlers`, `internal/jellycompat`, `internal/playback`, `internal/proxy`, and `internal/transcodenode` tests, with FFmpeg probe and readiness failures. One representative failure, `TestDetectHWAccelReportsACompleteWalk`, also reproduces on clean main. The full Go gate is not green locally.

Provider behavior was exercised with local mock HTTP responses; no live Trakt account or production deployment was used.

## Risks

Large histories require additional requests. Failed fetches must retry from the beginning. No migrations or native API contract changes; Apple, Android, and Jellyfin clients consume the existing shared watch state and require no changes.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: OpenAI Codex desktop app.
- Tool(s): Codex `functions.exec` / `exec_command`, `web__run`, Git, and GitHub CLI.
- Model(s): `gpt-6-astra`.
- Involvement: AI-generated implementation and tests under user direction; AI-assisted review and PR preparation.
- Adversarial review: The same Codex agent reviewed the complete change against Trakt's API announcement, traced pagination errors through the import service, and checked short-page termination and regression coverage. No actionable correctness findings; lint subsequently identified unchecked test writes and a repeated string, both fixed. This was not an independent-agent review. Focused race tests and lint passed after those fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Watched movie and show history now imports all available pages instead of stopping after the first page.
  - Show history includes episode progress details such as play counts and watched timestamps.
  - Prevents incomplete watch history from being returned when a later page fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->