### PR TITLE
feat(settings): consolidate server public URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,6 @@ POSTGRES_SHM_SIZE=8gb
 # SECRET_KEY=replace-with-output-of-openssl-rand-base64-48
 
 # Optional public URL for Silo. If not set, the server will use the IP address of the container.
-# SILO_PUBLIC_URL=https://silo.example.com
 
 # Optional trusted reverse-proxy CIDRs for client IP resolution. When set, this
 # overrides the "Trusted Proxies" admin setting on every startup (the value is

--- a/cmd/silo/main.go
+++ b/cmd/silo/main.go
@@ -1144,7 +1144,7 @@ func main() {
 		ScanRegistry:                 scanRegistry,
 		OpsLogRepo:                   opsRepo,
 		FFmpegLogSink:                playback.NewSlogFFmpegLogSink(slog.Default(), nodeID),
-		PublicURL:                    os.Getenv("SILO_PUBLIC_URL"),
+		PublicURL:                    cfg.Server.PublicURL,
 		CatalogSearchSettings:        new(catalogSearchStartupSettings),
 		RequestServerRestart: func(context.Context) error {
 			if !restartRequested.CompareAndSwap(false, true) {

--- a/contracts/api/v2/scenarios/api/api-v1-admin-invitations.json
+++ b/contracts/api/v2/scenarios/api/api-v1-admin-invitations.json
@@ -994,7 +994,7 @@
             ]
           },
           "settings": {
-            "notifications.email.external_url": "${public_url}"
+            "server.public_url": "${public_url}"
           },
           "fresh_state": true,
           "v2_expectation": {
@@ -1100,7 +1100,7 @@
             ]
           },
           "settings": {
-            "notifications.email.external_url": "${public_url}"
+            "server.public_url": "${public_url}"
           },
           "fresh_state": true,
           "v2_expectation": {
@@ -1173,7 +1173,7 @@
         {
           "id": "adm_inv_create.public_url_fallback",
           "category": "data_meaning",
-          "description": "With no external_url setting the server PublicURL is the link base.",
+          "description": "With no separate email URL setting the server public URL is the link base.",
           "principal": {
             "class": "acting_admin"
           },

--- a/contracts/api/v2/scenarios/tools/gen_wave1.py
+++ b/contracts/api/v2/scenarios/tools/gen_wave1.py
@@ -576,11 +576,11 @@ def admin_invitations():
     ], not_applicable=na({"filtering": "No filter parameters; every invitation is listed.", "pagination": "Unpaged admin list."}, NA_RAW))
     create_row = row("POST", "/api/v1/admin/invitations/", [
         sc("adm_inv_create.ok", "status_headers", "Sending an invitation answers 201 with the invitation, email_sent, and the claim URL.", "acting_admin", {"path": base, "body": send_body},
-           {"status": 201, "headers": JSON_CT, "body": [{"pointer": "", "op": "keys_equal", "value": ["invitation", "email_sent", "claim_url"]}]}, settings={"notifications.email.external_url": "${public_url}"}, fresh_state=True),
+           {"status": 201, "headers": JSON_CT, "body": [{"pointer": "", "op": "keys_equal", "value": ["invitation", "email_sent", "claim_url"]}]}, settings={"server.public_url": "${public_url}"}, fresh_state=True),
         sc("adm_inv_create.meaning", "data_meaning", "Without SMTP the invitation is still created (email_sent false) and the claim URL embeds a fresh token under the configured link base; defaults are role user, create_profile true, show_tour true.", "acting_admin", {"path": base, "body": send_body},
            {"status": 201, "body": [{"pointer": "/email_sent", "op": "equals", "value": False}, {"pointer": "/claim_url", "op": "matches", "value": "^https://silo\\.example\\.test/invite/[A-Za-z0-9_-]{43}$"},
                                     {"pointer": "/invitation/status", "op": "equals", "value": "pending"}, {"pointer": "/invitation/create_profile", "op": "equals", "value": True}, {"pointer": "/invitation/show_tour", "op": "equals", "value": True},
-                                    {"pointer": "/invitation/invited_by", "op": "equals", "value": "${admin_user_id:int}"}, {"pointer": "/invitation/note", "op": "equals", "value": "welcome"}]}, settings={"notifications.email.external_url": "${public_url}"}, fresh_state=True),
+                                    {"pointer": "/invitation/invited_by", "op": "equals", "value": "${admin_user_id:int}"}, {"pointer": "/invitation/note", "op": "equals", "value": "welcome"}]}, settings={"server.public_url": "${public_url}"}, fresh_state=True),
         sc("adm_inv_create.public_url_fallback", "data_meaning", "With no external_url setting the server PublicURL is the link base.", "acting_admin", {"path": base, "body": send_body},
            {"status": 201, "body": [{"pointer": "/claim_url", "op": "matches", "value": "^https://silo\\.example\\.test/invite/"}]}, fresh_state=True),
         sc("adm_inv_create.supersedes", "filtering", "Re-inviting a pending address revokes the earlier invitation and issues a new one.", "acting_admin", {"path": base, "body": {"email": "fixture-invitee@silo.example.test"}},

--- a/docs/architecture/invitations-onboarding.md
+++ b/docs/architecture/invitations-onboarding.md
@@ -80,7 +80,7 @@ dump yields no usable links.
 - **Revoke is idempotent.** The administrator DELETE route revokes the link;
   physical history deletion is a separate repository operation.
 - **Mail degrades loudly, not silently.** Claim links resolve their base from
-  `notifications.email.external_url`, falling back to the server public URL;
+  the server public URL;
   with neither set, creation fails. With no mail sender configured, the row is
   still created and the claim URL returned with `EmailSent` false so the admin
   copies the link instead of believing an email went out.

--- a/docs/architecture/native-raw-handshakes.md
+++ b/docs/architecture/native-raw-handshakes.md
@@ -54,7 +54,7 @@ it does not omit the operation.
 ## WebSocket origin behind a reverse proxy
 
 The v2 events, playback-control, watch-together and admin-log sockets share a
-strict browser Origin check. `SILO_PUBLIC_URL`, when set, remains the explicit
+strict browser Origin check. The admin-configured Silo public URL remains the explicit
 allowed origin. It must identify this deployment; request headers cannot override
 it. Native clients without Origin still require their socket credential.
 

--- a/docs/wiki/deployment/docker.md
+++ b/docs/wiki/deployment/docker.md
@@ -164,7 +164,8 @@ if you do not use compatible clients.
 > The application and compatibility port mappings listen on all host interfaces
 > by default and do not provide TLS themselves. Before allowing access beyond a
 > trusted local network, use a correctly configured HTTPS reverse proxy and
-> firewall, then set `SILO_PUBLIC_URL` and `SILO_TRUSTED_PROXIES` for that
+> firewall, then configure the Silo public URL and trusted proxies in the admin
+> settings for that
 > deployment. Do not expose PostgreSQL or Redis publicly.
 
 ## Hardware acceleration

--- a/internal/api/handlers/admin_invitations.go
+++ b/internal/api/handlers/admin_invitations.go
@@ -207,7 +207,7 @@ func writeInvitationSendError(w http.ResponseWriter, err error) {
 			"Admin accounts cannot belong to an access group")
 	case errors.Is(err, invitations.ErrNoLinkBase):
 		writeError(w, http.StatusConflict, "no_link_base",
-			"Configure notifications.email.external_url (or a server public URL) so invitation links can be built")
+			"Configure the Silo public URL so invitation links can be built")
 	default:
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to send invitation")
 	}

--- a/internal/api/handlers/admin_logs_socket_v2.go
+++ b/internal/api/handlers/admin_logs_socket_v2.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/access"
@@ -38,6 +39,7 @@ type AdminLogsSocketV2 struct {
 	Validate EventsSocketValidator
 	// PublicOrigin is the configured external origin, never a forwarded header.
 	PublicOrigin  string
+	publicOrigin  atomic.Pointer[string]
 	checkInterval time.Duration
 }
 
@@ -88,7 +90,7 @@ func (h *AdminLogsSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid handshake", http.StatusBadRequest)
 		return
 	}
-	if !socketOriginAllowed(r, h.PublicOrigin) {
+	if !socketOriginAllowed(r, h.currentPublicOrigin()) {
 		http.Error(w, "origin refused", http.StatusForbidden)
 		return
 	}
@@ -153,5 +155,17 @@ func (h *AdminLogsSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}()
-	h.Logs.serveLogStream(w, r.WithContext(ctx), websocket.Upgrader{Subprotocols: []string{AdminLogsSocketProtocol}, CheckOrigin: func(r *http.Request) bool { return socketOriginAllowed(r, h.PublicOrigin) }})
+	h.Logs.serveLogStream(w, r.WithContext(ctx), websocket.Upgrader{Subprotocols: []string{AdminLogsSocketProtocol}, CheckOrigin: func(r *http.Request) bool { return socketOriginAllowed(r, h.currentPublicOrigin()) }})
+}
+
+func (h *AdminLogsSocketV2) currentPublicOrigin() string {
+	if origin := h.publicOrigin.Load(); origin != nil {
+		return *origin
+	}
+	return h.PublicOrigin
+}
+
+func (h *AdminLogsSocketV2) SetPublicOrigin(origin string) {
+	normalized := strings.TrimRight(origin, "/")
+	h.publicOrigin.Store(&normalized)
 }

--- a/internal/api/handlers/events_socket_v2.go
+++ b/internal/api/handlers/events_socket_v2.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/access"
@@ -35,6 +36,7 @@ type EventsSocketV2 struct {
 	Validate EventsSocketValidator
 	// PublicOrigin is the configured external origin, never a forwarded header.
 	PublicOrigin  string
+	publicOrigin  atomic.Pointer[string]
 	checkInterval time.Duration
 }
 
@@ -130,7 +132,20 @@ func (h *EventsSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *EventsSocketV2) validOrigin(r *http.Request) bool {
-	return socketOriginAllowed(r, h.PublicOrigin)
+	return socketOriginAllowed(r, h.currentPublicOrigin())
+}
+
+func (h *EventsSocketV2) currentPublicOrigin() string {
+	if origin := h.publicOrigin.Load(); origin != nil {
+		return *origin
+	}
+	return h.PublicOrigin
+}
+
+// SetPublicOrigin updates the browser origin accepted by new handshakes.
+func (h *EventsSocketV2) SetPublicOrigin(origin string) {
+	normalized := strings.TrimRight(origin, "/")
+	h.publicOrigin.Store(&normalized)
 }
 
 func socketOriginAllowed(r *http.Request, publicOrigin string) bool {

--- a/internal/api/handlers/notification_discord_links.go
+++ b/internal/api/handlers/notification_discord_links.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 
 	"github.com/Silo-Server/silo-server/internal/discord"
 	"github.com/Silo-Server/silo-server/internal/notifications"
@@ -36,28 +37,45 @@ type NotificationDiscordLinkBackend interface {
 }
 
 type DiscordLinkHandler struct {
-	backend   NotificationDiscordLinkBackend
-	settings  *notifications.Settings
-	publicURL string
+	backend      NotificationDiscordLinkBackend
+	settings     *notifications.Settings
+	publicURL    string
+	publicOrigin atomic.Pointer[string]
 }
 
 func NewDiscordLinkHandler(backend NotificationDiscordLinkBackend, settings *notifications.Settings, publicURL string) *DiscordLinkHandler {
-	return &DiscordLinkHandler{backend: backend, settings: settings, publicURL: strings.TrimRight(publicURL, "/")}
+	h := &DiscordLinkHandler{backend: backend, settings: settings, publicURL: strings.TrimRight(publicURL, "/")}
+	h.SetPublicURL(publicURL)
+	return h
+}
+
+func (h *DiscordLinkHandler) currentPublicURL() string {
+	if value := h.publicOrigin.Load(); value != nil {
+		return *value
+	}
+	return h.publicURL
+}
+
+// SetPublicURL updates the origin used for future Discord link handshakes.
+func (h *DiscordLinkHandler) SetPublicURL(publicURL string) {
+	normalized := strings.TrimRight(strings.TrimSpace(publicURL), "/")
+	h.publicOrigin.Store(&normalized)
 }
 func (h *DiscordNotificationsHandler) linkHandler() *DiscordLinkHandler {
 	var settings *notifications.Settings
 	if h.system != nil {
 		settings = h.system.Settings
 	}
-	return NewDiscordLinkHandler(h.system, settings, h.publicURL)
+	return NewDiscordLinkHandler(h.system, settings, h.currentPublicURL())
 }
 
 func (h *DiscordLinkHandler) beginLink(ctx context.Context, userID int, callbackPath string) (string, error) {
 	if h.backend == nil || !h.backend.DiscordAvailable(ctx) {
 		return "", apiError(409, "not_configured", "Discord integration is not enabled by the administrator")
 	}
-	if h.publicURL == "" {
-		return "", apiError(409, "no_public_url", "Linking requires SILO_PUBLIC_URL to be configured")
+	publicURL := h.currentPublicURL()
+	if publicURL == "" {
+		return "", apiError(409, "no_public_url", "Linking requires the Silo public URL to be configured")
 	}
 	stateBytes := make([]byte, 32)
 	if _, err := rand.Read(stateBytes); err != nil {
@@ -67,7 +85,7 @@ func (h *DiscordLinkHandler) beginLink(ctx context.Context, userID int, callback
 	if err := h.backend.BeginDiscordLink(ctx, state, userID); err != nil {
 		return "", apiError(500, "internal_error", "Failed to start Discord link")
 	}
-	query := url.Values{"client_id": {h.settings.DiscordClientID(ctx)}, "response_type": {discordLinkCode}, discordLinkScope: {"identify"}, "redirect_uri": {h.publicURL + callbackPath}, discordLinkState: {state}}
+	query := url.Values{"client_id": {h.settings.DiscordClientID(ctx)}, "response_type": {discordLinkCode}, discordLinkScope: {"identify"}, "redirect_uri": {publicURL + callbackPath}, discordLinkState: {state}}
 	return discord.AuthorizeURL + "?" + query.Encode(), nil
 }
 
@@ -100,7 +118,7 @@ func (h *DiscordLinkHandler) handleCallback(w http.ResponseWriter, r *http.Reque
 		redirectBack(url.Values{discordLinkDiscordError: {discordLinkStateInvalid}})
 		return
 	}
-	if _, err = h.backend.CompleteDiscordLink(r.Context(), userID, code, h.publicURL+callbackPath); err != nil {
+	if _, err = h.backend.CompleteDiscordLink(r.Context(), userID, code, h.currentPublicURL()+callbackPath); err != nil {
 		redirectBack(url.Values{discordLinkDiscordError: {discordLinkExchangeFailed}})
 		return
 	}

--- a/internal/api/handlers/notifications_discord.go
+++ b/internal/api/handlers/notifications_discord.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	apimw "github.com/Silo-Server/silo-server/internal/api/middleware"
@@ -21,15 +22,31 @@ const discordSettingsPath = "/settings/notifications"
 // public because Discord redirects the browser there without credentials —
 // the one-time server-side state row authenticates it instead.
 type DiscordNotificationsHandler struct {
-	system    *notifications.System
-	publicURL string
+	system       *notifications.System
+	publicURL    string
+	publicOrigin atomic.Pointer[string]
 }
 
 // NewDiscordNotificationsHandler creates a DiscordNotificationsHandler.
 // publicURL may be empty, in which case linking is reported unavailable
 // (Discord needs a stable redirect_uri origin).
 func NewDiscordNotificationsHandler(system *notifications.System, publicURL string) *DiscordNotificationsHandler {
-	return &DiscordNotificationsHandler{system: system, publicURL: strings.TrimRight(publicURL, "/")}
+	h := &DiscordNotificationsHandler{system: system, publicURL: strings.TrimRight(publicURL, "/")}
+	h.SetPublicURL(publicURL)
+	return h
+}
+
+// SetPublicURL updates the origin used for future Discord link handshakes.
+func (h *DiscordNotificationsHandler) SetPublicURL(publicURL string) {
+	normalized := strings.TrimRight(strings.TrimSpace(publicURL), "/")
+	h.publicOrigin.Store(&normalized)
+}
+
+func (h *DiscordNotificationsHandler) currentPublicURL() string {
+	if value := h.publicOrigin.Load(); value != nil {
+		return *value
+	}
+	return h.publicURL
 }
 
 // discordPreferencesResponse is the account-level Discord DM setting plus

--- a/internal/api/handlers/playback_control_socket_v2.go
+++ b/internal/api/handlers/playback_control_socket_v2.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -184,6 +185,7 @@ type PlaybackControlSocketV2 struct {
 	Validate EventsSocketValidator
 	// PublicOrigin is the configured external origin, never a forwarded header.
 	PublicOrigin  string
+	publicOrigin  atomic.Pointer[string]
 	checkInterval time.Duration
 
 	laneMu sync.Mutex
@@ -275,7 +277,7 @@ func (h *PlaybackControlSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "invalid handshake", http.StatusBadRequest)
 		return
 	}
-	if !socketOriginAllowed(r, h.PublicOrigin) {
+	if !socketOriginAllowed(r, h.currentPublicOrigin()) {
 		http.Error(w, "origin refused", http.StatusForbidden)
 		return
 	}
@@ -332,7 +334,7 @@ func (h *PlaybackControlSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	ctx, cancel := context.WithDeadline(validated, deadline)
 	defer cancel()
 
-	upgrader := websocket.Upgrader{Subprotocols: []string{PlaybackControlSocketProtocol}, CheckOrigin: func(r *http.Request) bool { return socketOriginAllowed(r, h.PublicOrigin) }}
+	upgrader := websocket.Upgrader{Subprotocols: []string{PlaybackControlSocketProtocol}, CheckOrigin: func(r *http.Request) bool { return socketOriginAllowed(r, h.currentPublicOrigin()) }}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		slog.ErrorContext(r.Context(), "playback control websocket upgrade failed", "component", "api", "error", err, "session", sessionID, "playback_session_id", sessionID)
@@ -410,6 +412,18 @@ func (h *PlaybackControlSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			slog.WarnContext(r.Context(), "invalid realtime client message", "component", "api", "session", sessionID, "playback_session_id", sessionID, "error", err)
 		}
 	}
+}
+
+func (h *PlaybackControlSocketV2) currentPublicOrigin() string {
+	if origin := h.publicOrigin.Load(); origin != nil {
+		return *origin
+	}
+	return h.PublicOrigin
+}
+
+func (h *PlaybackControlSocketV2) SetPublicOrigin(origin string) {
+	normalized := strings.TrimRight(origin, "/")
+	h.publicOrigin.Store(&normalized)
 }
 
 func (h *PlaybackControlSocketV2) owns(sessionID string, lane *playbackControlLane) bool {

--- a/internal/api/handlers/watch_together_socket_v2.go
+++ b/internal/api/handlers/watch_together_socket_v2.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Silo-Server/silo-server/internal/access"
@@ -24,6 +25,7 @@ type WatchTogetherSocketV2 struct {
 	Tickets       roomSocketTickets
 	Validate      EventsSocketValidator
 	PublicOrigin  string
+	publicOrigin  atomic.Pointer[string]
 	checkInterval time.Duration
 }
 
@@ -80,7 +82,7 @@ func (h *WatchTogetherSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Request
 		http.Error(w, "invalid handshake", http.StatusBadRequest)
 		return
 	}
-	if !socketOriginAllowed(r, h.PublicOrigin) {
+	if !socketOriginAllowed(r, h.currentPublicOrigin()) {
 		http.Error(w, "origin refused", http.StatusForbidden)
 		return
 	}
@@ -124,7 +126,7 @@ func (h *WatchTogetherSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 	ctx, cancel := context.WithDeadline(validated, deadline)
 	defer cancel()
-	upgrader := websocket.Upgrader{Subprotocols: []string{watchtogether.RoomSocketProtocol}, CheckOrigin: func(r *http.Request) bool { return socketOriginAllowed(r, h.PublicOrigin) }}
+	upgrader := websocket.Upgrader{Subprotocols: []string{watchtogether.RoomSocketProtocol}, CheckOrigin: func(r *http.Request) bool { return socketOriginAllowed(r, h.currentPublicOrigin()) }}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
@@ -158,4 +160,16 @@ func (h *WatchTogetherSocketV2) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 	}()
 	h.Room.serveRoomConnection(ctx, conn, roomID, claims.UserID, credential.Session.ProfileID)
+}
+
+func (h *WatchTogetherSocketV2) currentPublicOrigin() string {
+	if origin := h.publicOrigin.Load(); origin != nil {
+		return *origin
+	}
+	return h.PublicOrigin
+}
+
+func (h *WatchTogetherSocketV2) SetPublicOrigin(origin string) {
+	normalized := strings.TrimRight(origin, "/")
+	h.publicOrigin.Store(&normalized)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -479,7 +479,7 @@ func newChiRouter(deps Dependencies) chi.Router {
 				authService,
 				mail.NewSMTPSender(settingsRepo),
 				settingsRepo,
-				deps.PublicURL,
+				"",
 			)
 		}
 		profileTokenService = access.NewProfileTokenService(deps.Config.Auth.JWTSecret, 0)
@@ -869,6 +869,9 @@ func newChiRouter(deps Dependencies) chi.Router {
 				deps.RedisClient,
 			)
 			autoscanHandler = handlers.NewAutoscanHandler(autoscanRepo, autoscanSvc)
+			if deps.OnConfigChange != nil {
+				deps.OnConfigChange(func(_, updated *config.Config) { autoscanHandler.SetPublicURL(updated.Server.PublicURL) })
+			}
 			// Wire the optional poll-task rescheduler so a settings change
 			// re-applies the poll interval without a restart.
 			if deps.TaskManager != nil {
@@ -1961,7 +1964,7 @@ func newChiRouter(deps Dependencies) chi.Router {
 	// so completeOAuthLogin shares it with the v1 routes.
 	var oauthHandler *auth.OAuthHandler
 	if authHandler != nil {
-		if deps.PublicURL != "" && deps.DB != nil && authService != nil && jwtService != nil {
+		if deps.DB != nil && authService != nil && jwtService != nil {
 			stateSecret := auth.DeriveOAuthStateSecret([]byte(deps.Config.Auth.JWTSecret))
 			oauthStore := auth.NewPGOAuthStore(deps.DB, stateSecret)
 			resolveClient := func(ctx context.Context, installationID int) (auth.OAuthClient, string, error) {
@@ -1984,6 +1987,11 @@ func newChiRouter(deps Dependencies) chi.Router {
 				HostBaseURL:     deps.PublicURL,
 				StateTTL:        10 * time.Minute,
 			})
+			if deps.OnConfigChange != nil {
+				deps.OnConfigChange(func(_, updated *config.Config) {
+					oauthHandler.SetHostBaseURL(updated.Server.PublicURL)
+				})
+			}
 		}
 	}
 
@@ -2011,7 +2019,11 @@ func newChiRouter(deps Dependencies) chi.Router {
 		v2deps.ScanControls = libraryHandler
 	}
 	if deps.OpsLogRepo != nil && deps.ActivityLogRepo != nil && deps.LogStreamHub != nil && sessionRepo != nil && userRepo != nil {
-		v2deps.AdminLogsSocket = handlers.NewAdminLogsSocketV2(handlers.NewAdminLogsHandler(deps.OpsLogRepo, deps.ActivityLogRepo, deps.LogStreamHub), evt.NewSocketTicketStore(deps.RedisClient), sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+		socket := handlers.NewAdminLogsSocketV2(handlers.NewAdminLogsHandler(deps.OpsLogRepo, deps.ActivityLogRepo, deps.LogStreamHub), evt.NewSocketTicketStore(deps.RedisClient), sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+		v2deps.AdminLogsSocket = socket
+		if deps.OnConfigChange != nil {
+			deps.OnConfigChange(func(_, updated *config.Config) { socket.SetPublicOrigin(updated.Server.PublicURL) })
+		}
 	}
 	if autoscanHandler != nil {
 		v2deps.AutoscanDelivery = autoscanHandler
@@ -2109,7 +2121,11 @@ func newChiRouter(deps Dependencies) chi.Router {
 	if playbackHandler != nil {
 		v2deps.Playback = playbackHandler
 		if sessionRepo != nil && userRepo != nil {
-			v2deps.PlaybackControlSocket = handlers.NewPlaybackControlSocketV2(playbackHandler, deps.RedisClient, sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+			socket := handlers.NewPlaybackControlSocketV2(playbackHandler, deps.RedisClient, sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+			v2deps.PlaybackControlSocket = socket
+			if deps.OnConfigChange != nil {
+				deps.OnConfigChange(func(_, updated *config.Config) { socket.SetPublicOrigin(updated.Server.PublicURL) })
+			}
 		}
 		// Raw v2 delivery shares the byte-protocol handlers; fonts use the typed
 		// service. Both retain token-carried reconstruction and deny markers.
@@ -2187,7 +2203,11 @@ func newChiRouter(deps Dependencies) chi.Router {
 		v2deps.WatchTogetherSelection = watchTogetherHandler
 		v2deps.WatchTogetherCreate = watchTogetherHandler
 		if deps.RedisClient != nil && sessionRepo != nil && userRepo != nil {
-			v2deps.WatchTogetherSocket = handlers.NewWatchTogetherSocketV2(watchTogetherHandler, watchtogether.NewRoomSocketCredentialStore(deps.RedisClient), sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+			socket := handlers.NewWatchTogetherSocketV2(watchTogetherHandler, watchtogether.NewRoomSocketCredentialStore(deps.RedisClient), sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+			v2deps.WatchTogetherSocket = socket
+			if deps.OnConfigChange != nil {
+				deps.OnConfigChange(func(_, updated *config.Config) { socket.SetPublicOrigin(updated.Server.PublicURL) })
+			}
 		}
 	}
 	if deps.EventsHub != nil {
@@ -2195,7 +2215,11 @@ func newChiRouter(deps Dependencies) chi.Router {
 		events.SetNotificationsSystem(deps.Notifications)
 		v2deps.EventsCapability = events
 		if sessionRepo != nil && userRepo != nil {
-			v2deps.EventsSocket = handlers.NewEventsSocketV2(events, evt.NewSocketTicketStore(deps.RedisClient), sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+			socket := handlers.NewEventsSocketV2(events, evt.NewSocketTicketStore(deps.RedisClient), sessionRepo, userRepo, viewerResolver, checkPrimaryProfile, deps.PublicURL)
+			v2deps.EventsSocket = socket
+			if deps.OnConfigChange != nil {
+				deps.OnConfigChange(func(_, updated *config.Config) { socket.SetPublicOrigin(updated.Server.PublicURL) })
+			}
 		}
 	}
 	if deps.Notifications != nil {
@@ -2212,7 +2236,11 @@ func newChiRouter(deps Dependencies) chi.Router {
 		v2deps.NotificationChannels = deps.Notifications
 		v2deps.NotificationEmailVerification = deps.Notifications.EmailVerification
 		v2deps.NotificationEmailLinks = handlers.NewEmailLinkHandler(deps.Notifications)
-		v2deps.NotificationDiscordLinks = handlers.NewDiscordLinkHandler(deps.Notifications, deps.Notifications.Settings, deps.PublicURL)
+		linkHandler := handlers.NewDiscordLinkHandler(deps.Notifications, deps.Notifications.Settings, deps.PublicURL)
+		v2deps.NotificationDiscordLinks = linkHandler
+		if deps.OnConfigChange != nil {
+			deps.OnConfigChange(func(_, updated *config.Config) { linkHandler.SetPublicURL(updated.Server.PublicURL) })
+		}
 		v2deps.NotificationRelay = handlers.NewAdminApplePushHandler(deps.Notifications, settingsRepo)
 	}
 	v2deps.AdminAccessGroups = accessGroupHandler
@@ -2667,6 +2695,10 @@ func newChiRouter(deps Dependencies) chi.Router {
 		var discordNotificationsHandler *handlers.DiscordNotificationsHandler
 		if deps.Notifications != nil {
 			discordNotificationsHandler = handlers.NewDiscordNotificationsHandler(deps.Notifications, deps.PublicURL)
+			if deps.OnConfigChange != nil {
+				h := discordNotificationsHandler
+				deps.OnConfigChange(func(_, updated *config.Config) { h.SetPublicURL(updated.Server.PublicURL) })
+			}
 			r.Get("/notifications/discord/link/callback", discordNotificationsHandler.HandleLinkCallback)
 
 			// Tokenized email links: public — clicked from mail clients on

--- a/internal/api/testdata/media_routes.txt
+++ b/internal/api/testdata/media_routes.txt
@@ -950,6 +950,9 @@ POST /api/v1/auth/impersonation/end	non-media
 POST /api/v1/auth/login	non-media
 POST /api/v1/auth/logout	non-media
 GET /api/v1/auth/me	non-media
+POST /api/v1/auth/oauth/complete	non-media
+GET /api/v1/auth/oauth/{install_id}/callback	non-media
+POST /api/v1/auth/oauth/{install_id}/init	non-media
 POST /api/v1/auth/plugin-launch	non-media
 GET /api/v1/auth/providers	non-media
 POST /api/v1/auth/refresh	non-media

--- a/internal/auth/oauth_handler.go
+++ b/internal/auth/oauth_handler.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	pluginv1 "github.com/Silo-Server/silo-plugin-sdk/pkg/pluginproto/silo/plugin/v1"
@@ -65,7 +66,8 @@ type OAuthHandlerDeps struct {
 
 // OAuthHandler serves /init and /callback for OAuth-capable auth plugins.
 type OAuthHandler struct {
-	deps OAuthHandlerDeps
+	deps        OAuthHandlerDeps
+	hostBaseURL atomic.Pointer[string]
 }
 
 func NewOAuthHandler(d OAuthHandlerDeps) *OAuthHandler {
@@ -80,7 +82,23 @@ func NewOAuthHandler(d OAuthHandlerDeps) *OAuthHandler {
 			d.CompletionStore = store
 		}
 	}
-	return &OAuthHandler{deps: d}
+	h := &OAuthHandler{deps: d}
+	h.SetHostBaseURL(d.HostBaseURL)
+	return h
+}
+
+// SetHostBaseURL updates the externally reachable origin used for future
+// OAuth redirects.
+func (h *OAuthHandler) SetHostBaseURL(url string) {
+	normalized := strings.TrimRight(strings.TrimSpace(url), "/")
+	h.hostBaseURL.Store(&normalized)
+}
+
+func (h *OAuthHandler) currentHostBaseURL() string {
+	if value := h.hostBaseURL.Load(); value != nil {
+		return *value
+	}
+	return h.deps.HostBaseURL
 }
 
 // ErrMissingInstallID is returned when the URL path has no install_id.
@@ -125,13 +143,16 @@ func writeHandshakeError(w http.ResponseWriter, err error) {
 // prefix ("/api/v1" or "/api/v2"). The provider must have the URI it is
 // handed registered, so the init and callback of one flow share a prefix.
 func (h *OAuthHandler) CallbackURL(prefix string, installID int) string {
-	return strings.TrimRight(h.deps.HostBaseURL, "/") + prefix + "/auth/oauth/" + strconv.Itoa(installID) + "/callback"
+	return h.currentHostBaseURL() + prefix + "/auth/oauth/" + strconv.Itoa(installID) + "/callback"
 }
 
 // Init opens an OAuth session with the plugin and returns the provider's
 // authorize URL the browser is sent to. v1 POST /auth/oauth/{install_id}/init
 // and the v2 handshake both call it; a failure is an *OAuthHandshakeError.
 func (h *OAuthHandler) Init(ctx context.Context, installID int, next, redirectURI string) (string, error) {
+	if h.currentHostBaseURL() == "" {
+		return "", &OAuthHandshakeError{Status: http.StatusConflict, Message: "Silo public URL is not configured"}
+	}
 	next = normalizeOAuthNext(next)
 
 	client, _, err := h.deps.ResolveClient(ctx, installID)
@@ -296,7 +317,7 @@ func (h *OAuthHandler) Callback(ctx context.Context, in OAuthCallbackInput) stri
 
 	values := url.Values{}
 	values.Set("code", completionCode)
-	completeURL := strings.TrimRight(h.deps.HostBaseURL, "/") + h.deps.FrontendCompletePath + "?" + values.Encode()
+	completeURL := h.currentHostBaseURL() + h.deps.FrontendCompletePath + "?" + values.Encode()
 	return completeURL
 }
 

--- a/internal/config/admin_settings.go
+++ b/internal/config/admin_settings.go
@@ -55,6 +55,7 @@ var adminSettingDefaults = map[string]string{
 	"auth.refresh_token_expiry": "30d",
 	"server.log_level":          "info",
 	"server.log_quiet":          "",
+	"server.public_url":         "",
 	"branding.server_name":      "Silo",
 	"branding.login_subtitle":   "Sign in with an existing account.",
 	"clientip.trusted_proxies":  "10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, ::1/128",
@@ -498,7 +499,7 @@ func NormalizeAdminSetting(key, raw string) (string, error) {
 		return value, nil
 
 	case "ai.base_url", "ai.asr_base_url", "recommendations.embedding_base_url",
-		"jellyfin_compat.public_url", "notifications.email.external_url",
+		"server.public_url", "jellyfin_compat.public_url",
 		"s3.public_endpoint", "s3.public_read_endpoint", "s3.private_endpoint",
 		"s3.user_db_endpoint", "catalog.search.meilisearch.url":
 		return normalizeAdminURL(key, value)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type ServerConfig struct {
 	LogLevel  string `yaml:"log_level"`
 	LogFormat string `yaml:"log_format"`
 	LogQuiet  string `yaml:"log_quiet"`
+	PublicURL string `yaml:"public_url"`
 }
 
 // DatabaseConfig holds the primary PostgreSQL connection settings.

--- a/internal/config/db_loader.go
+++ b/internal/config/db_loader.go
@@ -223,6 +223,7 @@ func LoadFromDB(m map[string]string) (*Config, error) {
 	// Client IP resolution ("" = clientip package defaults). Kept in the
 	// config snapshot so the nodeconfig watcher hot-reloads the resolver.
 	cfg.ClientIP.TrustedProxies = stringOr(m, "clientip.trusted_proxies", "")
+	cfg.Server.PublicURL = stringOr(m, "server.public_url", "")
 
 	// TMDB collection presets (independent of metadata providers)
 	cfg.TMDBAPIKey = stringOr(m, "tmdb.api_key", "")

--- a/internal/invitations/service.go
+++ b/internal/invitations/service.go
@@ -87,7 +87,7 @@ type Service struct {
 
 // NewService wires the invitation service. publicURL is the server's
 // externally reachable origin, used as the link-base fallback when
-// notifications.email.external_url is unset; may be empty.
+// server.public_url is unset; may be empty.
 func NewService(
 	repo *Repository,
 	users userDirectory,
@@ -338,11 +338,10 @@ func (s *Service) claimable(ctx context.Context, token string) (*models.Invitati
 	return inv, nil
 }
 
-// linkBase resolves the externally reachable base URL for claim links:
-// notifications.email.external_url, falling back to the server public URL.
+// linkBase resolves the canonical externally reachable base URL for claim links.
 func (s *Service) linkBase(ctx context.Context) string {
 	if s.settings != nil {
-		if base, err := s.settings.Get(ctx, "notifications.email.external_url"); err == nil {
+		if base, err := s.settings.Get(ctx, "server.public_url"); err == nil {
 			if base = strings.TrimRight(strings.TrimSpace(base), "/"); base != "" {
 				return base
 			}

--- a/internal/invitations/service_test.go
+++ b/internal/invitations/service_test.go
@@ -416,14 +416,14 @@ func TestLookupHidesLifecycleDetail(t *testing.T) {
 
 func TestLinkBasePrefersExternalURLSetting(t *testing.T) {
 	svc := newTestService(newFakeRepo(), adminInviter(), &fakeAccounts{}, &fakeSessions{}, &fakeMail{configured: true},
-		fakeSettings{"notifications.email.external_url": "https://media.example.net/"})
+		fakeSettings{"server.public_url": "https://media.example.net/"})
 
 	result, err := svc.Send(context.Background(), SendInput{Email: testInvitee, InvitedBy: 1})
 	if err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if !strings.HasPrefix(result.ClaimURL, "https://media.example.net/invite/") {
-		t.Errorf("claim URL = %q, want external_url base", result.ClaimURL)
+		t.Errorf("claim URL = %q, want server public URL base", result.ClaimURL)
 	}
 }
 

--- a/internal/notifications/email_address.go
+++ b/internal/notifications/email_address.go
@@ -44,8 +44,7 @@ func hashEmailToken(token string) string {
 }
 
 // emailLinkBase is the externally reachable base URL for tokenized email
-// links: the admin's notifications.email.external_url, falling back to the
-// server's public URL.
+// links: the admin's server.public_url setting.
 func (s *System) emailLinkBase(ctx context.Context) string {
 	if base := s.Settings.EmailExternalURL(ctx); base != "" {
 		return base
@@ -54,8 +53,7 @@ func (s *System) emailLinkBase(ctx context.Context) string {
 }
 
 // SetPublicURL wires the server's externally reachable base URL, used as the
-// fallback for verification links when notifications.email.external_url is
-// unset. Optional.
+// fallback for verification links when the setting is unavailable. Optional.
 func (s *System) SetPublicURL(url string) {
 	if s != nil {
 		s.publicURL = strings.TrimRight(url, "/")

--- a/internal/notifications/settings.go
+++ b/internal/notifications/settings.go
@@ -45,7 +45,6 @@ const (
 	SettingEmailEnabled         = "notifications.email_enabled"
 	SettingEmailAllowPerEpisode = "notifications.email.allow_per_episode"
 	SettingEmailDigestHour      = "notifications.email.digest_hour"
-	SettingEmailExternalURL     = "notifications.email.external_url"
 
 	SettingDiscordEnabled         = "notifications.discord_enabled"
 	SettingDiscordAllowPerEpisode = "notifications.discord.allow_per_episode"
@@ -331,11 +330,10 @@ func (s *Settings) EmailDigestHour(ctx context.Context) int {
 	return s.intSetting(ctx, SettingEmailDigestHour, defaultDigestHour, 0, 23)
 }
 
-// EmailExternalURL is the externally reachable base URL of this server, used
-// for deep links inside notification emails. Empty renders emails without
-// links (webhooks deliberately never leak the origin; email is opt-in here).
+// EmailExternalURL is the canonical externally reachable base URL of this
+// server, used for deep links inside notification emails.
 func (s *Settings) EmailExternalURL(ctx context.Context) string {
-	return strings.TrimRight(strings.TrimSpace(s.raw(ctx, SettingEmailExternalURL)), "/")
+	return strings.TrimRight(strings.TrimSpace(s.raw(ctx, "server.public_url")), "/")
 }
 
 // DiscordEnabled is the master switch for the Discord bot integration. Like

--- a/internal/scenariocatalog/admin_invitation_lifecycle_pairing.go
+++ b/internal/scenariocatalog/admin_invitation_lifecycle_pairing.go
@@ -73,7 +73,7 @@ func AdminInvitationLifecycleAcceptance(catalogs []*Catalog) ([]*Catalog, error)
 						}
 						want.Body = s.Request.Body
 						if s.ID == "adm_inv_create.ok" || s.ID == "adm_inv_create.meaning" {
-							settings = map[string]string{"notifications.email.external_url": "${public_url}"}
+						settings = map[string]string{"server.public_url": "${public_url}"}
 						}
 					case 2:
 						want.Path += "${invitation_pending_id}/resend"

--- a/internal/scenariocatalog/executor/env.go
+++ b/internal/scenariocatalog/executor/env.go
@@ -371,7 +371,7 @@ func (e *Env) Reseed() {
 			true, false, 5, 5,
 			ARRAY['marker_edit'], true
 		)`,
-		`DELETE FROM server_settings WHERE key IN ('demo.enabled','signup.enabled','notifications.email.external_url','branding.server_name','sections.allow_profile_custom_sections')`,
+		`DELETE FROM server_settings WHERE key IN ('demo.enabled','signup.enabled','server.public_url','branding.server_name','sections.allow_profile_custom_sections')`,
 	} {
 		if _, err := e.pool.Exec(ctx, stmt); err != nil {
 			e.t.Fatalf("scenario executor: reseed %q: %v", stmt, err)

--- a/migrations/sql/20260911010527_consolidate_server_public_url.sql
+++ b/migrations/sql/20260911010527_consolidate_server_public_url.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+INSERT INTO server_settings (key, value)
+SELECT 'server.public_url', value
+FROM server_settings
+WHERE key = 'notifications.email.external_url'
+  AND value <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM server_settings
+    WHERE key = 'server.public_url' AND value <> ''
+  )
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+WHERE server_settings.value = '';
+
+DELETE FROM server_settings WHERE key = 'notifications.email.external_url';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- The old setting is intentionally not restored; its value was migrated into
+-- server.public_url and cannot be safely split back from the canonical key.
+-- +goose StatementEnd

--- a/web/src/pages/admin-settings/GeneralSettings.test.tsx
+++ b/web/src/pages/admin-settings/GeneralSettings.test.tsx
@@ -65,6 +65,7 @@ describe("GeneralSettings", () => {
     renderPage();
 
     expect(useSettingsFormMock.mock.calls[0]?.[0]?.keys).toEqual([
+      "server.public_url",
       "branding.server_name",
       "branding.login_subtitle",
       "signup.enabled",

--- a/web/src/pages/admin-settings/GeneralSettings.tsx
+++ b/web/src/pages/admin-settings/GeneralSettings.tsx
@@ -19,7 +19,7 @@ const ACCESS_KEYS = ["signup.enabled"];
 const LOGGING_ADVANCED_KEYS = ["server.log_quiet"];
 const LOGGING_KEYS = ["server.log_level", ...LOGGING_ADVANCED_KEYS];
 
-const KEYS = [...IDENTITY_KEYS, ...ACCESS_KEYS, ...LOGGING_KEYS];
+const KEYS = ["server.public_url", ...IDENTITY_KEYS, ...ACCESS_KEYS, ...LOGGING_KEYS];
 
 export default function GeneralSettings() {
   const form = useSettingsForm({ keys: useMemo(() => KEYS, []) });
@@ -72,6 +72,19 @@ export default function GeneralSettings() {
             value={form.getValue("branding.login_subtitle")}
             onChange={(v) => form.setValue("branding.login_subtitle", v)}
             restartRequired={restartKeys.has("branding.login_subtitle")}
+          />
+        </FieldGroup>
+
+        <FieldGroup label="Network">
+          <SettingField
+            label="Silo public URL"
+            settingKey="server.public_url"
+            dirty={form.isDirty("server.public_url")}
+            description="The HTTPS address users open. Used for websocket origins and links in email notifications."
+            hint="https://silo.example.com"
+            value={form.getValue("server.public_url")}
+            onChange={(v) => form.setValue("server.public_url", v)}
+            restartRequired={restartKeys.has("server.public_url")}
           />
         </FieldGroup>
 

--- a/web/src/pages/admin-settings/NotificationsAdminSettings.tsx
+++ b/web/src/pages/admin-settings/NotificationsAdminSettings.tsx
@@ -131,7 +131,6 @@ const KEYS = [
   "notifications.email_enabled",
   "notifications.email.allow_per_episode",
   "notifications.email.digest_hour",
-  "notifications.email.external_url",
   "notifications.discord_enabled",
   "notifications.discord.allow_per_episode",
   "notifications.discord.digest_hour",
@@ -520,7 +519,7 @@ function DiscordSetupGuide() {
               <code className="bg-muted mx-1 rounded px-1">
                 {"<public URL>"}/api/v2/notifications/discord/link/callback
               </code>
-              using this server&apos;s public URL (SILO_PUBLIC_URL) — it must match exactly.
+              using this server&apos;s public URL — it must match exactly.
             </li>
             <li>
               Bot page: reset and copy the <strong>Token</strong>. Leave all Privileged Gateway
@@ -1190,14 +1189,6 @@ export default function NotificationsAdminSettings() {
                 value={numberValue("notifications.email.digest_hour", "8")}
                 onChange={(v) => form.setValue("notifications.email.digest_hour", v)}
                 restartRequired={needsRestart("notifications.email.digest_hour")}
-              />
-              <SettingField
-                label="Public URL"
-                description="Used for links inside emails; leave empty to omit them."
-                type="text"
-                value={form.getValue("notifications.email.external_url")}
-                onChange={(v) => form.setValue("notifications.email.external_url", v)}
-                restartRequired={needsRestart("notifications.email.external_url")}
               />
             </div>
           </ChannelCard>


### PR DESCRIPTION
## Problem
The server public URL was split between `SILO_PUBLIC_URL` and an email-specific admin setting. That made Compose configuration mandatory for features that should be controlled by the admin UI, and WebSocket and redirect consumers could drift apart.

## Solution
Add `server.public_url` as the canonical admin setting in General settings, migrate the email URL value, remove the email-specific field and Compose example, and hot-reload the value into WebSocket origin checks, OAuth, Discord, autoscan, invitations, and notification links. Keep `jellyfin_compat.public_url` independent.

Related issue: N/A — narrow fix

## Validation
- Focused Go package compile checks passed.
- General settings Vitest passed (6 tests).
- API route manifest regenerated and verified.
- Shared-dev deployed successfully after correcting the migration marker format; health, readiness, and authenticated admin checks passed.

## Risks and follow-up
Existing installations need the included migration. An unset canonical URL leaves same-origin WebSocket checks available while absolute links and OAuth flows report that a public URL is unavailable.

## AI disclosure
Implemented with OpenAI GPT-5.6 (Codex) using the Codex agent harness. Tooling used: shell commands, Go tests, Vitest, Docker Compose deployment, and GitHub CLI. Independent review: n/a.
