### PR TITLE
fix(build): use pinned plugin SDK in dev Docker builds

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -75,6 +75,20 @@ runs from a clean checkout without them, and release builds set `GOWORK=off`.
 Any SDK package or symbol this repository uses must therefore be pushed and
 tagged in `silo-plugin-sdk` before the change here can merge.
 
+`Dockerfile.dev` uses the SDK version pinned in `go.mod` by default, even when
+a `silo_plugin_sdk` build context is supplied. To test SDK changes from a local
+checkout, opt in explicitly:
+
+```sh
+docker buildx build -f Dockerfile.dev \
+  --build-arg PLUGIN_SDK_SOURCE=local \
+  --build-context silo_plugin_sdk=../silo-plugin-sdk \
+  -t silo:dev --load .
+```
+
+The local checkout must contain all SDK APIs used by the server. Omit the build
+argument and context for a build using the pinned SDK.
+
 Plugin authors should start in the `silo-plugin-sdk` repository, usually checked
 out beside this one. It owns the plugin package format, protobuf contracts,
 generated plugin API, import paths, and manifest helpers.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
+# Use go.mod by default. Local SDK development requires both
+# --build-arg PLUGIN_SDK_SOURCE=local and --build-context silo_plugin_sdk=...
+ARG PLUGIN_SDK_SOURCE=module
+
 # Stage 1: Build frontend
 FROM node:22-slim AS frontend
 RUN corepack enable && corepack prepare pnpm@10.32.1 --activate
@@ -15,7 +19,7 @@ COPY contracts/api/v2/fixtures/ /app/contracts/api/v2/fixtures/
 RUN pnpm run build
 
 # Stage 2: Prepare Go build workspace
-FROM golang:1.26 AS build-base
+FROM golang:1.26 AS go-base
 ENV CGO_ENABLED=1
 ENV GOPROXY=https://proxy.golang.org,direct
 ENV GOPRIVATE=github.com/Silo-Server/*
@@ -24,6 +28,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends libvips-dev && 
 WORKDIR /app
 COPY go.mod go.sum ./
 COPY internal/compat/zishang520-webtransport-go/ internal/compat/zishang520-webtransport-go/
+
+FROM go-base AS sdk-module
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+FROM go-base AS sdk-local
 # Apply the local SDK replacement before downloading modules. Copy its module
 # metadata first so SDK source edits do not invalidate the dependency layer.
 COPY --from=silo_plugin_sdk go.mod go.sum /tmp/silo-plugin-sdk/
@@ -33,6 +44,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go mod edit -replace=github.com/Silo-Server/silo-plugin-sdk=/tmp/silo-plugin-sdk && \
     go mod download
 COPY --from=silo_plugin_sdk pkg/ /tmp/silo-plugin-sdk/pkg/
+
+FROM sdk-${PLUGIN_SDK_SOURCE} AS build-base
 COPY web/embed.go web/embed.go
 COPY --from=frontend /app/web/dist web/dist
 COPY cmd/ cmd/
@@ -42,8 +55,7 @@ COPY migrations/ migrations/
 # internal/, so the build fails without it.
 COPY contracts/ contracts/
 
-# Stage 3: Build Go binary for dev using a local plugin SDK checkout passed via
-# BuildKit named context `silo_plugin_sdk`.
+# Stage 3: Build Go binary for dev with the selected SDK source.
 FROM build-base AS build
 ARG BUILD_REVISION
 ARG BUILD_DIRTY=false


### PR DESCRIPTION
## Problem

Related issue: N/A — narrow fix

Development Docker builds replaced the SDK version in `go.mod` with a sibling checkout. An older checkout caused six undefined-symbol errors for `WatchSyncDeviceAuthorization`, even though the pinned SDK already contained the API.

## Approach

Use the pinned SDK by default. Testing local SDK changes now requires `--build-arg PLUGIN_SDK_SOURCE=local` and the `silo_plugin_sdk` build context. Document both paths in `DEVELOPMENT.md`.

## Validation

- Reproduced all six compiler errors with the stale SDK override; the pinned SDK passed the plugin-host tests.
- BuildKit completed the frontend and Go build stages with a stale context supplied, no SDK context, and an explicit compatible local SDK. These builds used the integration worktree; this PR contains only the two build-related files.
- Rechecked the Go binary build, `go test -count=1 ./internal/pluginhost`, `make verify-local-paths`, and `git diff --check` on this branch.
- The full repository gate and deployment restart were not repeated for this change.
- Required `autoreview --mode local` could not complete because its reviewer returned HTTP 401. This PR remains draft pending that review.

## Risks

Build scripts that intentionally use an SDK checkout must add the new build argument; supplying the context alone now uses the pinned module.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

- Harness: Codex via T3 Code.
- Tool(s): Codex agents; Codex CLI through `autoreview` (review attempt failed).
- Model(s): `gpt-6-astra`; `gpt-5.6-sol` was requested by autoreview but produced no review.
- Involvement: AI-assisted.
- Adversarial review: A separate `gpt-6-astra` agent inspected both changed files for SDK-selection errors and regressions in local SDK builds. It found no actionable issues. This does not replace the pending autoreview gate.
