### PR TITLE
test(api): cover v2 auth denial envelopes

### DIFF
--- a/internal/api/router_v2_auth_test.go
+++ b/internal/api/router_v2_auth_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Silo-Server/silo-server/internal/apiv2"
+	"github.com/Silo-Server/silo-server/internal/clientip"
+	"github.com/Silo-Server/silo-server/internal/config"
+	"github.com/Silo-Server/silo-server/internal/secret"
+)
+
+// TestRouterAuthDenialEnvelopes checks the shared auth middleware through
+// the complete listener, including the outer middleware and v2 delegation.
+func TestRouterAuthDenialEnvelopes(t *testing.T) {
+	cfg, err := config.LoadFromDB(map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Configure the real repositories against an unavailable target so the
+	// API-key lookup takes its failure path without requiring a database.
+	pool, err := pgxpool.New(t.Context(), "postgres://nobody:nobody@127.0.0.1:1/none?sslmode=disable&connect_timeout=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	cipher, err := secret.New(bytes.Repeat([]byte{0}, secret.MinMasterKeyLen))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(NewRouter(Dependencies{
+		Config:           cfg,
+		AppContext:       t.Context(),
+		DB:               pool,
+		SecretCipher:     cipher,
+		ClientIPResolver: clientip.NewResolver(nil),
+		NodeID:           "auth-envelope-test",
+		PublicURL:        "https://silo.example.test",
+	}))
+	t.Cleanup(server.Close)
+
+	for _, tc := range []struct {
+		name    string
+		header  string
+		legacy  string
+		problem apiv2.ProblemType
+	}{
+		{"missing credential", "", "Missing or malformed authorization header", apiv2.TypeAuthenticationRequired},
+		{"malformed header", "Basic invalid", "Missing or malformed authorization header", apiv2.TypeAuthenticationRequired},
+		{"invalid JWT", "Bearer invalid", "Invalid or expired token", apiv2.TypeInvalidToken},
+		{"failed API key lookup", "Bearer sa_missing", "Invalid API key", apiv2.TypeInvalidToken},
+	} {
+		for _, path := range []string{"/api/v1/auth/me", "/api/v2/account/me"} {
+			t.Run(tc.name+path, func(t *testing.T) {
+				req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL+path, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.Header.Set("Authorization", tc.header)
+				req.Header.Set("X-Request-ID", "client-selected")
+				response, err := server.Client().Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { _ = response.Body.Close() }()
+				body, err := io.ReadAll(response.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if response.StatusCode != http.StatusUnauthorized {
+					t.Fatalf("status = %d, body = %s", response.StatusCode, body)
+				}
+				var fields map[string]json.RawMessage
+				if err := json.Unmarshal(body, &fields); err != nil {
+					t.Fatalf("invalid JSON: %v: %s", err, body)
+				}
+				if path == "/api/v1/auth/me" {
+					var legacy struct{ Error, Message string }
+					if err := json.Unmarshal(body, &legacy); err != nil {
+						t.Fatal(err)
+					}
+					if response.Header.Get("Content-Type") != "application/json" || len(fields) != 2 || legacy.Error != "unauthorized" || legacy.Message != tc.legacy {
+						t.Fatalf("legacy denial changed: headers = %v, body = %s", response.Header, body)
+					}
+					return
+				}
+				var problem apiv2.Problem
+				if err := json.Unmarshal(body, &problem); err != nil {
+					t.Fatal(err)
+				}
+				requestID := response.Header.Get(apiv2.RequestIDHeader)
+				if response.Header.Get("Content-Type") != "application/problem+json" || response.Header.Get("Cache-Control") != "no-store" {
+					t.Fatalf("problem headers = %v", response.Header)
+				}
+				if len(fields) != 5 || problem.Type != tc.problem.URI() || problem.Title != tc.problem.Title || problem.Status != response.StatusCode || problem.Detail == "" {
+					t.Fatalf("invalid problem envelope: %s", body)
+				}
+				if requestID == "" || requestID == "client-selected" || problem.Instance != "urn:silo:request:"+requestID {
+					t.Fatalf("request ID = %q, problem instance = %q", requestID, problem.Instance)
+				}
+			})
+		}
+	}
+}

--- a/internal/apiv2/parity_test.go
+++ b/internal/apiv2/parity_test.go
@@ -213,6 +213,46 @@ func TestMiddlewareParity(t *testing.T) {
 	}
 }
 
+// TestAPIKeyDenialProblems exercises RequireAuth's early exits through a
+// production v2 operation, including the reason recorded before a 401 write.
+func TestAPIKeyDenialProblems(t *testing.T) {
+	authMiddleware := apimw.NewAuthMiddleware(
+		fakeTokens{}, fakeSessions{},
+		fakeAPIKeys{keys: map[string]*models.APIKey{
+			"sa_disabled": {ID: 8, UserID: 2},
+			"sa_orphaned": {ID: 9, UserID: 3},
+			"sa_scoped":   {ID: 10, UserID: 1, Scopes: []string{auth.ScopeAdminUsers}},
+		}},
+		fakeUsers{users: map[int]*models.User{
+			1: {ID: 1, Role: "admin", Enabled: true},
+			2: {ID: 2, Role: "admin", Enabled: false},
+		}},
+	)
+	h := NewHandler(Dependencies{Auth: authMiddleware})
+	for _, tc := range []struct {
+		name   string
+		key    string
+		want   ProblemType
+		detail string
+	}{
+		{"unknown key", "sa_missing", TypeInvalidToken, "The credential is invalid or expired."},
+		{"disabled account", "sa_disabled", TypeInvalidToken, "The credential is invalid or expired."},
+		{"missing owner", "sa_orphaned", TypeInvalidToken, "The credential is invalid or expired."},
+		{"scope denial", "sa_scoped", TypePermissionDenied, "API key scopes do not permit this route"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := do(t, h, http.MethodGet, Prefix+"/account/me", "", bearer(tc.key))
+			p := requireProblem(t, rec, tc.want)
+			if p.Detail != tc.detail {
+				t.Fatalf("detail = %q, want %q", p.Detail, tc.detail)
+			}
+			if strings.Contains(rec.Body.String(), `"error":`) || strings.Contains(rec.Body.String(), `"message":`) {
+				t.Fatalf("v2 denial contains legacy fields: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
 // TestHandlersReadIdentityFromContext: claims, profile and viewer scope reach
 // the handler through the context the gates set, not through headers.
 func TestHandlersReadIdentityFromContext(t *testing.T) {


### PR DESCRIPTION
## Problem

Related issue: #135

The v2 adapter already converts auth middleware denials to RFC 9457 on `fix/web-apiv2-qa`. The reported legacy envelope did not reproduce there: the cited `RequireAuth` mount belongs to the v1 group. Coverage was missing for API-key rejection details and auth responses through the complete API listener.

## Approach

Add four v2 cases for unknown keys, disabled accounts, missing owners, and scope denials. Add eight real HTTP requests through `NewRouter` covering missing credentials, malformed headers, invalid JWTs, and failed API-key lookups on both versions. Assert v2 problem fields, media type, cache policy, and request ID correlation, plus the exact v1 legacy envelope.

## Validation

- Full Go build, vet, formatting, lint against the PR base, and `make test-go` passed.
- Web lint, formatting, build, and `make test-web` passed: 574 files, 4,246 tests (the repository's four existing exclusions apply).
- All required settings, playback, route, migration, scenario, OpenAPI, API fixture, contract-diff, and local-path checks passed. The contract diff used `BASE_REF=origin/fix/web-apiv2-qa`.
- Both new tests and existing auth parity checks passed. Bypassing the adapter through a temporary Go overlay made the eight new v2 cases fail on the legacy content type; v1 assertions still passed.

The listener test forces an API-key repository error using an unavailable database; the four v2 API-key cases use synthetic stores. This validates response translation without a deployed server or persisted account workflow.

## Risks

None identified. This PR adds tests. Apple, Android, and Jellyfin compatibility follow-up is unnecessary because it changes no runtime contract.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Codex CLI 0.153.4 via T3 Code.
- Tool(s): Codex and Codex subagents; Modern Go Guidelines CLI; repository unslop skill.
- Model(s): `gpt-6-astra` for implementation and review agents.
- Involvement: AI-assisted; investigation, tests, verification, and PR text prepared by the agent.
- Adversarial review: independent contract, defect, and integration passes traced middleware translation and reviewed both tests. The reported implementation gap was ruled out on the base branch. An injected adapter bypass made all eight new v2 denial cases fail while the four v1 cases still passed.
