### PR TITLE
fix(deploy): require an explicit PostgreSQL password in Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Silo Docker deployment
-# For the default docker compose setup, MEDIA_ROOT is the main value you need to set.
+# Set MEDIA_ROOT, POSTGRES_PASSWORD and SECRET_KEY before the first start.
 
 # Optional: layer compose files through env. Leave unset for CPU-only defaults.
 # Linux example for Intel/AMD VA-API or Intel Quick Sync:
@@ -26,8 +26,10 @@ SILO_IMAGE=ghcr.io/silo-server/silo-server:latest
 
 # Quick-start bundled PostgreSQL settings used by docker-compose.yml.
 POSTGRES_USER=silo
-# Set POSTGRES_PASSWORD before first start (the quick start appends a generated one).
-# POSTGRES_PASSWORD=silo
+# Required by both Compose stacks. The quick start appends a generated password.
+# Generate one for a new database with: openssl rand -hex 24
+# Existing databases must use their current password until it is rotated.
+# POSTGRES_PASSWORD=
 POSTGRES_DB=silo
 POSTGRES_SHM_SIZE=8gb
 # POSTGRES_PORT=5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,18 @@ jobs:
         working-directory: .
         run: make verify-settings-bindings-web
 
+  compose:
+    name: Compose credentials
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Verify Compose requires an explicit database password
+        run: python3 scripts/check-compose-credentials.py
+
   docs:
     name: Docs hygiene
     runs-on: ubuntu-latest

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,13 +25,19 @@ pre-submission gate are in [CONTRIBUTING.md](CONTRIBUTING.md).
 Source builds use [docker-compose.yml](docker-compose.yml) only for PostgreSQL
 and Redis; the deploy-oriented stack in the README is separate.
 
+For an existing local database, set `postgres_password` below to its current
+password instead of generating a new one. Changing `.env` does not change the
+password stored in PostgreSQL.
+
 ```sh
-# Create the local bootstrap configuration
+# Create the bootstrap configuration for a new local database
 cp .env.example .env
 chmod 600 .env
-printf '\nSECRET_KEY=%s\nDATABASE_URL=%s\nREDIS_URL=%s\n' \
+postgres_password="$(openssl rand -hex 24)"
+printf '\nPOSTGRES_PASSWORD=%s\nSECRET_KEY=%s\nDATABASE_URL=%s\nREDIS_URL=%s\n' \
+  "$postgres_password" \
   "$(openssl rand -base64 48)" \
-  'postgres://silo:silo@localhost:5432/silo?sslmode=disable' \
+  "postgres://silo:${postgres_password}@localhost:5432/silo?sslmode=disable" \
   'redis://localhost:6379' >> .env
 
 # Start local PostgreSQL and Redis

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
     shm_size: ${POSTGRES_SHM_SIZE:-2gb}
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-silo}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-silo}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       POSTGRES_DB: ${POSTGRES_DB:-silo}
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
@@ -107,7 +107,7 @@ services:
     environment:
       MODE: integrated
       PORT: "8080"
-      DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:-silo}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
+      DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
       REDIS_URL: redis://redis:6379
       SILO_PLUGIN_CACHE_DIR: /var/lib/silo/plugins
       POSTGRES_TUNE: "off"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     shm_size: ${POSTGRES_SHM_SIZE:-8gb}
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-silo}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-silo}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
       POSTGRES_DB: ${POSTGRES_DB:-silo}
     ports:
       - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
@@ -65,7 +65,7 @@ services:
       # Back it up SEPARATELY from your database dumps; losing it makes encrypted
       # secrets unrecoverable. See docs/architecture/secret-encryption.md.
       SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env — generate one with openssl rand -base64 48}
-      DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:-silo}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
+      DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
       REDIS_URL: redis://redis:6379
       SILO_PLUGIN_CACHE_DIR: /var/lib/silo/plugins
       POSTGRES_TUNE: ${POSTGRES_TUNE:-auto}
@@ -108,7 +108,7 @@ services:
   #     MODE: proxy
   #     # Must be the SAME SECRET_KEY as the primary node (shared encrypted data).
   #     SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env — generate one with openssl rand -base64 48}
-  #     DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:-silo}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
+  #     DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
   #     REDIS_URL: redis://redis:6379
   #     PORT: "8080"
   #   ports:
@@ -140,7 +140,7 @@ services:
   #     MODE: transcode
   #     # Must be the SAME SECRET_KEY as the primary node (shared encrypted data).
   #     SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env — generate one with openssl rand -base64 48}
-  #     DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:-silo}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
+  #     DATABASE_URL: postgres://${POSTGRES_USER:-silo}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@postgres:5432/${POSTGRES_DB:-silo}?sslmode=disable
   #     REDIS_URL: redis://redis:6379
   #     SILO_PLUGIN_CACHE_DIR: /var/lib/silo/plugins
   #     PORT: "8080"

--- a/docs/wiki/deployment/docker.md
+++ b/docs/wiki/deployment/docker.md
@@ -61,6 +61,16 @@ printf '\nPOSTGRES_PASSWORD=%s\nSECRET_KEY=%s\n' \
   "$(openssl rand -hex 24)" "$(openssl rand -base64 48)" >> .env
 ```
 
+Both `docker-compose.yml` and `docker-compose.dev.yml` require a non-empty
+`POSTGRES_PASSWORD`. Compose rejects a missing or empty value before starting
+containers. Copying `.env.example` alone does not configure a password.
+
+For an existing database, set `POSTGRES_PASSWORD` to its current password before
+using the updated Compose files. Changing `.env` does not change the password
+stored in PostgreSQL. Coordinate password rotation with the database role and
+all clients that use it; generating a new value only in `.env` breaks their
+connections.
+
 Set the host path to your media:
 
 ```dotenv

--- a/scripts/check-compose-credentials.py
+++ b/scripts/check-compose-credentials.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Check Compose credential interpolation without starting any containers."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import unittest
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_FILES = ("docker-compose.yml", "docker-compose.dev.yml")
+
+
+def read_compose(filename):
+    return (ROOT / filename).read_text()
+
+
+def render_compose(filename, password=None):
+    # Ignore the caller's deployment settings and .env, including env_file
+    # entries on services. These checks only need the Compose CLI.
+    env = {
+        "PATH": os.environ.get("PATH", os.defpath),
+        "HOME": "/nonexistent",
+        "DOCKER_CONFIG": "/nonexistent",
+        "MEDIA_ROOT": "/tmp/silo-compose-test/media",
+        "SECRET_KEY": "compose-test-only-secret-key-32-characters",
+    }
+    if password is not None:
+        env["POSTGRES_PASSWORD"] = password
+    return subprocess.run(
+        [
+            "docker", "compose",
+            "--project-name", "silo-credential-test",
+            "--project-directory", "/",
+            "--env-file", "/dev/null",
+            "-f", "-",
+            "config", "--no-env-resolution", "--format", "json",
+        ],
+        input=read_compose(filename),
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+class ComposeCredentialsTest(unittest.TestCase):
+    def test_missing_password_is_rejected(self):
+        for filename in COMPOSE_FILES:
+            with self.subTest(compose=filename):
+                result = render_compose(filename)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("POSTGRES_PASSWORD", result.stderr)
+
+    def test_empty_password_is_rejected(self):
+        for filename in COMPOSE_FILES:
+            with self.subTest(compose=filename):
+                result = render_compose(filename, "")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("POSTGRES_PASSWORD", result.stderr)
+
+    def test_explicit_password_reaches_both_services_unchanged(self):
+        passwords = (
+            ("hex", "0123456789abcdef" * 3),
+            ("literal", "compose-test$literal"),
+            ("existing_default", "silo"),
+        )
+        for filename in COMPOSE_FILES:
+            for password_kind, password in passwords:
+                with self.subTest(compose=filename, password_kind=password_kind):
+                    result = render_compose(filename, password)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    services = json.loads(result.stdout)["services"]
+                    # Compose escapes dollars when serialising its reusable
+                    # config output, including JSON.
+                    rendered_password = password.replace("$", "$$")
+                    self.assertEqual(
+                        services["postgres"]["environment"]["POSTGRES_PASSWORD"],
+                        rendered_password,
+                    )
+                    database_url = services["silo"]["environment"]["DATABASE_URL"]
+                    self.assertEqual(urlsplit(database_url).password, rendered_password)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Related issue: N/A, narrow fix

Both Compose stacks silently use a known PostgreSQL password when
`POSTGRES_PASSWORD` is missing or empty. The application URL uses the same
fallback, so the stack can start successfully with that credential. Production
binds the database port to loopback; development binds it to all interfaces by
default.

The environment example also suggests the default even though the documented
quick start already generates a password.

The source-development bootstrap also relied on the fallback: it wrote
`DATABASE_URL` without `POSTGRES_PASSWORD`. Enforcing the requirement without
updating that bootstrap prevents even `docker compose up -d postgres redis`
from starting.

## Approach

I require a non-empty `POSTGRES_PASSWORD` in both Compose stacks, including the
commented distributed-role examples. Compose now rejects a missing or empty
value before starting containers. Explicitly configured passwords continue to
reach PostgreSQL and the application URL unchanged.

I updated the environment example, deployment guide and source-development
bootstrap, and added a Compose credential regression check to CI. The source
bootstrap generates one password for both `POSTGRES_PASSWORD` and the local
backend's `DATABASE_URL`, with instructions to reuse an existing database
password when appropriate. Requiring an explicit value keeps credential
generation under the operator's control. Existing installations can set their
current password explicitly. This change does not enforce password strength or
rotate a stored database password.

This branch is based on upstream `main` at
`1cc0237e2ac03be3f32640f6cf47c725182528cf` and contains only this seven-file fix.

## Validation

Current head: `38b6742656262419a80790e7cf929cbadfee73f8`.

- Reproduced on upstream `main`: both stacks accepted missing and empty
  passwords, causing all four rejection checks to fail. Explicit-password
  controls passed.
- The patched `python3 scripts/check-compose-credentials.py` suite passed all
  three tests and ten configuration cases: missing, empty, hexadecimal,
  literal-dollar and explicitly configured legacy passwords in both stacks.
  It checks the PostgreSQL environment and application URL together.
- The focused baseline and patched checks used Python 3 and Docker Compose
  5.1.4 on Linux, with source supplied in memory and synthetic credentials.
  The test uses `docker compose config --no-env-resolution --format json`
  with an explicit environment file, project directory and standard input.
  It starts no containers and reads no deployment environment file.
- Python syntax compilation, workflow YAML parsing and `git diff --check`
  passed.
- Reproduced Greptile's source-bootstrap failure from `DEVELOPMENT.md` at
  `105dfdec846c175e400bd429a5b6125db82d53b0`: the generated environment lacked
  `POSTGRES_PASSWORD`, and Compose configuration failed. At the current head,
  the generated-password and existing-password variants both render
  `postgres` and `redis` successfully. The database value matches the source
  backend URL, and the generated environment file has permissions `600`.
  These checks executed the documented shell block with deterministic test
  credentials, then ran Compose configuration rendering with in-memory inputs.
  No containers were started.
- [Full upstream CI for the original fix](https://github.com/Silo-Server/silo-server/actions/runs/34676225145)
  passed at `105dfdec846c175e400bd429a5b6125db82d53b0`.
- [CI for the current head](https://github.com/Silo-Server/silo-server/actions/runs/34676957521)
  is running. Compose credentials and Docs hygiene have passed; Go and Web
  remain in progress.

The same portable configuration change has also been exercised in a running
fork deployment: application startup, database authentication, readiness and
frontend asset checks passed. That deployment uses additional fork code, so it
is supporting evidence rather than an upstream application deployment test.

## Risks

**Upgrade requirement:** installations relying on the fallback must explicitly
configure their current PostgreSQL password before using the updated Compose
files. Changing only `.env` does not update the database role password and can
break client connections. The deployment guide explains this requirement.

Explicitly configuring the previous default remains valid for compatibility;
operators still choose their password policy. Host file permissions and port
bindings are unchanged.

There are no database migrations or client API changes. Apple, Android and
Jellyfin clients require no corresponding code changes.

## Benchmarks

Not applicable. This change validates deployment configuration and does not
alter application runtime performance paths.

## Checklist

- [x] I read and can explain the complete diff.
- [x] This pull request addresses one concern.

## AI Disclosure

AI-assisted with Astra. I directed the task and designed the work.

- Harness: OpenAI Codex desktop app.
- Tool(s): Codex `functions.exec` with `exec_command` and file editing,
  GitHub CLI (`gh`), Docker Compose, Python `unittest` and Greptile automated PR review.
- Model(s): `gpt-6-astra`, Ultra reasoning, confirmed by the task owner.
  Greptile did not supply its underlying model identifier.
- Involvement: AI-assisted. Human review of the final diff is pending.
- Adversarial review: A separate pass by the same agent traced credential
  interpolation through both Compose stacks, application URLs and distributed
  examples, then checked upgrade behaviour and test isolation. Baseline tests
  reproduced the missing/empty-value failures; the patch passed those checks
  and preserved explicit passwords, including literal-dollar and legacy
  values. Greptile then identified the omitted source-development password.
  I reproduced that failure and verified the generated and existing-password
  paths after updating `DEVELOPMENT.md`. No Codex subagent was used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deployment**
  - Docker Compose now requires a non-empty `POSTGRES_PASSWORD` instead of using a default.
  - Startup reports an error when the database password is missing.
  - Existing database deployments must continue using their stored PostgreSQL password.

- **Documentation**
  - Added `SECRET_KEY`, `MEDIA_ROOT`, and `POSTGRES_PASSWORD` to first-startup requirements.
  - Clarified generated-password guidance for new databases and local development.

- **Tests**
  - Added automated checks for required credential handling in Docker Compose configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->