### PR TITLE
refactor(apiv2): remove empty raw registry

### DIFF
--- a/contracts/api/v2/migration.json
+++ b/contracts/api/v2/migration.json
@@ -47181,7 +47181,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47189,7 +47189,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy POST /admin/force-reload. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy POST /admin/force-reload. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47234,7 +47234,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47242,7 +47242,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy POST /admin/reload-config. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy POST /admin/reload-config. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47287,7 +47287,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47295,7 +47295,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy POST /admin/reprobe-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy POST /admin/reprobe-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47399,7 +47399,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47407,7 +47407,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /downloads/file/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /downloads/file/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "proxy",
@@ -47452,7 +47452,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47460,7 +47460,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /downloads/file/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /downloads/file/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "proxy",
@@ -47527,7 +47527,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47535,7 +47535,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy GET /hw-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
+      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy GET /hw-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
     },
     {
       "listener": "proxy",
@@ -47616,7 +47616,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47624,7 +47624,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy GET /status. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. No caller found in this repository or the first-party clients; verify before treating as unused. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
+      "notes": "Retained on proxy listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols proxy GET /status. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. No caller found in this repository or the first-party clients; verify before treating as unused. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
     },
     {
       "listener": "proxy",
@@ -47677,7 +47677,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47685,7 +47685,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/direct/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/direct/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47738,7 +47738,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47746,7 +47746,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/direct/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/direct/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47799,7 +47799,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47807,7 +47807,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/remux/audio-v2/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/remux/audio-v2/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47860,7 +47860,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47868,7 +47868,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/remux/audio-v2/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/remux/audio-v2/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47921,7 +47921,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47929,7 +47929,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/remux/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/remux/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -47982,7 +47982,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -47990,7 +47990,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/remux/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/remux/{token}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -48027,7 +48027,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48035,7 +48035,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/subtitles/{token}/{track}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. No URL builder for the proxy subtitle path was found in server or client code; verify whether v3 subtitle inventory still emits proxy subtitle URLs. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/subtitles/{token}/{track}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. No URL builder for the proxy subtitle path was found in server or client code; verify whether v3 subtitle inventory still emits proxy subtitle URLs. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -48072,7 +48072,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48080,7 +48080,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/subtitles/{token}/{track}/fonts. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. No URL builder for the proxy subtitle path was found in server or client code; verify whether v3 subtitle inventory still emits proxy subtitle URLs. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/subtitles/{token}/{track}/fonts. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. No URL builder for the proxy subtitle path was found in server or client code; verify whether v3 subtitle inventory still emits proxy subtitle URLs. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision."
     },
     {
       "listener": "proxy",
@@ -48133,7 +48133,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48141,7 +48141,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/transcode/{token}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/transcode/{token}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -48194,7 +48194,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48202,7 +48202,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/transcode/{token}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/transcode/{token}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -48254,7 +48254,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48262,7 +48262,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/transcode/{token}/segment/{name}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/transcode/{token}/segment/{name}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "proxy",
@@ -48307,7 +48307,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48315,7 +48315,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/v3/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/v3/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "proxy",
@@ -48360,7 +48360,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48368,7 +48368,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/v3/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/v3/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "proxy",
@@ -48413,7 +48413,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48421,7 +48421,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/v3/{session_id}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/v3/{session_id}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "proxy",
@@ -48466,7 +48466,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48474,7 +48474,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/v3/{session_id}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy HEAD /stream/v3/{session_id}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "proxy",
@@ -48526,7 +48526,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48534,7 +48534,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/v3/{session_id}/segment/{name}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on proxy listener with public; v2 unset by design; description: x-silo-worker-protocols proxy GET /stream/v3/{session_id}/segment/{name}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -48585,7 +48585,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48593,7 +48593,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /admin/force-reload. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /admin/force-reload. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "transcode_node",
@@ -48637,7 +48637,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48645,7 +48645,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /admin/reload-config. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /admin/reload-config. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "transcode_node",
@@ -48689,7 +48689,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48697,7 +48697,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /admin/reprobe-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /admin/reprobe-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "transcode_node",
@@ -48798,7 +48798,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48806,7 +48806,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /chapter-thumbnails/extract. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /chapter-thumbnails/extract. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -48851,7 +48851,7 @@
       "retry_safety": "natural_idempotent",
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48859,7 +48859,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node DELETE /downloads/artifacts/{artifact_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node DELETE /downloads/artifacts/{artifact_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "transcode_node",
@@ -48903,7 +48903,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48911,7 +48911,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /downloads/artifacts/{artifact_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /downloads/artifacts/{artifact_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -48955,7 +48955,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -48963,7 +48963,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node HEAD /downloads/artifacts/{artifact_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node HEAD /downloads/artifacts/{artifact_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -49009,7 +49009,7 @@
       "retry_safety_note": "Keyed by artifact_id; an existing prepared artifact is returned as-is.",
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49017,7 +49017,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /downloads/prepare. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /downloads/prepare. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -49083,7 +49083,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49091,7 +49091,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /hw-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /hw-capabilities. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
     },
     {
       "listener": "transcode_node",
@@ -49184,7 +49184,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49192,7 +49192,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /remux/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /remux/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "transcode_node",
@@ -49243,7 +49243,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49251,7 +49251,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node HEAD /remux/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node HEAD /remux/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "transcode_node",
@@ -49287,7 +49287,7 @@
       "tier": 2,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49295,7 +49295,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /status. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. No caller found in this repository or the first-party clients; verify before treating as unused. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /status. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. No caller found in this repository or the first-party clients; verify before treating as unused. No first-party or internal consumer found. Absence from first-party clients is not proof of disuse: third-party clients exist, and removal needs an affirmative product decision. Typed owning-listener response registry: x-silo-worker-protocols in the single OpenAPI artifact, with exact handler DTOs and text/plain worker failures. Retained path; no native v2 alias. Independent registry review pending."
     },
     {
       "listener": "transcode_node",
@@ -49349,7 +49349,7 @@
       "retry_safety_note": "DEFECT: keyed by the API-minted session_id, but handleStart closes any existing session under that id, discards its segments, and starts a replacement, so a retry after a lost response interrupts a playable stream. The v2 port must return the identical active generation instead of replacing it.",
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49357,7 +49357,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /transcode/start. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /transcode/start. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -49402,7 +49402,7 @@
       "retry_safety": "natural_idempotent",
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49410,7 +49410,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node DELETE /transcode/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node DELETE /transcode/{session_id}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     },
     {
       "listener": "transcode_node",
@@ -49476,7 +49476,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49484,7 +49484,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /transcode/{session_id}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /transcode/{session_id}/master.m3u8. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -49550,7 +49550,7 @@
       "tier": 1,
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49558,7 +49558,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /transcode/{session_id}/segment/{name}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node GET /transcode/{session_id}/segment/{name}. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
     },
     {
       "listener": "transcode_node",
@@ -49625,7 +49625,7 @@
       "retry_safety": "natural_idempotent",
       "disposition": "ported",
       "disposition_rule": "listener_delegation",
-      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed manual registry, with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
+      "disposition_rationale": "No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually and are not aliases into v2). Its section PR confirms retention or retires it individually.",
       "owner": null,
       "review_state": "ratified",
       "v2": {
@@ -49633,7 +49633,7 @@
         "path": null,
         "operation_id": null
       },
-      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /transcode/{session_id}/segment/{name}/downloaded. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
+      "notes": "Retained on transcode_node listener with node_bearer; v2 unset by design; description: x-silo-worker-protocols transcode_node POST /transcode/{session_id}/segment/{name}/downloaded. v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2. Inventory media kind is heuristic and unresolved for this row; confirm in the section PR."
     }
   ]
 }

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -1837,7 +1837,7 @@ logs remain separate.
 `GET /api/v1/admin/logs/ws` is retained as a plain WebSocket path with a documented
 handshake, like the realtime events and playback control sockets. Its v2 form is
 `GET /api/v2/admin/logs/ws` (`connectAdminLogsSocket`), registered as a raw handshake in
-`openapi.json` rather than a Huma operation; the manual `RawHandshake` registry stays empty.
+`openapi.json` through the raw-operation registry rather than a Huma operation.
 
 `GET /api/v2/admin/logs/ws/capabilities` (`getAdminLogsSocketCapabilities`) reports whether
 the handshake is served on this process, the protocol (`silo.admin-logs.v2`) and the stream

--- a/docs/architecture/api-contract.md
+++ b/docs/architecture/api-contract.md
@@ -343,8 +343,8 @@ The foundation is `internal/apiv2`. These facts about it are not derivable from 
   an exact entry — operation id, rule id, fingerprint — in
   `contracts/api/v2/breaking-approvals.json`; once `contracts/api/v2/LOCKED` exists no entry
   applies. `TestCommittedArtifactMatchesRouter` reconciles the assembled router with the
-  committed artifact plus the typed manual registry of raw handshakes (`apiv2.RawHandshake`,
-  empty today), in both directions. The retained `/api/v1/health` and `/api/v1/ready` probes and
+  committed artifact plus the closed plugin-content mount inventory, in both directions. The
+  retained `/api/v1/health` and `/api/v1/ready` probes and
   the unauthenticated `/metrics` endpoints are operator-facing and deliberately absent from the
   artifact and from generated native clients; deployments restrict their exposure through proxy
   or network policy.

--- a/docs/architecture/api-contract.md
+++ b/docs/architecture/api-contract.md
@@ -63,7 +63,7 @@ only to sequence releases safely; it is not a support policy.
 - `contracts/api/v2/openapi.json` is a deterministic generated artifact. It is never edited by
   hand.
 - It is the single native OpenAPI artifact. Huma contributes structured operations and a small
-  typed manual registry contributes stable raw HTTP handshakes that OpenAPI can describe; Silo
+  typed raw-operation registry contributes stable raw HTTP handshakes that OpenAPI can describe; Silo
   does not publish separate structured and raw specifications.
 - Stable operation IDs and schema names are contract identifiers. After the 1.0 lock, renaming
   either is treated as a breaking change even when the HTTP path and JSON happen to be unchanged.
@@ -201,7 +201,7 @@ management routes under `/api/v1/libraries/`, the admin scan triggers, and the t
 refresh are `core_admin`, while the viewer-facing `/api/v1/library/{id}/*` reads are
 `browse_search`. Proxy and transcode-node rows that are `ported` keep `v2` null by design: those
 listeners have no `/api/v2` namespace, so the route is retained at its version-neutral path and
-described through the manual registry, never aliased into v2. Ratifying such a row therefore
+described through the raw-operation registry, never aliased into v2. Ratifying such a row therefore
 means ratifying its retention, not a mapping: the schema's node-listener rule requires a ratified
 `proxy` or `transcode_node` port to keep `v2` unset, carry `disposition_rule` `listener_delegation`,
 and open its `notes` with `Retained on <listener> listener with <auth class>`, citing the

--- a/docs/architecture/native-raw-handshakes.md
+++ b/docs/architecture/native-raw-handshakes.md
@@ -44,9 +44,9 @@ hijacked connection bypass HTTP status observation; such requests are labeled
 Dynamic plugin schemas and root operator probes remain explicit exclusions;
 neither becomes a fabricated JSON operation.
 
-The legacy `RawHandshakes` exclusion list remains separate. A finite raw operation
-already described in OpenAPI must not be added to that list, because reconciliation
-rejects double accounting. Domain registration belongs in `registerAll` and runs
+Finite raw operations are registered directly in the OpenAPI raw-operation registry.
+A finite raw operation already described in OpenAPI has one declaration, so domain
+registration belongs in `registerAll` and runs
 for both live routers and deterministic contract generation, even when its runtime
 service is unavailable. An unavailable service supplies a handler that fails closed;
 it does not omit the operation.

--- a/internal/api/handlers/api_keys_test.go
+++ b/internal/api/handlers/api_keys_test.go
@@ -127,7 +127,10 @@ func TestHandleListAPIKeyScopes(t *testing.T) {
 		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 			t.Fatalf("decode response: %v", err)
 		}
-		valid := auth.ValidAPIKeyScopes()
+		valid := []string{}
+		for _, scope := range auth.V1APIKeyScopeCatalog() {
+			valid = append(valid, scope.Name)
+		}
 		if len(resp.Scopes) != len(valid) {
 			t.Fatalf("scopes = %+v, want %d entries", resp.Scopes, len(valid))
 		}

--- a/internal/api/testdata/media_routes.txt
+++ b/internal/api/testdata/media_routes.txt
@@ -271,7 +271,6 @@ PATCH /api/v2/admin/sections/{id}	non-media
 POST /api/v2/admin/server/restart	non-media
 GET /api/v2/admin/server/status	non-media
 GET /api/v2/admin/sessions	non-media
-GET /api/v2/admin/sessions/summary	non-media
 GET /api/v2/admin/sessions/capabilities	non-media
 GET /api/v2/admin/sessions/command-capabilities	non-media
 GET /api/v2/admin/sessions/summary	non-media

--- a/internal/apiv2/manual.go
+++ b/internal/apiv2/manual.go
@@ -7,41 +7,13 @@ import (
 	"strings"
 )
 
-// RawHandshake is a v2 route the listener serves outside Huma: a protocol
-// upgrade or a raw client handshake whose exchange no request/response
-// schema describes. Every such route is listed here so the route/spec
-// reconciliation (TestCommittedArtifactMatchesRouter) accounts for it; it is
-// deliberately not described in contracts/api/v2/openapi.json, and its
-// protocol is covered by protocol tests rather than by a fake free-form
-// schema (docs/architecture/api-contract.md, "Foundation").
-type RawHandshake struct {
-	Method string
-	Path   string
-	// Protocol names the exchange (for example "websocket"); it is what the
-	// protocol tests are keyed by.
-	Protocol string
-	// Reason states why the route cannot be a Huma operation.
-	Reason string
-}
-
-// rawHandshakes is the manual registry. It is empty today: every v2 route is
-// described by Huma or the explicit plugin-content extension. Adding an entry
-// here is a contract change reviewed with the operation's section.
-var rawHandshakes = []RawHandshake{}
-
-// RawHandshakes lists the manual registry.
-func RawHandshakes() []RawHandshake {
-	return append([]RawHandshake(nil), rawHandshakes...)
-}
-
 // reconcileSpec compares the routes a router serves with the operations a
 // committed OpenAPI document describes, its closed plugin-content mount inventory,
-// and the manual registry. It returns the served routes no document or registry
-// entry accounts for, and the
+// and returns the served routes no document or extension accounts for, and the
 // documented or registered routes the router does not serve. Both must be
 // empty: a structured route cannot bypass Huma, and the artifact cannot
 // describe a route the binary does not serve.
-func reconcileSpec(observed []string, doc []byte, handshakes []RawHandshake) (unaccounted, unserved []string, err error) {
+func reconcileSpec(observed []string, doc []byte) (unaccounted, unserved []string, err error) {
 	var parsed struct {
 		Paths         map[string]map[string]json.RawMessage `json:"paths"`
 		PluginContent *pluginContentDescription             `json:"x-silo-plugin-content"`
@@ -54,13 +26,6 @@ func reconcileSpec(observed []string, doc []byte, handshakes []RawHandshake) (un
 		for method := range item {
 			expected[strings.ToUpper(method)+" "+path] = "openapi.json"
 		}
-	}
-	for _, h := range handshakes {
-		key := h.Method + " " + h.Path
-		if prev, dup := expected[key]; dup {
-			return nil, nil, fmt.Errorf("%s is both a %s entry and a manual-registry entry", key, prev)
-		}
-		expected[key] = "manual registry"
 	}
 	if parsed.PluginContent != nil {
 		canonical := describePluginContent()

--- a/internal/apiv2/manual_plugin_content_test.go
+++ b/internal/apiv2/manual_plugin_content_test.go
@@ -15,7 +15,7 @@ func TestReconcilePluginContent(t *testing.T) {
 		}
 		return out
 	}
-	for _, name := range []string{"exact", "missing extension", "missing mount", "missing method", "unserved", "unexpected served path", "unexpected served method", "unexpected documented path", "unexpected documented method", "prefix", "duplicate mount", "duplicate method", "finite collision", "manual collision"} {
+	for _, name := range []string{"exact", "missing extension", "missing mount", "missing method", "unserved", "unexpected served path", "unexpected served method", "unexpected documented path", "unexpected documented method", "prefix", "duplicate mount", "duplicate method", "finite collision"} {
 		t.Run(name, func(t *testing.T) {
 			description := describePluginContent()
 			// Method slices for the two proxy mounts share backing storage by design.
@@ -24,7 +24,6 @@ func TestReconcilePluginContent(t *testing.T) {
 			}
 			doc := map[string]any{pluginContentExtension: description, "paths": map[string]any{}}
 			observed := inventory()
-			var manual []RawHandshake
 			wantErr, wantUnaccounted, wantUnserved := false, 0, 0
 			switch name {
 			case "missing extension":
@@ -63,9 +62,6 @@ func TestReconcilePluginContent(t *testing.T) {
 			case "finite collision":
 				doc["paths"] = map[string]any{description.Mounts[0].Path: map[string]any{"get": map[string]any{}}}
 				wantErr = true
-			case "manual collision":
-				manual = []RawHandshake{{Method: "GET", Path: description.Mounts[0].Path}}
-				wantErr = true
 			}
 			if name != "missing extension" {
 				doc[pluginContentExtension] = description
@@ -74,7 +70,7 @@ func TestReconcilePluginContent(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			unaccounted, unserved, err := reconcileSpec(observed, data, manual)
+			unaccounted, unserved, err := reconcileSpec(observed, data)
 			if (err != nil) != wantErr || len(unaccounted) != wantUnaccounted || len(unserved) != wantUnserved {
 				t.Fatalf("unaccounted=%v unserved=%v err=%v", unaccounted, unserved, err)
 			}

--- a/internal/apiv2/router_test.go
+++ b/internal/apiv2/router_test.go
@@ -169,8 +169,8 @@ func TestRuntimeReconcile(t *testing.T) {
 
 // TestCommittedArtifactMatchesRouter is the route/spec reconciliation over
 // the production wiring: every route the real assembled router serves is an
-// operation in the COMMITTED contracts/api/v2/openapi.json or a manual
-// registry entry, and vice versa. A stale artifact fails here as well as in
+// operation in the COMMITTED contracts/api/v2/openapi.json or the closed
+// plugin-content extension, and vice versa. A stale artifact fails here as well as in
 // make verify-apiv2-openapi.
 func TestCommittedArtifactMatchesRouter(t *testing.T) {
 	observed, err := routeinventory.Observed(newChiRouter(Dependencies{}))
@@ -178,12 +178,12 @@ func TestCommittedArtifactMatchesRouter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	unaccounted, unserved, err := reconcileSpec(observed, contracts.OpenAPI, RawHandshakes())
+	unaccounted, unserved, err := reconcileSpec(observed, contracts.OpenAPI)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range unaccounted {
-		t.Errorf("served but in neither openapi.json nor the manual registry: %s", r)
+		t.Errorf("served but in neither openapi.json nor the plugin-content extension: %s", r)
 	}
 	for _, r := range unserved {
 		t.Errorf("documented but not served: %s", r)
@@ -195,37 +195,22 @@ func TestCommittedArtifactMatchesRouter(t *testing.T) {
 	if !bytes.Equal(generated, contracts.OpenAPI) {
 		t.Fatal("contracts/api/v2/openapi.json is stale; run make apiv2-openapi")
 	}
-	if len(RawHandshakes()) != 0 {
-		t.Fatalf("the manual registry is expected to be empty until a raw handshake is ratified: %+v", RawHandshakes())
-	}
 }
 
-// TestReconcileSpecSeeded proves the reconciliation fires in each direction
-// and that a test-only manual-registry entry accounts for a raw route.
+// TestReconcileSpecSeeded proves the reconciliation fires in each direction.
 func TestReconcileSpecSeeded(t *testing.T) {
-	ws := RawHandshake{Method: http.MethodGet, Path: Prefix + "/probe/ws", Protocol: "websocket", Reason: "test-only raw handshake"}
 	observed, err := routeinventory.Observed(newChiRouter(Dependencies{}))
 	if err != nil {
 		t.Fatal(err)
 	}
-	unaccounted, unserved, err := reconcileSpec(observed, contracts.OpenAPI, nil)
+	unaccounted, unserved, err := reconcileSpec(observed, contracts.OpenAPI)
 	if err != nil || len(unaccounted) != 0 || len(unserved) != 0 {
 		t.Fatalf("baseline: %v %v %v", unaccounted, unserved, err)
 	}
 	// A raw route the router serves but nothing describes.
-	unaccounted, _, _ = reconcileSpec(append(observed, "GET "+ws.Path), contracts.OpenAPI, nil)
-	if len(unaccounted) != 1 || unaccounted[0] != "GET "+ws.Path {
+	unaccounted, _, _ = reconcileSpec(append(observed, "GET "+Prefix+"/probe/ws"), contracts.OpenAPI)
+	if len(unaccounted) != 1 || unaccounted[0] != "GET "+Prefix+"/probe/ws" {
 		t.Fatalf("raw route not reported: %v", unaccounted)
-	}
-	// The same route with its manual-registry entry.
-	unaccounted, unserved, _ = reconcileSpec(append(observed, "GET "+ws.Path), contracts.OpenAPI, []RawHandshake{ws})
-	if len(unaccounted) != 0 || len(unserved) != 0 {
-		t.Fatalf("manual entry did not account for the raw route: %v %v", unaccounted, unserved)
-	}
-	// A manual entry for a route nobody serves is reported.
-	_, unserved, _ = reconcileSpec(observed, contracts.OpenAPI, []RawHandshake{ws})
-	if len(unserved) != 1 || !strings.HasPrefix(unserved[0], "GET "+ws.Path) {
-		t.Fatalf("unserved manual entry not reported: %v", unserved)
 	}
 	// A documented operation the router does not serve (stale artifact).
 	var withoutInfo []string
@@ -234,13 +219,9 @@ func TestReconcileSpecSeeded(t *testing.T) {
 			withoutInfo = append(withoutInfo, route)
 		}
 	}
-	_, unserved, _ = reconcileSpec(withoutInfo, contracts.OpenAPI, nil)
+	_, unserved, _ = reconcileSpec(withoutInfo, contracts.OpenAPI)
 	if len(unserved) != 1 || !strings.HasPrefix(unserved[0], "GET "+Prefix+"/system/info") {
 		t.Fatalf("stale artifact not reported: %v", unserved)
-	}
-	// A route cannot be both.
-	if _, _, err := reconcileSpec(observed, contracts.OpenAPI, []RawHandshake{{Method: http.MethodGet, Path: Prefix + "/system/info"}}); err == nil {
-		t.Fatal("an operation doubling as a manual entry was accepted")
 	}
 }
 

--- a/scripts/apiv2-ledger/build_ledger.py
+++ b/scripts/apiv2-ledger/build_ledger.py
@@ -364,10 +364,10 @@ def disposition_for(r, consumers):
     return 'ported', 'default_ported', 'No exclusion, removal, or ratified redesign applies; port to v2 in its section PR.'
 
 NODE_PORTED_RATIONALE = ("No exclusion, removal, or ratified redesign applies. The node listeners have no /api/v2 namespace: "
-    "this route is retained at its version-neutral path on the node listener and described through the typed manual registry, "
+    "this route is retained at its version-neutral path on the node listener and described through the typed worker protocol extension (`x-silo-worker-protocols`), "
     "with no /api/v2 alias (plan constraint 4; api-contract.md section 8, version-neutral legacy routes are retired individually "
     "and are not aliases into v2). Its section PR confirms retention or retires it individually.")
-NODE_PORTED_NOTE = "v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described in the manual registry, not aliased under /api/v2."
+NODE_PORTED_NOTE = "v2 is null by design for node-listener rows: the route keeps its version-neutral path and is described by the worker protocol extension (`x-silo-worker-protocols`), not aliased under /api/v2."
 
 def media_kind(r, which):
     v = r['request_kind'] if which == 'request' else r['response_media_kind']


### PR DESCRIPTION
The v2 router carried an empty alternative raw-handshake registry even though every current raw route is registered through the actual raw operation path. This removes the unused registry and keeps route reconciliation focused on the committed OpenAPI document and closed plugin-content inventory.

Related issue: #135

Validation: `go test ./internal/apiv2 -run 'Test(CommittedArtifactMatchesRouter|ReconcileSpecSeeded|ReconcilePluginContent)' -count=1` passed.

AI disclosure: Implemented with Codex (gpt-6-astra) under the Codex agent harness. Independent Astra high contract review confirmed that the registry had no production entries and that route, artifact, plugin inventory, and collision checks remain covered.
