### PR TITLE
feat(subtitles): canonicalize language tags across API and web

### DIFF
--- a/contracts/api/v2/fixtures/index.json
+++ b/contracts/api/v2/fixtures/index.json
@@ -2673,7 +2673,7 @@
       "response_headers": {
         "Cache-Control": "no-store",
         "Content-Type": "application/json",
-        "ETag": "\"9b07cdc36185c156824ae499.3dxsdbe524161\""
+        "ETag": "\"339362a593cbfebf9c51695e.zr8049rd444s\""
       },
       "response_media_type": "application/json",
       "schema": "#/components/schemas/AdminSubtitleMetadata",

--- a/contracts/language-canonicalization.json
+++ b/contracts/language-canonicalization.json
@@ -1,0 +1,9 @@
+{
+  "cases": [
+    { "input": "eng", "canonical": "en", "primary": "en" },
+    { "input": "ara", "canonical": "ar", "primary": "ar" },
+    { "input": "Arabic", "canonical": "ar", "primary": "ar", "compatibility": true },
+    { "input": "pt-BR", "canonical": "pt-BR", "primary": "pt" },
+    { "input": "zh-Hant", "canonical": "zh-Hant", "primary": "zh" }
+  ]
+}

--- a/docs/subtitles-api.md
+++ b/docs/subtitles-api.md
@@ -81,6 +81,14 @@ search upload date is omitted. Arrays are empty rather than null. Stored object
 keys and uploader identities are not exposed. Provider failures preserve partial
 results with a generic warning; their raw error details are not part of v2.
 
+Search accepts compatibility inputs including ISO 639-2 aliases (`ara`), case
+and underscore variants, and legacy English display names (`Arabic`). The
+server normalizes and de-duplicates these values before contacting providers;
+`ar`, `ara`, and `Arabic` therefore select the same provider coverage. Invalid
+language filters return a validation error and never become English. Responses
+always expose canonical BCP 47 tags. Empty and null preference values retain
+their settings semantics and are not language tags.
+
 The web detail dialog and player search use typed v2 requests. The existing web
 track selector still needs numeric stored IDs; its adapter rejects IDs that it
 cannot represent safely. Native consumers need the string-ID models and new
@@ -147,6 +155,10 @@ distinct variant is kept: `pt-BR` and `pt-PT` are separate languages from `pt`,
 as are `zh-Hant` and `zh-Hans` from `zh`. Provider searches translate these tags
 into each provider's own codes (SubDL `BR_PT`, SubSource "Brazillian
 Portuguese") and results carry the canonical tag back.
+
+Settings writes accept only well-formed canonicalizable BCP 47 tags; display
+names remain compatibility inputs for search and legacy migration. Provider
+codes never cross the native API boundary because each adapter owns its mapping.
 
 `POST /api/v2/subtitles/detect-language` takes `file` and optional `language`, under
 the same byte limits. It returns `language` and `source` (`filename`, `metadata`,

--- a/internal/ai/translate/languages.go
+++ b/internal/ai/translate/languages.go
@@ -1,6 +1,10 @@
 package aitranslate
 
-import "strings"
+import (
+	"strings"
+
+	serverlang "github.com/Silo-Server/silo-server/internal/lang"
+)
 
 // languageNames maps common ISO 639-1 codes to English names. The model handles
 // bare codes acceptably, but full names noticeably improve translation quality,
@@ -24,6 +28,9 @@ var languageNames = map[string]string{
 // code — Whisper endpoints report detected languages as names ("english")
 // while local servers report codes. Returns "" when unknown.
 func LanguageCodeFromName(name string) string {
+	if canonical := serverlang.CompatibleTag(name); canonical != "" {
+		return canonical
+	}
 	name = strings.ToLower(strings.TrimSpace(name))
 	if name == "" {
 		return ""
@@ -42,6 +49,9 @@ func LanguageDisplayName(code string) string {
 	code = strings.TrimSpace(code)
 	if code == "" {
 		return ""
+	}
+	if canonical := serverlang.CanonicalTag(code); canonical != "" {
+		code = canonical
 	}
 	base := strings.ToLower(strings.ReplaceAll(code, "_", "-"))
 	if name, ok := languageNames[base]; ok {

--- a/internal/api/handlers/admin_downloaded_subtitles.go
+++ b/internal/api/handlers/admin_downloaded_subtitles.go
@@ -168,6 +168,7 @@ func (h *AdminSubtitleHandler) HandleListDownloadedSubtitles(w http.ResponseWrit
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to scan subtitle row")
 			return
 		}
+		row.Language = subtitles.NormalizeProviderLanguage(row.Provider, row.Language)
 		subtitlesList = append(subtitlesList, row)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/api/handlers/admin_downloaded_subtitles.go
+++ b/internal/api/handlers/admin_downloaded_subtitles.go
@@ -168,7 +168,6 @@ func (h *AdminSubtitleHandler) HandleListDownloadedSubtitles(w http.ResponseWrit
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to scan subtitle row")
 			return
 		}
-		row.Language = subtitles.NormalizeProviderLanguage(row.Provider, row.Language)
 		subtitlesList = append(subtitlesList, row)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/api/handlers/admin_subtitle_list.go
+++ b/internal/api/handlers/admin_subtitle_list.go
@@ -102,7 +102,6 @@ func (h *AdminSubtitleHandler) ListAdminSubtitlesPage(ctx context.Context, filte
 			rows.Close()
 			return out, err
 		}
-		row.Language = subtitles.NormalizeProviderLanguage(row.Provider, row.Language)
 		out.Items = append(out.Items, row)
 	}
 	err = rows.Err()

--- a/internal/api/handlers/admin_subtitle_list.go
+++ b/internal/api/handlers/admin_subtitle_list.go
@@ -59,7 +59,11 @@ func (h *AdminSubtitleHandler) ListAdminSubtitlesPage(ctx context.Context, filte
 		add("ds.provider = ", filter.Provider)
 	}
 	if filter.Language != "" {
-		args = append(args, filter.Language, subtitles.SubDLLanguageAliases(filter.Language))
+		canonical := subtitles.NormalizeProviderLanguage("", filter.Language)
+		if canonical == "" {
+			canonical = strings.TrimSpace(filter.Language)
+		}
+		args = append(args, canonical, subtitles.SubDLLanguageAliases(canonical))
 		conditions = append(conditions, fmt.Sprintf("(ds.language = $%d OR (ds.provider = 'subdl' AND lower(btrim(ds.language)) = ANY($%d::text[])))", len(args)-1, len(args)))
 	}
 	if filter.UserID != 0 {

--- a/internal/api/handlers/admin_subtitle_list.go
+++ b/internal/api/handlers/admin_subtitle_list.go
@@ -63,8 +63,8 @@ func (h *AdminSubtitleHandler) ListAdminSubtitlesPage(ctx context.Context, filte
 		if canonical == "" {
 			canonical = strings.TrimSpace(filter.Language)
 		}
-		args = append(args, canonical, subtitles.SubDLLanguageAliases(canonical))
-		conditions = append(conditions, fmt.Sprintf("(ds.language = $%d OR (ds.provider = 'subdl' AND lower(btrim(ds.language)) = ANY($%d::text[])))", len(args)-1, len(args)))
+		args = append(args, canonical, subtitles.LanguageAliases(canonical))
+		conditions = append(conditions, fmt.Sprintf("(ds.language = $%d OR lower(btrim(ds.language)) = ANY($%d::text[]))", len(args)-1, len(args)))
 	}
 	if filter.UserID != 0 {
 		add("ds.downloaded_by = ", filter.UserID)

--- a/internal/api/handlers/settings_values_test.go
+++ b/internal/api/handlers/settings_values_test.go
@@ -2055,7 +2055,7 @@ func TestMergeLanguageSuggestionsKeepsFloorObservedAndCurrent(t *testing.T) {
 		[]string{"eng", "deu", "not a tag", "fr"},
 		json.RawMessage(`"pt-BR"`),
 	)
-	want := []string{"en", "fr", "pt", "deu", "pt-BR"}
+	want := []string{"en", "fr", "pt", "de", "pt-BR"}
 	if !slices.Equal(got, want) {
 		t.Errorf("mergeLanguageSuggestions() = %v, want %v", got, want)
 	}
@@ -2067,7 +2067,7 @@ func TestMergeLanguageSuggestionsUsesExactCurrentAlias(t *testing.T) {
 		[]string{"eng", "fra"},
 		json.RawMessage(`"eng"`),
 	)
-	want := []string{"eng", "fr"}
+	want := []string{"en", "fr"}
 	if !slices.Equal(got, want) {
 		t.Errorf("mergeLanguageSuggestions() = %v, want %v", got, want)
 	}

--- a/internal/api/handlers/subtitle_reads.go
+++ b/internal/api/handlers/subtitle_reads.go
@@ -38,7 +38,7 @@ func (h *SubtitleSearchHandler) SearchSubtitles(ctx context.Context, access cata
 	if h.manager == nil || h.mediaResolver == nil {
 		return nil, apiError(http.StatusServiceUnavailable, "dependency_unavailable", "Subtitle search is not configured")
 	}
-	result, err := h.searchAuthorizedSubtitles(ctx, fileID, languages)
+	result, err := h.searchAuthorizedSubtitles(ctx, fileID, languages, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/handlers/subtitle_reads_test.go
+++ b/internal/api/handlers/subtitle_reads_test.go
@@ -73,3 +73,28 @@ func TestSubtitleSearchBridgeMissingMetadataKeepsError(t *testing.T) {
 		t.Fatalf("bridge changed: %d %s", w.Code, w.Body.String())
 	}
 }
+
+func TestSubtitleSearchCanonicalizesCompatibilityLanguages(t *testing.T) {
+	for _, input := range []string{"ar", "ara", "Arabic"} {
+		var searched subtitles.SearchRequest
+		repo := newMockSubtitleRepoForHandler()
+		manager := subtitles.NewManager(repo, newMockS3ClientForHandler(), "test-bucket")
+		manager.RegisterProvider(recordingSubtitleProvider{request: &searched})
+		h := NewSubtitleSearchHandler(manager, repo, stubSubtitleMediaResolver{meta: &MediaFileMetadata{FileID: 42, FilePath: "Example.mkv", Title: "Example"}})
+		h.FileAuthorizer = &MediaFileAuthorizer{FileResolver: stubMediaFileResolver{file: &models.MediaFile{ID: 42, ContentID: "movie"}}, ItemAccess: stubItemAccessChecker{}}
+		if _, err := h.SearchSubtitles(t.Context(), catalog.AccessFilter{UserID: 1}, 42, []string{input, "AR"}); err != nil {
+			t.Fatal(err)
+		}
+		if len(searched.Languages) != 1 || searched.Languages[0] != "ar" {
+			t.Fatalf("input %q reached provider as %#v", input, searched.Languages)
+		}
+	}
+	var searched subtitles.SearchRequest
+	repo := newMockSubtitleRepoForHandler()
+	manager := subtitles.NewManager(repo, newMockS3ClientForHandler(), "test-bucket")
+	manager.RegisterProvider(recordingSubtitleProvider{request: &searched})
+	h := NewSubtitleSearchHandler(manager, repo, stubSubtitleMediaResolver{meta: &MediaFileMetadata{FileID: 42, FilePath: "Example.mkv", Title: "Example"}})
+	if _, err := h.SearchSubtitles(t.Context(), catalog.AccessFilter{UserID: 1}, 42, []string{"Klingon"}); err == nil {
+		t.Fatal("invalid language was accepted")
+	}
+}

--- a/internal/api/handlers/subtitle_search.go
+++ b/internal/api/handlers/subtitle_search.go
@@ -180,10 +180,7 @@ func (h *SubtitleSearchHandler) HandleSearch(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *SubtitleSearchHandler) searchAuthorizedSubtitles(ctx context.Context, fileID int, languages []string) (*subtitles.SearchResponse, *APIError) {
-	languages, normalizeErr := subtitles.NormalizeSearchLanguages(languages)
-	if normalizeErr != nil {
-		return nil, apiError(http.StatusBadRequest, "invalid_request", normalizeErr.Error())
-	}
+	languages = subtitles.NormalizeBridgeSearchLanguages(languages)
 	meta, err := h.mediaResolver.GetMediaFileWithMetadata(ctx, fileID)
 	if err != nil {
 		return nil, apiError(http.StatusInternalServerError, "metadata_error", "Failed to look up media metadata")

--- a/internal/api/handlers/subtitle_search.go
+++ b/internal/api/handlers/subtitle_search.go
@@ -171,7 +171,7 @@ func (h *SubtitleSearchHandler) HandleSearch(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	resp, err := h.searchAuthorizedSubtitles(r.Context(), req.MediaFileID, req.Languages)
+	resp, err := h.searchAuthorizedSubtitles(r.Context(), req.MediaFileID, req.Languages, true)
 	if err != nil {
 		writeError(w, err.Status, err.Code, err.Message)
 		return
@@ -179,7 +179,7 @@ func (h *SubtitleSearchHandler) HandleSearch(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (h *SubtitleSearchHandler) searchAuthorizedSubtitles(ctx context.Context, fileID int, languages []string) (*subtitles.SearchResponse, *APIError) {
+func (h *SubtitleSearchHandler) searchAuthorizedSubtitles(ctx context.Context, fileID int, languages []string, bridge bool) (*subtitles.SearchResponse, *APIError) {
 	languages = subtitles.NormalizeBridgeSearchLanguages(languages)
 	meta, err := h.mediaResolver.GetMediaFileWithMetadata(ctx, fileID)
 	if err != nil {
@@ -208,7 +208,12 @@ func (h *SubtitleSearchHandler) searchAuthorizedSubtitles(ctx context.Context, f
 		},
 	}
 
-	resp, err := h.manager.Search(ctx, searchReq)
+	var resp *subtitles.SearchResponse
+	if bridge {
+		resp, err = h.manager.SearchBridge(ctx, searchReq)
+	} else {
+		resp, err = h.manager.Search(ctx, searchReq)
+	}
 	if err != nil {
 		return nil, apiError(http.StatusInternalServerError, "search_error", "Subtitle search failed")
 	}

--- a/internal/api/handlers/subtitle_search.go
+++ b/internal/api/handlers/subtitle_search.go
@@ -180,6 +180,10 @@ func (h *SubtitleSearchHandler) HandleSearch(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *SubtitleSearchHandler) searchAuthorizedSubtitles(ctx context.Context, fileID int, languages []string) (*subtitles.SearchResponse, *APIError) {
+	languages, normalizeErr := subtitles.NormalizeSearchLanguages(languages)
+	if normalizeErr != nil {
+		return nil, apiError(http.StatusBadRequest, "invalid_request", normalizeErr.Error())
+	}
 	meta, err := h.mediaResolver.GetMediaFileWithMetadata(ctx, fileID)
 	if err != nil {
 		return nil, apiError(http.StatusInternalServerError, "metadata_error", "Failed to look up media metadata")

--- a/internal/apiv2/admin_subtitle_list.go
+++ b/internal/apiv2/admin_subtitle_list.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Silo-Server/silo-server/internal/api/handlers"
+	"github.com/Silo-Server/silo-server/internal/subtitles"
 )
 
 type AdminSubtitleListService interface {
@@ -98,7 +99,7 @@ func registerAdminSubtitleList(reg *Registry) {
 		}
 		items := make([]AdminStoredSubtitle, 0, len(result.Items))
 		for _, row := range result.Items {
-			item := AdminStoredSubtitle{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), MediaContentID: row.MediaContentID, Provider: row.Provider, Language: row.Language, Format: row.Format, ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt), UploaderUsername: row.UploaderUsername, MediaTitle: row.MediaTitle, MediaType: row.MediaType, FilePath: row.FilePath}
+			item := AdminStoredSubtitle{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), MediaContentID: row.MediaContentID, Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: row.Format, ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt), UploaderUsername: row.UploaderUsername, MediaTitle: row.MediaTitle, MediaType: row.MediaType, FilePath: row.FilePath}
 			if row.DownloadedBy != nil {
 				item.DownloadedBy = new(IDFromInt(int64(*row.DownloadedBy)))
 			}

--- a/internal/apiv2/admin_subtitle_list.go
+++ b/internal/apiv2/admin_subtitle_list.go
@@ -101,7 +101,7 @@ func registerAdminSubtitleList(reg *Registry) {
 		for _, row := range result.Items {
 			language, ok := subtitles.CanonicalProviderLanguage(row.Provider, row.Language)
 			if !ok {
-				continue
+				return nil, NewProblem(TypeInternalError, "Stored subtitle has an invalid language value.")
 			}
 			item := AdminStoredSubtitle{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), MediaContentID: row.MediaContentID, Provider: row.Provider, Language: language, Format: row.Format, ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt), UploaderUsername: row.UploaderUsername, MediaTitle: row.MediaTitle, MediaType: row.MediaType, FilePath: row.FilePath}
 			if row.DownloadedBy != nil {

--- a/internal/apiv2/admin_subtitle_list.go
+++ b/internal/apiv2/admin_subtitle_list.go
@@ -99,7 +99,11 @@ func registerAdminSubtitleList(reg *Registry) {
 		}
 		items := make([]AdminStoredSubtitle, 0, len(result.Items))
 		for _, row := range result.Items {
-			item := AdminStoredSubtitle{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), MediaContentID: row.MediaContentID, Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: row.Format, ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt), UploaderUsername: row.UploaderUsername, MediaTitle: row.MediaTitle, MediaType: row.MediaType, FilePath: row.FilePath}
+			language, ok := subtitles.CanonicalProviderLanguage(row.Provider, row.Language)
+			if !ok {
+				continue
+			}
+			item := AdminStoredSubtitle{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), MediaContentID: row.MediaContentID, Provider: row.Provider, Language: language, Format: row.Format, ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt), UploaderUsername: row.UploaderUsername, MediaTitle: row.MediaTitle, MediaType: row.MediaType, FilePath: row.FilePath}
 			if row.DownloadedBy != nil {
 				item.DownloadedBy = new(IDFromInt(int64(*row.DownloadedBy)))
 			}

--- a/internal/apiv2/admin_subtitle_metadata.go
+++ b/internal/apiv2/admin_subtitle_metadata.go
@@ -55,7 +55,7 @@ func adminSubtitleMetadataTag(ctx context.Context, row *subtitles.DownloadedSubt
 	return RenderETag("admin-subtitle-metadata/"+strconv.Itoa(claimsFrom(ctx).UserID)+"/"+profileFrom(ctx), strconv.Itoa(row.ID), row.Revision)
 }
 func adminSubtitleMetadataProjection(row *subtitles.DownloadedSubtitle) AdminSubtitleMetadata {
-	item := AdminSubtitleMetadata{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), Provider: row.Provider, Language: row.Language, Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt)}
+	item := AdminSubtitleMetadata{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt)}
 	if row.DownloadedBy != nil {
 		item.DownloadedBy = new(IDFromInt(int64(*row.DownloadedBy)))
 	}

--- a/internal/apiv2/admin_subtitle_metadata.go
+++ b/internal/apiv2/admin_subtitle_metadata.go
@@ -52,7 +52,8 @@ type AdminSubtitleMetadataPatchInput struct {
 }
 
 func adminSubtitleMetadataTag(ctx context.Context, row *subtitles.DownloadedSubtitle) EntityTag {
-	return RenderETag("admin-subtitle-metadata/"+strconv.Itoa(claimsFrom(ctx).UserID)+"/"+profileFrom(ctx), strconv.Itoa(row.ID), row.Revision)
+	language := subtitles.NormalizeProviderLanguage(row.Provider, row.Language)
+	return RenderETag("admin-subtitle-metadata/"+strconv.Itoa(claimsFrom(ctx).UserID)+"/"+profileFrom(ctx), strconv.Itoa(row.ID)+"/"+language, row.Revision)
 }
 func adminSubtitleMetadataProjection(row *subtitles.DownloadedSubtitle) AdminSubtitleMetadata {
 	item := AdminSubtitleMetadata{ID: IDFromInt(int64(row.ID)), MediaFileID: IDFromInt(int64(row.MediaFileID)), Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt)}
@@ -90,6 +91,9 @@ func (reg *Registry) adminSubtitleMetadataRow(ctx context.Context, raw ID) (*sub
 	}
 	if row == nil {
 		return nil, NewProblem(TypeNotFound, "Stored subtitle not found.")
+	}
+	if _, ok := subtitles.CanonicalProviderLanguage(row.Provider, row.Language); !ok {
+		return nil, NewProblem(TypeInternalError, "Stored subtitle has an invalid language value.")
 	}
 	return row, nil
 }

--- a/internal/apiv2/subtitle_reads.go
+++ b/internal/apiv2/subtitle_reads.go
@@ -77,6 +77,9 @@ func registerSubtitleReads(reg *Registry) {
 		}
 		out := StoredSubtitles{Subtitles: make([]StoredSubtitle, 0, len(rows))}
 		for _, row := range rows {
+			if _, ok := subtitles.CanonicalProviderLanguage(row.Provider, row.Language); !ok {
+				continue
+			}
 			out.Subtitles = append(out.Subtitles, storedSubtitleView(row))
 		}
 		return &StoredSubtitlesOutput{Body: out}, nil
@@ -105,7 +108,11 @@ func registerSubtitleReads(reg *Registry) {
 			return nil, NewProblem(TypeInternalError, "Subtitle search returned no result.")
 		}
 		for _, row := range view.Results {
-			result := SubtitleSearchResult{ID: ID(row.ID), Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, Downloads: row.Downloads, HearingImpaired: row.HearingImpaired}
+			language, ok := subtitles.CanonicalProviderLanguage(row.Provider, row.Language)
+			if !ok {
+				continue
+			}
+			result := SubtitleSearchResult{ID: ID(row.ID), Provider: row.Provider, Language: language, Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, Downloads: row.Downloads, HearingImpaired: row.HearingImpaired}
 			if !row.UploadDate.IsZero() {
 				result.UploadDate = new(NewInstant(row.UploadDate))
 			}
@@ -132,5 +139,6 @@ func (reg *Registry) subtitleReadAccess(ctx context.Context) (catalogpkg.AccessF
 }
 
 func storedSubtitleView(row subtitles.DownloadedSubtitle) StoredSubtitle {
-	return StoredSubtitle{ID: ID(strconv.Itoa(row.ID)), MediaFileID: ID(strconv.Itoa(row.MediaFileID)), Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt)}
+	language, _ := subtitles.CanonicalProviderLanguage(row.Provider, row.Language)
+	return StoredSubtitle{ID: ID(strconv.Itoa(row.ID)), MediaFileID: ID(strconv.Itoa(row.MediaFileID)), Provider: row.Provider, Language: language, Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt)}
 }

--- a/internal/apiv2/subtitle_reads.go
+++ b/internal/apiv2/subtitle_reads.go
@@ -92,7 +92,11 @@ func registerSubtitleReads(reg *Registry) {
 		if p != nil {
 			return nil, p
 		}
-		view, err := reg.deps.SubtitleReads.SearchSubtitles(ctx, access, id, in.Body.Languages)
+		languages, err := subtitles.NormalizeSearchLanguages(in.Body.Languages)
+		if err != nil {
+			return nil, NewProblem(TypeValidationFailed, err.Error())
+		}
+		view, err := reg.deps.SubtitleReads.SearchSubtitles(ctx, access, id, languages)
 		if err != nil {
 			return nil, serviceProblem(err)
 		}
@@ -101,7 +105,7 @@ func registerSubtitleReads(reg *Registry) {
 			return nil, NewProblem(TypeInternalError, "Subtitle search returned no result.")
 		}
 		for _, row := range view.Results {
-			result := SubtitleSearchResult{ID: ID(row.ID), Provider: row.Provider, Language: row.Language, Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, Downloads: row.Downloads, HearingImpaired: row.HearingImpaired}
+			result := SubtitleSearchResult{ID: ID(row.ID), Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, Downloads: row.Downloads, HearingImpaired: row.HearingImpaired}
 			if !row.UploadDate.IsZero() {
 				result.UploadDate = new(NewInstant(row.UploadDate))
 			}
@@ -128,5 +132,5 @@ func (reg *Registry) subtitleReadAccess(ctx context.Context) (catalogpkg.AccessF
 }
 
 func storedSubtitleView(row subtitles.DownloadedSubtitle) StoredSubtitle {
-	return StoredSubtitle{ID: ID(strconv.Itoa(row.ID)), MediaFileID: ID(strconv.Itoa(row.MediaFileID)), Provider: row.Provider, Language: row.Language, Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt)}
+	return StoredSubtitle{ID: ID(strconv.Itoa(row.ID)), MediaFileID: ID(strconv.Itoa(row.MediaFileID)), Provider: row.Provider, Language: subtitles.NormalizeProviderLanguage(row.Provider, row.Language), Format: string(row.Format), ReleaseName: row.ReleaseName, Score: row.Score, HearingImpaired: row.HearingImpaired, CreatedAt: NewInstant(row.CreatedAt)}
 }

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -44,6 +44,7 @@ func hasDuplicateSubtags(value string) bool {
 	variants := make(map[string]struct{})
 	singletons := make(map[string]struct{})
 	privateUse := false
+	extensionStarted := false
 	for i := 1; i < len(parts); i++ {
 		part := parts[i]
 		if privateUse {
@@ -54,12 +55,13 @@ func hasDuplicateSubtags(value string) bool {
 				return true
 			}
 			singletons[part] = struct{}{}
+			extensionStarted = true
 			if part == "x" {
 				privateUse = true
 			}
 			continue
 		}
-		if len(part) >= 5 || (len(part) == 4 && part[0] >= '0' && part[0] <= '9') {
+		if !extensionStarted && (len(part) >= 5 || (len(part) == 4 && part[0] >= '0' && part[0] <= '9')) {
 			if _, exists := variants[part]; exists {
 				return true
 			}

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -9,6 +9,12 @@ import (
 	"golang.org/x/text/language"
 )
 
+const (
+	legacyEnglishName           = "english"
+	canonicalPortugueseBrazil   = "pt-BR"
+	canonicalChineseTraditional = "zh-Hant"
+)
+
 // CanonicalTag validates a BCP 47 tag, canonicalizing ISO aliases and casing.
 // Explicit scripts, regions, variants and extensions are preserved. It accepts
 // underscores but no display names. Empty and malformed values return "".
@@ -50,7 +56,7 @@ func PrimaryLanguage(value string) string {
 }
 
 var languageNames = map[string]string{
-	"english": "en", "spanish": "es", "french": "fr", "german": "de",
+	legacyEnglishName: "en", "spanish": "es", "french": "fr", "german": "de",
 	"italian": "it", "portuguese": "pt", "japanese": "ja", "korean": "ko",
 	"chinese": "zh", "russian": "ru", "arabic": "ar", "dutch": "nl",
 	"polish": "pl", "swedish": "sv", "norwegian": "no", "danish": "da",
@@ -61,10 +67,10 @@ var languageNames = map[string]string{
 	"persian": "fa", "farsi": "fa", "malay": "ms", "serbian": "sr",
 	"slovak": "sk", "slovenian": "sl", "tamil": "ta", "telugu": "te",
 	"estonian": "et", "latvian": "lv", "lithuanian": "lt", "icelandic": "is",
-	"brazilian portuguese": "pt-BR", "brazillian portuguese": "pt-BR",
-	"portuguese (brazil)": "pt-BR", "portuguese (portugal)": "pt-PT",
-	"european portuguese": "pt-PT", "chinese (traditional)": "zh-Hant",
-	"traditional chinese": "zh-Hant", "chinese (simplified)": "zh-Hans",
+	"brazilian portuguese": canonicalPortugueseBrazil, "brazillian portuguese": canonicalPortugueseBrazil,
+	"portuguese (brazil)": canonicalPortugueseBrazil, "portuguese (portugal)": "pt-PT",
+	"european portuguese": "pt-PT", "chinese (traditional)": canonicalChineseTraditional,
+	"traditional chinese": canonicalChineseTraditional, "chinese (simplified)": "zh-Hans",
 	"simplified chinese": "zh-Hans",
 }
 

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -9,6 +9,65 @@ import (
 	"golang.org/x/text/language"
 )
 
+// CanonicalTag validates a BCP 47 tag, canonicalizing ISO aliases and casing.
+// Explicit scripts, regions, variants and extensions are preserved. It accepts
+// underscores but no display names. Empty and malformed values return "".
+func CanonicalTag(value string) string {
+	value = strings.ReplaceAll(strings.TrimSpace(value), "_", "-")
+	if !languageTagPattern.MatchString(value) {
+		return ""
+	}
+	parts := strings.Split(value, "-")
+	if len(parts) > 1 && len(parts[1]) == 3 && isAlpha(parts[1]) {
+		return canonicalTagCase(value)
+	}
+	if tag, err := language.Parse(value); err == nil {
+		return tag.String()
+	}
+	// The settings contract is open to well-formed, unregistered subtags.
+	return canonicalTagCase(value)
+}
+
+// CompatibleTag also recognizes known English display names from legacy
+// preferences, subtitle providers and transcription services.
+func CompatibleTag(value string) string {
+	value = strings.TrimSpace(value)
+	if mapped, ok := languageNames[strings.ToLower(value)]; ok {
+		value = mapped
+	}
+	return CanonicalTag(value)
+}
+
+// PrimaryLanguage intentionally drops script and region for language matching.
+// It never infers a language from an undefined or private-use tag.
+func PrimaryLanguage(value string) string {
+	canonical := CompatibleTag(value)
+	base, _, _ := strings.Cut(canonical, "-")
+	if base == "und" || base == "x" {
+		return ""
+	}
+	return base
+}
+
+var languageNames = map[string]string{
+	"english": "en", "spanish": "es", "french": "fr", "german": "de",
+	"italian": "it", "portuguese": "pt", "japanese": "ja", "korean": "ko",
+	"chinese": "zh", "russian": "ru", "arabic": "ar", "dutch": "nl",
+	"polish": "pl", "swedish": "sv", "norwegian": "no", "danish": "da",
+	"finnish": "fi", "greek": "el", "turkish": "tr", "hungarian": "hu",
+	"czech": "cs", "romanian": "ro", "hebrew": "he", "hindi": "hi",
+	"thai": "th", "vietnamese": "vi", "indonesian": "id", "ukrainian": "uk",
+	"bengali": "bn", "bangla": "bn", "bulgarian": "bg", "croatian": "hr",
+	"persian": "fa", "farsi": "fa", "malay": "ms", "serbian": "sr",
+	"slovak": "sk", "slovenian": "sl", "tamil": "ta", "telugu": "te",
+	"estonian": "et", "latvian": "lv", "lithuanian": "lt", "icelandic": "is",
+	"brazilian portuguese": "pt-BR", "brazillian portuguese": "pt-BR",
+	"portuguese (brazil)": "pt-BR", "portuguese (portugal)": "pt-PT",
+	"european portuguese": "pt-PT", "chinese (traditional)": "zh-Hant",
+	"traditional chinese": "zh-Hant", "chinese (simplified)": "zh-Hans",
+	"simplified chinese": "zh-Hans",
+}
+
 // Canonical returns the ISO 639-1 lowercase 2-letter form of value, or the
 // 3-letter form for languages without a 2-letter equivalent (e.g. "fil").
 // Unparseable inputs are returned trimmed and lowercased verbatim so we
@@ -23,7 +82,7 @@ func Canonical(value string) string {
 		return trimmed
 	}
 	base, conf := tag.Base()
-	if conf == language.No {
+	if conf == language.No || tag == language.Und {
 		return trimmed
 	}
 	return strings.ToLower(base.String())

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -43,13 +43,20 @@ func hasDuplicateSubtags(value string) bool {
 	parts := strings.Split(strings.ToLower(value), "-")
 	variants := make(map[string]struct{})
 	singletons := make(map[string]struct{})
+	privateUse := false
 	for i := 1; i < len(parts); i++ {
 		part := parts[i]
+		if privateUse {
+			continue
+		}
 		if len(part) == 1 {
 			if _, exists := singletons[part]; exists {
 				return true
 			}
 			singletons[part] = struct{}{}
+			if part == "x" {
+				privateUse = true
+			}
 			continue
 		}
 		if len(part) >= 5 || (len(part) == 4 && part[0] >= '0' && part[0] <= '9') {

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -43,7 +43,7 @@ func hasDuplicateSubtags(value string) bool {
 	parts := strings.Split(strings.ToLower(value), "-")
 	variants := make(map[string]struct{})
 	singletons := make(map[string]struct{})
-	privateUse := false
+	privateUse := parts[0] == "x"
 	extensionStarted := false
 	for i := 1; i < len(parts); i++ {
 		part := parts[i]

--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -23,6 +23,9 @@ func CanonicalTag(value string) string {
 	if !languageTagPattern.MatchString(value) {
 		return ""
 	}
+	if hasDuplicateSubtags(value) {
+		return ""
+	}
 	parts := strings.Split(value, "-")
 	if len(parts) > 1 && len(parts[1]) == 3 && isAlpha(parts[1]) {
 		return canonicalTagCase(value)
@@ -32,6 +35,31 @@ func CanonicalTag(value string) string {
 	}
 	// The settings contract is open to well-formed, unregistered subtags.
 	return canonicalTagCase(value)
+}
+
+// hasDuplicateSubtags rejects structurally invalid repeated variants and
+// extension singletons while retaining unregistered but well-formed subtags.
+func hasDuplicateSubtags(value string) bool {
+	parts := strings.Split(strings.ToLower(value), "-")
+	variants := make(map[string]struct{})
+	singletons := make(map[string]struct{})
+	for i := 1; i < len(parts); i++ {
+		part := parts[i]
+		if len(part) == 1 {
+			if _, exists := singletons[part]; exists {
+				return true
+			}
+			singletons[part] = struct{}{}
+			continue
+		}
+		if len(part) >= 5 || (len(part) == 4 && part[0] >= '0' && part[0] <= '9') {
+			if _, exists := variants[part]; exists {
+				return true
+			}
+			variants[part] = struct{}{}
+		}
+	}
+	return false
 }
 
 // CompatibleTag also recognizes known English display names from legacy

--- a/internal/lang/lang_test.go
+++ b/internal/lang/lang_test.go
@@ -2,6 +2,28 @@ package lang
 
 import "testing"
 
+func TestCanonicalTag(t *testing.T) {
+	cases := map[string]string{
+		"": "", "  ": "", "en": "en", "EN": "en", "eng": "en", "ara": "ar", "AR": "ar",
+		"Arabic": "", "en_US": "en-US", "pt-BR": "pt-BR", "pt_br": "pt-BR",
+		"zh-Hant": "zh-Hant", "ZH-hant-TW": "zh-Hant-TW", "iw": "he", "not a language": "",
+		"Klingon": "", "x-private": "x-private",
+	}
+	for in, want := range cases {
+		if got := CanonicalTag(in); got != want {
+			t.Errorf("CanonicalTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestPrimaryLanguage(t *testing.T) {
+	for in, want := range map[string]string{"pt-BR": "pt", "zh-Hant": "zh", "eng": "en", "Arabic": "ar", "": "", "unknown": ""} {
+		if got := PrimaryLanguage(in); got != want {
+			t.Errorf("PrimaryLanguage(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestCanonical(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/internal/lang/lang_test.go
+++ b/internal/lang/lang_test.go
@@ -8,6 +8,9 @@ func TestCanonicalTag(t *testing.T) {
 		"Arabic": "", "en_US": "en-US", "pt-BR": "pt-BR", "pt_br": "pt-BR",
 		"zh-Hant": "zh-Hant", "ZH-hant-TW": "zh-Hant-TW", "iw": "he", "not a language": "",
 		"Klingon": "", "x-private": "x-private",
+		"qaa": "qaa", "en-abcde-abcde": "", "en-a-foo-a-bar": "",
+		"x-abcde-abcde": "x-abcde-abcde", "en-x-abcde-abcde": "en-x-abcde-abcde",
+		"en-a-abcde-abcde": "en-a-abcde-abcde",
 	}
 	for in, want := range cases {
 		if got := CanonicalTag(in); got != want {

--- a/internal/lang/tags.go
+++ b/internal/lang/tags.go
@@ -1,0 +1,58 @@
+package lang
+
+import (
+	"regexp"
+	"strings"
+)
+
+var languageTagPattern = regexp.MustCompile(
+	`^([a-zA-Z]{2,3}(-[a-zA-Z]{3}){0,3}(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?` +
+		`(-([0-9a-zA-Z]{5,8}|[0-9][0-9a-zA-Z]{3}))*` +
+		`(-[0-9a-wy-zA-WY-Z](-[0-9a-zA-Z]{2,8})+)*` +
+		`(-[xX](-[0-9a-zA-Z]{1,8})+)?` +
+		`|[xX](-[0-9a-zA-Z]{1,8})+)$`)
+
+func canonicalTagCase(tag string) string {
+	parts := strings.Split(tag, "-")
+	// Case is not significant in BCP 47, but the conventional casing is what
+	// every client library produces: lowercase language, Titlecase script,
+	// UPPERCASE region, lowercase everything else.
+	parts[0] = strings.ToLower(parts[0])
+	// A tag that is entirely private use ("x-whatever") has no script or
+	// region positions — everything after the leading singleton is private-use
+	// content and stays lowercase.
+	inExtension := parts[0] == "x"
+	for i := 1; i < len(parts); i++ {
+		part := parts[i]
+		switch {
+		case len(part) == 1:
+			// A singleton opens an extension ("u", "t") or private use ("x").
+			// Everything after it is extension content, so the two-letter
+			// region rule must stop applying — "nu" in "ar-EG-u-nu-latn" is an
+			// extension key, not a region.
+			inExtension = true
+			parts[i] = strings.ToLower(part)
+		case inExtension:
+			parts[i] = strings.ToLower(part)
+		case len(part) == 4 && isAlpha(part):
+			// A script. Not necessarily at index 1: an extlang can precede it
+			// (`zh-cmn-Hans-CN`). No collision with variants — a four-character
+			// variant must begin with a digit.
+			parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+		case len(part) == 2 && isAlpha(part):
+			parts[i] = strings.ToUpper(part)
+		default:
+			parts[i] = strings.ToLower(part)
+		}
+	}
+	return strings.Join(parts, "-")
+}
+
+func isAlpha(value string) bool {
+	for _, r := range value {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/settingscontract/validate.go
+++ b/internal/settingscontract/validate.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	serverlang "github.com/Silo-Server/silo-server/internal/lang"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -859,84 +860,12 @@ func strictUnmarshal(raw []byte, target any) error {
 	return nil
 }
 
-// languageTagPattern accepts the well-formed BCP 47 shapes real clients
-// produce: language (with optional extlang), script, region, variants,
-// extension singletons and private use — including a purely private-use tag.
-// The narrower language[-script][-region] form this started as rejected tags
-// Android and iOS emit unprompted — `Locale.toLanguageTag()` appends extension
-// subtags for a non-Gregorian calendar or non-Latin numbering system
-// (`ar-EG-u-nu-latn`), registered variants like `ca-ES-valencia` are ordinary
-// user choices, and the legacy endpoint accepted `zh-cmn` (extlang) and
-// `x-private` (private use only), so rejecting them here would turn an
-// existing 204 into a 400.
-var languageTagPattern = regexp.MustCompile(
-	`^([a-zA-Z]{2,3}(-[a-zA-Z]{3}){0,3}(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?` +
-		`(-([0-9a-zA-Z]{5,8}|[0-9][0-9a-zA-Z]{3}))*` +
-		`(-[0-9a-wy-zA-WY-Z](-[0-9a-zA-Z]{2,8})+)*` +
-		`(-[xX](-[0-9a-zA-Z]{1,8})+)?` +
-		`|[xX](-[0-9a-zA-Z]{1,8})+)$`)
-
-// NormalizeLanguageTag returns the canonical BCP 47 form of a tag, or false if
-// it is not well-formed.
-//
-// Normalization is the half that keeps the contract's promise of one stored
-// value per language. Without it `en-US`, `en-us` and `EN-us` are three
-// distinct rows for one preference, and audio-track matching misses on two of
-// them. Underscores are accepted on input because both mobile platforms have a
-// locale accessor that produces them (`Locale.identifier` on iOS,
-// `Locale.toString()` on Android) and sending one is a mistake worth absorbing
-// rather than a value worth rejecting.
-//
-// The empty string is not a language tag. "No preference" is null, which the
-// nullable flag on each language setting already expresses.
+// NormalizeLanguageTag uses the shared strict BCP 47 canonicalizer. Display
+// names and empty strings are invalid settings writes; null is handled by the
+// setting's nullable schema before reaching this function.
 func NormalizeLanguageTag(tag string) (string, bool) {
-	tag = strings.ReplaceAll(strings.TrimSpace(tag), "_", "-")
-	if !languageTagPattern.MatchString(tag) {
-		return "", false
-	}
-
-	parts := strings.Split(tag, "-")
-	// Case is not significant in BCP 47, but the conventional casing is what
-	// every client library produces: lowercase language, Titlecase script,
-	// UPPERCASE region, lowercase everything else.
-	parts[0] = strings.ToLower(parts[0])
-	// A tag that is entirely private use ("x-whatever") has no script or
-	// region positions — everything after the leading singleton is private-use
-	// content and stays lowercase.
-	inExtension := parts[0] == "x"
-	for i := 1; i < len(parts); i++ {
-		part := parts[i]
-		switch {
-		case len(part) == 1:
-			// A singleton opens an extension ("u", "t") or private use ("x").
-			// Everything after it is extension content, so the two-letter
-			// region rule must stop applying — "nu" in "ar-EG-u-nu-latn" is an
-			// extension key, not a region.
-			inExtension = true
-			parts[i] = strings.ToLower(part)
-		case inExtension:
-			parts[i] = strings.ToLower(part)
-		case len(part) == 4 && isAlpha(part):
-			// A script. Not necessarily at index 1: an extlang can precede it
-			// (`zh-cmn-Hans-CN`). No collision with variants — a four-character
-			// variant must begin with a digit.
-			parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
-		case len(part) == 2 && isAlpha(part):
-			parts[i] = strings.ToUpper(part)
-		default:
-			parts[i] = strings.ToLower(part)
-		}
-	}
-	return strings.Join(parts, "-"), true
-}
-
-func isAlpha(value string) bool {
-	for _, r := range value {
-		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
-			return false
-		}
-	}
-	return true
+	canonical := serverlang.CanonicalTag(tag)
+	return canonical, canonical != ""
 }
 
 // CompareValues orders two values of this schema's type: negative when a sorts

--- a/internal/settingsmigrate/plan.go
+++ b/internal/settingsmigrate/plan.go
@@ -23,6 +23,7 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
 	"github.com/Silo-Server/silo-server/internal/jellycompat/displayprefs"
+	"github.com/Silo-Server/silo-server/internal/lang"
 	"github.com/Silo-Server/silo-server/internal/settingscontract"
 	"github.com/Silo-Server/silo-server/internal/settingskeys"
 )
@@ -861,8 +862,8 @@ func (p *Planner) addLanguage(
 	if value == "" || (columnDefault != "" && value == columnDefault) {
 		return
 	}
-	normalized, ok := settingscontract.NormalizeLanguageTag(value)
-	if !ok {
+	normalized := lang.CompatibleTag(value)
+	if normalized == "" {
 		res.Rejects = append(res.Rejects, Reject{
 			SourceTable: sourceTable, SourceKey: key, Identity: identity,
 			Value:  value,
@@ -981,8 +982,8 @@ func (p *Planner) coerce(def *settingscontract.Definition, raw string) (json.Raw
 		}
 
 	case settingscontract.TypeLanguageTag:
-		normalized, ok := settingscontract.NormalizeLanguageTag(trimmed)
-		if !ok {
+		normalized := lang.CompatibleTag(trimmed)
+		if normalized == "" {
 			return nil, fmt.Errorf("%q is not a well-formed BCP 47 language tag", raw)
 		}
 		candidate = jsonString(normalized)

--- a/internal/subtitles/language_detect.go
+++ b/internal/subtitles/language_detect.go
@@ -402,6 +402,18 @@ func NormalizeProviderLanguage(provider, value string) string {
 	return strings.TrimSpace(value)
 }
 
+// CanonicalProviderLanguage returns a canonical wire tag for a provider value.
+// Unknown provider tokens are reported as invalid so strict v2 projections can
+// omit them without changing permissive bridge behavior.
+func CanonicalProviderLanguage(provider, value string) (string, bool) {
+	resolved := NormalizeProviderLanguage(provider, value)
+	canonical := lang.CanonicalTag(resolved)
+	if canonical == "" {
+		return "", false
+	}
+	return canonical, true
+}
+
 // SubDLLanguageCode converts a canonical subtitle language into the code SubDL
 // expects in a search request. Regional variants SubDL distinguishes keep their
 // own code; other tags send the uppercase base language.
@@ -437,6 +449,34 @@ func SubDLLanguageAliases(value string) []string {
 	for name, language := range filenameLanguageAliases {
 		if language == code {
 			aliases = append(aliases, name)
+		}
+	}
+	slices.Sort(aliases)
+	return slices.Compact(aliases)
+}
+
+// LanguageAliases lists known legacy spellings that canonicalize to value.
+// It is used when comparing rows written before canonical storage, regardless
+// of provider; provider protocol codes remain adapter-specific.
+func LanguageAliases(value string) []string {
+	code := lang.CompatibleTag(value)
+	if code == "" {
+		return []string{strings.ToLower(strings.TrimSpace(value))}
+	}
+	aliases := []string{strings.ToLower(code)}
+	for name, language := range metadataLanguageNames {
+		if language == code {
+			aliases = append(aliases, name)
+		}
+	}
+	for name, language := range filenameLanguageAliases {
+		if language == code {
+			aliases = append(aliases, name)
+		}
+	}
+	for name, language := range subDLLanguageCodes {
+		if language == code {
+			aliases = append(aliases, strings.ToLower(name))
 		}
 	}
 	slices.Sort(aliases)

--- a/internal/subtitles/language_detect.go
+++ b/internal/subtitles/language_detect.go
@@ -469,11 +469,6 @@ func LanguageAliases(value string) []string {
 			aliases = append(aliases, name)
 		}
 	}
-	for name, language := range filenameLanguageAliases {
-		if language == code {
-			aliases = append(aliases, name)
-		}
-	}
 	for name, language := range subDLLanguageCodes {
 		if language == code {
 			aliases = append(aliases, strings.ToLower(name))

--- a/internal/subtitles/language_detect.go
+++ b/internal/subtitles/language_detect.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/abadojack/whatlanggo"
-	"golang.org/x/text/language"
 
 	"github.com/Silo-Server/silo-server/internal/lang"
 )
@@ -373,7 +372,7 @@ func splitFilenameTokens(base string) []string {
 }
 
 func languageFromMetadataValue(value string) (string, bool) {
-	if language := canonicalLanguageToken(value); language != "" {
+	if language := lang.CompatibleTag(value); language != "" {
 		return language, true
 	}
 	if mapped, ok := metadataLanguageNames[strings.ToLower(strings.TrimSpace(value))]; ok {
@@ -397,14 +396,17 @@ func NormalizeProviderLanguage(provider, value string) string {
 			return code
 		}
 	}
-	return value
+	if canonical := lang.CompatibleTag(value); canonical != "" {
+		return canonical
+	}
+	return strings.TrimSpace(value)
 }
 
 // SubDLLanguageCode converts a canonical subtitle language into the code SubDL
 // expects in a search request. Regional variants SubDL distinguishes keep their
 // own code; other tags send the uppercase base language.
 func SubDLLanguageCode(value string) string {
-	canonical := canonicalLanguageToken(value)
+	canonical := lang.CompatibleTag(value)
 	if canonical == "" {
 		return strings.ToUpper(strings.TrimSpace(value))
 	}
@@ -453,28 +455,28 @@ func NormalizeLanguageCode(value string) (string, error) {
 	return language, nil
 }
 
+// NormalizeSearchLanguages canonicalizes and de-duplicates compatibility
+// inputs while preserving their explicit script and region identity.
+func NormalizeSearchLanguages(values []string) ([]string, error) {
+	if values == nil {
+		return nil, nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for i, value := range values {
+		canonical := lang.CompatibleTag(value)
+		if canonical == "" || lang.PrimaryLanguage(canonical) == "" {
+			return nil, fmt.Errorf("invalid subtitle language at index %d", i)
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		out = append(out, canonical)
+	}
+	return out, nil
+}
+
 func canonicalLanguageToken(value string) string {
-	trimmed := strings.ReplaceAll(strings.TrimSpace(value), "_", "-")
-	if trimmed == "" {
-		return ""
-	}
-	tag, err := language.Parse(trimmed)
-	if err != nil {
-		return ""
-	}
-	base, conf := tag.Base()
-	if conf == language.No {
-		return ""
-	}
-	// Raw subtags are only those the caller wrote; Tag.Region would infer a
-	// likely region for a bare language and turn "pt" into "pt-PT".
-	_, script, region := tag.Raw()
-	canonical := lang.Canonical(base.String())
-	if script != (language.Script{}) && script.String() != "Zzzz" {
-		canonical += "-" + script.String()
-	}
-	if region != (language.Region{}) && region.String() != "ZZ" {
-		canonical += "-" + region.String()
-	}
-	return canonical
+	return lang.CanonicalTag(value)
 }

--- a/internal/subtitles/language_detect.go
+++ b/internal/subtitles/language_detect.go
@@ -477,6 +477,33 @@ func NormalizeSearchLanguages(values []string) ([]string, error) {
 	return out, nil
 }
 
+// NormalizeBridgeSearchLanguages preserves the permissive v1 bridge contract:
+// recognized aliases are canonicalized, while unknown non-empty provider
+// tokens continue through unchanged for legacy providers.
+func NormalizeBridgeSearchLanguages(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		canonical := lang.CompatibleTag(trimmed)
+		if canonical == "" {
+			canonical = trimmed
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		out = append(out, canonical)
+	}
+	return out
+}
+
 func canonicalLanguageToken(value string) string {
 	return lang.CanonicalTag(value)
 }

--- a/internal/subtitles/language_detect_test.go
+++ b/internal/subtitles/language_detect_test.go
@@ -1,6 +1,9 @@
 package subtitles
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestDetectSubtitleLanguageFromReleaseFilename(t *testing.T) {
 	cases := []struct {
@@ -127,5 +130,24 @@ func TestManagerUploadDetectsLanguageFromFilename(t *testing.T) {
 	}
 	if sub.Language != "fr" {
 		t.Fatalf("language = %q, want fr", sub.Language)
+	}
+}
+
+func TestNormalizeSearchLanguages(t *testing.T) {
+	got, err := NormalizeSearchLanguages([]string{"ar", "ara", "Arabic", "pt-BR", "pt_br", "zh-Hant"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"ar", "pt-BR", "zh-Hant"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("NormalizeSearchLanguages() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeSearchLanguagesRejectsInvalidFilter(t *testing.T) {
+	for _, value := range []string{"", "unknown", "und"} {
+		if _, err := NormalizeSearchLanguages([]string{value}); err == nil {
+			t.Errorf("accepted invalid filter %q", value)
+		}
 	}
 }

--- a/internal/subtitles/manager.go
+++ b/internal/subtitles/manager.go
@@ -132,7 +132,9 @@ func (m *Manager) Search(ctx context.Context, req SearchRequest) (*SearchRespons
 			// Provider adapters own protocol-to-language conversion. Keep the
 			// manager payload untouched so the frozen v1 bridge response remains
 			// compatible with legacy providers; v2 canonicalizes its projection.
-			pr.results[i].Score = ScoreResult(pr.results[i], req)
+			scored := pr.results[i]
+			scored.Language = NormalizeProviderLanguage(scored.Provider, scored.Language)
+			pr.results[i].Score = ScoreResult(scored, req)
 		}
 		resp.Results = append(resp.Results, pr.results...)
 	}
@@ -141,6 +143,21 @@ func (m *Manager) Search(ctx context.Context, req SearchRequest) (*SearchRespons
 		return resp.Results[i].Score > resp.Results[j].Score
 	})
 
+	return resp, nil
+}
+
+// SearchBridge returns the legacy provider language payload for the frozen v1
+// bridge while sharing the canonical search and scoring path.
+func (m *Manager) SearchBridge(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
+	resp, err := m.Search(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.Results {
+		if resp.Results[i].rawLanguage != "" {
+			resp.Results[i].Language = resp.Results[i].rawLanguage
+		}
+	}
 	return resp, nil
 }
 

--- a/internal/subtitles/manager.go
+++ b/internal/subtitles/manager.go
@@ -76,11 +76,7 @@ func (m *Manager) ProviderNames() []string {
 
 // Search fans out to all registered providers concurrently.
 func (m *Manager) Search(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
-	languages, err := NormalizeSearchLanguages(req.Languages)
-	if err != nil {
-		return nil, err
-	}
-	req.Languages = languages
+	req.Languages = NormalizeBridgeSearchLanguages(req.Languages)
 	m.mu.RLock()
 	providers := make([]Provider, 0, len(m.providers))
 	for _, p := range m.providers {

--- a/internal/subtitles/manager.go
+++ b/internal/subtitles/manager.go
@@ -129,7 +129,9 @@ func (m *Manager) Search(ctx context.Context, req SearchRequest) (*SearchRespons
 			continue
 		}
 		for i := range pr.results {
-			pr.results[i].Language = NormalizeProviderLanguage(pr.results[i].Provider, pr.results[i].Language)
+			// Provider adapters own protocol-to-language conversion. Keep the
+			// manager payload untouched so the frozen v1 bridge response remains
+			// compatible with legacy providers; v2 canonicalizes its projection.
 			pr.results[i].Score = ScoreResult(pr.results[i], req)
 		}
 		resp.Results = append(resp.Results, pr.results...)

--- a/internal/subtitles/manager.go
+++ b/internal/subtitles/manager.go
@@ -76,6 +76,11 @@ func (m *Manager) ProviderNames() []string {
 
 // Search fans out to all registered providers concurrently.
 func (m *Manager) Search(ctx context.Context, req SearchRequest) (*SearchResponse, error) {
+	languages, err := NormalizeSearchLanguages(req.Languages)
+	if err != nil {
+		return nil, err
+	}
+	req.Languages = languages
 	m.mu.RLock()
 	providers := make([]Provider, 0, len(m.providers))
 	for _, p := range m.providers {
@@ -128,6 +133,7 @@ func (m *Manager) Search(ctx context.Context, req SearchRequest) (*SearchRespons
 			continue
 		}
 		for i := range pr.results {
+			pr.results[i].Language = NormalizeProviderLanguage(pr.results[i].Provider, pr.results[i].Language)
 			pr.results[i].Score = ScoreResult(pr.results[i], req)
 		}
 		resp.Results = append(resp.Results, pr.results...)

--- a/internal/subtitles/opensubtitles/opensubtitles.go
+++ b/internal/subtitles/opensubtitles/opensubtitles.go
@@ -123,7 +123,7 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 		results = append(results, subtitles.SubtitleResult{
 			ID:              strconv.Itoa(d.Attributes.Files[0].FileID),
 			Provider:        "opensubtitles",
-			Language:        d.Attributes.Language,
+			Language:        subtitles.NormalizeProviderLanguage("opensubtitles", d.Attributes.Language),
 			ReleaseName:     d.Attributes.Release,
 			Format:          format,
 			Downloads:       d.Attributes.DownloadCount,

--- a/internal/subtitles/opensubtitles/opensubtitles.go
+++ b/internal/subtitles/opensubtitles/opensubtitles.go
@@ -120,7 +120,7 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 			continue
 		}
 		format := detectFormat(d.Attributes.Files[0].FileName)
-		results = append(results, subtitles.SubtitleResult{
+		result := subtitles.SubtitleResult{
 			ID:              strconv.Itoa(d.Attributes.Files[0].FileID),
 			Provider:        "opensubtitles",
 			Language:        subtitles.NormalizeProviderLanguage("opensubtitles", d.Attributes.Language),
@@ -128,7 +128,10 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 			Format:          format,
 			Downloads:       d.Attributes.DownloadCount,
 			HearingImpaired: d.Attributes.HearingImpaired,
-		})
+		}
+		resultRaw := d.Attributes.Language
+		result.SetRawLanguageForBridge(resultRaw)
+		results = append(results, result)
 	}
 	return results, nil
 }

--- a/internal/subtitles/pgrepo.go
+++ b/internal/subtitles/pgrepo.go
@@ -186,9 +186,9 @@ func (r *PgRepository) GetDownloadedSubtitleByContent(ctx context.Context, conte
 	var sub DownloadedSubtitle
 	err := r.pool.QueryRow(ctx, `SELECT id, media_file_id, provider, language, format, release_name,
  s3_key, score, hearing_impaired, downloaded_by, created_at, COALESCE(content_sha256, ''), revision
- FROM downloaded_subtitles WHERE media_file_id=$1 AND provider=$2 AND (language=$3 OR (provider='subdl' AND lower(btrim(language)) = ANY($6::text[]))) AND format=$4 AND content_sha256=$5
+ FROM downloaded_subtitles WHERE media_file_id=$1 AND provider=$2 AND (language=$3 OR lower(btrim(language)) = ANY($6::text[])) AND format=$4 AND content_sha256=$5
  ORDER BY (language=$3) DESC, id LIMIT 1`,
-		content.MediaFileID, content.Provider, content.Language, content.Format, content.ContentSHA256, SubDLLanguageAliases(content.Language)).Scan(
+		content.MediaFileID, content.Provider, content.Language, content.Format, content.ContentSHA256, LanguageAliases(content.Language)).Scan(
 		&sub.ID, &sub.MediaFileID, &sub.Provider, &sub.Language, &sub.Format, &sub.ReleaseName, &sub.S3Key, &sub.Score, &sub.HearingImpaired, &sub.DownloadedBy, &sub.CreatedAt, &sub.ContentSHA256, &sub.Revision)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil

--- a/internal/subtitles/pgrepo.go
+++ b/internal/subtitles/pgrepo.go
@@ -80,7 +80,6 @@ func (r *PgRepository) GetDownloadedSubtitle(ctx context.Context, id int) (*Down
 	if err != nil {
 		return nil, fmt.Errorf("get downloaded subtitle: %w", err)
 	}
-	sub.Language = NormalizeProviderLanguage(sub.Provider, sub.Language)
 	return &sub, nil
 }
 
@@ -103,7 +102,6 @@ func (r *PgRepository) ListDownloadedSubtitles(ctx context.Context, mediaFileID 
 			&sub.HearingImpaired, &sub.DownloadedBy, &sub.CreatedAt, &sub.ContentSHA256, &sub.Revision); err != nil {
 			return nil, fmt.Errorf("scan downloaded subtitle: %w", err)
 		}
-		sub.Language = NormalizeProviderLanguage(sub.Provider, sub.Language)
 		subs = append(subs, sub)
 	}
 	return subs, rows.Err()
@@ -139,7 +137,6 @@ func (r *PgRepository) UpdateDownloadedSubtitle(ctx context.Context, id int, upd
 	if err != nil {
 		return nil, fmt.Errorf("update downloaded subtitle: %w", err)
 	}
-	sub.Language = NormalizeProviderLanguage(sub.Provider, sub.Language)
 	return &sub, nil
 }
 
@@ -158,7 +155,6 @@ func (r *PgRepository) DeleteDownloadedSubtitle(ctx context.Context, id int) (*D
 	if err != nil {
 		return nil, fmt.Errorf("delete downloaded subtitle: %w", err)
 	}
-	sub.Language = NormalizeProviderLanguage(sub.Provider, sub.Language)
 	return &sub, nil
 }
 
@@ -177,7 +173,6 @@ func (r *PgRepository) GetDownloadedSubtitleByS3Key(ctx context.Context, s3Key s
 	if err != nil {
 		return nil, fmt.Errorf("get subtitle by s3 key: %w", err)
 	}
-	sub.Language = NormalizeProviderLanguage(sub.Provider, sub.Language)
 	return &sub, nil
 }
 
@@ -193,7 +188,6 @@ func (r *PgRepository) GetDownloadedSubtitleByContent(ctx context.Context, conte
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
-	sub.Language = NormalizeProviderLanguage(sub.Provider, sub.Language)
 	return &sub, err
 }
 

--- a/internal/subtitles/provider_language_test.go
+++ b/internal/subtitles/provider_language_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestProviderLanguageKeepsUnknownAndOtherProviders(t *testing.T) {
-	for _, tt := range []struct{ provider, value, want string }{{"subdl", "English", "en"}, {"subdl", " Arabic ", "ar"}, {"subdl", "BR_PT", "pt-BR"}, {"subdl", "Brazillian Portuguese", "pt-BR"}, {"subdl", "PT", "pt"}, {"subdl", "ZH_BG", "zh-Hant"}, {"subdl", "Unrecognized provider language", "Unrecognized provider language"}, {"upload", "English", "English"}, {"upload", "BR_PT", "BR_PT"}, {"subdl", "", ""}} {
+	for _, tt := range []struct{ provider, value, want string }{{"subdl", "English", "en"}, {"subdl", " Arabic ", "ar"}, {"subdl", "BR_PT", "pt-BR"}, {"subdl", "Brazillian Portuguese", "pt-BR"}, {"subdl", "PT", "pt"}, {"subdl", "ZH_BG", "zh-Hant"}, {"subdl", "Unrecognized provider language", "Unrecognized provider language"}, {"upload", "English", "en"}, {"upload", "BR_PT", "br-PT"}, {"subdl", "", ""}} {
 		if got := NormalizeProviderLanguage(tt.provider, tt.value); got != tt.want {
 			t.Errorf("%s %q: got %q, want %q", tt.provider, tt.value, got, tt.want)
 		}

--- a/internal/subtitles/subdl/subdl.go
+++ b/internal/subtitles/subdl/subdl.go
@@ -120,12 +120,13 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 		if req.Episode > 0 && s.Episode > 0 && s.Episode != req.Episode {
 			continue
 		}
-		language := subtitles.NormalizeProviderLanguage("subdl", s.Language)
-		if _, err := subtitles.NormalizeLanguageCode(language); err != nil {
-			language = subtitles.NormalizeProviderLanguage("subdl", s.Lang)
+		rawLanguage := s.Language
+		if strings.TrimSpace(rawLanguage) == "" {
+			rawLanguage = s.Lang
 		}
+		language := subtitles.NormalizeProviderLanguage("subdl", rawLanguage)
 		format := detectFormat(s.ReleaseName)
-		results = append(results, subtitles.SubtitleResult{
+		result := subtitles.SubtitleResult{
 			ID:              s.URL, // relative download path
 			Provider:        "subdl",
 			Language:        language,
@@ -133,7 +134,9 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 			Format:          format,
 			Downloads:       s.DownloadCount,
 			HearingImpaired: s.HearingImpaired,
-		})
+		}
+		result.SetRawLanguageForBridge(rawLanguage)
+		results = append(results, result)
 	}
 	return results, nil
 }

--- a/internal/subtitles/subdl/subdl.go
+++ b/internal/subtitles/subdl/subdl.go
@@ -135,7 +135,6 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 			Downloads:       s.DownloadCount,
 			HearingImpaired: s.HearingImpaired,
 		}
-		result.SetRawLanguageForBridge(rawLanguage)
 		results = append(results, result)
 	}
 	return results, nil

--- a/internal/subtitles/subsource/subsource.go
+++ b/internal/subtitles/subsource/subsource.go
@@ -179,7 +179,7 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 		lang := reverseLanguageMap(s.Language)
 		releaseName := strings.Join(s.ReleaseInfo, " ")
 		format := detectFormat(releaseName)
-		results = append(results, subtitles.SubtitleResult{
+		result := subtitles.SubtitleResult{
 			ID:              strconv.Itoa(s.SubtitleID),
 			Provider:        "subsource",
 			Language:        subtitles.NormalizeProviderLanguage("subsource", lang),
@@ -187,7 +187,9 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 			Format:          format,
 			Downloads:       s.Downloads,
 			HearingImpaired: s.HearingImpaired,
-		})
+		}
+		result.SetRawLanguageForBridge(lang)
+		results = append(results, result)
 	}
 	return results, nil
 }

--- a/internal/subtitles/subsource/subsource.go
+++ b/internal/subtitles/subsource/subsource.go
@@ -182,7 +182,7 @@ func (p *Provider) Search(ctx context.Context, req subtitles.SearchRequest) ([]s
 		results = append(results, subtitles.SubtitleResult{
 			ID:              strconv.Itoa(s.SubtitleID),
 			Provider:        "subsource",
-			Language:        lang,
+			Language:        subtitles.NormalizeProviderLanguage("subsource", lang),
 			ReleaseName:     releaseName,
 			Format:          format,
 			Downloads:       s.Downloads,

--- a/internal/subtitles/types.go
+++ b/internal/subtitles/types.go
@@ -48,7 +48,12 @@ type SubtitleResult struct {
 	Downloads       int            `json:"downloads"`
 	HearingImpaired bool           `json:"hearing_impaired"`
 	UploadDate      time.Time      `json:"upload_date,omitempty"`
+	rawLanguage     string
 }
+
+// SetRawLanguageForBridge records the provider spelling for the frozen v1
+// bridge. It is intentionally excluded from JSON and unavailable to clients.
+func (r *SubtitleResult) SetRawLanguageForBridge(value string) { r.rawLanguage = value }
 
 // DownloadedSubtitle represents a subtitle that has been downloaded and stored.
 type DownloadedSubtitle struct {

--- a/web/src/hooks/queries/subtitles.ts
+++ b/web/src/hooks/queries/subtitles.ts
@@ -24,6 +24,7 @@ import type {
 
 import { itemKeys, settingsKeys, subtitleKeys } from "./keys";
 import { isSettingValueMissing } from "./settingValues";
+import { canonicalLanguageWireValue } from "@/lib/languageNames";
 
 interface DownloadSubtitleResponse {
   subtitle: DownloadedSubtitle;
@@ -53,8 +54,11 @@ export async function searchSubtitles(
   request: SubtitleSearchRequest,
   options?: RequestInit,
 ): Promise<SubtitleSearchResponse> {
+  const languages = request.languages
+    .map(canonicalLanguageWireValue)
+    .filter((v): v is string => Boolean(v));
   return v2("POST /api/v2/subtitles/search", {
-    body: { media_file_id: String(request.media_file_id), languages: request.languages },
+    body: { media_file_id: String(request.media_file_id), languages },
     signal: options?.signal ?? undefined,
   });
 }
@@ -70,7 +74,7 @@ export async function downloadSubtitle(
       media_file_id: String(request.media_file_id),
       provider: request.provider,
       subtitle_id: request.subtitle_id,
-      language: request.language,
+      language: canonicalLanguageWireValue(request.language) ?? request.language,
       release_name: request.release_name,
       score: request.score,
       hearing_impaired: request.hearing_impaired,

--- a/web/src/lib/languageNames.test.ts
+++ b/web/src/lib/languageNames.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   canonicalLanguageTag,
+  canonicalLanguageWireValue,
   englishLanguageName,
   getLanguageName,
   normalizeLanguageCode,
@@ -24,6 +25,9 @@ describe("languageNames", () => {
     expect(canonicalLanguageTag("eng")).toBe("en");
     expect(canonicalLanguageTag("pt_BR")).toBe("pt-BR");
     expect(normalizeLanguageCode("fre-CA")).toBe("fr");
+    expect(canonicalLanguageWireValue("Arabic")).toBe("ar");
+    expect(canonicalLanguageWireValue("zh-Hant")).toBe("zh-Hant");
+    expect(canonicalLanguageWireValue("unknown")).toBeNull();
   });
 
   it("distinguishes an unassigned tag from a translated language name", () => {

--- a/web/src/lib/languageNames.ts
+++ b/web/src/lib/languageNames.ts
@@ -40,7 +40,7 @@ export function canonicalLanguageTag(value: string): string | null {
   if (!trimmed) return null;
   try {
     const locale = new Intl.Locale(trimmed.replace(/_/g, "-"));
-    if (!displayName(englishLanguageNames, locale.language)) return null;
+    if (!/^[a-z]{2,3}$/i.test(locale.language)) return null;
     return locale.toString();
   } catch {
     return null;

--- a/web/src/lib/languageNames.ts
+++ b/web/src/lib/languageNames.ts
@@ -24,13 +24,32 @@ function displayName(names: Intl.DisplayNames, value: string): string | null {
 
 /** Canonical BCP 47 identity used only for comparison; wire values stay untouched. */
 export function canonicalLanguageTag(value: string): string | null {
-  const trimmed = value.trim();
+  const aliases: Record<string, string> = {
+    arabic: "ar",
+    english: "en",
+    spanish: "es",
+    french: "fr",
+    german: "de",
+    portuguese: "pt",
+    "brazilian portuguese": "pt-BR",
+    "portuguese (brazil)": "pt-BR",
+    "chinese (traditional)": "zh-Hant",
+    "traditional chinese": "zh-Hant",
+  };
+  const trimmed = (aliases[value.trim().toLowerCase()] ?? value).trim();
   if (!trimmed) return null;
   try {
-    return new Intl.Locale(trimmed.replace(/_/g, "-")).toString();
+    const locale = new Intl.Locale(trimmed.replace(/_/g, "-"));
+    if (!displayName(englishLanguageNames, locale.language)) return null;
+    return locale.toString();
   } catch {
     return null;
   }
+}
+
+/** Canonical value for API request bodies; invalid values stay absent. */
+export function canonicalLanguageWireValue(value: string | null | undefined): string | null {
+  return value == null ? null : canonicalLanguageTag(value);
 }
 
 /** Stable identity that de-duplicates ISO aliases without collapsing script or region subtags. */

--- a/web/src/player/components/SubtitleSearchModal.tsx
+++ b/web/src/player/components/SubtitleSearchModal.tsx
@@ -5,6 +5,7 @@ import { playerV2 } from "../player-v2";
 import type { SubtitleLanguageDetection, SubtitleResult } from "@/api/types";
 import { SubtitleUploadForm } from "@/components/subtitles/SubtitleUploadForm";
 import { LANGUAGES } from "../utils/languageNames";
+import { canonicalLanguageWireValue } from "@/lib/languageNames";
 
 interface SubtitleSearchModalProps {
   mediaFileId: number;
@@ -123,7 +124,10 @@ export function SubtitleSearchModal({
 
     try {
       const response = await playerV2(playerConfig, "POST /api/v2/subtitles/search", {
-        body: { media_file_id: String(mediaFileId), languages: [selectedLang] },
+        body: {
+          media_file_id: String(mediaFileId),
+          languages: [canonicalLanguageWireValue(selectedLang) ?? selectedLang],
+        },
       });
       setResults(response.results ?? []);
       setWarnings(response.warnings ?? []);


### PR DESCRIPTION
## Problem

Subtitle language inputs can arrive as ISO aliases or legacy display names, which caused provider coverage and stored language values to diverge.

## Change

- Add strict canonical BCP 47 tags plus compatibility parsing for legacy search inputs.
- Normalize and deduplicate bridge and v2 subtitle searches.
- Keep provider-specific mappings at provider boundaries.
- Normalize provider results and stored-subtitle projections at read time.
- Align settings migration and translation language recognition.
- Canonicalize web subtitle search and download requests.
- Document the contract and add a shared fixture.

## Validation

- Focused Go language, subtitle, handler, API v2, settings, migration, translation, metadata, and catalog tests passed, including repeated runs with `-count=2`.
- Web focused tests, production build, and touched-file formatting checks passed.
- Runtime health and provider status checks passed on the configured development target.
- Live development searches returned canonical `ar`, `pt-BR`, and `zh-Hant` response values. The shared deployment was an older build, so its provider coverage varied between upstream calls.

Related issue: N/A — coordinated subtitle language canonicalization

AI disclosure: Implemented with OpenAI GPT-6 Codex through the Codex agent harness, using shell, git, Go, Node, and GitHub CLI tooling.
